### PR TITLE
Remove the CHIPClusters ReadAttribute* APIs.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -74,7 +74,15 @@ CHIP_ERROR LogValue(const char * label, size_t indent, chip::CharSpan value)
 
 CHIP_ERROR LogValue(const char * label, size_t indent, chip::ByteSpan value)
 {
-    ChipLogProgress(chipTool, "%s%s: %zu", IndentStr(indent).c_str(), label, value.size());
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    if (CHIP_NO_ERROR == chip::Encoding::BytesToUppercaseHexString(value.data(), value.size(), &buffer[0], CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
+    {
+        ChipLogProgress(chipTool, "%s%s: %s", IndentStr(indent).c_str(), label, buffer);
+    }
+    else
+    {
+      ChipLogProgress(chipTool, "%s%s: %zu", IndentStr(indent).c_str(), label, value.size());
+    }
     return CHIP_NO_ERROR;
 }
 
@@ -197,25 +205,9 @@ static void OnBooleanAttributeReport(void * context, bool value)
     ChipLogProgress(chipTool, "Boolean attribute Response: %d", value);
 }
 
-static void OnBooleanAttributeResponse(void * context, bool value)
-{
-    OnBooleanAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt8uAttributeReport(void * context, uint8_t value)
 {
     ChipLogProgress(chipTool, "Int8u attribute Response: %" PRIu8, value);
-}
-
-static void OnInt8uAttributeResponse(void * context, uint8_t value)
-{
-    OnInt8uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16uAttributeReport(void * context, uint16_t value)
@@ -223,25 +215,9 @@ static void OnInt16uAttributeReport(void * context, uint16_t value)
     ChipLogProgress(chipTool, "Int16u attribute Response: %" PRIu16, value);
 }
 
-static void OnInt16uAttributeResponse(void * context, uint16_t value)
-{
-    OnInt16uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt32uAttributeReport(void * context, uint32_t value)
 {
     ChipLogProgress(chipTool, "Int32u attribute Response: %" PRIu32, value);
-}
-
-static void OnInt32uAttributeResponse(void * context, uint32_t value)
-{
-    OnInt32uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64uAttributeReport(void * context, uint64_t value)
@@ -249,25 +225,9 @@ static void OnInt64uAttributeReport(void * context, uint64_t value)
     ChipLogProgress(chipTool, "Int64u attribute Response: %" PRIu64, value);
 }
 
-static void OnInt64uAttributeResponse(void * context, uint64_t value)
-{
-    OnInt64uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt8sAttributeReport(void * context, int8_t value)
 {
     ChipLogProgress(chipTool, "Int8s attribute Response: %" PRId8, value);
-}
-
-static void OnInt8sAttributeResponse(void * context, int8_t value)
-{
-    OnInt8sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16sAttributeReport(void * context, int16_t value)
@@ -275,25 +235,9 @@ static void OnInt16sAttributeReport(void * context, int16_t value)
     ChipLogProgress(chipTool, "Int16s attribute Response: %" PRId16, value);
 }
 
-static void OnInt16sAttributeResponse(void * context, int16_t value)
-{
-    OnInt16sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt32sAttributeReport(void * context, int32_t value)
 {
     ChipLogProgress(chipTool, "Int32s attribute Response: %" PRId32, value);
-}
-
-static void OnInt32sAttributeResponse(void * context, int32_t value)
-{
-    OnInt32sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64sAttributeReport(void * context, int64_t value)
@@ -301,38 +245,14 @@ static void OnInt64sAttributeReport(void * context, int64_t value)
     ChipLogProgress(chipTool, "Int64s attribute Response: %" PRId64, value);
 }
 
-static void OnInt64sAttributeResponse(void * context, int64_t value)
-{
-    OnInt64sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnFloatAttributeReport(void * context, float value)
 {
     ChipLogProgress(chipTool, "Float attribute Response: %f", value);
 }
 
-static void OnFloatAttributeResponse(void * context, float value)
-{
-    OnFloatAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnDoubleAttributeReport(void * context, double value)
 {
     ChipLogProgress(chipTool, "Double attribute Response: %f", value);
-}
-
-static void OnDoubleAttributeResponse(void * context, double value)
-{
-    OnDoubleAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOctetStringAttributeReport(void * context, const chip::ByteSpan value)
@@ -345,41 +265,19 @@ static void OnOctetStringAttributeReport(void * context, const chip::ByteSpan va
     }
 }
 
-static void OnOctetStringAttributeResponse(void * context, const chip::ByteSpan value)
-{
-    OnOctetStringAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnCharStringAttributeReport(void * context, const chip::CharSpan value)
 {
     ChipLogProgress(chipTool, "CharString attribute Response: %.*s", static_cast<int>(value.size()), value.data());
 }
 
-static void OnCharStringAttributeResponse(void * context, const chip::CharSpan value)
+template <typename T>
+static void OnGeneralAttributeResponse(void * context, const char * label, T value)
 {
-    OnCharStringAttributeReport(context, value);
+    CHIP_ERROR err = LogValue(label, 0, value);
 
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
-{{#chip_client_clusters}}
-{{#chip_server_cluster_attributes}}
-{{#if isList}}
-static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list)
-{
-    CHIP_ERROR err = LogValue("On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
+    auto * command = static_cast<ModelCommand *>(context);
     command->SetCommandExitStatus(err);
 }
-
-{{/if}}
-{{/chip_server_cluster_attributes}}
-{{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
@@ -471,8 +369,6 @@ public:
 
     ~Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
     {
-      delete onSuccessCallback;
-      delete onFailureCallback;
     }
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
@@ -481,16 +377,15 @@ public:
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo>(this,
+          OnAttributeResponse,
+          OnDefaultFailure);
     }
 
-private:
-{{#if isList}}
-    chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>(On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse, this);
-{{else}}
-    chip::Callback::Callback<{{chipCallback.name}}AttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{chipCallback.name}}AttributeCallback>(On{{chipCallback.name}}AttributeResponse, this);
-{{/if}}
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} value)
+    {
+        OnGeneralAttributeResponse(context, "{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response", value);
+    }
 };
 
 {{#if isWritableAttribute}}

--- a/examples/chip-tool/templates/reporting-commands.zapt
+++ b/examples/chip-tool/templates/reporting-commands.zapt
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <commands/reporting/ReportingCommand.h>
-
+#include "../cluster/Commands.h" // For the LogValue bits and read callbacks
 
 typedef void (*UnsupportedAttributeCallback)(void * context);
 
@@ -45,49 +45,14 @@ public:
 {{/chip_client_clusters}}
     }
 
-    static void OnDefaultSuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Default Success Response");
-    }
-
-    static void OnDefaultFailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Default Failure Response: 0x%02x", status);
-    }
-
-    static void OnUnsupportedAttributeResponse(void * context)
-    {
-        ChipLogError(chipTool, "Unsupported attribute Response. This should never happen !");
-    }
-
-    static void OnBooleanAttributeResponse(void * context, bool value)
-    {
-        ChipLogProgress(chipTool, "Boolean attribute Response: %d", value);
-    }
-
-    static void OnInt8uAttributeResponse(void * context, uint8_t value)
-    {
-        ChipLogProgress(chipTool, "Int8u attribute Response: %" PRIu8, value);
-    }
-
-    static void OnInt16uAttributeResponse(void * context, uint16_t value)
-    {
-        ChipLogProgress(chipTool, "Int16u attribute Response: %" PRIu16, value);
-    }
-
-    static void OnInt16sAttributeResponse(void * context, int16_t value)
-    {
-        ChipLogProgress(chipTool, "Int16s attribute Response: %" PRId16, value);
-    }
-
 private:
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
 {{#unless isList}}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
-    chip::Callback::Callback<{{chipCallback.name}}AttributeCallback> * onReport{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Callback = new chip::Callback::Callback<{{chipCallback.name}}AttributeCallback>(On{{chipCallback.name}}AttributeResponse, this);
-{{/unless}}
+    chip::Callback::Callback<decltype(&Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}::OnAttributeResponse)> * onReport{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Callback = new chip::Callback::Callback<decltype(&Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}::OnAttributeResponse)>(Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}::OnAttributeResponse, this);
+    {{/unless}}
 {{/unless}}
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/app/DeviceProxy.cpp
+++ b/src/app/DeviceProxy.cpp
@@ -74,34 +74,6 @@ void DeviceProxy::AddReportHandler(EndpointId endpoint, ClusterId cluster, Attri
     mCallbacksMgr.AddReportCallback(GetDeviceId(), endpoint, cluster, attribute, onReportCallback, tlvDataFilter);
 }
 
-CHIP_ERROR DeviceProxy::SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter)
-{
-    VerifyOrReturnLogError(IsSecureConnected(), CHIP_ERROR_INCORRECT_STATE);
-
-    app::ReadClient * readClient = nullptr;
-    ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewReadClient(
-        &readClient, app::ReadClient::InteractionType::Read, &GetInteractionModelDelegate()->GetBufferedCallback()));
-
-    if (onSuccessCallback != nullptr || onFailureCallback != nullptr)
-    {
-        AddIMResponseHandler(readClient, onSuccessCallback, onFailureCallback, aTlvDataFilter);
-    }
-    // The application context is used to identify different requests from client application the type of it is intptr_t, here we
-    // use the seqNum.
-    chip::app::ReadPrepareParams readPrepareParams(GetSecureSession().Value());
-    readPrepareParams.mpAttributePathParamsList    = &aPath;
-    readPrepareParams.mAttributePathParamsListSize = 1;
-
-    CHIP_ERROR err = readClient->SendReadRequest(readPrepareParams);
-
-    if (err != CHIP_NO_ERROR)
-    {
-        CancelIMResponseHandler(readClient);
-    }
-    return err;
-}
-
 CHIP_ERROR DeviceProxy::SendSubscribeAttributeRequest(app::AttributePathParams aPath, uint16_t mMinIntervalFloorSeconds,
                                                       uint16_t mMaxIntervalCeilingSeconds, Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -51,9 +51,6 @@ public:
 
     virtual bool GetAddress(Inet::IPAddress & addr, uint16_t & port) const { return false; }
 
-    virtual CHIP_ERROR SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,
-                                                Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter);
-
     virtual CHIP_ERROR SendSubscribeAttributeRequest(app::AttributePathParams aPath, uint16_t mMinIntervalFloorSeconds,
                                                      uint16_t mMaxIntervalCeilingSeconds, Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback);

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -77,15 +77,6 @@ exit:
 // {{asUpperCamelCase name}} Cluster Attributes
 {{#chip_server_cluster_attributes}}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
-CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::ReadAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId = mEndpoint;
-    attributePath.mClusterId  = mClusterId;
-    attributePath.mAttributeId    = {{asHex code 8}};
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,{{#if isList}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}ListAttributeFilter{{else}}BasicAttributeFilter<{{chipCallback.name}}AttributeCallback>{{/if}});
-}
-
 {{#if isReportableAttribute}}
 {{#unless isList}}
 CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::SubscribeAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval)

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -31,7 +31,6 @@ public:
     // Cluster Attributes
     {{#chip_server_cluster_attributes}}
     {{#unless (isStrEqual chipCallback.name "Unsupported")}}
-    CHIP_ERROR ReadAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     {{#if isReportableAttribute}}
     {{#unless isList}}
     CHIP_ERROR SubscribeAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval);

--- a/zzz_generated/all-clusters-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/CHIPClusters.cpp
@@ -185,17 +185,6 @@ exit:
 }
 
 // OtaSoftwareUpdateProvider Cluster Attributes
-CHIP_ERROR OtaSoftwareUpdateProviderCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR OtaSoftwareUpdateProviderCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)

--- a/zzz_generated/all-clusters-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/all-clusters-app/zap-generated/CHIPClusters.h
@@ -47,7 +47,6 @@ public:
                           chip::ByteSpan metadataForProvider);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -185,7 +185,16 @@ CHIP_ERROR LogValue(const char * label, size_t indent, chip::CharSpan value)
 
 CHIP_ERROR LogValue(const char * label, size_t indent, chip::ByteSpan value)
 {
-    ChipLogProgress(chipTool, "%s%s: %zu", IndentStr(indent).c_str(), label, value.size());
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    if (CHIP_NO_ERROR ==
+        chip::Encoding::BytesToUppercaseHexString(value.data(), value.size(), &buffer[0], CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
+    {
+        ChipLogProgress(chipTool, "%s%s: %s", IndentStr(indent).c_str(), label, buffer);
+    }
+    else
+    {
+        ChipLogProgress(chipTool, "%s%s: %zu", IndentStr(indent).c_str(), label, value.size());
+    }
     return CHIP_NO_ERROR;
 }
 
@@ -2251,25 +2260,9 @@ static void OnBooleanAttributeReport(void * context, bool value)
     ChipLogProgress(chipTool, "Boolean attribute Response: %d", value);
 }
 
-static void OnBooleanAttributeResponse(void * context, bool value)
-{
-    OnBooleanAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt8uAttributeReport(void * context, uint8_t value)
 {
     ChipLogProgress(chipTool, "Int8u attribute Response: %" PRIu8, value);
-}
-
-static void OnInt8uAttributeResponse(void * context, uint8_t value)
-{
-    OnInt8uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16uAttributeReport(void * context, uint16_t value)
@@ -2277,25 +2270,9 @@ static void OnInt16uAttributeReport(void * context, uint16_t value)
     ChipLogProgress(chipTool, "Int16u attribute Response: %" PRIu16, value);
 }
 
-static void OnInt16uAttributeResponse(void * context, uint16_t value)
-{
-    OnInt16uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt32uAttributeReport(void * context, uint32_t value)
 {
     ChipLogProgress(chipTool, "Int32u attribute Response: %" PRIu32, value);
-}
-
-static void OnInt32uAttributeResponse(void * context, uint32_t value)
-{
-    OnInt32uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64uAttributeReport(void * context, uint64_t value)
@@ -2303,25 +2280,9 @@ static void OnInt64uAttributeReport(void * context, uint64_t value)
     ChipLogProgress(chipTool, "Int64u attribute Response: %" PRIu64, value);
 }
 
-static void OnInt64uAttributeResponse(void * context, uint64_t value)
-{
-    OnInt64uAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt8sAttributeReport(void * context, int8_t value)
 {
     ChipLogProgress(chipTool, "Int8s attribute Response: %" PRId8, value);
-}
-
-static void OnInt8sAttributeResponse(void * context, int8_t value)
-{
-    OnInt8sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16sAttributeReport(void * context, int16_t value)
@@ -2329,25 +2290,9 @@ static void OnInt16sAttributeReport(void * context, int16_t value)
     ChipLogProgress(chipTool, "Int16s attribute Response: %" PRId16, value);
 }
 
-static void OnInt16sAttributeResponse(void * context, int16_t value)
-{
-    OnInt16sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnInt32sAttributeReport(void * context, int32_t value)
 {
     ChipLogProgress(chipTool, "Int32s attribute Response: %" PRId32, value);
-}
-
-static void OnInt32sAttributeResponse(void * context, int32_t value)
-{
-    OnInt32sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64sAttributeReport(void * context, int64_t value)
@@ -2355,38 +2300,14 @@ static void OnInt64sAttributeReport(void * context, int64_t value)
     ChipLogProgress(chipTool, "Int64s attribute Response: %" PRId64, value);
 }
 
-static void OnInt64sAttributeResponse(void * context, int64_t value)
-{
-    OnInt64sAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnFloatAttributeReport(void * context, float value)
 {
     ChipLogProgress(chipTool, "Float attribute Response: %f", value);
 }
 
-static void OnFloatAttributeResponse(void * context, float value)
-{
-    OnFloatAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnDoubleAttributeReport(void * context, double value)
 {
     ChipLogProgress(chipTool, "Double attribute Response: %f", value);
-}
-
-static void OnDoubleAttributeResponse(void * context, double value)
-{
-    OnDoubleAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOctetStringAttributeReport(void * context, const chip::ByteSpan value)
@@ -2403,412 +2324,17 @@ static void OnOctetStringAttributeReport(void * context, const chip::ByteSpan va
     }
 }
 
-static void OnOctetStringAttributeResponse(void * context, const chip::ByteSpan value)
-{
-    OnOctetStringAttributeReport(context, value);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
 static void OnCharStringAttributeReport(void * context, const chip::CharSpan value)
 {
     ChipLogProgress(chipTool, "CharString attribute Response: %.*s", static_cast<int>(value.size()), value.data());
 }
 
-static void OnCharStringAttributeResponse(void * context, const chip::CharSpan value)
+template <typename T>
+static void OnGeneralAttributeResponse(void * context, const char * label, T value)
 {
-    OnCharStringAttributeReport(context, value);
+    CHIP_ERROR err = LogValue(label, 0, value);
 
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
-}
-
-static void OnAccessControlAclListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::DecodableType> &
-        list)
-{
-    CHIP_ERROR err = LogValue("OnAccessControlAclListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnAccessControlExtensionListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::ExtensionEntry::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnAccessControlExtensionListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void
-OnApplicationLauncherApplicationLauncherListListAttributeResponse(void * context,
-                                                                  const chip::app::DataModel::DecodableList<uint16_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnApplicationLauncherApplicationLauncherListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnAudioOutputAudioOutputListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnAudioOutputAudioOutputListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnBridgedActionsActionListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnBridgedActionsActionListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnBridgedActionsEndpointListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType> &
-        list)
-{
-    CHIP_ERROR err = LogValue("OnBridgedActionsEndpointListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void
-OnContentLauncherAcceptsHeaderListListAttributeResponse(void * context,
-                                                        const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
-{
-    CHIP_ERROR err = LogValue("OnContentLauncherAcceptsHeaderListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnContentLauncherSupportedStreamingTypesListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::ContentLauncher::ContentLaunchStreamingType> & list)
-{
-    CHIP_ERROR err = LogValue("OnContentLauncherSupportedStreamingTypesListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnDescriptorDeviceListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnDescriptorDeviceListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnDescriptorServerListListAttributeResponse(void * context,
-                                                        const chip::app::DataModel::DecodableList<chip::ClusterId> & list)
-{
-    CHIP_ERROR err = LogValue("OnDescriptorServerListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnDescriptorClientListListAttributeResponse(void * context,
-                                                        const chip::app::DataModel::DecodableList<chip::ClusterId> & list)
-{
-    CHIP_ERROR err = LogValue("OnDescriptorClientListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnDescriptorPartsListListAttributeResponse(void * context,
-                                                       const chip::app::DataModel::DecodableList<chip::EndpointId> & list)
-{
-    CHIP_ERROR err = LogValue("OnDescriptorPartsListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnFixedLabelLabelListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnFixedLabelLabelListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGeneralCommissioningBasicCommissioningInfoListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfoType::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnGeneralCommissioningBasicCommissioningInfoListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGeneralDiagnosticsActiveHardwareFaultsListAttributeResponse(void * context,
-                                                                          const chip::app::DataModel::DecodableList<uint8_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnGeneralDiagnosticsActiveHardwareFaultsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGeneralDiagnosticsActiveRadioFaultsListAttributeResponse(void * context,
-                                                                       const chip::app::DataModel::DecodableList<uint8_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnGeneralDiagnosticsActiveRadioFaultsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGeneralDiagnosticsActiveNetworkFaultsListAttributeResponse(void * context,
-                                                                         const chip::app::DataModel::DecodableList<uint8_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnGeneralDiagnosticsActiveNetworkFaultsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGroupKeyManagementGroupsListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupState::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnGroupKeyManagementGroupsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnGroupKeyManagementGroupKeysListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnGroupKeyManagementGroupKeysListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnMediaInputMediaInputListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnMediaInputMediaInputListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnModeSelectSupportedModesListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnModeSelectSupportedModesListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnOperationalCredentialsFabricsListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnOperationalCredentialsFabricsListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse(
-    void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
-{
-    CHIP_ERROR err = LogValue("OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnPowerSourceActiveBatteryFaultsListAttributeResponse(void * context,
-                                                                  const chip::app::DataModel::DecodableList<uint8_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnPowerSourceActiveBatteryFaultsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnPowerSourceConfigurationSourcesListAttributeResponse(void * context,
-                                                                   const chip::app::DataModel::DecodableList<uint8_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnPowerSourceConfigurationSourcesListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnSoftwareDiagnosticsThreadMetricsListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::DecodableType> &
-        list)
-{
-    CHIP_ERROR err = LogValue("OnSoftwareDiagnosticsThreadMetricsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTvChannelTvChannelListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnTvChannelTvChannelListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnTargetNavigatorTargetNavigatorListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTestClusterListInt8uListAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & list)
-{
-    CHIP_ERROR err = LogValue("OnTestClusterListInt8uListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTestClusterListOctetStringListAttributeResponse(void * context,
-                                                              const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
-{
-    CHIP_ERROR err = LogValue("OnTestClusterListOctetStringListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTestClusterListStructOctetStringListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnTestClusterListStructOctetStringListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTestClusterListNullablesAndOptionalsStructListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnTestClusterListNullablesAndOptionalsStructListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnTestClusterListLongOctetStringListAttributeResponse(void * context,
-                                                                  const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
-{
-    CHIP_ERROR err = LogValue("OnTestClusterListLongOctetStringListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType> &
-        list)
-{
-    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse(
-    void * context,
-    const chip::app::DataModel::DecodableList<
-        chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType> & list)
-{
-    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(err);
-}
-
-static void OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse(
-    void * context, const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFault> & list)
-{
-    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse", 0, list);
-
-    ModelCommand * command = static_cast<ModelCommand *>(context);
+    auto * command = static_cast<ModelCommand *>(context);
     command->SetCommandExitStatus(err);
 }
 
@@ -4113,11 +3639,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAccessControlAcl()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAccessControlAcl() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4125,14 +3647,17 @@ public:
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAcl(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AccessControl::Attributes::Acl::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<AccessControlAclListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<AccessControlAclListAttributeCallback>(OnAccessControlAclListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "AccessControl.Acl response", value);
+    }
 };
 
 /*
@@ -4147,11 +3672,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAccessControlExtension()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAccessControlExtension() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4159,15 +3680,17 @@ public:
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeExtension(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AccessControl::Attributes::Extension::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<AccessControlExtensionListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<AccessControlExtensionListAttributeCallback>(OnAccessControlExtensionListAttributeResponse,
-                                                                                  this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::ExtensionEntry::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "AccessControl.Extension response", value);
+    }
 };
 
 /*
@@ -4182,11 +3705,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAccessControlClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAccessControlClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4194,14 +3713,14 @@ public:
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AccessControl::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "AccessControl.ClusterRevision response", value);
+    }
 };
 
 /*----------------------------------------------------------------------------*\
@@ -4276,11 +3795,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAccountLoginClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAccountLoginClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4288,14 +3803,14 @@ public:
 
         chip::Controller::AccountLoginCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AccountLogin::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "AccountLogin.ClusterRevision response", value);
+    }
 };
 
 class ReportAccountLoginClusterRevision : public ModelCommand
@@ -4447,11 +3962,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAdministratorCommissioningClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAdministratorCommissioningClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4459,14 +3970,14 @@ public:
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AdministratorCommissioning::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "AdministratorCommissioning.ClusterRevision response", value);
+    }
 };
 
 class ReportAdministratorCommissioningClusterRevision : public ModelCommand
@@ -4575,11 +4086,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicVendorName()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicVendorName() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4587,14 +4094,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeVendorName(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.VendorName response", value);
+    }
 };
 
 class ReportApplicationBasicVendorName : public ModelCommand
@@ -4661,11 +4168,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicVendorId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicVendorId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4673,14 +4176,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeVendorId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.VendorId response", value);
+    }
 };
 
 class ReportApplicationBasicVendorId : public ModelCommand
@@ -4747,11 +4250,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicApplicationName()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicApplicationName() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4759,14 +4258,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeApplicationName(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationName::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.ApplicationName response", value);
+    }
 };
 
 class ReportApplicationBasicApplicationName : public ModelCommand
@@ -4833,11 +4332,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicProductId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicProductId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4845,14 +4340,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeProductId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ProductId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.ProductId response", value);
+    }
 };
 
 class ReportApplicationBasicProductId : public ModelCommand
@@ -4919,11 +4414,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicApplicationId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicApplicationId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -4931,14 +4422,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeApplicationId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.ApplicationId response", value);
+    }
 };
 
 class ReportApplicationBasicApplicationId : public ModelCommand
@@ -5005,11 +4496,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicCatalogVendorId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicCatalogVendorId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5017,14 +4504,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCatalogVendorId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::CatalogVendorId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.CatalogVendorId response", value);
+    }
 };
 
 class ReportApplicationBasicCatalogVendorId : public ModelCommand
@@ -5091,11 +4578,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicApplicationStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicApplicationStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5103,14 +4586,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeApplicationStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationStatus::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.ApplicationStatus response", value);
+    }
 };
 
 class ReportApplicationBasicApplicationStatus : public ModelCommand
@@ -5178,11 +4661,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationBasicClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationBasicClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5190,14 +4669,14 @@ public:
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationBasic.ClusterRevision response", value);
+    }
 };
 
 class ReportApplicationBasicClusterRevision : public ModelCommand
@@ -5303,11 +4782,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationLauncherApplicationLauncherList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationLauncherApplicationLauncherList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5315,15 +4790,14 @@ public:
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeApplicationLauncherList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::ApplicationLauncherList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ApplicationLauncherApplicationLauncherListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ApplicationLauncherApplicationLauncherListListAttributeCallback>(
-            OnApplicationLauncherApplicationLauncherListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationLauncher.ApplicationLauncherList response", value);
+    }
 };
 
 /*
@@ -5338,11 +4812,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationLauncherCatalogVendorId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationLauncherCatalogVendorId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5350,14 +4820,14 @@ public:
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCatalogVendorId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::CatalogVendorId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationLauncher.CatalogVendorId response", value);
+    }
 };
 
 class ReportApplicationLauncherCatalogVendorId : public ModelCommand
@@ -5424,11 +4894,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationLauncherApplicationId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationLauncherApplicationId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5436,14 +4902,14 @@ public:
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeApplicationId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::ApplicationId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationLauncher.ApplicationId response", value);
+    }
 };
 
 class ReportApplicationLauncherApplicationId : public ModelCommand
@@ -5510,11 +4976,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadApplicationLauncherClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadApplicationLauncherClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5522,14 +4984,14 @@ public:
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ApplicationLauncher.ClusterRevision response", value);
+    }
 };
 
 class ReportApplicationLauncherClusterRevision : public ModelCommand
@@ -5658,11 +5120,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAudioOutputAudioOutputList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAudioOutputAudioOutputList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5670,15 +5128,17 @@ public:
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAudioOutputList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AudioOutput::Attributes::AudioOutputList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<AudioOutputAudioOutputListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<AudioOutputAudioOutputListListAttributeCallback>(
-            OnAudioOutputAudioOutputListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "AudioOutput.AudioOutputList response", value);
+    }
 };
 
 /*
@@ -5693,11 +5153,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAudioOutputCurrentAudioOutput()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAudioOutputCurrentAudioOutput() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5705,14 +5161,14 @@ public:
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentAudioOutput(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AudioOutput::Attributes::CurrentAudioOutput::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "AudioOutput.CurrentAudioOutput response", value);
+    }
 };
 
 class ReportAudioOutputCurrentAudioOutput : public ModelCommand
@@ -5780,11 +5236,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadAudioOutputClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadAudioOutputClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5792,14 +5244,14 @@ public:
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AudioOutput::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "AudioOutput.ClusterRevision response", value);
+    }
 };
 
 class ReportAudioOutputClusterRevision : public ModelCommand
@@ -5925,11 +5377,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBarrierControlBarrierMovingState()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBarrierControlBarrierMovingState() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -5937,14 +5385,14 @@ public:
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBarrierMovingState(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BarrierControl::Attributes::BarrierMovingState::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "BarrierControl.BarrierMovingState response", value);
+    }
 };
 
 class ReportBarrierControlBarrierMovingState : public ModelCommand
@@ -6012,11 +5460,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBarrierControlBarrierSafetyStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBarrierControlBarrierSafetyStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6024,14 +5468,14 @@ public:
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBarrierSafetyStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BarrierControl::Attributes::BarrierSafetyStatus::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "BarrierControl.BarrierSafetyStatus response", value);
+    }
 };
 
 class ReportBarrierControlBarrierSafetyStatus : public ModelCommand
@@ -6099,11 +5543,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBarrierControlBarrierCapabilities()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBarrierControlBarrierCapabilities() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6111,14 +5551,14 @@ public:
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBarrierCapabilities(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BarrierControl::Attributes::BarrierCapabilities::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "BarrierControl.BarrierCapabilities response", value);
+    }
 };
 
 class ReportBarrierControlBarrierCapabilities : public ModelCommand
@@ -6186,11 +5626,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBarrierControlBarrierPosition()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBarrierControlBarrierPosition() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6198,14 +5634,14 @@ public:
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBarrierPosition(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BarrierControl::Attributes::BarrierPosition::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "BarrierControl.BarrierPosition response", value);
+    }
 };
 
 class ReportBarrierControlBarrierPosition : public ModelCommand
@@ -6272,11 +5708,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBarrierControlClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBarrierControlClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6284,14 +5716,14 @@ public:
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BarrierControl::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "BarrierControl.ClusterRevision response", value);
+    }
 };
 
 class ReportBarrierControlClusterRevision : public ModelCommand
@@ -6407,11 +5839,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicInteractionModelVersion()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicInteractionModelVersion() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6419,14 +5847,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInteractionModelVersion(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::InteractionModelVersion::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.InteractionModelVersion response", value);
+    }
 };
 
 class ReportBasicInteractionModelVersion : public ModelCommand
@@ -6494,11 +5922,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicVendorName()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicVendorName() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6506,14 +5930,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeVendorName(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorName::TypeInfo>(this, OnAttributeResponse,
+                                                                                                   OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.VendorName response", value);
+    }
 };
 
 class ReportBasicVendorName : public ModelCommand
@@ -6580,11 +6004,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicVendorID()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicVendorID() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6592,14 +6012,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeVendorID(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorID::TypeInfo>(this, OnAttributeResponse,
+                                                                                                 OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.VendorID response", value);
+    }
 };
 
 class ReportBasicVendorID : public ModelCommand
@@ -6666,11 +6086,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicProductName()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicProductName() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6678,14 +6094,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeProductName(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductName::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.ProductName response", value);
+    }
 };
 
 class ReportBasicProductName : public ModelCommand
@@ -6752,11 +6168,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicProductID()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicProductID() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6764,14 +6176,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeProductID(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductID::TypeInfo>(this, OnAttributeResponse,
+                                                                                                  OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.ProductID response", value);
+    }
 };
 
 class ReportBasicProductID : public ModelCommand
@@ -6838,11 +6250,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicNodeLabel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicNodeLabel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6850,14 +6258,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNodeLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::NodeLabel::TypeInfo>(this, OnAttributeResponse,
+                                                                                                  OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.NodeLabel response", value);
+    }
 };
 
 class WriteBasicNodeLabel : public ModelCommand
@@ -6950,11 +6358,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicLocation()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicLocation() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -6962,14 +6366,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLocation(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(this, OnAttributeResponse,
+                                                                                                 OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.Location response", value);
+    }
 };
 
 class WriteBasicLocation : public ModelCommand
@@ -7062,11 +6466,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicHardwareVersion()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicHardwareVersion() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7074,14 +6474,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeHardwareVersion(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::HardwareVersion::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.HardwareVersion response", value);
+    }
 };
 
 class ReportBasicHardwareVersion : public ModelCommand
@@ -7148,11 +6548,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicHardwareVersionString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicHardwareVersionString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7160,14 +6556,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeHardwareVersionString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::HardwareVersionString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.HardwareVersionString response", value);
+    }
 };
 
 class ReportBasicHardwareVersionString : public ModelCommand
@@ -7235,11 +6631,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicSoftwareVersion()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicSoftwareVersion() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7247,14 +6639,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSoftwareVersion(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersion::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.SoftwareVersion response", value);
+    }
 };
 
 class ReportBasicSoftwareVersion : public ModelCommand
@@ -7321,11 +6713,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicSoftwareVersionString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicSoftwareVersionString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7333,14 +6721,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSoftwareVersionString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersionString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.SoftwareVersionString response", value);
+    }
 };
 
 class ReportBasicSoftwareVersionString : public ModelCommand
@@ -7408,11 +6796,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicManufacturingDate()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicManufacturingDate() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7420,14 +6804,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeManufacturingDate(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ManufacturingDate::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.ManufacturingDate response", value);
+    }
 };
 
 class ReportBasicManufacturingDate : public ModelCommand
@@ -7495,11 +6879,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicPartNumber()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicPartNumber() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7507,14 +6887,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePartNumber(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::PartNumber::TypeInfo>(this, OnAttributeResponse,
+                                                                                                   OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.PartNumber response", value);
+    }
 };
 
 class ReportBasicPartNumber : public ModelCommand
@@ -7581,11 +6961,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicProductURL()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicProductURL() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7593,14 +6969,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeProductURL(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductURL::TypeInfo>(this, OnAttributeResponse,
+                                                                                                   OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.ProductURL response", value);
+    }
 };
 
 class ReportBasicProductURL : public ModelCommand
@@ -7667,11 +7043,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicProductLabel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicProductLabel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7679,14 +7051,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeProductLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductLabel::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.ProductLabel response", value);
+    }
 };
 
 class ReportBasicProductLabel : public ModelCommand
@@ -7753,11 +7125,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicSerialNumber()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicSerialNumber() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7765,14 +7133,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSerialNumber(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SerialNumber::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.SerialNumber response", value);
+    }
 };
 
 class ReportBasicSerialNumber : public ModelCommand
@@ -7839,11 +7207,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicLocalConfigDisabled()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicLocalConfigDisabled() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7851,14 +7215,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLocalConfigDisabled(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::LocalConfigDisabled::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.LocalConfigDisabled response", value);
+    }
 };
 
 class WriteBasicLocalConfigDisabled : public ModelCommand
@@ -7952,11 +7316,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicReachable()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicReachable() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -7964,14 +7324,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeReachable(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Reachable::TypeInfo>(this, OnAttributeResponse,
+                                                                                                  OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.Reachable response", value);
+    }
 };
 
 class ReportBasicReachable : public ModelCommand
@@ -8038,11 +7398,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicUniqueID()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicUniqueID() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8050,14 +7406,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeUniqueID(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::UniqueID::TypeInfo>(this, OnAttributeResponse,
+                                                                                                 OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.UniqueID response", value);
+    }
 };
 
 /*
@@ -8072,11 +7428,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBasicClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBasicClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8084,14 +7436,14 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ClusterRevision::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Basic.ClusterRevision response", value);
+    }
 };
 
 class ReportBasicClusterRevision : public ModelCommand
@@ -8170,11 +7522,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBinaryInputBasicOutOfService()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBinaryInputBasicOutOfService() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8182,14 +7530,14 @@ public:
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOutOfService(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "BinaryInputBasic.OutOfService response", value);
+    }
 };
 
 class WriteBinaryInputBasicOutOfService : public ModelCommand
@@ -8282,11 +7630,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBinaryInputBasicPresentValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBinaryInputBasicPresentValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8294,14 +7638,14 @@ public:
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePresentValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "BinaryInputBasic.PresentValue response", value);
+    }
 };
 
 class WriteBinaryInputBasicPresentValue : public ModelCommand
@@ -8394,11 +7738,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBinaryInputBasicStatusFlags()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBinaryInputBasicStatusFlags() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8406,14 +7746,14 @@ public:
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStatusFlags(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "BinaryInputBasic.StatusFlags response", value);
+    }
 };
 
 class ReportBinaryInputBasicStatusFlags : public ModelCommand
@@ -8480,11 +7820,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBinaryInputBasicClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBinaryInputBasicClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8492,14 +7828,14 @@ public:
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "BinaryInputBasic.ClusterRevision response", value);
+    }
 };
 
 class ReportBinaryInputBasicClusterRevision : public ModelCommand
@@ -8631,11 +7967,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBindingClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBindingClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8643,14 +7975,14 @@ public:
 
         chip::Controller::BindingCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Binding::Attributes::ClusterRevision::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Binding.ClusterRevision response", value);
+    }
 };
 
 class ReportBindingClusterRevision : public ModelCommand
@@ -8727,11 +8059,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBooleanStateStateValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBooleanStateStateValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8739,14 +8067,14 @@ public:
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStateValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "BooleanState.StateValue response", value);
+    }
 };
 
 class ReportBooleanStateStateValue : public ModelCommand
@@ -8813,11 +8141,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBooleanStateClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBooleanStateClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -8825,14 +8149,14 @@ public:
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "BooleanState.ClusterRevision response", value);
+    }
 };
 
 class ReportBooleanStateClusterRevision : public ModelCommand
@@ -9228,11 +8552,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBridgedActionsActionList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBridgedActionsActionList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -9240,15 +8560,17 @@ public:
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActionList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BridgedActions::Attributes::ActionList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BridgedActionsActionListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BridgedActionsActionListListAttributeCallback>(OnBridgedActionsActionListListAttributeResponse,
-                                                                                    this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "BridgedActions.ActionList response", value);
+    }
 };
 
 /*
@@ -9263,11 +8585,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBridgedActionsEndpointList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBridgedActionsEndpointList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -9275,15 +8593,17 @@ public:
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEndpointList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BridgedActions::Attributes::EndpointList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BridgedActionsEndpointListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BridgedActionsEndpointListListAttributeCallback>(
-            OnBridgedActionsEndpointListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "BridgedActions.EndpointList response", value);
+    }
 };
 
 /*
@@ -9298,11 +8618,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBridgedActionsSetupUrl()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBridgedActionsSetupUrl() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -9310,14 +8626,14 @@ public:
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSetupUrl(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BridgedActions::Attributes::SetupUrl::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "BridgedActions.SetupUrl response", value);
+    }
 };
 
 class ReportBridgedActionsSetupUrl : public ModelCommand
@@ -9384,11 +8700,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBridgedActionsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBridgedActionsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -9396,14 +8708,14 @@ public:
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BridgedActions::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "BridgedActions.ClusterRevision response", value);
+    }
 };
 
 class ReportBridgedActionsClusterRevision : public ModelCommand
@@ -9479,11 +8791,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadBridgedDeviceBasicClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadBridgedDeviceBasicClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -9491,14 +8799,14 @@ public:
 
         chip::Controller::BridgedDeviceBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BridgedDeviceBasic::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "BridgedDeviceBasic.ClusterRevision response", value);
+    }
 };
 
 class ReportBridgedDeviceBasicClusterRevision : public ModelCommand
@@ -10187,11 +9495,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlCurrentHue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlCurrentHue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10199,14 +9503,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentHue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.CurrentHue response", value);
+    }
 };
 
 class ReportColorControlCurrentHue : public ModelCommand
@@ -10273,11 +9577,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlCurrentSaturation()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlCurrentSaturation() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10285,14 +9585,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentSaturation(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.CurrentSaturation response", value);
+    }
 };
 
 class ReportColorControlCurrentSaturation : public ModelCommand
@@ -10360,11 +9660,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlRemainingTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlRemainingTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10372,14 +9668,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRemainingTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.RemainingTime response", value);
+    }
 };
 
 class ReportColorControlRemainingTime : public ModelCommand
@@ -10446,11 +9742,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlCurrentX()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlCurrentX() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10458,14 +9750,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentX(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.CurrentX response", value);
+    }
 };
 
 class ReportColorControlCurrentX : public ModelCommand
@@ -10532,11 +9824,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlCurrentY()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlCurrentY() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10544,14 +9832,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentY(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.CurrentY response", value);
+    }
 };
 
 class ReportColorControlCurrentY : public ModelCommand
@@ -10618,11 +9906,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlDriftCompensation()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlDriftCompensation() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10630,14 +9914,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDriftCompensation(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::DriftCompensation::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.DriftCompensation response", value);
+    }
 };
 
 class ReportColorControlDriftCompensation : public ModelCommand
@@ -10705,11 +9989,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlCompensationText()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlCompensationText() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10717,14 +9997,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCompensationText(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CompensationText::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.CompensationText response", value);
+    }
 };
 
 class ReportColorControlCompensationText : public ModelCommand
@@ -10791,11 +10071,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorTemperature()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorTemperature() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10803,14 +10079,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorTemperature(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTemperature::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorTemperature response", value);
+    }
 };
 
 class ReportColorControlColorTemperature : public ModelCommand
@@ -10877,11 +10153,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10889,14 +10161,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorMode::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorMode response", value);
+    }
 };
 
 class ReportColorControlColorMode : public ModelCommand
@@ -10963,11 +10235,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorControlOptions()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorControlOptions() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -10975,14 +10243,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorControlOptions(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorControlOptions response", value);
+    }
 };
 
 class WriteColorControlColorControlOptions : public ModelCommand
@@ -11076,11 +10344,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlNumberOfPrimaries()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlNumberOfPrimaries() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11088,14 +10352,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNumberOfPrimaries(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::NumberOfPrimaries::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.NumberOfPrimaries response", value);
+    }
 };
 
 class ReportColorControlNumberOfPrimaries : public ModelCommand
@@ -11163,11 +10427,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary1X()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary1X() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11175,14 +10435,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary1X(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1X::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary1X response", value);
+    }
 };
 
 class ReportColorControlPrimary1X : public ModelCommand
@@ -11249,11 +10509,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary1Y()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary1Y() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11261,14 +10517,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary1Y(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Y::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary1Y response", value);
+    }
 };
 
 class ReportColorControlPrimary1Y : public ModelCommand
@@ -11335,11 +10591,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary1Intensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary1Intensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11347,14 +10599,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary1Intensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Intensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary1Intensity response", value);
+    }
 };
 
 class ReportColorControlPrimary1Intensity : public ModelCommand
@@ -11422,11 +10674,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary2X()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary2X() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11434,14 +10682,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary2X(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2X::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary2X response", value);
+    }
 };
 
 class ReportColorControlPrimary2X : public ModelCommand
@@ -11508,11 +10756,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary2Y()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary2Y() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11520,14 +10764,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary2Y(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Y::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary2Y response", value);
+    }
 };
 
 class ReportColorControlPrimary2Y : public ModelCommand
@@ -11594,11 +10838,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary2Intensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary2Intensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11606,14 +10846,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary2Intensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Intensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary2Intensity response", value);
+    }
 };
 
 class ReportColorControlPrimary2Intensity : public ModelCommand
@@ -11681,11 +10921,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary3X()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary3X() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11693,14 +10929,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary3X(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3X::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary3X response", value);
+    }
 };
 
 class ReportColorControlPrimary3X : public ModelCommand
@@ -11767,11 +11003,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary3Y()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary3Y() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11779,14 +11011,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary3Y(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Y::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary3Y response", value);
+    }
 };
 
 class ReportColorControlPrimary3Y : public ModelCommand
@@ -11853,11 +11085,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary3Intensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary3Intensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11865,14 +11093,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary3Intensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Intensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary3Intensity response", value);
+    }
 };
 
 class ReportColorControlPrimary3Intensity : public ModelCommand
@@ -11940,11 +11168,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary4X()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary4X() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -11952,14 +11176,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary4X(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4X::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary4X response", value);
+    }
 };
 
 class ReportColorControlPrimary4X : public ModelCommand
@@ -12026,11 +11250,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary4Y()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary4Y() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12038,14 +11258,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary4Y(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Y::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary4Y response", value);
+    }
 };
 
 class ReportColorControlPrimary4Y : public ModelCommand
@@ -12112,11 +11332,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary4Intensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary4Intensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12124,14 +11340,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary4Intensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Intensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary4Intensity response", value);
+    }
 };
 
 class ReportColorControlPrimary4Intensity : public ModelCommand
@@ -12199,11 +11415,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary5X()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary5X() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12211,14 +11423,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary5X(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5X::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary5X response", value);
+    }
 };
 
 class ReportColorControlPrimary5X : public ModelCommand
@@ -12285,11 +11497,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary5Y()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary5Y() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12297,14 +11505,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary5Y(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Y::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary5Y response", value);
+    }
 };
 
 class ReportColorControlPrimary5Y : public ModelCommand
@@ -12371,11 +11579,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary5Intensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary5Intensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12383,14 +11587,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary5Intensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Intensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary5Intensity response", value);
+    }
 };
 
 class ReportColorControlPrimary5Intensity : public ModelCommand
@@ -12458,11 +11662,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary6X()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary6X() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12470,14 +11670,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary6X(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6X::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary6X response", value);
+    }
 };
 
 class ReportColorControlPrimary6X : public ModelCommand
@@ -12544,11 +11744,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary6Y()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary6Y() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12556,14 +11752,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary6Y(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Y::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary6Y response", value);
+    }
 };
 
 class ReportColorControlPrimary6Y : public ModelCommand
@@ -12630,11 +11826,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlPrimary6Intensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlPrimary6Intensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12642,14 +11834,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePrimary6Intensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Intensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.Primary6Intensity response", value);
+    }
 };
 
 class ReportColorControlPrimary6Intensity : public ModelCommand
@@ -12717,11 +11909,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlWhitePointX()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlWhitePointX() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12729,14 +11917,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeWhitePointX(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointX::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.WhitePointX response", value);
+    }
 };
 
 class WriteColorControlWhitePointX : public ModelCommand
@@ -12829,11 +12017,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlWhitePointY()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlWhitePointY() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12841,14 +12025,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeWhitePointY(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointY::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.WhitePointY response", value);
+    }
 };
 
 class WriteColorControlWhitePointY : public ModelCommand
@@ -12941,11 +12125,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointRX()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointRX() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -12953,14 +12133,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointRX(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRX::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointRX response", value);
+    }
 };
 
 class WriteColorControlColorPointRX : public ModelCommand
@@ -13053,11 +12233,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointRY()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointRY() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13065,14 +12241,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointRY(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRY::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointRY response", value);
+    }
 };
 
 class WriteColorControlColorPointRY : public ModelCommand
@@ -13165,11 +12341,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointRIntensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointRIntensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13177,14 +12349,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointRIntensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRIntensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointRIntensity response", value);
+    }
 };
 
 class WriteColorControlColorPointRIntensity : public ModelCommand
@@ -13278,11 +12450,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointGX()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointGX() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13290,14 +12458,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointGX(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGX::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointGX response", value);
+    }
 };
 
 class WriteColorControlColorPointGX : public ModelCommand
@@ -13390,11 +12558,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointGY()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointGY() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13402,14 +12566,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointGY(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGY::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointGY response", value);
+    }
 };
 
 class WriteColorControlColorPointGY : public ModelCommand
@@ -13502,11 +12666,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointGIntensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointGIntensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13514,14 +12674,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointGIntensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGIntensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointGIntensity response", value);
+    }
 };
 
 class WriteColorControlColorPointGIntensity : public ModelCommand
@@ -13615,11 +12775,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointBX()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointBX() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13627,14 +12783,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointBX(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBX::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointBX response", value);
+    }
 };
 
 class WriteColorControlColorPointBX : public ModelCommand
@@ -13727,11 +12883,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointBY()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointBY() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13739,14 +12891,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointBY(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBY::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointBY response", value);
+    }
 };
 
 class WriteColorControlColorPointBY : public ModelCommand
@@ -13839,11 +12991,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorPointBIntensity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorPointBIntensity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13851,14 +12999,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorPointBIntensity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBIntensity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorPointBIntensity response", value);
+    }
 };
 
 class WriteColorControlColorPointBIntensity : public ModelCommand
@@ -13952,11 +13100,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlEnhancedCurrentHue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlEnhancedCurrentHue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -13964,14 +13108,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEnhancedCurrentHue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.EnhancedCurrentHue response", value);
+    }
 };
 
 class ReportColorControlEnhancedCurrentHue : public ModelCommand
@@ -14039,11 +13183,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlEnhancedColorMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlEnhancedColorMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14051,14 +13191,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEnhancedColorMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedColorMode::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.EnhancedColorMode response", value);
+    }
 };
 
 class ReportColorControlEnhancedColorMode : public ModelCommand
@@ -14126,11 +13266,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorLoopActive()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorLoopActive() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14138,14 +13274,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorLoopActive(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopActive response", value);
+    }
 };
 
 class ReportColorControlColorLoopActive : public ModelCommand
@@ -14212,11 +13348,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorLoopDirection()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorLoopDirection() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14224,14 +13356,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorLoopDirection(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopDirection response", value);
+    }
 };
 
 class ReportColorControlColorLoopDirection : public ModelCommand
@@ -14299,11 +13431,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorLoopTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorLoopTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14311,14 +13439,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorLoopTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopTime response", value);
+    }
 };
 
 class ReportColorControlColorLoopTime : public ModelCommand
@@ -14385,11 +13513,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorLoopStartEnhancedHue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorLoopStartEnhancedHue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14397,14 +13521,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopStartEnhancedHue response", value);
+    }
 };
 
 class ReportColorControlColorLoopStartEnhancedHue : public ModelCommand
@@ -14472,11 +13596,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorLoopStoredEnhancedHue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorLoopStoredEnhancedHue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14484,14 +13604,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorLoopStoredEnhancedHue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopStoredEnhancedHue response", value);
+    }
 };
 
 class ReportColorControlColorLoopStoredEnhancedHue : public ModelCommand
@@ -14559,11 +13679,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorCapabilities()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorCapabilities() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14571,14 +13687,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorCapabilities(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorCapabilities response", value);
+    }
 };
 
 class ReportColorControlColorCapabilities : public ModelCommand
@@ -14646,11 +13762,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorTempPhysicalMin()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorTempPhysicalMin() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14658,14 +13770,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorTempPhysicalMin(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorTempPhysicalMin response", value);
+    }
 };
 
 class ReportColorControlColorTempPhysicalMin : public ModelCommand
@@ -14733,11 +13845,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlColorTempPhysicalMax()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlColorTempPhysicalMax() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14745,14 +13853,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeColorTempPhysicalMax(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ColorTempPhysicalMax response", value);
+    }
 };
 
 class ReportColorControlColorTempPhysicalMax : public ModelCommand
@@ -14820,11 +13928,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlCoupleColorTempToLevelMinMireds()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlCoupleColorTempToLevelMinMireds() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14832,14 +13936,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCoupleColorTempToLevelMinMireds(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CoupleColorTempToLevelMinMireds::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.CoupleColorTempToLevelMinMireds response", value);
+    }
 };
 
 class ReportColorControlCoupleColorTempToLevelMinMireds : public ModelCommand
@@ -14907,11 +14011,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlStartUpColorTemperatureMireds()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlStartUpColorTemperatureMireds() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -14919,14 +14019,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStartUpColorTemperatureMireds(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.StartUpColorTemperatureMireds response", value);
+    }
 };
 
 class WriteColorControlStartUpColorTemperatureMireds : public ModelCommand
@@ -15020,11 +14120,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadColorControlClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadColorControlClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15032,14 +14128,14 @@ public:
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ColorControl.ClusterRevision response", value);
+    }
 };
 
 class ReportColorControlClusterRevision : public ModelCommand
@@ -15169,11 +14265,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadContentLauncherAcceptsHeaderList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadContentLauncherAcceptsHeaderList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15181,15 +14273,14 @@ public:
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAcceptsHeaderList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ContentLauncher::Attributes::AcceptsHeaderList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ContentLauncherAcceptsHeaderListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ContentLauncherAcceptsHeaderListListAttributeCallback>(
-            OnContentLauncherAcceptsHeaderListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
+    {
+        OnGeneralAttributeResponse(context, "ContentLauncher.AcceptsHeaderList response", value);
+    }
 };
 
 /*
@@ -15204,11 +14295,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadContentLauncherSupportedStreamingTypes()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadContentLauncherSupportedStreamingTypes() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15216,15 +14303,16 @@ public:
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSupportedStreamingTypes(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingTypes::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ContentLauncherSupportedStreamingTypesListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ContentLauncherSupportedStreamingTypesListAttributeCallback>(
-            OnContentLauncherSupportedStreamingTypesListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::ContentLauncher::ContentLaunchStreamingType> & value)
+    {
+        OnGeneralAttributeResponse(context, "ContentLauncher.SupportedStreamingTypes response", value);
+    }
 };
 
 /*
@@ -15239,11 +14327,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadContentLauncherClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadContentLauncherClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15251,14 +14335,14 @@ public:
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ContentLauncher::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ContentLauncher.ClusterRevision response", value);
+    }
 };
 
 class ReportContentLauncherClusterRevision : public ModelCommand
@@ -15338,11 +14422,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDescriptorDeviceList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDescriptorDeviceList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15350,14 +14430,16 @@ public:
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDeviceList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::DeviceList::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<DescriptorDeviceListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DescriptorDeviceListListAttributeCallback>(OnDescriptorDeviceListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "Descriptor.DeviceList response", value);
+    }
 };
 
 /*
@@ -15372,11 +14454,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDescriptorServerList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDescriptorServerList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15384,14 +14462,14 @@ public:
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeServerList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ServerList::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<DescriptorServerListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DescriptorServerListListAttributeCallback>(OnDescriptorServerListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & value)
+    {
+        OnGeneralAttributeResponse(context, "Descriptor.ServerList response", value);
+    }
 };
 
 /*
@@ -15406,11 +14484,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDescriptorClientList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDescriptorClientList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15418,14 +14492,14 @@ public:
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClientList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ClientList::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<DescriptorClientListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DescriptorClientListListAttributeCallback>(OnDescriptorClientListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & value)
+    {
+        OnGeneralAttributeResponse(context, "Descriptor.ClientList response", value);
+    }
 };
 
 /*
@@ -15440,11 +14514,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDescriptorPartsList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDescriptorPartsList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15452,14 +14522,14 @@ public:
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePartsList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::PartsList::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<DescriptorPartsListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DescriptorPartsListListAttributeCallback>(OnDescriptorPartsListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & value)
+    {
+        OnGeneralAttributeResponse(context, "Descriptor.PartsList response", value);
+    }
 };
 
 /*
@@ -15474,11 +14544,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDescriptorClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDescriptorClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -15486,14 +14552,14 @@ public:
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Descriptor.ClusterRevision response", value);
+    }
 };
 
 class ReportDescriptorClusterRevision : public ModelCommand
@@ -16207,11 +15273,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDoorLockActuatorEnabled()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDoorLockActuatorEnabled() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16219,14 +15281,14 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActuatorEnabled(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::ActuatorEnabled::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "DoorLock.ActuatorEnabled response", value);
+    }
 };
 
 class ReportDoorLockActuatorEnabled : public ModelCommand
@@ -16293,11 +15355,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadDoorLockClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadDoorLockClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16305,14 +15363,14 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "DoorLock.ClusterRevision response", value);
+    }
 };
 
 class ReportDoorLockClusterRevision : public ModelCommand
@@ -16399,11 +15457,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementMeasurementType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementMeasurementType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16411,14 +15465,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeasurementType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::MeasurementType::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.MeasurementType response", value);
+    }
 };
 
 class ReportElectricalMeasurementMeasurementType : public ModelCommand
@@ -16485,11 +15539,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementTotalActivePower()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementTotalActivePower() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16497,14 +15547,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTotalActivePower(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::TotalActivePower::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.TotalActivePower response", value);
+    }
 };
 
 class ReportElectricalMeasurementTotalActivePower : public ModelCommand
@@ -16571,11 +15621,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementRmsVoltage()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementRmsVoltage() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16583,14 +15629,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRmsVoltage(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::RmsVoltage::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsVoltage response", value);
+    }
 };
 
 class ReportElectricalMeasurementRmsVoltage : public ModelCommand
@@ -16657,11 +15703,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementRmsVoltageMin()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementRmsVoltageMin() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16669,14 +15711,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRmsVoltageMin(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::RmsVoltageMin::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsVoltageMin response", value);
+    }
 };
 
 class ReportElectricalMeasurementRmsVoltageMin : public ModelCommand
@@ -16743,11 +15785,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementRmsVoltageMax()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementRmsVoltageMax() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16755,14 +15793,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRmsVoltageMax(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::RmsVoltageMax::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsVoltageMax response", value);
+    }
 };
 
 class ReportElectricalMeasurementRmsVoltageMax : public ModelCommand
@@ -16829,11 +15867,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementRmsCurrent()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementRmsCurrent() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16841,14 +15875,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRmsCurrent(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::RmsCurrent::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsCurrent response", value);
+    }
 };
 
 class ReportElectricalMeasurementRmsCurrent : public ModelCommand
@@ -16915,11 +15949,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementRmsCurrentMin()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementRmsCurrentMin() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -16927,14 +15957,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRmsCurrentMin(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::RmsCurrentMin::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsCurrentMin response", value);
+    }
 };
 
 class ReportElectricalMeasurementRmsCurrentMin : public ModelCommand
@@ -17001,11 +16031,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementRmsCurrentMax()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementRmsCurrentMax() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17013,14 +16039,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRmsCurrentMax(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::RmsCurrentMax::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsCurrentMax response", value);
+    }
 };
 
 class ReportElectricalMeasurementRmsCurrentMax : public ModelCommand
@@ -17087,11 +16113,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementActivePower()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementActivePower() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17099,14 +16121,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActivePower(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ActivePower::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ActivePower response", value);
+    }
 };
 
 class ReportElectricalMeasurementActivePower : public ModelCommand
@@ -17173,11 +16195,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementActivePowerMin()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementActivePowerMin() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17185,14 +16203,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActivePowerMin(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ActivePowerMin::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ActivePowerMin response", value);
+    }
 };
 
 class ReportElectricalMeasurementActivePowerMin : public ModelCommand
@@ -17259,11 +16277,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementActivePowerMax()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementActivePowerMax() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17271,14 +16285,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActivePowerMax(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ActivePowerMax::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ActivePowerMax response", value);
+    }
 };
 
 class ReportElectricalMeasurementActivePowerMax : public ModelCommand
@@ -17345,11 +16359,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadElectricalMeasurementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadElectricalMeasurementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17357,14 +16367,14 @@ public:
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ClusterRevision response", value);
+    }
 };
 
 class ReportElectricalMeasurementClusterRevision : public ModelCommand
@@ -17471,11 +16481,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsPHYRate()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsPHYRate() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17483,14 +16489,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePHYRate(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::PHYRate::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.PHYRate response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsPHYRate : public ModelCommand
@@ -17557,11 +16563,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsFullDuplex()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsFullDuplex() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17569,14 +16571,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFullDuplex(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::FullDuplex::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.FullDuplex response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsFullDuplex : public ModelCommand
@@ -17643,11 +16645,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsPacketRxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsPacketRxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17655,14 +16653,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePacketRxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::PacketRxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.PacketRxCount response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsPacketRxCount : public ModelCommand
@@ -17729,11 +16727,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsPacketTxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsPacketTxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17741,14 +16735,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePacketTxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::PacketTxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.PacketTxCount response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsPacketTxCount : public ModelCommand
@@ -17815,11 +16809,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsTxErrCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsTxErrCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17827,14 +16817,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxErrCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::TxErrCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.TxErrCount response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsTxErrCount : public ModelCommand
@@ -17901,11 +16891,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsCollisionCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsCollisionCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17913,14 +16899,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCollisionCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::CollisionCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.CollisionCount response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsCollisionCount : public ModelCommand
@@ -17987,11 +16973,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsOverrunCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsOverrunCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -17999,14 +16981,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOverrunCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::OverrunCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.OverrunCount response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsOverrunCount : public ModelCommand
@@ -18073,11 +17055,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsCarrierDetect()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsCarrierDetect() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18085,14 +17063,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCarrierDetect(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::CarrierDetect::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.CarrierDetect response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsCarrierDetect : public ModelCommand
@@ -18159,11 +17137,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsTimeSinceReset()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsTimeSinceReset() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18171,14 +17145,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTimeSinceReset(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::TimeSinceReset::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.TimeSinceReset response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsTimeSinceReset : public ModelCommand
@@ -18245,11 +17219,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18257,14 +17227,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.FeatureMap response", value);
+    }
 };
 
 /*
@@ -18279,11 +17249,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadEthernetNetworkDiagnosticsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadEthernetNetworkDiagnosticsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18291,14 +17257,14 @@ public:
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::EthernetNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.ClusterRevision response", value);
+    }
 };
 
 class ReportEthernetNetworkDiagnosticsClusterRevision : public ModelCommand
@@ -18375,11 +17341,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFixedLabelLabelList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFixedLabelLabelList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18387,14 +17349,16 @@ public:
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLabelList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FixedLabel::Attributes::LabelList::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<FixedLabelLabelListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<FixedLabelLabelListListAttributeCallback>(OnFixedLabelLabelListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "FixedLabel.LabelList response", value);
+    }
 };
 
 /*
@@ -18409,11 +17373,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFixedLabelClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFixedLabelClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18421,14 +17381,14 @@ public:
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FixedLabel::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "FixedLabel.ClusterRevision response", value);
+    }
 };
 
 class ReportFixedLabelClusterRevision : public ModelCommand
@@ -18508,11 +17468,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFlowMeasurementMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFlowMeasurementMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18520,14 +17476,14 @@ public:
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "FlowMeasurement.MeasuredValue response", value);
+    }
 };
 
 class ReportFlowMeasurementMeasuredValue : public ModelCommand
@@ -18594,11 +17550,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFlowMeasurementMinMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFlowMeasurementMinMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18606,14 +17558,14 @@ public:
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "FlowMeasurement.MinMeasuredValue response", value);
+    }
 };
 
 class ReportFlowMeasurementMinMeasuredValue : public ModelCommand
@@ -18680,11 +17632,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFlowMeasurementMaxMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFlowMeasurementMaxMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18692,14 +17640,14 @@ public:
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "FlowMeasurement.MaxMeasuredValue response", value);
+    }
 };
 
 class ReportFlowMeasurementMaxMeasuredValue : public ModelCommand
@@ -18766,11 +17714,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFlowMeasurementTolerance()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFlowMeasurementTolerance() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18778,14 +17722,14 @@ public:
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTolerance(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "FlowMeasurement.Tolerance response", value);
+    }
 };
 
 class ReportFlowMeasurementTolerance : public ModelCommand
@@ -18852,11 +17796,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadFlowMeasurementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadFlowMeasurementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -18864,14 +17804,14 @@ public:
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "FlowMeasurement.ClusterRevision response", value);
+    }
 };
 
 class ReportFlowMeasurementClusterRevision : public ModelCommand
@@ -19028,11 +17968,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralCommissioningBreadcrumb()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralCommissioningBreadcrumb() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19040,14 +17976,14 @@ public:
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBreadcrumb(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralCommissioning::Attributes::Breadcrumb::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralCommissioning.Breadcrumb response", value);
+    }
 };
 
 class WriteGeneralCommissioningBreadcrumb : public ModelCommand
@@ -19140,11 +18076,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralCommissioningBasicCommissioningInfoList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralCommissioningBasicCommissioningInfoList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19152,15 +18084,17 @@ public:
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBasicCommissioningInfoList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfoList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GeneralCommissioningBasicCommissioningInfoListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GeneralCommissioningBasicCommissioningInfoListListAttributeCallback>(
-            OnGeneralCommissioningBasicCommissioningInfoListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfoType::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralCommissioning.BasicCommissioningInfoList response", value);
+    }
 };
 
 /*
@@ -19175,11 +18109,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralCommissioningRegulatoryConfig()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralCommissioningRegulatoryConfig() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19187,14 +18117,14 @@ public:
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRegulatoryConfig(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralCommissioning::Attributes::RegulatoryConfig::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralCommissioning.RegulatoryConfig response", value);
+    }
 };
 
 /*
@@ -19209,11 +18139,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralCommissioningLocationCapability()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralCommissioningLocationCapability() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19221,14 +18147,14 @@ public:
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLocationCapability(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralCommissioning::Attributes::LocationCapability::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralCommissioning.LocationCapability response", value);
+    }
 };
 
 /*
@@ -19243,11 +18169,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralCommissioningClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralCommissioningClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19255,14 +18177,14 @@ public:
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralCommissioning::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralCommissioning.ClusterRevision response", value);
+    }
 };
 
 class ReportGeneralCommissioningClusterRevision : public ModelCommand
@@ -19346,11 +18268,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsNetworkInterfaces()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsNetworkInterfaces() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19358,15 +18276,17 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNetworkInterfaces(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::NetworkInterfaces::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GeneralDiagnosticsNetworkInterfacesListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GeneralDiagnosticsNetworkInterfacesListAttributeCallback>(
-            OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.NetworkInterfaces response", value);
+    }
 };
 
 /*
@@ -19381,11 +18301,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsRebootCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsRebootCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19393,14 +18309,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRebootCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::RebootCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.RebootCount response", value);
+    }
 };
 
 class ReportGeneralDiagnosticsRebootCount : public ModelCommand
@@ -19467,11 +18383,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsUpTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsUpTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19479,14 +18391,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeUpTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::UpTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.UpTime response", value);
+    }
 };
 
 class ReportGeneralDiagnosticsUpTime : public ModelCommand
@@ -19553,11 +18465,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsTotalOperationalHours()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsTotalOperationalHours() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19565,14 +18473,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTotalOperationalHours(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::TotalOperationalHours::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.TotalOperationalHours response", value);
+    }
 };
 
 class ReportGeneralDiagnosticsTotalOperationalHours : public ModelCommand
@@ -19640,11 +18548,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsBootReasons()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsBootReasons() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19652,14 +18556,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBootReasons(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::BootReasons::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.BootReasons response", value);
+    }
 };
 
 class ReportGeneralDiagnosticsBootReasons : public ModelCommand
@@ -19726,11 +18630,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsActiveHardwareFaults()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsActiveHardwareFaults() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19738,15 +18638,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActiveHardwareFaults(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::ActiveHardwareFaults::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GeneralDiagnosticsActiveHardwareFaultsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GeneralDiagnosticsActiveHardwareFaultsListAttributeCallback>(
-            OnGeneralDiagnosticsActiveHardwareFaultsListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ActiveHardwareFaults response", value);
+    }
 };
 
 /*
@@ -19761,11 +18660,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsActiveRadioFaults()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsActiveRadioFaults() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19773,15 +18668,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActiveRadioFaults(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::ActiveRadioFaults::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GeneralDiagnosticsActiveRadioFaultsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GeneralDiagnosticsActiveRadioFaultsListAttributeCallback>(
-            OnGeneralDiagnosticsActiveRadioFaultsListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ActiveRadioFaults response", value);
+    }
 };
 
 /*
@@ -19796,11 +18690,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsActiveNetworkFaults()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsActiveNetworkFaults() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19808,15 +18698,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActiveNetworkFaults(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::ActiveNetworkFaults::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GeneralDiagnosticsActiveNetworkFaultsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GeneralDiagnosticsActiveNetworkFaultsListAttributeCallback>(
-            OnGeneralDiagnosticsActiveNetworkFaultsListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ActiveNetworkFaults response", value);
+    }
 };
 
 /*
@@ -19831,11 +18720,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGeneralDiagnosticsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGeneralDiagnosticsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19843,14 +18728,14 @@ public:
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ClusterRevision response", value);
+    }
 };
 
 class ReportGeneralDiagnosticsClusterRevision : public ModelCommand
@@ -19928,11 +18813,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGroupKeyManagementGroups()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGroupKeyManagementGroups() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19940,15 +18821,17 @@ public:
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeGroups(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::Groups::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GroupKeyManagementGroupsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GroupKeyManagementGroupsListAttributeCallback>(OnGroupKeyManagementGroupsListAttributeResponse,
-                                                                                    this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupState::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "GroupKeyManagement.Groups response", value);
+    }
 };
 
 /*
@@ -19963,11 +18846,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGroupKeyManagementGroupKeys()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGroupKeyManagementGroupKeys() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -19975,15 +18854,17 @@ public:
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeGroupKeys(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeys::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<GroupKeyManagementGroupKeysListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<GroupKeyManagementGroupKeysListAttributeCallback>(
-            OnGroupKeyManagementGroupKeysListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "GroupKeyManagement.GroupKeys response", value);
+    }
 };
 
 /*
@@ -19998,11 +18879,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGroupKeyManagementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGroupKeyManagementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20010,14 +18887,14 @@ public:
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "GroupKeyManagement.ClusterRevision response", value);
+    }
 };
 
 class ReportGroupKeyManagementClusterRevision : public ModelCommand
@@ -20242,11 +19119,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGroupsNameSupport()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGroupsNameSupport() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20254,14 +19127,14 @@ public:
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNameSupport(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Groups::Attributes::NameSupport::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Groups.NameSupport response", value);
+    }
 };
 
 class ReportGroupsNameSupport : public ModelCommand
@@ -20328,11 +19201,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadGroupsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadGroupsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20340,14 +19209,14 @@ public:
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Groups::Attributes::ClusterRevision::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Groups.ClusterRevision response", value);
+    }
 };
 
 class ReportGroupsClusterRevision : public ModelCommand
@@ -20499,11 +19368,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIdentifyIdentifyTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIdentifyIdentifyTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20511,14 +19376,14 @@ public:
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeIdentifyTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Identify::Attributes::IdentifyTime::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Identify.IdentifyTime response", value);
+    }
 };
 
 class WriteIdentifyIdentifyTime : public ModelCommand
@@ -20611,11 +19476,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIdentifyIdentifyType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIdentifyIdentifyType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20623,14 +19484,14 @@ public:
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeIdentifyType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Identify::Attributes::IdentifyType::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Identify.IdentifyType response", value);
+    }
 };
 
 class ReportIdentifyIdentifyType : public ModelCommand
@@ -20697,11 +19558,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIdentifyClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIdentifyClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20709,14 +19566,14 @@ public:
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Identify::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Identify.ClusterRevision response", value);
+    }
 };
 
 class ReportIdentifyClusterRevision : public ModelCommand
@@ -20797,11 +19654,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIlluminanceMeasurementMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIlluminanceMeasurementMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20809,14 +19662,14 @@ public:
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.MeasuredValue response", value);
+    }
 };
 
 class ReportIlluminanceMeasurementMeasuredValue : public ModelCommand
@@ -20883,11 +19736,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIlluminanceMeasurementMinMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIlluminanceMeasurementMinMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20895,14 +19744,14 @@ public:
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.MinMeasuredValue response", value);
+    }
 };
 
 class ReportIlluminanceMeasurementMinMeasuredValue : public ModelCommand
@@ -20969,11 +19818,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIlluminanceMeasurementMaxMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIlluminanceMeasurementMaxMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -20981,14 +19826,14 @@ public:
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.MaxMeasuredValue response", value);
+    }
 };
 
 class ReportIlluminanceMeasurementMaxMeasuredValue : public ModelCommand
@@ -21055,11 +19900,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIlluminanceMeasurementTolerance()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIlluminanceMeasurementTolerance() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21067,14 +19908,14 @@ public:
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTolerance(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.Tolerance response", value);
+    }
 };
 
 class ReportIlluminanceMeasurementTolerance : public ModelCommand
@@ -21141,11 +19982,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIlluminanceMeasurementLightSensorType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIlluminanceMeasurementLightSensorType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21153,14 +19990,14 @@ public:
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLightSensorType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::LightSensorType::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.LightSensorType response", value);
+    }
 };
 
 class ReportIlluminanceMeasurementLightSensorType : public ModelCommand
@@ -21227,11 +20064,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadIlluminanceMeasurementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadIlluminanceMeasurementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21239,14 +20072,14 @@ public:
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.ClusterRevision response", value);
+    }
 };
 
 class ReportIlluminanceMeasurementClusterRevision : public ModelCommand
@@ -21348,11 +20181,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadKeypadInputClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadKeypadInputClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21360,14 +20189,14 @@ public:
 
         chip::Controller::KeypadInputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::KeypadInput::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "KeypadInput.ClusterRevision response", value);
+    }
 };
 
 class ReportKeypadInputClusterRevision : public ModelCommand
@@ -21672,11 +20501,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlCurrentLevel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlCurrentLevel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21684,14 +20509,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.CurrentLevel response", value);
+    }
 };
 
 class ReportLevelControlCurrentLevel : public ModelCommand
@@ -21758,11 +20583,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlRemainingTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlRemainingTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21770,14 +20591,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRemainingTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::RemainingTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.RemainingTime response", value);
+    }
 };
 
 class ReportLevelControlRemainingTime : public ModelCommand
@@ -21844,11 +20665,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlMinLevel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlMinLevel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21856,14 +20673,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinLevel::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.MinLevel response", value);
+    }
 };
 
 class ReportLevelControlMinLevel : public ModelCommand
@@ -21930,11 +20747,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlMaxLevel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlMaxLevel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -21942,14 +20755,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxLevel::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.MaxLevel response", value);
+    }
 };
 
 class ReportLevelControlMaxLevel : public ModelCommand
@@ -22016,11 +20829,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlCurrentFrequency()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlCurrentFrequency() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22028,14 +20837,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentFrequency(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentFrequency::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.CurrentFrequency response", value);
+    }
 };
 
 class ReportLevelControlCurrentFrequency : public ModelCommand
@@ -22102,11 +20911,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlMinFrequency()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlMinFrequency() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22114,14 +20919,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinFrequency(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinFrequency::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.MinFrequency response", value);
+    }
 };
 
 class ReportLevelControlMinFrequency : public ModelCommand
@@ -22188,11 +20993,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlMaxFrequency()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlMaxFrequency() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22200,14 +21001,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxFrequency(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxFrequency::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.MaxFrequency response", value);
+    }
 };
 
 class ReportLevelControlMaxFrequency : public ModelCommand
@@ -22274,11 +21075,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlOptions()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlOptions() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22286,14 +21083,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOptions(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::Options::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.Options response", value);
+    }
 };
 
 class WriteLevelControlOptions : public ModelCommand
@@ -22386,11 +21183,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlOnOffTransitionTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlOnOffTransitionTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22398,14 +21191,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOnOffTransitionTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.OnOffTransitionTime response", value);
+    }
 };
 
 class WriteLevelControlOnOffTransitionTime : public ModelCommand
@@ -22499,11 +21292,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlOnLevel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlOnLevel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22511,14 +21300,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOnLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnLevel::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.OnLevel response", value);
+    }
 };
 
 class WriteLevelControlOnLevel : public ModelCommand
@@ -22611,11 +21400,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlOnTransitionTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlOnTransitionTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22623,14 +21408,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOnTransitionTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnTransitionTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.OnTransitionTime response", value);
+    }
 };
 
 class WriteLevelControlOnTransitionTime : public ModelCommand
@@ -22723,11 +21508,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlOffTransitionTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlOffTransitionTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22735,14 +21516,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOffTransitionTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OffTransitionTime::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.OffTransitionTime response", value);
+    }
 };
 
 class WriteLevelControlOffTransitionTime : public ModelCommand
@@ -22836,11 +21617,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlDefaultMoveRate()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlDefaultMoveRate() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22848,14 +21625,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDefaultMoveRate(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.DefaultMoveRate response", value);
+    }
 };
 
 class WriteLevelControlDefaultMoveRate : public ModelCommand
@@ -22948,11 +21725,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlStartUpCurrentLevel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlStartUpCurrentLevel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -22960,14 +21733,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStartUpCurrentLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::StartUpCurrentLevel::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.StartUpCurrentLevel response", value);
+    }
 };
 
 class WriteLevelControlStartUpCurrentLevel : public ModelCommand
@@ -23061,11 +21834,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLevelControlClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLevelControlClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23073,14 +21842,14 @@ public:
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LevelControl.ClusterRevision response", value);
+    }
 };
 
 class ReportLevelControlClusterRevision : public ModelCommand
@@ -23177,11 +21946,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadLowPowerClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadLowPowerClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23189,14 +21954,14 @@ public:
 
         chip::Controller::LowPowerCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LowPower::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "LowPower.ClusterRevision response", value);
+    }
 };
 
 class ReportLowPowerClusterRevision : public ModelCommand
@@ -23367,11 +22132,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaInputMediaInputList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaInputMediaInputList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23379,15 +22140,16 @@ public:
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMediaInputList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::MediaInputList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<MediaInputMediaInputListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<MediaInputMediaInputListListAttributeCallback>(OnMediaInputMediaInputListListAttributeResponse,
-                                                                                    this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "MediaInput.MediaInputList response", value);
+    }
 };
 
 /*
@@ -23402,11 +22164,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaInputCurrentMediaInput()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaInputCurrentMediaInput() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23414,14 +22172,14 @@ public:
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentMediaInput(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::CurrentMediaInput::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaInput.CurrentMediaInput response", value);
+    }
 };
 
 class ReportMediaInputCurrentMediaInput : public ModelCommand
@@ -23489,11 +22247,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaInputClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaInputClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23501,14 +22255,14 @@ public:
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaInput.ClusterRevision response", value);
+    }
 };
 
 class ReportMediaInputClusterRevision : public ModelCommand
@@ -23835,11 +22589,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackPlaybackState()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackPlaybackState() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23847,14 +22597,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePlaybackState(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PlaybackState::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.PlaybackState response", value);
+    }
 };
 
 class ReportMediaPlaybackPlaybackState : public ModelCommand
@@ -23921,11 +22671,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackStartTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackStartTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -23933,14 +22679,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStartTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::StartTime::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.StartTime response", value);
+    }
 };
 
 class ReportMediaPlaybackStartTime : public ModelCommand
@@ -24007,11 +22753,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackDuration()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackDuration() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24019,14 +22761,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDuration(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::Duration::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.Duration response", value);
+    }
 };
 
 class ReportMediaPlaybackDuration : public ModelCommand
@@ -24093,11 +22835,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackPositionUpdatedAt()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackPositionUpdatedAt() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24105,14 +22843,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePositionUpdatedAt(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PositionUpdatedAt::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.PositionUpdatedAt response", value);
+    }
 };
 
 class ReportMediaPlaybackPositionUpdatedAt : public ModelCommand
@@ -24180,11 +22918,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackPosition()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackPosition() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24192,14 +22926,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePosition(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::Position::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.Position response", value);
+    }
 };
 
 class ReportMediaPlaybackPosition : public ModelCommand
@@ -24266,11 +23000,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackPlaybackSpeed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackPlaybackSpeed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24278,14 +23008,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePlaybackSpeed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PlaybackSpeed::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.PlaybackSpeed response", value);
+    }
 };
 
 class ReportMediaPlaybackPlaybackSpeed : public ModelCommand
@@ -24352,11 +23082,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackSeekRangeEnd()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackSeekRangeEnd() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24364,14 +23090,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSeekRangeEnd(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeEnd::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.SeekRangeEnd response", value);
+    }
 };
 
 class ReportMediaPlaybackSeekRangeEnd : public ModelCommand
@@ -24438,11 +23164,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackSeekRangeStart()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackSeekRangeStart() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24450,14 +23172,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSeekRangeStart(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeStart::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.SeekRangeStart response", value);
+    }
 };
 
 class ReportMediaPlaybackSeekRangeStart : public ModelCommand
@@ -24524,11 +23246,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadMediaPlaybackClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadMediaPlaybackClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24536,14 +23254,14 @@ public:
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "MediaPlayback.ClusterRevision response", value);
+    }
 };
 
 class ReportMediaPlaybackClusterRevision : public ModelCommand
@@ -24649,11 +23367,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadModeSelectCurrentMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadModeSelectCurrentMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24661,14 +23375,14 @@ public:
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::CurrentMode::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ModeSelect.CurrentMode response", value);
+    }
 };
 
 class ReportModeSelectCurrentMode : public ModelCommand
@@ -24735,11 +23449,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadModeSelectSupportedModes()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadModeSelectSupportedModes() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24747,15 +23457,17 @@ public:
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSupportedModes(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::SupportedModes::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ModeSelectSupportedModesListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ModeSelectSupportedModesListAttributeCallback>(OnModeSelectSupportedModesListAttributeResponse,
-                                                                                    this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "ModeSelect.SupportedModes response", value);
+    }
 };
 
 /*
@@ -24770,11 +23482,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadModeSelectOnMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadModeSelectOnMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24782,14 +23490,14 @@ public:
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOnMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::OnMode::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ModeSelect.OnMode response", value);
+    }
 };
 
 class WriteModeSelectOnMode : public ModelCommand
@@ -24882,11 +23590,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadModeSelectStartUpMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadModeSelectStartUpMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24894,14 +23598,14 @@ public:
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStartUpMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::StartUpMode::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ModeSelect.StartUpMode response", value);
+    }
 };
 
 class ReportModeSelectStartUpMode : public ModelCommand
@@ -24968,11 +23672,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadModeSelectDescription()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadModeSelectDescription() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -24980,14 +23680,14 @@ public:
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDescription(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::Description::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ModeSelect.Description response", value);
+    }
 };
 
 class ReportModeSelectDescription : public ModelCommand
@@ -25054,11 +23754,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadModeSelectClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadModeSelectClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25066,14 +23762,14 @@ public:
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ModeSelect.ClusterRevision response", value);
+    }
 };
 
 class ReportModeSelectClusterRevision : public ModelCommand
@@ -25368,11 +24064,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadNetworkCommissioningFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadNetworkCommissioningFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25380,14 +24072,14 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::NetworkCommissioning::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "NetworkCommissioning.FeatureMap response", value);
+    }
 };
 
 class ReportNetworkCommissioningFeatureMap : public ModelCommand
@@ -25454,11 +24146,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadNetworkCommissioningClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadNetworkCommissioningClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25466,14 +24154,14 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::NetworkCommissioning::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "NetworkCommissioning.ClusterRevision response", value);
+    }
 };
 
 class ReportNetworkCommissioningClusterRevision : public ModelCommand
@@ -25633,11 +24321,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOtaSoftwareUpdateProviderClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOtaSoftwareUpdateProviderClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25645,14 +24329,14 @@ public:
 
         chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OtaSoftwareUpdateProvider::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateProvider.ClusterRevision response", value);
+    }
 };
 
 class ReportOtaSoftwareUpdateProviderClusterRevision : public ModelCommand
@@ -25760,11 +24444,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOtaSoftwareUpdateRequestorDefaultOtaProvider()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOtaSoftwareUpdateRequestorDefaultOtaProvider() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25772,14 +24452,14 @@ public:
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDefaultOtaProvider(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOtaProvider::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.DefaultOtaProvider response", value);
+    }
 };
 
 class WriteOtaSoftwareUpdateRequestorDefaultOtaProvider : public ModelCommand
@@ -25873,11 +24553,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOtaSoftwareUpdateRequestorUpdatePossible()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOtaSoftwareUpdateRequestorUpdatePossible() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25885,14 +24561,14 @@ public:
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeUpdatePossible(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OtaSoftwareUpdateRequestor::Attributes::UpdatePossible::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.UpdatePossible response", value);
+    }
 };
 
 class ReportOtaSoftwareUpdateRequestorUpdatePossible : public ModelCommand
@@ -25959,11 +24635,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOtaSoftwareUpdateRequestorClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOtaSoftwareUpdateRequestorClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -25971,14 +24643,14 @@ public:
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OtaSoftwareUpdateRequestor::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.ClusterRevision response", value);
+    }
 };
 
 class ReportOtaSoftwareUpdateRequestorClusterRevision : public ModelCommand
@@ -26057,11 +24729,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOccupancySensingOccupancy()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOccupancySensingOccupancy() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26069,14 +24737,14 @@ public:
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOccupancy(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OccupancySensing.Occupancy response", value);
+    }
 };
 
 class ReportOccupancySensingOccupancy : public ModelCommand
@@ -26143,11 +24811,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOccupancySensingOccupancySensorType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOccupancySensingOccupancySensorType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26155,14 +24819,14 @@ public:
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOccupancySensorType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorType::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OccupancySensing.OccupancySensorType response", value);
+    }
 };
 
 class ReportOccupancySensingOccupancySensorType : public ModelCommand
@@ -26230,11 +24894,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOccupancySensingOccupancySensorTypeBitmap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOccupancySensingOccupancySensorTypeBitmap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26242,14 +24902,14 @@ public:
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOccupancySensorTypeBitmap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorTypeBitmap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OccupancySensing.OccupancySensorTypeBitmap response", value);
+    }
 };
 
 class ReportOccupancySensingOccupancySensorTypeBitmap : public ModelCommand
@@ -26317,11 +24977,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOccupancySensingClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOccupancySensingClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26329,14 +24985,14 @@ public:
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OccupancySensing.ClusterRevision response", value);
+    }
 };
 
 class ReportOccupancySensingClusterRevision : public ModelCommand
@@ -26558,11 +25214,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffOnOff()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffOnOff() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26570,14 +25222,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOnOff(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnAttributeResponse,
+                                                                                              OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.OnOff response", value);
+    }
 };
 
 class ReportOnOffOnOff : public ModelCommand
@@ -26644,11 +25296,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffGlobalSceneControl()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffGlobalSceneControl() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26656,14 +25304,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeGlobalSceneControl(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.GlobalSceneControl response", value);
+    }
 };
 
 class ReportOnOffGlobalSceneControl : public ModelCommand
@@ -26731,11 +25379,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffOnTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffOnTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26743,14 +25387,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOnTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnAttributeResponse,
+                                                                                               OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.OnTime response", value);
+    }
 };
 
 class WriteOnOffOnTime : public ModelCommand
@@ -26843,11 +25487,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffOffWaitTime()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffOffWaitTime() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26855,14 +25495,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOffWaitTime(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.OffWaitTime response", value);
+    }
 };
 
 class WriteOnOffOffWaitTime : public ModelCommand
@@ -26955,11 +25595,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffStartUpOnOff()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffStartUpOnOff() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -26967,14 +25603,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStartUpOnOff(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.StartUpOnOff response", value);
+    }
 };
 
 class WriteOnOffStartUpOnOff : public ModelCommand
@@ -27067,11 +25703,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27079,14 +25711,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::FeatureMap::TypeInfo>(this, OnAttributeResponse,
+                                                                                                   OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.FeatureMap response", value);
+    }
 };
 
 class ReportOnOffFeatureMap : public ModelCommand
@@ -27153,11 +25785,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27165,14 +25793,14 @@ public:
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::ClusterRevision::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOff.ClusterRevision response", value);
+    }
 };
 
 class ReportOnOffClusterRevision : public ModelCommand
@@ -27250,11 +25878,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffSwitchConfigurationSwitchType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffSwitchConfigurationSwitchType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27262,14 +25886,14 @@ public:
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSwitchType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOffSwitchConfiguration::Attributes::SwitchType::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.SwitchType response", value);
+    }
 };
 
 class ReportOnOffSwitchConfigurationSwitchType : public ModelCommand
@@ -27336,11 +25960,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffSwitchConfigurationSwitchActions()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffSwitchConfigurationSwitchActions() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27348,14 +25968,14 @@ public:
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSwitchActions(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOffSwitchConfiguration::Attributes::SwitchActions::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.SwitchActions response", value);
+    }
 };
 
 class WriteOnOffSwitchConfigurationSwitchActions : public ModelCommand
@@ -27448,11 +26068,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOnOffSwitchConfigurationClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOnOffSwitchConfigurationClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27460,14 +26076,14 @@ public:
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOffSwitchConfiguration::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.ClusterRevision response", value);
+    }
 };
 
 class ReportOnOffSwitchConfigurationClusterRevision : public ModelCommand
@@ -27778,11 +26394,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOperationalCredentialsFabricsList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOperationalCredentialsFabricsList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27790,15 +26402,17 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFabricsList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::FabricsList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OperationalCredentialsFabricsListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OperationalCredentialsFabricsListListAttributeCallback>(
-            OnOperationalCredentialsFabricsListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "OperationalCredentials.FabricsList response", value);
+    }
 };
 
 /*
@@ -27813,11 +26427,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOperationalCredentialsSupportedFabrics()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOperationalCredentialsSupportedFabrics() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27825,14 +26435,14 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSupportedFabrics(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::SupportedFabrics::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OperationalCredentials.SupportedFabrics response", value);
+    }
 };
 
 class ReportOperationalCredentialsSupportedFabrics : public ModelCommand
@@ -27899,11 +26509,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOperationalCredentialsCommissionedFabrics()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOperationalCredentialsCommissionedFabrics() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27911,14 +26517,14 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCommissionedFabrics(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CommissionedFabrics::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "OperationalCredentials.CommissionedFabrics response", value);
+    }
 };
 
 class ReportOperationalCredentialsCommissionedFabrics : public ModelCommand
@@ -27986,11 +26592,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOperationalCredentialsTrustedRootCertificates()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOperationalCredentialsTrustedRootCertificates() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -27998,15 +26600,14 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTrustedRootCertificates(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::TrustedRootCertificates::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>(
-            OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
+    {
+        OnGeneralAttributeResponse(context, "OperationalCredentials.TrustedRootCertificates response", value);
+    }
 };
 
 /*
@@ -28021,11 +26622,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOperationalCredentialsCurrentFabricIndex()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOperationalCredentialsCurrentFabricIndex() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28033,14 +26630,14 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentFabricIndex(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CurrentFabricIndex::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::FabricIndex value)
+    {
+        OnGeneralAttributeResponse(context, "OperationalCredentials.CurrentFabricIndex response", value);
+    }
 };
 
 class ReportOperationalCredentialsCurrentFabricIndex : public ModelCommand
@@ -28108,11 +26705,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadOperationalCredentialsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadOperationalCredentialsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28120,14 +26713,14 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "OperationalCredentials.ClusterRevision response", value);
+    }
 };
 
 class ReportOperationalCredentialsClusterRevision : public ModelCommand
@@ -28213,11 +26806,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28225,14 +26814,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::Status::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.Status response", value);
+    }
 };
 
 class ReportPowerSourceStatus : public ModelCommand
@@ -28299,11 +26888,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceOrder()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceOrder() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28311,14 +26896,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOrder(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::Order::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.Order response", value);
+    }
 };
 
 class ReportPowerSourceOrder : public ModelCommand
@@ -28385,11 +26970,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceDescription()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceDescription() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28397,14 +26978,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDescription(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::Description::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.Description response", value);
+    }
 };
 
 class ReportPowerSourceDescription : public ModelCommand
@@ -28471,11 +27052,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceBatteryVoltage()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceBatteryVoltage() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28483,14 +27060,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBatteryVoltage(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::BatteryVoltage::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.BatteryVoltage response", value);
+    }
 };
 
 class ReportPowerSourceBatteryVoltage : public ModelCommand
@@ -28557,11 +27134,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceBatteryPercentRemaining()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceBatteryPercentRemaining() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28569,14 +27142,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBatteryPercentRemaining(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::BatteryPercentRemaining::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.BatteryPercentRemaining response", value);
+    }
 };
 
 class ReportPowerSourceBatteryPercentRemaining : public ModelCommand
@@ -28644,11 +27217,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceBatteryTimeRemaining()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceBatteryTimeRemaining() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28656,14 +27225,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBatteryTimeRemaining(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::BatteryTimeRemaining::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.BatteryTimeRemaining response", value);
+    }
 };
 
 class ReportPowerSourceBatteryTimeRemaining : public ModelCommand
@@ -28731,11 +27300,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceBatteryChargeLevel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceBatteryChargeLevel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28743,14 +27308,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBatteryChargeLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::BatteryChargeLevel::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.BatteryChargeLevel response", value);
+    }
 };
 
 class ReportPowerSourceBatteryChargeLevel : public ModelCommand
@@ -28818,11 +27383,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceActiveBatteryFaults()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceActiveBatteryFaults() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28830,15 +27391,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActiveBatteryFaults(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::ActiveBatteryFaults::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<PowerSourceActiveBatteryFaultsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<PowerSourceActiveBatteryFaultsListAttributeCallback>(
-            OnPowerSourceActiveBatteryFaultsListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.ActiveBatteryFaults response", value);
+    }
 };
 
 /*
@@ -28853,11 +27413,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceBatteryChargeState()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceBatteryChargeState() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28865,14 +27421,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBatteryChargeState(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::BatteryChargeState::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.BatteryChargeState response", value);
+    }
 };
 
 class ReportPowerSourceBatteryChargeState : public ModelCommand
@@ -28940,11 +27496,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -28952,14 +27504,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::FeatureMap::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.FeatureMap response", value);
+    }
 };
 
 class ReportPowerSourceFeatureMap : public ModelCommand
@@ -29026,11 +27578,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29038,14 +27586,14 @@ public:
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSource.ClusterRevision response", value);
+    }
 };
 
 class ReportPowerSourceClusterRevision : public ModelCommand
@@ -29122,11 +27670,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceConfigurationSources()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceConfigurationSources() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29134,15 +27678,14 @@ public:
 
         chip::Controller::PowerSourceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSources(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSourceConfiguration::Attributes::Sources::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<PowerSourceConfigurationSourcesListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<PowerSourceConfigurationSourcesListAttributeCallback>(
-            OnPowerSourceConfigurationSourcesListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSourceConfiguration.Sources response", value);
+    }
 };
 
 /*
@@ -29157,11 +27700,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPowerSourceConfigurationClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPowerSourceConfigurationClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29169,14 +27708,14 @@ public:
 
         chip::Controller::PowerSourceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PowerSourceConfiguration::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PowerSourceConfiguration.ClusterRevision response", value);
+    }
 };
 
 /*----------------------------------------------------------------------------*\
@@ -29203,11 +27742,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPressureMeasurementMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPressureMeasurementMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29215,14 +27750,14 @@ public:
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PressureMeasurement.MeasuredValue response", value);
+    }
 };
 
 class ReportPressureMeasurementMeasuredValue : public ModelCommand
@@ -29289,11 +27824,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPressureMeasurementMinMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPressureMeasurementMinMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29301,14 +27832,14 @@ public:
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PressureMeasurement.MinMeasuredValue response", value);
+    }
 };
 
 class ReportPressureMeasurementMinMeasuredValue : public ModelCommand
@@ -29375,11 +27906,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPressureMeasurementMaxMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPressureMeasurementMaxMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29387,14 +27914,14 @@ public:
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PressureMeasurement.MaxMeasuredValue response", value);
+    }
 };
 
 class ReportPressureMeasurementMaxMeasuredValue : public ModelCommand
@@ -29461,11 +27988,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPressureMeasurementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPressureMeasurementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29473,14 +27996,14 @@ public:
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PressureMeasurement.ClusterRevision response", value);
+    }
 };
 
 class ReportPressureMeasurementClusterRevision : public ModelCommand
@@ -29581,11 +28104,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxPressure()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxPressure() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29593,14 +28112,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxPressure(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxPressure response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxPressure : public ModelCommand
@@ -29667,11 +28186,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxSpeed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxSpeed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29679,14 +28194,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxSpeed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxSpeed::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxSpeed response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxSpeed : public ModelCommand
@@ -29753,11 +28268,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxFlow()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxFlow() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29765,14 +28276,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxFlow(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxFlow::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxFlow response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxFlow : public ModelCommand
@@ -29839,11 +28350,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMinConstPressure()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMinConstPressure() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29851,14 +28358,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinConstPressure(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstPressure::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstPressure response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMinConstPressure : public ModelCommand
@@ -29925,11 +28432,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxConstPressure()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxConstPressure() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -29937,14 +28440,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxConstPressure(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstPressure::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstPressure response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxConstPressure : public ModelCommand
@@ -30011,11 +28514,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMinCompPressure()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMinCompPressure() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30023,14 +28522,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinCompPressure(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinCompPressure::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinCompPressure response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMinCompPressure : public ModelCommand
@@ -30097,11 +28596,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxCompPressure()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxCompPressure() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30109,14 +28604,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxCompPressure(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxCompPressure::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxCompPressure response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxCompPressure : public ModelCommand
@@ -30183,11 +28678,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMinConstSpeed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMinConstSpeed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30195,14 +28686,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinConstSpeed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstSpeed::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstSpeed response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMinConstSpeed : public ModelCommand
@@ -30269,11 +28760,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxConstSpeed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxConstSpeed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30281,14 +28768,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxConstSpeed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstSpeed::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstSpeed response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxConstSpeed : public ModelCommand
@@ -30355,11 +28842,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMinConstFlow()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMinConstFlow() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30367,14 +28850,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinConstFlow(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstFlow::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstFlow response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMinConstFlow : public ModelCommand
@@ -30441,11 +28924,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxConstFlow()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxConstFlow() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30453,14 +28932,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxConstFlow(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstFlow::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstFlow response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxConstFlow : public ModelCommand
@@ -30527,11 +29006,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMinConstTemp()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMinConstTemp() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30539,14 +29014,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinConstTemp(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstTemp::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstTemp response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMinConstTemp : public ModelCommand
@@ -30613,11 +29088,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlMaxConstTemp()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlMaxConstTemp() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30625,14 +29096,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxConstTemp(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstTemp::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstTemp response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlMaxConstTemp : public ModelCommand
@@ -30699,11 +29170,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlPumpStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlPumpStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30711,14 +29178,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePumpStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.PumpStatus response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlPumpStatus : public ModelCommand
@@ -30785,11 +29252,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlEffectiveOperationMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlEffectiveOperationMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30797,14 +29260,15 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEffectiveOperationMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.EffectiveOperationMode response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlEffectiveOperationMode : public ModelCommand
@@ -30872,11 +29336,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlEffectiveControlMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlEffectiveControlMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30884,14 +29344,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEffectiveControlMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.EffectiveControlMode response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlEffectiveControlMode : public ModelCommand
@@ -30959,11 +29419,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlCapacity()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlCapacity() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -30971,14 +29427,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCapacity(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.Capacity response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlCapacity : public ModelCommand
@@ -31045,11 +29501,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlSpeed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlSpeed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31057,14 +29509,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSpeed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Speed::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.Speed response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlSpeed : public ModelCommand
@@ -31131,11 +29583,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlLifetimeRunningHours()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlLifetimeRunningHours() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31143,14 +29591,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLifetimeRunningHours(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.LifetimeRunningHours response", value);
+    }
 };
 
 class WritePumpConfigurationAndControlLifetimeRunningHours : public ModelCommand
@@ -31244,11 +29692,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlPower()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlPower() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31256,14 +29700,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePower(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Power::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.Power response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlPower : public ModelCommand
@@ -31330,11 +29774,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlLifetimeEnergyConsumed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlLifetimeEnergyConsumed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31342,14 +29782,15 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLifetimeEnergyConsumed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.LifetimeEnergyConsumed response", value);
+    }
 };
 
 class WritePumpConfigurationAndControlLifetimeEnergyConsumed : public ModelCommand
@@ -31444,11 +29885,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlOperationMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlOperationMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31456,14 +29893,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOperationMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::OperationMode::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.OperationMode response", value);
+    }
 };
 
 class WritePumpConfigurationAndControlOperationMode : public ModelCommand
@@ -31556,11 +29993,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlControlMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlControlMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31568,14 +30001,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeControlMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.ControlMode response", value);
+    }
 };
 
 class WritePumpConfigurationAndControlControlMode : public ModelCommand
@@ -31668,11 +30101,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlAlarmMask()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlAlarmMask() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31680,14 +30109,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAlarmMask(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::AlarmMask::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.AlarmMask response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlAlarmMask : public ModelCommand
@@ -31754,11 +30183,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31766,14 +30191,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.FeatureMap response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlFeatureMap : public ModelCommand
@@ -31840,11 +30265,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadPumpConfigurationAndControlClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadPumpConfigurationAndControlClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31852,14 +30273,14 @@ public:
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.ClusterRevision response", value);
+    }
 };
 
 class ReportPumpConfigurationAndControlClusterRevision : public ModelCommand
@@ -31939,11 +30360,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadRelativeHumidityMeasurementMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadRelativeHumidityMeasurementMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -31951,14 +30368,14 @@ public:
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.MeasuredValue response", value);
+    }
 };
 
 class ReportRelativeHumidityMeasurementMeasuredValue : public ModelCommand
@@ -32025,11 +30442,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadRelativeHumidityMeasurementMinMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadRelativeHumidityMeasurementMinMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32037,14 +30450,14 @@ public:
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.MinMeasuredValue response", value);
+    }
 };
 
 class ReportRelativeHumidityMeasurementMinMeasuredValue : public ModelCommand
@@ -32111,11 +30524,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadRelativeHumidityMeasurementMaxMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadRelativeHumidityMeasurementMaxMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32123,14 +30532,14 @@ public:
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.MaxMeasuredValue response", value);
+    }
 };
 
 class ReportRelativeHumidityMeasurementMaxMeasuredValue : public ModelCommand
@@ -32197,11 +30606,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadRelativeHumidityMeasurementTolerance()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadRelativeHumidityMeasurementTolerance() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32209,14 +30614,14 @@ public:
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTolerance(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.Tolerance response", value);
+    }
 };
 
 class ReportRelativeHumidityMeasurementTolerance : public ModelCommand
@@ -32283,11 +30688,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadRelativeHumidityMeasurementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadRelativeHumidityMeasurementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32295,14 +30696,14 @@ public:
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.ClusterRevision response", value);
+    }
 };
 
 class ReportRelativeHumidityMeasurementClusterRevision : public ModelCommand
@@ -32567,11 +30968,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadScenesSceneCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadScenesSceneCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32579,14 +30976,14 @@ public:
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSceneCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Scenes::Attributes::SceneCount::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Scenes.SceneCount response", value);
+    }
 };
 
 class ReportScenesSceneCount : public ModelCommand
@@ -32653,11 +31050,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadScenesCurrentScene()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadScenesCurrentScene() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32665,14 +31058,14 @@ public:
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentScene(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Scenes::Attributes::CurrentScene::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Scenes.CurrentScene response", value);
+    }
 };
 
 class ReportScenesCurrentScene : public ModelCommand
@@ -32739,11 +31132,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadScenesCurrentGroup()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadScenesCurrentGroup() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32751,14 +31140,14 @@ public:
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentGroup(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Scenes::Attributes::CurrentGroup::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Scenes.CurrentGroup response", value);
+    }
 };
 
 class ReportScenesCurrentGroup : public ModelCommand
@@ -32825,11 +31214,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadScenesSceneValid()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadScenesSceneValid() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32837,14 +31222,14 @@ public:
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSceneValid(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Scenes::Attributes::SceneValid::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "Scenes.SceneValid response", value);
+    }
 };
 
 class ReportScenesSceneValid : public ModelCommand
@@ -32911,11 +31296,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadScenesNameSupport()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadScenesNameSupport() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -32923,14 +31304,14 @@ public:
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNameSupport(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Scenes::Attributes::NameSupport::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Scenes.NameSupport response", value);
+    }
 };
 
 class ReportScenesNameSupport : public ModelCommand
@@ -32997,11 +31378,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadScenesClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadScenesClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33009,14 +31386,14 @@ public:
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Scenes::Attributes::ClusterRevision::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Scenes.ClusterRevision response", value);
+    }
 };
 
 class ReportScenesClusterRevision : public ModelCommand
@@ -33118,11 +31495,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSoftwareDiagnosticsThreadMetrics()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSoftwareDiagnosticsThreadMetrics() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33130,15 +31503,17 @@ public:
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeThreadMetrics(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::ThreadMetrics::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<SoftwareDiagnosticsThreadMetricsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<SoftwareDiagnosticsThreadMetricsListAttributeCallback>(
-            OnSoftwareDiagnosticsThreadMetricsListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.ThreadMetrics response", value);
+    }
 };
 
 /*
@@ -33153,11 +31528,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSoftwareDiagnosticsCurrentHeapFree()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSoftwareDiagnosticsCurrentHeapFree() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33165,14 +31536,14 @@ public:
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentHeapFree(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapFree::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.CurrentHeapFree response", value);
+    }
 };
 
 class ReportSoftwareDiagnosticsCurrentHeapFree : public ModelCommand
@@ -33239,11 +31610,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSoftwareDiagnosticsCurrentHeapUsed()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSoftwareDiagnosticsCurrentHeapUsed() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33251,14 +31618,14 @@ public:
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentHeapUsed(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapUsed::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.CurrentHeapUsed response", value);
+    }
 };
 
 class ReportSoftwareDiagnosticsCurrentHeapUsed : public ModelCommand
@@ -33325,11 +31692,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSoftwareDiagnosticsCurrentHeapHighWatermark()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSoftwareDiagnosticsCurrentHeapHighWatermark() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33337,14 +31700,14 @@ public:
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentHeapHighWatermark(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.CurrentHeapHighWatermark response", value);
+    }
 };
 
 class ReportSoftwareDiagnosticsCurrentHeapHighWatermark : public ModelCommand
@@ -33412,11 +31775,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSoftwareDiagnosticsFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSoftwareDiagnosticsFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33424,14 +31783,14 @@ public:
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.FeatureMap response", value);
+    }
 };
 
 /*
@@ -33446,11 +31805,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSoftwareDiagnosticsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSoftwareDiagnosticsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33458,14 +31813,14 @@ public:
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.ClusterRevision response", value);
+    }
 };
 
 class ReportSoftwareDiagnosticsClusterRevision : public ModelCommand
@@ -33545,11 +31900,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSwitchNumberOfPositions()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSwitchNumberOfPositions() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33557,14 +31908,14 @@ public:
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNumberOfPositions(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::NumberOfPositions::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Switch.NumberOfPositions response", value);
+    }
 };
 
 class ReportSwitchNumberOfPositions : public ModelCommand
@@ -33632,11 +31983,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSwitchCurrentPosition()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSwitchCurrentPosition() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33644,14 +31991,14 @@ public:
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPosition(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::CurrentPosition::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Switch.CurrentPosition response", value);
+    }
 };
 
 class ReportSwitchCurrentPosition : public ModelCommand
@@ -33718,11 +32065,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSwitchMultiPressMax()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSwitchMultiPressMax() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33730,14 +32073,14 @@ public:
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMultiPressMax(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::MultiPressMax::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Switch.MultiPressMax response", value);
+    }
 };
 
 class ReportSwitchMultiPressMax : public ModelCommand
@@ -33804,11 +32147,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSwitchFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSwitchFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33816,14 +32155,14 @@ public:
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::FeatureMap::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "Switch.FeatureMap response", value);
+    }
 };
 
 class ReportSwitchFeatureMap : public ModelCommand
@@ -33890,11 +32229,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadSwitchClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadSwitchClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -33902,14 +32237,14 @@ public:
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::ClusterRevision::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Switch.ClusterRevision response", value);
+    }
 };
 
 class ReportSwitchClusterRevision : public ModelCommand
@@ -34064,11 +32399,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTvChannelTvChannelList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTvChannelTvChannelList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34076,15 +32407,16 @@ public:
 
         chip::Controller::TvChannelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTvChannelList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TvChannel::Attributes::TvChannelList::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TvChannelTvChannelListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TvChannelTvChannelListListAttributeCallback>(OnTvChannelTvChannelListListAttributeResponse,
-                                                                                  this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "TvChannel.TvChannelList response", value);
+    }
 };
 
 /*
@@ -34099,11 +32431,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTvChannelTvChannelLineup()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTvChannelTvChannelLineup() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34111,14 +32439,14 @@ public:
 
         chip::Controller::TvChannelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTvChannelLineup(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TvChannel::Attributes::TvChannelLineup::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "TvChannel.TvChannelLineup response", value);
+    }
 };
 
 class ReportTvChannelTvChannelLineup : public ModelCommand
@@ -34185,11 +32513,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTvChannelCurrentTvChannel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTvChannelCurrentTvChannel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34197,14 +32521,14 @@ public:
 
         chip::Controller::TvChannelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentTvChannel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TvChannel::Attributes::CurrentTvChannel::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "TvChannel.CurrentTvChannel response", value);
+    }
 };
 
 class ReportTvChannelCurrentTvChannel : public ModelCommand
@@ -34271,11 +32595,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTvChannelClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTvChannelClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34283,14 +32603,14 @@ public:
 
         chip::Controller::TvChannelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TvChannel::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TvChannel.ClusterRevision response", value);
+    }
 };
 
 class ReportTvChannelClusterRevision : public ModelCommand
@@ -34393,11 +32713,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTargetNavigatorTargetNavigatorList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTargetNavigatorTargetNavigatorList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34405,15 +32721,17 @@ public:
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTargetNavigatorList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::TargetNavigatorList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TargetNavigatorTargetNavigatorListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TargetNavigatorTargetNavigatorListListAttributeCallback>(
-            OnTargetNavigatorTargetNavigatorListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "TargetNavigator.TargetNavigatorList response", value);
+    }
 };
 
 /*
@@ -34428,11 +32746,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTargetNavigatorClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTargetNavigatorClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34440,14 +32754,14 @@ public:
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TargetNavigator.ClusterRevision response", value);
+    }
 };
 
 class ReportTargetNavigatorClusterRevision : public ModelCommand
@@ -34527,11 +32841,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTemperatureMeasurementMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTemperatureMeasurementMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34539,14 +32849,14 @@ public:
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TemperatureMeasurement.MeasuredValue response", value);
+    }
 };
 
 class ReportTemperatureMeasurementMeasuredValue : public ModelCommand
@@ -34613,11 +32923,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTemperatureMeasurementMinMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTemperatureMeasurementMinMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34625,14 +32931,14 @@ public:
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TemperatureMeasurement.MinMeasuredValue response", value);
+    }
 };
 
 class ReportTemperatureMeasurementMinMeasuredValue : public ModelCommand
@@ -34699,11 +33005,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTemperatureMeasurementMaxMeasuredValue()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTemperatureMeasurementMaxMeasuredValue() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34711,14 +33013,14 @@ public:
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TemperatureMeasurement.MaxMeasuredValue response", value);
+    }
 };
 
 class ReportTemperatureMeasurementMaxMeasuredValue : public ModelCommand
@@ -34785,11 +33087,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTemperatureMeasurementTolerance()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTemperatureMeasurementTolerance() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34797,14 +33095,14 @@ public:
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTolerance(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TemperatureMeasurement.Tolerance response", value);
+    }
 };
 
 class ReportTemperatureMeasurementTolerance : public ModelCommand
@@ -34871,11 +33169,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTemperatureMeasurementClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTemperatureMeasurementClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -34883,14 +33177,14 @@ public:
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TemperatureMeasurement.ClusterRevision response", value);
+    }
 };
 
 class ReportTemperatureMeasurementClusterRevision : public ModelCommand
@@ -35451,11 +33745,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterBoolean()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterBoolean() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -35463,14 +33753,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBoolean(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Boolean response", value);
+    }
 };
 
 class WriteTestClusterBoolean : public ModelCommand
@@ -35563,11 +33853,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterBitmap8()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterBitmap8() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -35575,14 +33861,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBitmap8(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Bitmap8 response", value);
+    }
 };
 
 class WriteTestClusterBitmap8 : public ModelCommand
@@ -35675,11 +33961,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterBitmap16()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterBitmap16() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -35687,14 +33969,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBitmap16(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Bitmap16 response", value);
+    }
 };
 
 class WriteTestClusterBitmap16 : public ModelCommand
@@ -35787,11 +34069,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterBitmap32()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterBitmap32() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -35799,14 +34077,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBitmap32(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Bitmap32 response", value);
+    }
 };
 
 class WriteTestClusterBitmap32 : public ModelCommand
@@ -35899,11 +34177,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterBitmap64()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterBitmap64() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -35911,14 +34185,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBitmap64(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Bitmap64 response", value);
+    }
 };
 
 class WriteTestClusterBitmap64 : public ModelCommand
@@ -36011,11 +34285,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt8u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt8u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36023,14 +34293,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt8u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int8u response", value);
+    }
 };
 
 class WriteTestClusterInt8u : public ModelCommand
@@ -36123,11 +34393,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt16u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt16u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36135,14 +34401,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt16u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int16u response", value);
+    }
 };
 
 class WriteTestClusterInt16u : public ModelCommand
@@ -36235,11 +34501,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt24u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt24u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36247,14 +34509,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt24u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int24u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int24u response", value);
+    }
 };
 
 class WriteTestClusterInt24u : public ModelCommand
@@ -36347,11 +34609,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt32u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt32u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36359,14 +34617,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt32u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int32u response", value);
+    }
 };
 
 class WriteTestClusterInt32u : public ModelCommand
@@ -36459,11 +34717,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt40u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt40u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36471,14 +34725,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt40u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int40u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int40u response", value);
+    }
 };
 
 class WriteTestClusterInt40u : public ModelCommand
@@ -36571,11 +34825,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt48u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt48u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36583,14 +34833,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt48u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int48u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int48u response", value);
+    }
 };
 
 class WriteTestClusterInt48u : public ModelCommand
@@ -36683,11 +34933,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt56u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt56u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36695,14 +34941,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt56u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int56u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int56u response", value);
+    }
 };
 
 class WriteTestClusterInt56u : public ModelCommand
@@ -36795,11 +35041,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt64u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt64u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36807,14 +35049,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt64u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int64u response", value);
+    }
 };
 
 class WriteTestClusterInt64u : public ModelCommand
@@ -36907,11 +35149,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt8s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt8s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -36919,14 +35157,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt8s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int8_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int8s response", value);
+    }
 };
 
 class WriteTestClusterInt8s : public ModelCommand
@@ -37019,11 +35257,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt16s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt16s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37031,14 +35265,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt16s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int16s response", value);
+    }
 };
 
 class WriteTestClusterInt16s : public ModelCommand
@@ -37131,11 +35365,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt24s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt24s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37143,14 +35373,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt24s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int24s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int32_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int24s response", value);
+    }
 };
 
 class WriteTestClusterInt24s : public ModelCommand
@@ -37243,11 +35473,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt32s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt32s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37255,14 +35481,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt32s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int32_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int32s response", value);
+    }
 };
 
 class WriteTestClusterInt32s : public ModelCommand
@@ -37355,11 +35581,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt40s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt40s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37367,14 +35589,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt40s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int40s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int40s response", value);
+    }
 };
 
 class WriteTestClusterInt40s : public ModelCommand
@@ -37467,11 +35689,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt48s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt48s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37479,14 +35697,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt48s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int48s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int48s response", value);
+    }
 };
 
 class WriteTestClusterInt48s : public ModelCommand
@@ -37579,11 +35797,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt56s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt56s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37591,14 +35805,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt56s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int56s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int56s response", value);
+    }
 };
 
 class WriteTestClusterInt56s : public ModelCommand
@@ -37691,11 +35905,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterInt64s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterInt64s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37703,14 +35913,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInt64s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Int64s response", value);
+    }
 };
 
 class WriteTestClusterInt64s : public ModelCommand
@@ -37803,11 +36013,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterEnum8()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterEnum8() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37815,14 +36021,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEnum8(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnAttributeResponse,
+                                                                                                    OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Enum8 response", value);
+    }
 };
 
 class WriteTestClusterEnum8 : public ModelCommand
@@ -37915,11 +36121,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterEnum16()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterEnum16() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -37927,14 +36129,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEnum16(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Enum16 response", value);
+    }
 };
 
 class WriteTestClusterEnum16 : public ModelCommand
@@ -38027,11 +36229,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterFloatSingle()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterFloatSingle() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38039,14 +36237,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFloatSingle(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<FloatAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<FloatAttributeCallback>(OnFloatAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, float value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.FloatSingle response", value);
+    }
 };
 
 class WriteTestClusterFloatSingle : public ModelCommand
@@ -38139,11 +36337,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterFloatDouble()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterFloatDouble() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38151,14 +36345,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFloatDouble(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<DoubleAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DoubleAttributeCallback>(OnDoubleAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, double value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.FloatDouble response", value);
+    }
 };
 
 class WriteTestClusterFloatDouble : public ModelCommand
@@ -38251,11 +36445,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterOctetString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterOctetString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38263,14 +36453,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.OctetString response", value);
+    }
 };
 
 class WriteTestClusterOctetString : public ModelCommand
@@ -38363,11 +36553,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterListInt8u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterListInt8u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38375,14 +36561,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeListInt8u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TestClusterListInt8uListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TestClusterListInt8uListAttributeCallback>(OnTestClusterListInt8uListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.ListInt8u response", value);
+    }
 };
 
 /*
@@ -38397,11 +36583,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterListOctetString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterListOctetString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38409,15 +36591,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeListOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TestClusterListOctetStringListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TestClusterListOctetStringListAttributeCallback>(
-            OnTestClusterListOctetStringListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.ListOctetString response", value);
+    }
 };
 
 /*
@@ -38432,11 +36613,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterListStructOctetString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterListStructOctetString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38444,15 +36621,17 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeListStructOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TestClusterListStructOctetStringListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TestClusterListStructOctetStringListAttributeCallback>(
-            OnTestClusterListStructOctetStringListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
+            value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.ListStructOctetString response", value);
+    }
 };
 
 /*
@@ -38467,11 +36646,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterLongOctetString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterLongOctetString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38479,14 +36654,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLongOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.LongOctetString response", value);
+    }
 };
 
 class WriteTestClusterLongOctetString : public ModelCommand
@@ -38579,11 +36754,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterCharString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterCharString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38591,14 +36762,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.CharString response", value);
+    }
 };
 
 class WriteTestClusterCharString : public ModelCommand
@@ -38691,11 +36862,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterLongCharString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterLongCharString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38703,14 +36870,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLongCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.LongCharString response", value);
+    }
 };
 
 class WriteTestClusterLongCharString : public ModelCommand
@@ -38803,11 +36970,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterEpochUs()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterEpochUs() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38815,14 +36978,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEpochUs(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.EpochUs response", value);
+    }
 };
 
 class WriteTestClusterEpochUs : public ModelCommand
@@ -38915,11 +37078,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterEpochS()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterEpochS() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -38927,14 +37086,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEpochS(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnAttributeResponse,
+                                                                                                     OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.EpochS response", value);
+    }
 };
 
 class WriteTestClusterEpochS : public ModelCommand
@@ -39027,11 +37186,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterVendorId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterVendorId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39039,14 +37194,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeVendorId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnAttributeResponse,
+                                                                                                       OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::VendorId value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.VendorId response", value);
+    }
 };
 
 class WriteTestClusterVendorId : public ModelCommand
@@ -39139,11 +37294,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterListNullablesAndOptionalsStruct()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterListNullablesAndOptionalsStruct() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39151,15 +37302,17 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeListNullablesAndOptionalsStruct(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListNullablesAndOptionalsStruct::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TestClusterListNullablesAndOptionalsStructListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TestClusterListNullablesAndOptionalsStructListAttributeCallback>(
-            OnTestClusterListNullablesAndOptionalsStructListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.ListNullablesAndOptionalsStruct response", value);
+    }
 };
 
 /*
@@ -39174,11 +37327,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterRangeRestrictedInt8u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterRangeRestrictedInt8u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39186,14 +37335,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRangeRestrictedInt8u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt8u response", value);
+    }
 };
 
 class WriteTestClusterRangeRestrictedInt8u : public ModelCommand
@@ -39287,11 +37436,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterRangeRestrictedInt8s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterRangeRestrictedInt8s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39299,14 +37444,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRangeRestrictedInt8s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int8_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt8s response", value);
+    }
 };
 
 class WriteTestClusterRangeRestrictedInt8s : public ModelCommand
@@ -39400,11 +37545,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterRangeRestrictedInt16u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterRangeRestrictedInt16u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39412,14 +37553,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRangeRestrictedInt16u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt16u response", value);
+    }
 };
 
 class WriteTestClusterRangeRestrictedInt16u : public ModelCommand
@@ -39513,11 +37654,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterRangeRestrictedInt16s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterRangeRestrictedInt16s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39525,14 +37662,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRangeRestrictedInt16s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt16s response", value);
+    }
 };
 
 class WriteTestClusterRangeRestrictedInt16s : public ModelCommand
@@ -39626,11 +37763,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterListLongOctetString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterListLongOctetString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39638,15 +37771,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeListLongOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListLongOctetString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<TestClusterListLongOctetStringListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<TestClusterListLongOctetStringListAttributeCallback>(
-            OnTestClusterListLongOctetStringListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.ListLongOctetString response", value);
+    }
 };
 
 /*
@@ -39661,11 +37793,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterTimedWriteBoolean()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterTimedWriteBoolean() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39673,14 +37801,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTimedWriteBoolean(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.TimedWriteBoolean response", value);
+    }
 };
 
 class WriteTestClusterTimedWriteBoolean : public ModelCommand
@@ -39721,11 +37849,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterUnsupported()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterUnsupported() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39733,14 +37857,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeUnsupported(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Unsupported::TypeInfo>(this, OnAttributeResponse,
+                                                                                                          OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, bool value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.Unsupported response", value);
+    }
 };
 
 class WriteTestClusterUnsupported : public ModelCommand
@@ -39833,11 +37957,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableBoolean()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableBoolean() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39845,14 +37965,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableBoolean(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<BooleanAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<bool> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableBoolean response", value);
+    }
 };
 
 class WriteTestClusterNullableBoolean : public ModelCommand
@@ -39945,11 +38065,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableBitmap8()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableBitmap8() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -39957,14 +38073,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableBitmap8(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap8 response", value);
+    }
 };
 
 class WriteTestClusterNullableBitmap8 : public ModelCommand
@@ -40057,11 +38173,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableBitmap16()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableBitmap16() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40069,14 +38181,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableBitmap16(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap16 response", value);
+    }
 };
 
 class WriteTestClusterNullableBitmap16 : public ModelCommand
@@ -40169,11 +38281,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableBitmap32()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableBitmap32() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40181,14 +38289,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableBitmap32(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap32 response", value);
+    }
 };
 
 class WriteTestClusterNullableBitmap32 : public ModelCommand
@@ -40281,11 +38389,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableBitmap64()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableBitmap64() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40293,14 +38397,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableBitmap64(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap64 response", value);
+    }
 };
 
 class WriteTestClusterNullableBitmap64 : public ModelCommand
@@ -40393,11 +38497,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt8u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt8u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40405,14 +38505,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt8u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt8u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt8u : public ModelCommand
@@ -40505,11 +38605,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt16u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt16u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40517,14 +38613,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt16u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt16u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt16u : public ModelCommand
@@ -40617,11 +38713,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt24u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt24u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40629,14 +38721,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt24u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt24u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt24u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt24u : public ModelCommand
@@ -40729,11 +38821,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt32u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt32u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40741,14 +38829,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt32u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt32u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt32u : public ModelCommand
@@ -40841,11 +38929,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt40u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt40u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40853,14 +38937,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt40u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt40u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt40u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt40u : public ModelCommand
@@ -40953,11 +39037,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt48u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt48u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -40965,14 +39045,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt48u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt48u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt48u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt48u : public ModelCommand
@@ -41065,11 +39145,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt56u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt56u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41077,14 +39153,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt56u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt56u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt56u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt56u : public ModelCommand
@@ -41177,11 +39253,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt64u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt64u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41189,14 +39261,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt64u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt64u response", value);
+    }
 };
 
 class WriteTestClusterNullableInt64u : public ModelCommand
@@ -41289,11 +39361,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt8s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt8s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41301,14 +39369,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt8s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt8s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt8s : public ModelCommand
@@ -41401,11 +39469,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt16s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt16s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41413,14 +39477,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt16s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt16s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt16s : public ModelCommand
@@ -41513,11 +39577,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt24s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt24s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41525,14 +39585,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt24s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt24s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt24s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt24s : public ModelCommand
@@ -41625,11 +39685,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt32s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt32s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41637,14 +39693,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt32s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int32_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt32s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt32s : public ModelCommand
@@ -41737,11 +39793,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt40s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt40s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41749,14 +39801,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt40s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt40s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt40s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt40s : public ModelCommand
@@ -41849,11 +39901,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt48s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt48s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41861,14 +39909,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt48s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt48s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt48s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt48s : public ModelCommand
@@ -41961,11 +40009,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt56s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt56s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -41973,14 +40017,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt56s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt56s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt56s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt56s : public ModelCommand
@@ -42073,11 +40117,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableInt64s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableInt64s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42085,14 +40125,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableInt64s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableInt64s response", value);
+    }
 };
 
 class WriteTestClusterNullableInt64s : public ModelCommand
@@ -42185,11 +40225,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableEnum8()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableEnum8() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42197,14 +40233,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableEnum8(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableEnum8 response", value);
+    }
 };
 
 class WriteTestClusterNullableEnum8 : public ModelCommand
@@ -42297,11 +40333,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableEnum16()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableEnum16() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42309,14 +40341,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableEnum16(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableEnum16 response", value);
+    }
 };
 
 class WriteTestClusterNullableEnum16 : public ModelCommand
@@ -42409,11 +40441,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableFloatSingle()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableFloatSingle() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42421,14 +40449,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableFloatSingle(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<FloatAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<FloatAttributeCallback>(OnFloatAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<float> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableFloatSingle response", value);
+    }
 };
 
 class WriteTestClusterNullableFloatSingle : public ModelCommand
@@ -42522,11 +40550,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableFloatDouble()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableFloatDouble() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42534,14 +40558,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableFloatDouble(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<DoubleAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DoubleAttributeCallback>(OnDoubleAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<double> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableFloatDouble response", value);
+    }
 };
 
 class WriteTestClusterNullableFloatDouble : public ModelCommand
@@ -42635,11 +40659,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableOctetString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableOctetString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42647,14 +40667,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableOctetString response", value);
+    }
 };
 
 class WriteTestClusterNullableOctetString : public ModelCommand
@@ -42748,11 +40768,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableCharString()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableCharString() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42760,14 +40776,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableCharString response", value);
+    }
 };
 
 class WriteTestClusterNullableCharString : public ModelCommand
@@ -42861,11 +40877,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableRangeRestrictedInt8u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableRangeRestrictedInt8u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42873,14 +40885,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableRangeRestrictedInt8u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt8u response", value);
+    }
 };
 
 class WriteTestClusterNullableRangeRestrictedInt8u : public ModelCommand
@@ -42974,11 +40986,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableRangeRestrictedInt8s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableRangeRestrictedInt8s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -42986,14 +40994,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableRangeRestrictedInt8s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int8_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt8s response", value);
+    }
 };
 
 class WriteTestClusterNullableRangeRestrictedInt8s : public ModelCommand
@@ -43087,11 +41095,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableRangeRestrictedInt16u()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableRangeRestrictedInt16u() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43099,14 +41103,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableRangeRestrictedInt16u(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt16u response", value);
+    }
 };
 
 class WriteTestClusterNullableRangeRestrictedInt16u : public ModelCommand
@@ -43200,11 +41204,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterNullableRangeRestrictedInt16s()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterNullableRangeRestrictedInt16s() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43212,14 +41212,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNullableRangeRestrictedInt16s(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int16_t> & value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt16s response", value);
+    }
 };
 
 class WriteTestClusterNullableRangeRestrictedInt16s : public ModelCommand
@@ -43313,11 +41313,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadTestClusterClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadTestClusterClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43325,14 +41321,14 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "TestCluster.ClusterRevision response", value);
+    }
 };
 
 class ReportTestClusterClusterRevision : public ModelCommand
@@ -43555,11 +41551,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatLocalTemperature()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatLocalTemperature() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43567,14 +41559,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLocalTemperature(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::LocalTemperature::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.LocalTemperature response", value);
+    }
 };
 
 class ReportThermostatLocalTemperature : public ModelCommand
@@ -43641,11 +41633,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatAbsMinHeatSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatAbsMinHeatSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43653,14 +41641,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAbsMinHeatSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinHeatSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.AbsMinHeatSetpointLimit response", value);
+    }
 };
 
 class ReportThermostatAbsMinHeatSetpointLimit : public ModelCommand
@@ -43728,11 +41716,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatAbsMaxHeatSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatAbsMaxHeatSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43740,14 +41724,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAbsMaxHeatSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxHeatSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.AbsMaxHeatSetpointLimit response", value);
+    }
 };
 
 class ReportThermostatAbsMaxHeatSetpointLimit : public ModelCommand
@@ -43815,11 +41799,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatAbsMinCoolSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatAbsMinCoolSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43827,14 +41807,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAbsMinCoolSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinCoolSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.AbsMinCoolSetpointLimit response", value);
+    }
 };
 
 class ReportThermostatAbsMinCoolSetpointLimit : public ModelCommand
@@ -43902,11 +41882,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatAbsMaxCoolSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatAbsMaxCoolSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -43914,14 +41890,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAbsMaxCoolSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxCoolSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.AbsMaxCoolSetpointLimit response", value);
+    }
 };
 
 class ReportThermostatAbsMaxCoolSetpointLimit : public ModelCommand
@@ -43989,11 +41965,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatOccupiedCoolingSetpoint()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatOccupiedCoolingSetpoint() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44001,14 +41973,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOccupiedCoolingSetpoint(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.OccupiedCoolingSetpoint response", value);
+    }
 };
 
 class WriteThermostatOccupiedCoolingSetpoint : public ModelCommand
@@ -44102,11 +42074,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatOccupiedHeatingSetpoint()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatOccupiedHeatingSetpoint() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44114,14 +42082,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOccupiedHeatingSetpoint(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.OccupiedHeatingSetpoint response", value);
+    }
 };
 
 class WriteThermostatOccupiedHeatingSetpoint : public ModelCommand
@@ -44215,11 +42183,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatMinHeatSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatMinHeatSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44227,14 +42191,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinHeatSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.MinHeatSetpointLimit response", value);
+    }
 };
 
 class WriteThermostatMinHeatSetpointLimit : public ModelCommand
@@ -44328,11 +42292,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatMaxHeatSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatMaxHeatSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44340,14 +42300,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxHeatSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.MaxHeatSetpointLimit response", value);
+    }
 };
 
 class WriteThermostatMaxHeatSetpointLimit : public ModelCommand
@@ -44441,11 +42401,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatMinCoolSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatMinCoolSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44453,14 +42409,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinCoolSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.MinCoolSetpointLimit response", value);
+    }
 };
 
 class WriteThermostatMinCoolSetpointLimit : public ModelCommand
@@ -44554,11 +42510,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatMaxCoolSetpointLimit()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatMaxCoolSetpointLimit() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44566,14 +42518,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMaxCoolSetpointLimit(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.MaxCoolSetpointLimit response", value);
+    }
 };
 
 class WriteThermostatMaxCoolSetpointLimit : public ModelCommand
@@ -44667,11 +42619,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatMinSetpointDeadBand()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatMinSetpointDeadBand() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44679,14 +42627,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMinSetpointDeadBand(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinSetpointDeadBand::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.MinSetpointDeadBand response", value);
+    }
 };
 
 class WriteThermostatMinSetpointDeadBand : public ModelCommand
@@ -44780,11 +42728,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatControlSequenceOfOperation()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatControlSequenceOfOperation() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44792,14 +42736,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeControlSequenceOfOperation(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.ControlSequenceOfOperation response", value);
+    }
 };
 
 class WriteThermostatControlSequenceOfOperation : public ModelCommand
@@ -44893,11 +42837,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatSystemMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatSystemMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -44905,14 +42845,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSystemMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::SystemMode::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.SystemMode response", value);
+    }
 };
 
 class WriteThermostatSystemMode : public ModelCommand
@@ -45005,11 +42945,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatStartOfWeek()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatStartOfWeek() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45017,14 +42953,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStartOfWeek(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::StartOfWeek::TypeInfo>(this, OnAttributeResponse,
+                                                                                                         OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.StartOfWeek response", value);
+    }
 };
 
 class ReportThermostatStartOfWeek : public ModelCommand
@@ -45091,11 +43027,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatNumberOfWeeklyTransitions()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatNumberOfWeeklyTransitions() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45103,14 +43035,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNumberOfWeeklyTransitions(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::NumberOfWeeklyTransitions::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.NumberOfWeeklyTransitions response", value);
+    }
 };
 
 class ReportThermostatNumberOfWeeklyTransitions : public ModelCommand
@@ -45178,11 +43110,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatNumberOfDailyTransitions()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatNumberOfDailyTransitions() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45190,14 +43118,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNumberOfDailyTransitions(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::NumberOfDailyTransitions::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.NumberOfDailyTransitions response", value);
+    }
 };
 
 class ReportThermostatNumberOfDailyTransitions : public ModelCommand
@@ -45265,11 +43193,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45277,14 +43201,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::FeatureMap::TypeInfo>(this, OnAttributeResponse,
+                                                                                                        OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.FeatureMap response", value);
+    }
 };
 
 class ReportThermostatFeatureMap : public ModelCommand
@@ -45351,11 +43275,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45363,14 +43283,14 @@ public:
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "Thermostat.ClusterRevision response", value);
+    }
 };
 
 class ReportThermostatClusterRevision : public ModelCommand
@@ -45449,11 +43369,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45461,14 +43377,15 @@ public:
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTemperatureDisplayMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.TemperatureDisplayMode response", value);
+    }
 };
 
 class WriteThermostatUserInterfaceConfigurationTemperatureDisplayMode : public ModelCommand
@@ -45563,11 +43480,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatUserInterfaceConfigurationKeypadLockout()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatUserInterfaceConfigurationKeypadLockout() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45575,14 +43488,15 @@ public:
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeKeypadLockout(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.KeypadLockout response", value);
+    }
 };
 
 class WriteThermostatUserInterfaceConfigurationKeypadLockout : public ModelCommand
@@ -45676,11 +43590,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45688,14 +43598,15 @@ public:
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeScheduleProgrammingVisibility(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<
+            chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.ScheduleProgrammingVisibility response", value);
+    }
 };
 
 class WriteThermostatUserInterfaceConfigurationScheduleProgrammingVisibility : public ModelCommand
@@ -45790,11 +43701,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThermostatUserInterfaceConfigurationClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThermostatUserInterfaceConfigurationClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45802,14 +43709,15 @@ public:
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ClusterRevision::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.ClusterRevision response", value);
+    }
 };
 
 class ReportThermostatUserInterfaceConfigurationClusterRevision : public ModelCommand
@@ -45970,11 +43878,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsChannel()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsChannel() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -45982,14 +43886,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeChannel(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::Channel::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.Channel response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsChannel : public ModelCommand
@@ -46056,11 +43960,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRoutingRole()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRoutingRole() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46068,14 +43968,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRoutingRole(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RoutingRole::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RoutingRole response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRoutingRole : public ModelCommand
@@ -46142,11 +44042,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsNetworkName()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsNetworkName() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46154,14 +44050,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNetworkName(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::NetworkName::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.NetworkName response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsNetworkName : public ModelCommand
@@ -46228,11 +44124,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsPanId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsPanId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46240,14 +44132,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePanId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::PanId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PanId response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsPanId : public ModelCommand
@@ -46314,11 +44206,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsExtendedPanId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsExtendedPanId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46326,14 +44214,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeExtendedPanId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ExtendedPanId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ExtendedPanId response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsExtendedPanId : public ModelCommand
@@ -46400,11 +44288,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsMeshLocalPrefix()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsMeshLocalPrefix() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46412,14 +44296,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMeshLocalPrefix(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.MeshLocalPrefix response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsMeshLocalPrefix : public ModelCommand
@@ -46486,11 +44370,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsOverrunCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsOverrunCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46498,14 +44378,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOverrunCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::OverrunCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.OverrunCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsOverrunCount : public ModelCommand
@@ -46572,11 +44452,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsNeighborTableList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsNeighborTableList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46584,15 +44460,17 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeNeighborTableList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::NeighborTableList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ThreadNetworkDiagnosticsNeighborTableListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ThreadNetworkDiagnosticsNeighborTableListListAttributeCallback>(
-            OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.NeighborTableList response", value);
+    }
 };
 
 /*
@@ -46607,11 +44485,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRouteTableList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRouteTableList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46619,15 +44493,16 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRouteTableList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RouteTableList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ThreadNetworkDiagnosticsRouteTableListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ThreadNetworkDiagnosticsRouteTableListListAttributeCallback>(
-            OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context,
+                                    const chip::app::DataModel::DecodableList<
+                                        chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RouteTableList response", value);
+    }
 };
 
 /*
@@ -46642,11 +44517,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsPartitionId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsPartitionId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46654,14 +44525,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePartitionId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::PartitionId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PartitionId response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsPartitionId : public ModelCommand
@@ -46728,11 +44599,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsWeighting()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsWeighting() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46740,14 +44607,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeWeighting(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::Weighting::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.Weighting response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsWeighting : public ModelCommand
@@ -46814,11 +44681,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsDataVersion()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsDataVersion() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46826,14 +44689,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDataVersion(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::DataVersion::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.DataVersion response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsDataVersion : public ModelCommand
@@ -46900,11 +44763,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsStableDataVersion()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsStableDataVersion() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46912,14 +44771,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeStableDataVersion(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::StableDataVersion::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.StableDataVersion response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsStableDataVersion : public ModelCommand
@@ -46987,11 +44846,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsLeaderRouterId()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsLeaderRouterId() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -46999,14 +44854,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLeaderRouterId(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::LeaderRouterId::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.LeaderRouterId response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsLeaderRouterId : public ModelCommand
@@ -47073,11 +44928,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsDetachedRoleCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsDetachedRoleCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47085,14 +44936,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDetachedRoleCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.DetachedRoleCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsDetachedRoleCount : public ModelCommand
@@ -47160,11 +45011,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsChildRoleCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsChildRoleCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47172,14 +45019,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeChildRoleCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ChildRoleCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ChildRoleCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsChildRoleCount : public ModelCommand
@@ -47246,11 +45093,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRouterRoleCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRouterRoleCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47258,14 +45101,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRouterRoleCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RouterRoleCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RouterRoleCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRouterRoleCount : public ModelCommand
@@ -47332,11 +45175,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsLeaderRoleCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsLeaderRoleCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47344,14 +45183,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeLeaderRoleCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.LeaderRoleCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsLeaderRoleCount : public ModelCommand
@@ -47418,11 +45257,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsAttachAttemptCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsAttachAttemptCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47430,14 +45265,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeAttachAttemptCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.AttachAttemptCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsAttachAttemptCount : public ModelCommand
@@ -47505,11 +45340,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsPartitionIdChangeCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsPartitionIdChangeCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47517,14 +45348,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePartitionIdChangeCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PartitionIdChangeCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsPartitionIdChangeCount : public ModelCommand
@@ -47592,11 +45423,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47604,14 +45431,15 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBetterPartitionAttachAttemptCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.BetterPartitionAttachAttemptCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount : public ModelCommand
@@ -47679,11 +45507,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsParentChangeCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsParentChangeCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47691,14 +45515,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeParentChangeCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ParentChangeCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ParentChangeCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsParentChangeCount : public ModelCommand
@@ -47766,11 +45590,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxTotalCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxTotalCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47778,14 +45598,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxTotalCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxTotalCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxTotalCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxTotalCount : public ModelCommand
@@ -47852,11 +45672,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxUnicastCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxUnicastCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47864,14 +45680,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxUnicastCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxUnicastCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxUnicastCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxUnicastCount : public ModelCommand
@@ -47938,11 +45754,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxBroadcastCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxBroadcastCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -47950,14 +45762,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxBroadcastCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxBroadcastCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxBroadcastCount : public ModelCommand
@@ -48024,11 +45836,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxAckRequestedCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxAckRequestedCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48036,14 +45844,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxAckRequestedCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxAckRequestedCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxAckRequestedCount : public ModelCommand
@@ -48111,11 +45919,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxAckedCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxAckedCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48123,14 +45927,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxAckedCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxAckedCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxAckedCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxAckedCount : public ModelCommand
@@ -48197,11 +46001,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxNoAckRequestedCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxNoAckRequestedCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48209,14 +46009,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxNoAckRequestedCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxNoAckRequestedCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxNoAckRequestedCount : public ModelCommand
@@ -48284,11 +46084,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxDataCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxDataCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48296,14 +46092,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxDataCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDataCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxDataCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxDataCount : public ModelCommand
@@ -48370,11 +46166,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxDataPollCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxDataPollCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48382,14 +46174,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxDataPollCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDataPollCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxDataPollCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxDataPollCount : public ModelCommand
@@ -48456,11 +46248,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxBeaconCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxBeaconCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48468,14 +46256,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxBeaconCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBeaconCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxBeaconCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxBeaconCount : public ModelCommand
@@ -48542,11 +46330,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxBeaconRequestCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxBeaconRequestCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48554,14 +46338,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxBeaconRequestCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxBeaconRequestCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxBeaconRequestCount : public ModelCommand
@@ -48629,11 +46413,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxOtherCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxOtherCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48641,14 +46421,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxOtherCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxOtherCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxOtherCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxOtherCount : public ModelCommand
@@ -48715,11 +46495,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxRetryCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxRetryCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48727,14 +46503,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxRetryCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxRetryCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxRetryCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxRetryCount : public ModelCommand
@@ -48801,11 +46577,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48813,14 +46585,15 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxDirectMaxRetryExpiryCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxDirectMaxRetryExpiryCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount : public ModelCommand
@@ -48888,11 +46661,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48900,14 +46669,15 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxIndirectMaxRetryExpiryCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxIndirectMaxRetryExpiryCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount : public ModelCommand
@@ -48975,11 +46745,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxErrCcaCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxErrCcaCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -48987,14 +46753,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxErrCcaCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxErrCcaCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxErrCcaCount : public ModelCommand
@@ -49061,11 +46827,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxErrAbortCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxErrAbortCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49073,14 +46835,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxErrAbortCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxErrAbortCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxErrAbortCount : public ModelCommand
@@ -49147,11 +46909,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsTxErrBusyChannelCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsTxErrBusyChannelCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49159,14 +46917,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTxErrBusyChannelCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxErrBusyChannelCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsTxErrBusyChannelCount : public ModelCommand
@@ -49234,11 +46992,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxTotalCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxTotalCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49246,14 +47000,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxTotalCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxTotalCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxTotalCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxTotalCount : public ModelCommand
@@ -49320,11 +47074,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxUnicastCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxUnicastCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49332,14 +47082,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxUnicastCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxUnicastCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxUnicastCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxUnicastCount : public ModelCommand
@@ -49406,11 +47156,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxBroadcastCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxBroadcastCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49418,14 +47164,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxBroadcastCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxBroadcastCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxBroadcastCount : public ModelCommand
@@ -49492,11 +47238,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxDataCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxDataCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49504,14 +47246,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxDataCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDataCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDataCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxDataCount : public ModelCommand
@@ -49578,11 +47320,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxDataPollCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxDataPollCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49590,14 +47328,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxDataPollCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDataPollCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDataPollCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxDataPollCount : public ModelCommand
@@ -49664,11 +47402,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxBeaconCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxBeaconCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49676,14 +47410,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxBeaconCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBeaconCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxBeaconCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxBeaconCount : public ModelCommand
@@ -49750,11 +47484,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxBeaconRequestCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxBeaconRequestCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49762,14 +47492,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxBeaconRequestCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxBeaconRequestCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxBeaconRequestCount : public ModelCommand
@@ -49837,11 +47567,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxOtherCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxOtherCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49849,14 +47575,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxOtherCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxOtherCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxOtherCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxOtherCount : public ModelCommand
@@ -49923,11 +47649,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxAddressFilteredCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxAddressFilteredCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -49935,14 +47657,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxAddressFilteredCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxAddressFilteredCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxAddressFilteredCount : public ModelCommand
@@ -50010,11 +47732,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50022,14 +47740,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxDestAddrFilteredCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDestAddrFilteredCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxDestAddrFilteredCount : public ModelCommand
@@ -50097,11 +47815,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxDuplicatedCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxDuplicatedCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50109,14 +47823,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxDuplicatedCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDuplicatedCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxDuplicatedCount : public ModelCommand
@@ -50184,11 +47898,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxErrNoFrameCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxErrNoFrameCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50196,14 +47906,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxErrNoFrameCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrNoFrameCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxErrNoFrameCount : public ModelCommand
@@ -50271,11 +47981,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50283,14 +47989,15 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxErrUnknownNeighborCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrUnknownNeighborCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxErrUnknownNeighborCount : public ModelCommand
@@ -50358,11 +48065,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50370,14 +48073,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxErrInvalidSrcAddrCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrInvalidSrcAddrCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount : public ModelCommand
@@ -50445,11 +48148,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxErrSecCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxErrSecCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50457,14 +48156,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxErrSecCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrSecCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrSecCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxErrSecCount : public ModelCommand
@@ -50531,11 +48230,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxErrFcsCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxErrFcsCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50543,14 +48238,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxErrFcsCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrFcsCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxErrFcsCount : public ModelCommand
@@ -50617,11 +48312,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsRxErrOtherCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsRxErrOtherCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50629,14 +48320,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRxErrOtherCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrOtherCount response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsRxErrOtherCount : public ModelCommand
@@ -50703,11 +48394,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsActiveTimestamp()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsActiveTimestamp() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50715,14 +48402,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActiveTimestamp(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ActiveTimestamp response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsActiveTimestamp : public ModelCommand
@@ -50789,11 +48476,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsPendingTimestamp()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsPendingTimestamp() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50801,14 +48484,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePendingTimestamp(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::PendingTimestamp::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PendingTimestamp response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsPendingTimestamp : public ModelCommand
@@ -50875,11 +48558,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsDelay()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsDelay() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50887,14 +48566,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeDelay(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::Delay::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.Delay response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsDelay : public ModelCommand
@@ -50961,11 +48640,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsSecurityPolicy()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsSecurityPolicy() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -50973,15 +48648,17 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSecurityPolicy(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::SecurityPolicy::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ThreadNetworkDiagnosticsSecurityPolicyListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ThreadNetworkDiagnosticsSecurityPolicyListAttributeCallback>(
-            OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void
+    OnAttributeResponse(void * context,
+                        const chip::app::DataModel::DecodableList<
+                            chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.SecurityPolicy response", value);
+    }
 };
 
 /*
@@ -50996,11 +48673,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsChannelMask()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsChannelMask() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51008,14 +48681,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeChannelMask(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ChannelMask::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ChannelMask response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsChannelMask : public ModelCommand
@@ -51082,11 +48755,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsOperationalDatasetComponents()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsOperationalDatasetComponents() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51094,15 +48763,18 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOperationalDatasetComponents(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::TypeInfo>(
+                this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeCallback>(
-            OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<
+            chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType> & value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.OperationalDatasetComponents response", value);
+    }
 };
 
 /*
@@ -51117,11 +48789,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsActiveNetworkFaultsList()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsActiveNetworkFaultsList() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51129,15 +48797,16 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeActiveNetworkFaultsList(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<ThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<ThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallback>(
-            OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFault> & value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ActiveNetworkFaultsList response", value);
+    }
 };
 
 /*
@@ -51152,11 +48821,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51164,14 +48829,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.FeatureMap response", value);
+    }
 };
 
 /*
@@ -51186,11 +48851,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadThreadNetworkDiagnosticsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadThreadNetworkDiagnosticsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51198,14 +48859,14 @@ public:
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ClusterRevision response", value);
+    }
 };
 
 class ReportThreadNetworkDiagnosticsClusterRevision : public ModelCommand
@@ -51282,11 +48943,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWakeOnLanWakeOnLanMacAddress()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWakeOnLanWakeOnLanMacAddress() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51294,14 +48951,14 @@ public:
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeWakeOnLanMacAddress(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WakeOnLan::Attributes::WakeOnLanMacAddress::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::CharSpan value)
+    {
+        OnGeneralAttributeResponse(context, "WakeOnLan.WakeOnLanMacAddress response", value);
+    }
 };
 
 class ReportWakeOnLanWakeOnLanMacAddress : public ModelCommand
@@ -51369,11 +49026,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWakeOnLanClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWakeOnLanClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51381,14 +49034,14 @@ public:
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WakeOnLan::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WakeOnLan.ClusterRevision response", value);
+    }
 };
 
 class ReportWakeOnLanClusterRevision : public ModelCommand
@@ -51499,11 +49152,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsBssid()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsBssid() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51511,14 +49160,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBssid(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::Bssid::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, chip::ByteSpan value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.Bssid response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsBssid : public ModelCommand
@@ -51585,11 +49234,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsSecurityType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsSecurityType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51597,14 +49242,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSecurityType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::SecurityType::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.SecurityType response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsSecurityType : public ModelCommand
@@ -51671,11 +49316,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsWiFiVersion()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsWiFiVersion() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51683,14 +49324,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeWiFiVersion(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::WiFiVersion::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.WiFiVersion response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsWiFiVersion : public ModelCommand
@@ -51757,11 +49398,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsChannelNumber()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsChannelNumber() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51769,14 +49406,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeChannelNumber(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::ChannelNumber::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.ChannelNumber response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsChannelNumber : public ModelCommand
@@ -51843,11 +49480,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsRssi()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsRssi() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51855,14 +49488,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeRssi(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::Rssi::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8sAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, int8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.Rssi response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsRssi : public ModelCommand
@@ -51929,11 +49562,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsBeaconLostCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsBeaconLostCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -51941,14 +49570,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBeaconLostCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::BeaconLostCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.BeaconLostCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsBeaconLostCount : public ModelCommand
@@ -52015,11 +49644,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsBeaconRxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsBeaconRxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52027,14 +49652,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeBeaconRxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::BeaconRxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.BeaconRxCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsBeaconRxCount : public ModelCommand
@@ -52101,11 +49726,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsPacketMulticastRxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsPacketMulticastRxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52113,14 +49734,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePacketMulticastRxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::PacketMulticastRxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketMulticastRxCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsPacketMulticastRxCount : public ModelCommand
@@ -52188,11 +49809,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsPacketMulticastTxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsPacketMulticastTxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52200,14 +49817,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePacketMulticastTxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::PacketMulticastTxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketMulticastTxCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsPacketMulticastTxCount : public ModelCommand
@@ -52275,11 +49892,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsPacketUnicastRxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsPacketUnicastRxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52287,14 +49900,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePacketUnicastRxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::PacketUnicastRxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketUnicastRxCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsPacketUnicastRxCount : public ModelCommand
@@ -52362,11 +49975,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsPacketUnicastTxCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsPacketUnicastTxCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52374,14 +49983,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributePacketUnicastTxCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::PacketUnicastTxCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketUnicastTxCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsPacketUnicastTxCount : public ModelCommand
@@ -52449,11 +50058,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsCurrentMaxRate()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsCurrentMaxRate() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52461,14 +50066,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentMaxRate(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::CurrentMaxRate::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.CurrentMaxRate response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsCurrentMaxRate : public ModelCommand
@@ -52535,11 +50140,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsOverrunCount()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsOverrunCount() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52547,14 +50148,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOverrunCount(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::OverrunCount::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int64uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint64_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.OverrunCount response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsOverrunCount : public ModelCommand
@@ -52621,11 +50222,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52633,14 +50230,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.FeatureMap response", value);
+    }
 };
 
 /*
@@ -52655,11 +50252,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWiFiNetworkDiagnosticsClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWiFiNetworkDiagnosticsClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52667,14 +50260,14 @@ public:
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.ClusterRevision response", value);
+    }
 };
 
 class ReportWiFiNetworkDiagnosticsClusterRevision : public ModelCommand
@@ -52934,11 +50527,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -52946,14 +50535,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.Type response", value);
+    }
 };
 
 class ReportWindowCoveringType : public ModelCommand
@@ -53020,11 +50609,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringCurrentPositionLift()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringCurrentPositionLift() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53032,14 +50617,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPositionLift(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLift::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionLift response", value);
+    }
 };
 
 class ReportWindowCoveringCurrentPositionLift : public ModelCommand
@@ -53107,11 +50692,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringCurrentPositionTilt()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringCurrentPositionTilt() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53119,14 +50700,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPositionTilt(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTilt::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionTilt response", value);
+    }
 };
 
 class ReportWindowCoveringCurrentPositionTilt : public ModelCommand
@@ -53194,11 +50775,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringConfigStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringConfigStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53206,14 +50783,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeConfigStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ConfigStatus::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.ConfigStatus response", value);
+    }
 };
 
 class ReportWindowCoveringConfigStatus : public ModelCommand
@@ -53280,11 +50857,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringCurrentPositionLiftPercentage()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringCurrentPositionLiftPercentage() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53292,14 +50865,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPositionLiftPercentage(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionLiftPercentage response", value);
+    }
 };
 
 class ReportWindowCoveringCurrentPositionLiftPercentage : public ModelCommand
@@ -53367,11 +50940,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringCurrentPositionTiltPercentage()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringCurrentPositionTiltPercentage() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53379,14 +50948,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPositionTiltPercentage(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionTiltPercentage response", value);
+    }
 };
 
 class ReportWindowCoveringCurrentPositionTiltPercentage : public ModelCommand
@@ -53454,11 +51023,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringOperationalStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringOperationalStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53466,14 +51031,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeOperationalStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.OperationalStatus response", value);
+    }
 };
 
 class ReportWindowCoveringOperationalStatus : public ModelCommand
@@ -53541,11 +51106,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringTargetPositionLiftPercent100ths()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringTargetPositionLiftPercent100ths() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53553,14 +51114,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTargetPositionLiftPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.TargetPositionLiftPercent100ths response", value);
+    }
 };
 
 class ReportWindowCoveringTargetPositionLiftPercent100ths : public ModelCommand
@@ -53628,11 +51189,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringTargetPositionTiltPercent100ths()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringTargetPositionTiltPercent100ths() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53640,14 +51197,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeTargetPositionTiltPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.TargetPositionTiltPercent100ths response", value);
+    }
 };
 
 class ReportWindowCoveringTargetPositionTiltPercent100ths : public ModelCommand
@@ -53715,11 +51272,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringEndProductType()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringEndProductType() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53727,14 +51280,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeEndProductType(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.EndProductType response", value);
+    }
 };
 
 class ReportWindowCoveringEndProductType : public ModelCommand
@@ -53801,11 +51354,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringCurrentPositionLiftPercent100ths()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringCurrentPositionLiftPercent100ths() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53813,14 +51362,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPositionLiftPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionLiftPercent100ths response", value);
+    }
 };
 
 class ReportWindowCoveringCurrentPositionLiftPercent100ths : public ModelCommand
@@ -53888,11 +51437,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringCurrentPositionTiltPercent100ths()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringCurrentPositionTiltPercent100ths() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53900,14 +51445,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeCurrentPositionTiltPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionTiltPercent100ths response", value);
+    }
 };
 
 class ReportWindowCoveringCurrentPositionTiltPercent100ths : public ModelCommand
@@ -53975,11 +51520,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringInstalledOpenLimitLift()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringInstalledOpenLimitLift() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -53987,14 +51528,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInstalledOpenLimitLift(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledOpenLimitLift::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.InstalledOpenLimitLift response", value);
+    }
 };
 
 class ReportWindowCoveringInstalledOpenLimitLift : public ModelCommand
@@ -54062,11 +51603,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringInstalledClosedLimitLift()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringInstalledClosedLimitLift() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54074,14 +51611,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInstalledClosedLimitLift(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledClosedLimitLift::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.InstalledClosedLimitLift response", value);
+    }
 };
 
 class ReportWindowCoveringInstalledClosedLimitLift : public ModelCommand
@@ -54149,11 +51686,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringInstalledOpenLimitTilt()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringInstalledOpenLimitTilt() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54161,14 +51694,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInstalledOpenLimitTilt(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledOpenLimitTilt::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.InstalledOpenLimitTilt response", value);
+    }
 };
 
 class ReportWindowCoveringInstalledOpenLimitTilt : public ModelCommand
@@ -54236,11 +51769,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringInstalledClosedLimitTilt()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringInstalledClosedLimitTilt() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54248,14 +51777,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeInstalledClosedLimitTilt(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledClosedLimitTilt::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.InstalledClosedLimitTilt response", value);
+    }
 };
 
 class ReportWindowCoveringInstalledClosedLimitTilt : public ModelCommand
@@ -54323,11 +51852,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringMode()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringMode() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54335,14 +51860,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeMode(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Mode::TypeInfo>(this, OnAttributeResponse,
+                                                                                                      OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int8uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint8_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.Mode response", value);
+    }
 };
 
 class WriteWindowCoveringMode : public ModelCommand
@@ -54435,11 +51960,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringSafetyStatus()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringSafetyStatus() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54447,14 +51968,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeSafetyStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::SafetyStatus::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.SafetyStatus response", value);
+    }
 };
 
 class ReportWindowCoveringSafetyStatus : public ModelCommand
@@ -54521,11 +52042,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringFeatureMap()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringFeatureMap() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54533,14 +52050,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeFeatureMap(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::FeatureMap::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int32uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint32_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.FeatureMap response", value);
+    }
 };
 
 class ReportWindowCoveringFeatureMap : public ModelCommand
@@ -54607,11 +52124,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~ReadWindowCoveringClusterRevision()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
+    ~ReadWindowCoveringClusterRevision() {}
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
@@ -54619,14 +52132,14 @@ public:
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttributeClusterRevision(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ClusterRevision::TypeInfo>(
+            this, OnAttributeResponse, OnDefaultFailure);
     }
 
-private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
+    static void OnAttributeResponse(void * context, uint16_t value)
+    {
+        OnGeneralAttributeResponse(context, "WindowCovering.ClusterRevision response", value);
+    }
 };
 
 class ReportWindowCoveringClusterRevision : public ModelCommand

--- a/zzz_generated/chip-tool/zap-generated/reporting/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/reporting/Commands.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "../cluster/Commands.h" // For the LogValue bits and read callbacks
 #include <commands/reporting/ReportingCommand.h>
 
 typedef void (*UnsupportedAttributeCallback)(void * context);
@@ -1699,972 +1700,1765 @@ public:
                                        BasicAttributeFilter<Int16uAttributeCallback>);
     }
 
-    static void OnDefaultSuccessResponse(void * context) { ChipLogProgress(chipTool, "Default Success Response"); }
-
-    static void OnDefaultFailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Default Failure Response: 0x%02x", status);
-    }
-
-    static void OnUnsupportedAttributeResponse(void * context)
-    {
-        ChipLogError(chipTool, "Unsupported attribute Response. This should never happen !");
-    }
-
-    static void OnBooleanAttributeResponse(void * context, bool value)
-    {
-        ChipLogProgress(chipTool, "Boolean attribute Response: %d", value);
-    }
-
-    static void OnInt8uAttributeResponse(void * context, uint8_t value)
-    {
-        ChipLogProgress(chipTool, "Int8u attribute Response: %" PRIu8, value);
-    }
-
-    static void OnInt16uAttributeResponse(void * context, uint16_t value)
-    {
-        ChipLogProgress(chipTool, "Int16u attribute Response: %" PRIu16, value);
-    }
-
-    static void OnInt16sAttributeResponse(void * context, int16_t value)
-    {
-        ChipLogProgress(chipTool, "Int16s attribute Response: %" PRId16, value);
-    }
-
 private:
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportAccountLoginClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportAdministratorCommissioningClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportApplicationBasicVendorNameCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportApplicationBasicVendorIdCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportApplicationBasicApplicationNameCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportApplicationBasicProductIdCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportApplicationBasicApplicationIdCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportApplicationBasicCatalogVendorIdCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportApplicationBasicApplicationStatusCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportApplicationBasicClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportApplicationLauncherCatalogVendorIdCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportApplicationLauncherApplicationIdCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportApplicationLauncherClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportAudioOutputCurrentAudioOutputCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportAudioOutputClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportBarrierControlBarrierMovingStateCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBarrierControlBarrierSafetyStatusCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportBarrierControlBarrierCapabilitiesCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportBarrierControlBarrierPositionCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBarrierControlClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBasicInteractionModelVersionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicVendorNameCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBasicVendorIDCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicProductNameCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBasicProductIDCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicNodeLabelCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicLocationCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBasicHardwareVersionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicHardwareVersionStringCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportBasicSoftwareVersionCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicSoftwareVersionStringCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicManufacturingDateCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicPartNumberCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicProductURLCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicProductLabelCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBasicSerialNumberCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportBasicLocalConfigDisabledCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportBasicReachableCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBasicClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportBinaryInputBasicOutOfServiceCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportBinaryInputBasicPresentValueCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportBinaryInputBasicStatusFlagsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBinaryInputBasicClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBindingClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportBooleanStateStateValueCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBooleanStateClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportBridgedActionsSetupUrlCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBridgedActionsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportBridgedDeviceBasicClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlCurrentHueCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlCurrentSaturationCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlRemainingTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlCurrentXCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlCurrentYCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlDriftCompensationCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportColorControlCompensationTextCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorTemperatureCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorControlOptionsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlNumberOfPrimariesCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary1XCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary1YCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlPrimary1IntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary2XCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary2YCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlPrimary2IntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary3XCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary3YCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlPrimary3IntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary4XCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary4YCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlPrimary4IntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary5XCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary5YCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlPrimary5IntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary6XCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlPrimary6YCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlPrimary6IntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlWhitePointXCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlWhitePointYCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorPointRXCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorPointRYCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorPointRIntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorPointGXCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorPointGYCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorPointGIntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorPointBXCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorPointBYCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorPointBIntensityCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlEnhancedCurrentHueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlEnhancedColorModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorLoopActiveCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportColorControlColorLoopDirectionCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorLoopTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorLoopStartEnhancedHueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorLoopStoredEnhancedHueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorCapabilitiesCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorTempPhysicalMinCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlColorTempPhysicalMaxCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlCoupleColorTempToLevelMinMiredsCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlStartUpColorTemperatureMiredsCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportColorControlClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportContentLauncherClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportDescriptorClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportDoorLockActuatorEnabledCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportDoorLockClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportElectricalMeasurementMeasurementTypeCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32sAttributeCallback> * onReportElectricalMeasurementTotalActivePowerCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementRmsVoltageCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementRmsVoltageMinCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementRmsVoltageMaxCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementRmsCurrentCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementRmsCurrentMinCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementRmsCurrentMaxCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportElectricalMeasurementActivePowerCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportElectricalMeasurementActivePowerMinCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportElectricalMeasurementActivePowerMaxCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportElectricalMeasurementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportEthernetNetworkDiagnosticsPHYRateCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportEthernetNetworkDiagnosticsFullDuplexCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportEthernetNetworkDiagnosticsPacketRxCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportEthernetNetworkDiagnosticsPacketTxCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportEthernetNetworkDiagnosticsTxErrCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportEthernetNetworkDiagnosticsCollisionCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportEthernetNetworkDiagnosticsOverrunCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportEthernetNetworkDiagnosticsCarrierDetectCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportEthernetNetworkDiagnosticsTimeSinceResetCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportEthernetNetworkDiagnosticsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportFixedLabelClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportFlowMeasurementMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportFlowMeasurementMinMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportFlowMeasurementMaxMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportFlowMeasurementToleranceCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportFlowMeasurementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportGeneralCommissioningBreadcrumbCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportGeneralCommissioningClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportGeneralDiagnosticsRebootCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportGeneralDiagnosticsUpTimeCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportGeneralDiagnosticsTotalOperationalHoursCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportGeneralDiagnosticsBootReasonsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportGeneralDiagnosticsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportGroupKeyManagementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportGroupsNameSupportCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportGroupsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIdentifyIdentifyTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportIdentifyIdentifyTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIdentifyClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIlluminanceMeasurementMeasuredValueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIlluminanceMeasurementMinMeasuredValueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIlluminanceMeasurementMaxMeasuredValueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIlluminanceMeasurementToleranceCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportIlluminanceMeasurementLightSensorTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportIlluminanceMeasurementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportKeypadInputClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlCurrentLevelCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlRemainingTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlMinLevelCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlMaxLevelCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlCurrentFrequencyCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlMinFrequencyCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlMaxFrequencyCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlOptionsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlOnOffTransitionTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlOnLevelCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlOnTransitionTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlOffTransitionTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlDefaultMoveRateCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportLevelControlStartUpCurrentLevelCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLevelControlClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportLowPowerClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportMediaInputCurrentMediaInputCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportMediaInputClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportMediaPlaybackPlaybackStateCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackStartTimeCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackDurationCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackPositionUpdatedAtCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackPositionCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackPlaybackSpeedCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackSeekRangeEndCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportMediaPlaybackSeekRangeStartCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportMediaPlaybackClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportModeSelectCurrentModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportModeSelectOnModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportModeSelectStartUpModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportModeSelectDescriptionCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportModeSelectClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportNetworkCommissioningFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportNetworkCommissioningClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOtaSoftwareUpdateProviderClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportOtaSoftwareUpdateRequestorDefaultOtaProviderCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportOtaSoftwareUpdateRequestorUpdatePossibleCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOtaSoftwareUpdateRequestorClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOccupancySensingOccupancyCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOccupancySensingOccupancySensorTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOccupancySensingOccupancySensorTypeBitmapCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOccupancySensingClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportOnOffOnOffCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportOnOffGlobalSceneControlCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOnOffOnTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOnOffOffWaitTimeCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOnOffStartUpOnOffCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportOnOffFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOnOffClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOnOffSwitchConfigurationSwitchTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOnOffSwitchConfigurationSwitchActionsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOnOffSwitchConfigurationClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOperationalCredentialsSupportedFabricsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOperationalCredentialsCommissionedFabricsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportOperationalCredentialsCurrentFabricIndexCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportOperationalCredentialsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPowerSourceStatusCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPowerSourceOrderCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportPowerSourceDescriptionCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPowerSourceBatteryVoltageCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPowerSourceBatteryPercentRemainingCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPowerSourceBatteryTimeRemainingCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPowerSourceBatteryChargeLevelCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPowerSourceBatteryChargeStateCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPowerSourceFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPowerSourceClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPressureMeasurementMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPressureMeasurementMinMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPressureMeasurementMaxMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPressureMeasurementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMaxPressureCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlMaxSpeedCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlMaxFlowCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMinConstPressureCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMaxConstPressureCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMinCompPressureCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMaxCompPressureCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlMinConstSpeedCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlMaxConstSpeedCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlMinConstFlowCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlMaxConstFlowCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMinConstTempCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlMaxConstTempCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlPumpStatusCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPumpConfigurationAndControlEffectiveOperationModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPumpConfigurationAndControlEffectiveControlModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportPumpConfigurationAndControlCapacityCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlSpeedCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPumpConfigurationAndControlLifetimeRunningHoursCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPumpConfigurationAndControlPowerCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPumpConfigurationAndControlLifetimeEnergyConsumedCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPumpConfigurationAndControlOperationModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportPumpConfigurationAndControlControlModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlAlarmMaskCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportPumpConfigurationAndControlFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportPumpConfigurationAndControlClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportRelativeHumidityMeasurementMeasuredValueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportRelativeHumidityMeasurementMinMeasuredValueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportRelativeHumidityMeasurementMaxMeasuredValueCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportRelativeHumidityMeasurementToleranceCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportRelativeHumidityMeasurementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportScenesSceneCountCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportScenesCurrentSceneCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportScenesCurrentGroupCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportScenesSceneValidCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportScenesNameSupportCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportScenesClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportSoftwareDiagnosticsCurrentHeapFreeCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportSoftwareDiagnosticsCurrentHeapUsedCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportSoftwareDiagnosticsCurrentHeapHighWatermarkCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportSoftwareDiagnosticsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportSwitchNumberOfPositionsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportSwitchCurrentPositionCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportSwitchMultiPressMaxCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportSwitchFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportSwitchClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportTvChannelTvChannelLineupCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportTvChannelCurrentTvChannelCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTvChannelClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTargetNavigatorClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTemperatureMeasurementMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTemperatureMeasurementMinMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTemperatureMeasurementMaxMeasuredValueCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTemperatureMeasurementToleranceCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTemperatureMeasurementClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportTestClusterBooleanCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterBitmap8Callback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterBitmap16Callback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterBitmap32Callback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterBitmap64Callback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterInt8uCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterInt16uCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterInt24uCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterInt32uCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterInt40uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterInt48uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterInt56uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterInt64uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int8sAttributeCallback> * onReportTestClusterInt8sCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTestClusterInt16sCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int32sAttributeCallback> * onReportTestClusterInt24sCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<Int32sAttributeCallback> * onReportTestClusterInt32sCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterInt40sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterInt48sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterInt56sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterInt64sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterEnum8Callback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterEnum16Callback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<FloatAttributeCallback> * onReportTestClusterFloatSingleCallback =
-        new chip::Callback::Callback<FloatAttributeCallback>(OnFloatAttributeResponse, this);
-    chip::Callback::Callback<DoubleAttributeCallback> * onReportTestClusterFloatDoubleCallback =
-        new chip::Callback::Callback<DoubleAttributeCallback>(OnDoubleAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportTestClusterOctetStringCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportTestClusterLongOctetStringCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportTestClusterCharStringCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportTestClusterLongCharStringCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterEpochUsCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterEpochSCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterVendorIdCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterRangeRestrictedInt8uCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8sAttributeCallback> * onReportTestClusterRangeRestrictedInt8sCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterRangeRestrictedInt16uCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTestClusterRangeRestrictedInt16sCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportTestClusterUnsupportedCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<BooleanAttributeCallback> * onReportTestClusterNullableBooleanCallback =
-        new chip::Callback::Callback<BooleanAttributeCallback>(OnBooleanAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterNullableBitmap8Callback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterNullableBitmap16Callback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterNullableBitmap32Callback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterNullableBitmap64Callback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterNullableInt8uCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterNullableInt16uCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterNullableInt24uCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportTestClusterNullableInt32uCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterNullableInt40uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterNullableInt48uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterNullableInt56uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportTestClusterNullableInt64uCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int8sAttributeCallback> * onReportTestClusterNullableInt8sCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTestClusterNullableInt16sCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int32sAttributeCallback> * onReportTestClusterNullableInt24sCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<Int32sAttributeCallback> * onReportTestClusterNullableInt32sCallback =
-        new chip::Callback::Callback<Int32sAttributeCallback>(OnInt32sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterNullableInt40sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterNullableInt48sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterNullableInt56sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int64sAttributeCallback> * onReportTestClusterNullableInt64sCallback =
-        new chip::Callback::Callback<Int64sAttributeCallback>(OnInt64sAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterNullableEnum8Callback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterNullableEnum16Callback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<FloatAttributeCallback> * onReportTestClusterNullableFloatSingleCallback =
-        new chip::Callback::Callback<FloatAttributeCallback>(OnFloatAttributeResponse, this);
-    chip::Callback::Callback<DoubleAttributeCallback> * onReportTestClusterNullableFloatDoubleCallback =
-        new chip::Callback::Callback<DoubleAttributeCallback>(OnDoubleAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportTestClusterNullableOctetStringCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportTestClusterNullableCharStringCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportTestClusterNullableRangeRestrictedInt8uCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8sAttributeCallback> * onReportTestClusterNullableRangeRestrictedInt8sCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterNullableRangeRestrictedInt16uCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportTestClusterNullableRangeRestrictedInt16sCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportTestClusterClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatLocalTemperatureCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatAbsMinHeatSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatAbsMaxHeatSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatAbsMinCoolSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatAbsMaxCoolSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatOccupiedCoolingSetpointCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatOccupiedHeatingSetpointCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatMinHeatSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatMaxHeatSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatMinCoolSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int16sAttributeCallback> * onReportThermostatMaxCoolSetpointLimitCallback =
-        new chip::Callback::Callback<Int16sAttributeCallback>(OnInt16sAttributeResponse, this);
-    chip::Callback::Callback<Int8sAttributeCallback> * onReportThermostatMinSetpointDeadBandCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatControlSequenceOfOperationCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatSystemModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatStartOfWeekCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatNumberOfWeeklyTransitionsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatNumberOfDailyTransitionsCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThermostatFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThermostatClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatUserInterfaceConfigurationTemperatureDisplayModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThermostatUserInterfaceConfigurationKeypadLockoutCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> *
-        onReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCallback =
-            new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThermostatUserInterfaceConfigurationClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsChannelCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThreadNetworkDiagnosticsRoutingRoleCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportThreadNetworkDiagnosticsNetworkNameCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsPanIdCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportThreadNetworkDiagnosticsExtendedPanIdCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportThreadNetworkDiagnosticsMeshLocalPrefixCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportThreadNetworkDiagnosticsOverrunCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsPartitionIdCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThreadNetworkDiagnosticsWeightingCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThreadNetworkDiagnosticsDataVersionCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThreadNetworkDiagnosticsStableDataVersionCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportThreadNetworkDiagnosticsLeaderRouterIdCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsDetachedRoleCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsChildRoleCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsRouterRoleCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsLeaderRoleCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsAttachAttemptCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsPartitionIdChangeCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsParentChangeCountCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxTotalCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxUnicastCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxBroadcastCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxAckRequestedCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxAckedCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxNoAckRequestedCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxDataCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxDataPollCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxBeaconCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxBeaconRequestCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxOtherCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxRetryCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxErrCcaCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxErrAbortCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsTxErrBusyChannelCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxTotalCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxUnicastCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxBroadcastCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxDataCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxDataPollCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxBeaconCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxBeaconRequestCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxOtherCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxAddressFilteredCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxDestAddrFilteredCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxDuplicatedCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxErrNoFrameCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxErrUnknownNeighborCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxErrInvalidSrcAddrCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxErrSecCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxErrFcsCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsRxErrOtherCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportThreadNetworkDiagnosticsActiveTimestampCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportThreadNetworkDiagnosticsPendingTimestampCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportThreadNetworkDiagnosticsDelayCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportThreadNetworkDiagnosticsChannelMaskCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportThreadNetworkDiagnosticsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<CharStringAttributeCallback> * onReportWakeOnLanWakeOnLanMacAddressCallback =
-        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWakeOnLanClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<OctetStringAttributeCallback> * onReportWiFiNetworkDiagnosticsBssidCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWiFiNetworkDiagnosticsSecurityTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWiFiNetworkDiagnosticsWiFiVersionCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWiFiNetworkDiagnosticsChannelNumberCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8sAttributeCallback> * onReportWiFiNetworkDiagnosticsRssiCallback =
-        new chip::Callback::Callback<Int8sAttributeCallback>(OnInt8sAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWiFiNetworkDiagnosticsBeaconLostCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWiFiNetworkDiagnosticsBeaconRxCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWiFiNetworkDiagnosticsPacketMulticastRxCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWiFiNetworkDiagnosticsPacketMulticastTxCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWiFiNetworkDiagnosticsPacketUnicastRxCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWiFiNetworkDiagnosticsPacketUnicastTxCountCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportWiFiNetworkDiagnosticsCurrentMaxRateCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int64uAttributeCallback> * onReportWiFiNetworkDiagnosticsOverrunCountCallback =
-        new chip::Callback::Callback<Int64uAttributeCallback>(OnInt64uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWiFiNetworkDiagnosticsClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringCurrentPositionLiftCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringCurrentPositionTiltCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringConfigStatusCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringCurrentPositionLiftPercentageCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringCurrentPositionTiltPercentageCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringOperationalStatusCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringTargetPositionLiftPercent100thsCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringTargetPositionTiltPercent100thsCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringEndProductTypeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringCurrentPositionLiftPercent100thsCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringCurrentPositionTiltPercent100thsCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringInstalledOpenLimitLiftCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringInstalledClosedLimitLiftCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringInstalledOpenLimitTiltCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringInstalledClosedLimitTiltCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int8uAttributeCallback> * onReportWindowCoveringModeCallback =
-        new chip::Callback::Callback<Int8uAttributeCallback>(OnInt8uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringSafetyStatusCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
-    chip::Callback::Callback<Int32uAttributeCallback> * onReportWindowCoveringFeatureMapCallback =
-        new chip::Callback::Callback<Int32uAttributeCallback>(OnInt32uAttributeResponse, this);
-    chip::Callback::Callback<Int16uAttributeCallback> * onReportWindowCoveringClusterRevisionCallback =
-        new chip::Callback::Callback<Int16uAttributeCallback>(OnInt16uAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadAccountLoginClusterRevision::OnAttributeResponse)> *
+        onReportAccountLoginClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadAccountLoginClusterRevision::OnAttributeResponse)>(
+                ReadAccountLoginClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadAdministratorCommissioningClusterRevision::OnAttributeResponse)> *
+        onReportAdministratorCommissioningClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadAdministratorCommissioningClusterRevision::OnAttributeResponse)>(
+                ReadAdministratorCommissioningClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicVendorName::OnAttributeResponse)> *
+        onReportApplicationBasicVendorNameCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicVendorName::OnAttributeResponse)>(
+                ReadApplicationBasicVendorName::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicVendorId::OnAttributeResponse)> *
+        onReportApplicationBasicVendorIdCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicVendorId::OnAttributeResponse)>(
+                ReadApplicationBasicVendorId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicApplicationName::OnAttributeResponse)> *
+        onReportApplicationBasicApplicationNameCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicApplicationName::OnAttributeResponse)>(
+                ReadApplicationBasicApplicationName::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicProductId::OnAttributeResponse)> *
+        onReportApplicationBasicProductIdCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicProductId::OnAttributeResponse)>(
+                ReadApplicationBasicProductId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicApplicationId::OnAttributeResponse)> *
+        onReportApplicationBasicApplicationIdCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicApplicationId::OnAttributeResponse)>(
+                ReadApplicationBasicApplicationId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicCatalogVendorId::OnAttributeResponse)> *
+        onReportApplicationBasicCatalogVendorIdCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicCatalogVendorId::OnAttributeResponse)>(
+                ReadApplicationBasicCatalogVendorId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicApplicationStatus::OnAttributeResponse)> *
+        onReportApplicationBasicApplicationStatusCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicApplicationStatus::OnAttributeResponse)>(
+                ReadApplicationBasicApplicationStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationBasicClusterRevision::OnAttributeResponse)> *
+        onReportApplicationBasicClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationBasicClusterRevision::OnAttributeResponse)>(
+                ReadApplicationBasicClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationLauncherCatalogVendorId::OnAttributeResponse)> *
+        onReportApplicationLauncherCatalogVendorIdCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationLauncherCatalogVendorId::OnAttributeResponse)>(
+                ReadApplicationLauncherCatalogVendorId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationLauncherApplicationId::OnAttributeResponse)> *
+        onReportApplicationLauncherApplicationIdCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationLauncherApplicationId::OnAttributeResponse)>(
+                ReadApplicationLauncherApplicationId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadApplicationLauncherClusterRevision::OnAttributeResponse)> *
+        onReportApplicationLauncherClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadApplicationLauncherClusterRevision::OnAttributeResponse)>(
+                ReadApplicationLauncherClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadAudioOutputCurrentAudioOutput::OnAttributeResponse)> *
+        onReportAudioOutputCurrentAudioOutputCallback =
+            new chip::Callback::Callback<decltype(&ReadAudioOutputCurrentAudioOutput::OnAttributeResponse)>(
+                ReadAudioOutputCurrentAudioOutput::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadAudioOutputClusterRevision::OnAttributeResponse)> *
+        onReportAudioOutputClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadAudioOutputClusterRevision::OnAttributeResponse)>(
+                ReadAudioOutputClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBarrierControlBarrierMovingState::OnAttributeResponse)> *
+        onReportBarrierControlBarrierMovingStateCallback =
+            new chip::Callback::Callback<decltype(&ReadBarrierControlBarrierMovingState::OnAttributeResponse)>(
+                ReadBarrierControlBarrierMovingState::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBarrierControlBarrierSafetyStatus::OnAttributeResponse)> *
+        onReportBarrierControlBarrierSafetyStatusCallback =
+            new chip::Callback::Callback<decltype(&ReadBarrierControlBarrierSafetyStatus::OnAttributeResponse)>(
+                ReadBarrierControlBarrierSafetyStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBarrierControlBarrierCapabilities::OnAttributeResponse)> *
+        onReportBarrierControlBarrierCapabilitiesCallback =
+            new chip::Callback::Callback<decltype(&ReadBarrierControlBarrierCapabilities::OnAttributeResponse)>(
+                ReadBarrierControlBarrierCapabilities::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBarrierControlBarrierPosition::OnAttributeResponse)> *
+        onReportBarrierControlBarrierPositionCallback =
+            new chip::Callback::Callback<decltype(&ReadBarrierControlBarrierPosition::OnAttributeResponse)>(
+                ReadBarrierControlBarrierPosition::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBarrierControlClusterRevision::OnAttributeResponse)> *
+        onReportBarrierControlClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadBarrierControlClusterRevision::OnAttributeResponse)>(
+                ReadBarrierControlClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicInteractionModelVersion::OnAttributeResponse)> *
+        onReportBasicInteractionModelVersionCallback =
+            new chip::Callback::Callback<decltype(&ReadBasicInteractionModelVersion::OnAttributeResponse)>(
+                ReadBasicInteractionModelVersion::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicVendorName::OnAttributeResponse)> * onReportBasicVendorNameCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicVendorName::OnAttributeResponse)>(ReadBasicVendorName::OnAttributeResponse,
+                                                                                          this);
+    chip::Callback::Callback<decltype(&ReadBasicVendorID::OnAttributeResponse)> * onReportBasicVendorIDCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicVendorID::OnAttributeResponse)>(ReadBasicVendorID::OnAttributeResponse,
+                                                                                        this);
+    chip::Callback::Callback<decltype(&ReadBasicProductName::OnAttributeResponse)> * onReportBasicProductNameCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicProductName::OnAttributeResponse)>(
+            ReadBasicProductName::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicProductID::OnAttributeResponse)> * onReportBasicProductIDCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicProductID::OnAttributeResponse)>(ReadBasicProductID::OnAttributeResponse,
+                                                                                         this);
+    chip::Callback::Callback<decltype(&ReadBasicNodeLabel::OnAttributeResponse)> * onReportBasicNodeLabelCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicNodeLabel::OnAttributeResponse)>(ReadBasicNodeLabel::OnAttributeResponse,
+                                                                                         this);
+    chip::Callback::Callback<decltype(&ReadBasicLocation::OnAttributeResponse)> * onReportBasicLocationCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicLocation::OnAttributeResponse)>(ReadBasicLocation::OnAttributeResponse,
+                                                                                        this);
+    chip::Callback::Callback<decltype(&ReadBasicHardwareVersion::OnAttributeResponse)> * onReportBasicHardwareVersionCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicHardwareVersion::OnAttributeResponse)>(
+            ReadBasicHardwareVersion::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicHardwareVersionString::OnAttributeResponse)> *
+        onReportBasicHardwareVersionStringCallback =
+            new chip::Callback::Callback<decltype(&ReadBasicHardwareVersionString::OnAttributeResponse)>(
+                ReadBasicHardwareVersionString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicSoftwareVersion::OnAttributeResponse)> * onReportBasicSoftwareVersionCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicSoftwareVersion::OnAttributeResponse)>(
+            ReadBasicSoftwareVersion::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicSoftwareVersionString::OnAttributeResponse)> *
+        onReportBasicSoftwareVersionStringCallback =
+            new chip::Callback::Callback<decltype(&ReadBasicSoftwareVersionString::OnAttributeResponse)>(
+                ReadBasicSoftwareVersionString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicManufacturingDate::OnAttributeResponse)> * onReportBasicManufacturingDateCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicManufacturingDate::OnAttributeResponse)>(
+            ReadBasicManufacturingDate::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicPartNumber::OnAttributeResponse)> * onReportBasicPartNumberCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicPartNumber::OnAttributeResponse)>(ReadBasicPartNumber::OnAttributeResponse,
+                                                                                          this);
+    chip::Callback::Callback<decltype(&ReadBasicProductURL::OnAttributeResponse)> * onReportBasicProductURLCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicProductURL::OnAttributeResponse)>(ReadBasicProductURL::OnAttributeResponse,
+                                                                                          this);
+    chip::Callback::Callback<decltype(&ReadBasicProductLabel::OnAttributeResponse)> * onReportBasicProductLabelCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicProductLabel::OnAttributeResponse)>(
+            ReadBasicProductLabel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicSerialNumber::OnAttributeResponse)> * onReportBasicSerialNumberCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicSerialNumber::OnAttributeResponse)>(
+            ReadBasicSerialNumber::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicLocalConfigDisabled::OnAttributeResponse)> *
+        onReportBasicLocalConfigDisabledCallback =
+            new chip::Callback::Callback<decltype(&ReadBasicLocalConfigDisabled::OnAttributeResponse)>(
+                ReadBasicLocalConfigDisabled::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBasicReachable::OnAttributeResponse)> * onReportBasicReachableCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicReachable::OnAttributeResponse)>(ReadBasicReachable::OnAttributeResponse,
+                                                                                         this);
+    chip::Callback::Callback<decltype(&ReadBasicClusterRevision::OnAttributeResponse)> * onReportBasicClusterRevisionCallback =
+        new chip::Callback::Callback<decltype(&ReadBasicClusterRevision::OnAttributeResponse)>(
+            ReadBasicClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBinaryInputBasicOutOfService::OnAttributeResponse)> *
+        onReportBinaryInputBasicOutOfServiceCallback =
+            new chip::Callback::Callback<decltype(&ReadBinaryInputBasicOutOfService::OnAttributeResponse)>(
+                ReadBinaryInputBasicOutOfService::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBinaryInputBasicPresentValue::OnAttributeResponse)> *
+        onReportBinaryInputBasicPresentValueCallback =
+            new chip::Callback::Callback<decltype(&ReadBinaryInputBasicPresentValue::OnAttributeResponse)>(
+                ReadBinaryInputBasicPresentValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBinaryInputBasicStatusFlags::OnAttributeResponse)> *
+        onReportBinaryInputBasicStatusFlagsCallback =
+            new chip::Callback::Callback<decltype(&ReadBinaryInputBasicStatusFlags::OnAttributeResponse)>(
+                ReadBinaryInputBasicStatusFlags::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBinaryInputBasicClusterRevision::OnAttributeResponse)> *
+        onReportBinaryInputBasicClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadBinaryInputBasicClusterRevision::OnAttributeResponse)>(
+                ReadBinaryInputBasicClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBindingClusterRevision::OnAttributeResponse)> * onReportBindingClusterRevisionCallback =
+        new chip::Callback::Callback<decltype(&ReadBindingClusterRevision::OnAttributeResponse)>(
+            ReadBindingClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBooleanStateStateValue::OnAttributeResponse)> * onReportBooleanStateStateValueCallback =
+        new chip::Callback::Callback<decltype(&ReadBooleanStateStateValue::OnAttributeResponse)>(
+            ReadBooleanStateStateValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBooleanStateClusterRevision::OnAttributeResponse)> *
+        onReportBooleanStateClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadBooleanStateClusterRevision::OnAttributeResponse)>(
+                ReadBooleanStateClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBridgedActionsSetupUrl::OnAttributeResponse)> * onReportBridgedActionsSetupUrlCallback =
+        new chip::Callback::Callback<decltype(&ReadBridgedActionsSetupUrl::OnAttributeResponse)>(
+            ReadBridgedActionsSetupUrl::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBridgedActionsClusterRevision::OnAttributeResponse)> *
+        onReportBridgedActionsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadBridgedActionsClusterRevision::OnAttributeResponse)>(
+                ReadBridgedActionsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadBridgedDeviceBasicClusterRevision::OnAttributeResponse)> *
+        onReportBridgedDeviceBasicClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadBridgedDeviceBasicClusterRevision::OnAttributeResponse)>(
+                ReadBridgedDeviceBasicClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlCurrentHue::OnAttributeResponse)> * onReportColorControlCurrentHueCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlCurrentHue::OnAttributeResponse)>(
+            ReadColorControlCurrentHue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlCurrentSaturation::OnAttributeResponse)> *
+        onReportColorControlCurrentSaturationCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlCurrentSaturation::OnAttributeResponse)>(
+                ReadColorControlCurrentSaturation::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlRemainingTime::OnAttributeResponse)> *
+        onReportColorControlRemainingTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlRemainingTime::OnAttributeResponse)>(
+                ReadColorControlRemainingTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlCurrentX::OnAttributeResponse)> * onReportColorControlCurrentXCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlCurrentX::OnAttributeResponse)>(
+            ReadColorControlCurrentX::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlCurrentY::OnAttributeResponse)> * onReportColorControlCurrentYCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlCurrentY::OnAttributeResponse)>(
+            ReadColorControlCurrentY::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlDriftCompensation::OnAttributeResponse)> *
+        onReportColorControlDriftCompensationCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlDriftCompensation::OnAttributeResponse)>(
+                ReadColorControlDriftCompensation::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlCompensationText::OnAttributeResponse)> *
+        onReportColorControlCompensationTextCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlCompensationText::OnAttributeResponse)>(
+                ReadColorControlCompensationText::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorTemperature::OnAttributeResponse)> *
+        onReportColorControlColorTemperatureCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorTemperature::OnAttributeResponse)>(
+                ReadColorControlColorTemperature::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorMode::OnAttributeResponse)> * onReportColorControlColorModeCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlColorMode::OnAttributeResponse)>(
+            ReadColorControlColorMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorControlOptions::OnAttributeResponse)> *
+        onReportColorControlColorControlOptionsCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorControlOptions::OnAttributeResponse)>(
+                ReadColorControlColorControlOptions::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlNumberOfPrimaries::OnAttributeResponse)> *
+        onReportColorControlNumberOfPrimariesCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlNumberOfPrimaries::OnAttributeResponse)>(
+                ReadColorControlNumberOfPrimaries::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary1X::OnAttributeResponse)> * onReportColorControlPrimary1XCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary1X::OnAttributeResponse)>(
+            ReadColorControlPrimary1X::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary1Y::OnAttributeResponse)> * onReportColorControlPrimary1YCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary1Y::OnAttributeResponse)>(
+            ReadColorControlPrimary1Y::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary1Intensity::OnAttributeResponse)> *
+        onReportColorControlPrimary1IntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlPrimary1Intensity::OnAttributeResponse)>(
+                ReadColorControlPrimary1Intensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary2X::OnAttributeResponse)> * onReportColorControlPrimary2XCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary2X::OnAttributeResponse)>(
+            ReadColorControlPrimary2X::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary2Y::OnAttributeResponse)> * onReportColorControlPrimary2YCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary2Y::OnAttributeResponse)>(
+            ReadColorControlPrimary2Y::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary2Intensity::OnAttributeResponse)> *
+        onReportColorControlPrimary2IntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlPrimary2Intensity::OnAttributeResponse)>(
+                ReadColorControlPrimary2Intensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary3X::OnAttributeResponse)> * onReportColorControlPrimary3XCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary3X::OnAttributeResponse)>(
+            ReadColorControlPrimary3X::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary3Y::OnAttributeResponse)> * onReportColorControlPrimary3YCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary3Y::OnAttributeResponse)>(
+            ReadColorControlPrimary3Y::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary3Intensity::OnAttributeResponse)> *
+        onReportColorControlPrimary3IntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlPrimary3Intensity::OnAttributeResponse)>(
+                ReadColorControlPrimary3Intensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary4X::OnAttributeResponse)> * onReportColorControlPrimary4XCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary4X::OnAttributeResponse)>(
+            ReadColorControlPrimary4X::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary4Y::OnAttributeResponse)> * onReportColorControlPrimary4YCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary4Y::OnAttributeResponse)>(
+            ReadColorControlPrimary4Y::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary4Intensity::OnAttributeResponse)> *
+        onReportColorControlPrimary4IntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlPrimary4Intensity::OnAttributeResponse)>(
+                ReadColorControlPrimary4Intensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary5X::OnAttributeResponse)> * onReportColorControlPrimary5XCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary5X::OnAttributeResponse)>(
+            ReadColorControlPrimary5X::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary5Y::OnAttributeResponse)> * onReportColorControlPrimary5YCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary5Y::OnAttributeResponse)>(
+            ReadColorControlPrimary5Y::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary5Intensity::OnAttributeResponse)> *
+        onReportColorControlPrimary5IntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlPrimary5Intensity::OnAttributeResponse)>(
+                ReadColorControlPrimary5Intensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary6X::OnAttributeResponse)> * onReportColorControlPrimary6XCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary6X::OnAttributeResponse)>(
+            ReadColorControlPrimary6X::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary6Y::OnAttributeResponse)> * onReportColorControlPrimary6YCallback =
+        new chip::Callback::Callback<decltype(&ReadColorControlPrimary6Y::OnAttributeResponse)>(
+            ReadColorControlPrimary6Y::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlPrimary6Intensity::OnAttributeResponse)> *
+        onReportColorControlPrimary6IntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlPrimary6Intensity::OnAttributeResponse)>(
+                ReadColorControlPrimary6Intensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlWhitePointX::OnAttributeResponse)> *
+        onReportColorControlWhitePointXCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlWhitePointX::OnAttributeResponse)>(
+                ReadColorControlWhitePointX::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlWhitePointY::OnAttributeResponse)> *
+        onReportColorControlWhitePointYCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlWhitePointY::OnAttributeResponse)>(
+                ReadColorControlWhitePointY::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointRX::OnAttributeResponse)> *
+        onReportColorControlColorPointRXCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointRX::OnAttributeResponse)>(
+                ReadColorControlColorPointRX::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointRY::OnAttributeResponse)> *
+        onReportColorControlColorPointRYCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointRY::OnAttributeResponse)>(
+                ReadColorControlColorPointRY::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointRIntensity::OnAttributeResponse)> *
+        onReportColorControlColorPointRIntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointRIntensity::OnAttributeResponse)>(
+                ReadColorControlColorPointRIntensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointGX::OnAttributeResponse)> *
+        onReportColorControlColorPointGXCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointGX::OnAttributeResponse)>(
+                ReadColorControlColorPointGX::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointGY::OnAttributeResponse)> *
+        onReportColorControlColorPointGYCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointGY::OnAttributeResponse)>(
+                ReadColorControlColorPointGY::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointGIntensity::OnAttributeResponse)> *
+        onReportColorControlColorPointGIntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointGIntensity::OnAttributeResponse)>(
+                ReadColorControlColorPointGIntensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointBX::OnAttributeResponse)> *
+        onReportColorControlColorPointBXCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointBX::OnAttributeResponse)>(
+                ReadColorControlColorPointBX::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointBY::OnAttributeResponse)> *
+        onReportColorControlColorPointBYCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointBY::OnAttributeResponse)>(
+                ReadColorControlColorPointBY::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorPointBIntensity::OnAttributeResponse)> *
+        onReportColorControlColorPointBIntensityCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorPointBIntensity::OnAttributeResponse)>(
+                ReadColorControlColorPointBIntensity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlEnhancedCurrentHue::OnAttributeResponse)> *
+        onReportColorControlEnhancedCurrentHueCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlEnhancedCurrentHue::OnAttributeResponse)>(
+                ReadColorControlEnhancedCurrentHue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlEnhancedColorMode::OnAttributeResponse)> *
+        onReportColorControlEnhancedColorModeCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlEnhancedColorMode::OnAttributeResponse)>(
+                ReadColorControlEnhancedColorMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorLoopActive::OnAttributeResponse)> *
+        onReportColorControlColorLoopActiveCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorLoopActive::OnAttributeResponse)>(
+                ReadColorControlColorLoopActive::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorLoopDirection::OnAttributeResponse)> *
+        onReportColorControlColorLoopDirectionCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorLoopDirection::OnAttributeResponse)>(
+                ReadColorControlColorLoopDirection::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorLoopTime::OnAttributeResponse)> *
+        onReportColorControlColorLoopTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorLoopTime::OnAttributeResponse)>(
+                ReadColorControlColorLoopTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorLoopStartEnhancedHue::OnAttributeResponse)> *
+        onReportColorControlColorLoopStartEnhancedHueCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorLoopStartEnhancedHue::OnAttributeResponse)>(
+                ReadColorControlColorLoopStartEnhancedHue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorLoopStoredEnhancedHue::OnAttributeResponse)> *
+        onReportColorControlColorLoopStoredEnhancedHueCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorLoopStoredEnhancedHue::OnAttributeResponse)>(
+                ReadColorControlColorLoopStoredEnhancedHue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorCapabilities::OnAttributeResponse)> *
+        onReportColorControlColorCapabilitiesCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorCapabilities::OnAttributeResponse)>(
+                ReadColorControlColorCapabilities::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorTempPhysicalMin::OnAttributeResponse)> *
+        onReportColorControlColorTempPhysicalMinCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorTempPhysicalMin::OnAttributeResponse)>(
+                ReadColorControlColorTempPhysicalMin::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlColorTempPhysicalMax::OnAttributeResponse)> *
+        onReportColorControlColorTempPhysicalMaxCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlColorTempPhysicalMax::OnAttributeResponse)>(
+                ReadColorControlColorTempPhysicalMax::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlCoupleColorTempToLevelMinMireds::OnAttributeResponse)> *
+        onReportColorControlCoupleColorTempToLevelMinMiredsCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlCoupleColorTempToLevelMinMireds::OnAttributeResponse)>(
+                ReadColorControlCoupleColorTempToLevelMinMireds::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlStartUpColorTemperatureMireds::OnAttributeResponse)> *
+        onReportColorControlStartUpColorTemperatureMiredsCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlStartUpColorTemperatureMireds::OnAttributeResponse)>(
+                ReadColorControlStartUpColorTemperatureMireds::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadColorControlClusterRevision::OnAttributeResponse)> *
+        onReportColorControlClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadColorControlClusterRevision::OnAttributeResponse)>(
+                ReadColorControlClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadContentLauncherClusterRevision::OnAttributeResponse)> *
+        onReportContentLauncherClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadContentLauncherClusterRevision::OnAttributeResponse)>(
+                ReadContentLauncherClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadDescriptorClusterRevision::OnAttributeResponse)> *
+        onReportDescriptorClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadDescriptorClusterRevision::OnAttributeResponse)>(
+                ReadDescriptorClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadDoorLockActuatorEnabled::OnAttributeResponse)> *
+        onReportDoorLockActuatorEnabledCallback =
+            new chip::Callback::Callback<decltype(&ReadDoorLockActuatorEnabled::OnAttributeResponse)>(
+                ReadDoorLockActuatorEnabled::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadDoorLockClusterRevision::OnAttributeResponse)> *
+        onReportDoorLockClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadDoorLockClusterRevision::OnAttributeResponse)>(
+                ReadDoorLockClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementMeasurementType::OnAttributeResponse)> *
+        onReportElectricalMeasurementMeasurementTypeCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementMeasurementType::OnAttributeResponse)>(
+                ReadElectricalMeasurementMeasurementType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementTotalActivePower::OnAttributeResponse)> *
+        onReportElectricalMeasurementTotalActivePowerCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementTotalActivePower::OnAttributeResponse)>(
+                ReadElectricalMeasurementTotalActivePower::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsVoltage::OnAttributeResponse)> *
+        onReportElectricalMeasurementRmsVoltageCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsVoltage::OnAttributeResponse)>(
+                ReadElectricalMeasurementRmsVoltage::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsVoltageMin::OnAttributeResponse)> *
+        onReportElectricalMeasurementRmsVoltageMinCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsVoltageMin::OnAttributeResponse)>(
+                ReadElectricalMeasurementRmsVoltageMin::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsVoltageMax::OnAttributeResponse)> *
+        onReportElectricalMeasurementRmsVoltageMaxCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsVoltageMax::OnAttributeResponse)>(
+                ReadElectricalMeasurementRmsVoltageMax::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsCurrent::OnAttributeResponse)> *
+        onReportElectricalMeasurementRmsCurrentCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsCurrent::OnAttributeResponse)>(
+                ReadElectricalMeasurementRmsCurrent::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsCurrentMin::OnAttributeResponse)> *
+        onReportElectricalMeasurementRmsCurrentMinCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsCurrentMin::OnAttributeResponse)>(
+                ReadElectricalMeasurementRmsCurrentMin::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsCurrentMax::OnAttributeResponse)> *
+        onReportElectricalMeasurementRmsCurrentMaxCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementRmsCurrentMax::OnAttributeResponse)>(
+                ReadElectricalMeasurementRmsCurrentMax::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementActivePower::OnAttributeResponse)> *
+        onReportElectricalMeasurementActivePowerCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementActivePower::OnAttributeResponse)>(
+                ReadElectricalMeasurementActivePower::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementActivePowerMin::OnAttributeResponse)> *
+        onReportElectricalMeasurementActivePowerMinCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementActivePowerMin::OnAttributeResponse)>(
+                ReadElectricalMeasurementActivePowerMin::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementActivePowerMax::OnAttributeResponse)> *
+        onReportElectricalMeasurementActivePowerMaxCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementActivePowerMax::OnAttributeResponse)>(
+                ReadElectricalMeasurementActivePowerMax::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadElectricalMeasurementClusterRevision::OnAttributeResponse)> *
+        onReportElectricalMeasurementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadElectricalMeasurementClusterRevision::OnAttributeResponse)>(
+                ReadElectricalMeasurementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsPHYRate::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsPHYRateCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsPHYRate::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsPHYRate::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsFullDuplex::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsFullDuplexCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsFullDuplex::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsFullDuplex::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsPacketRxCount::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsPacketRxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsPacketRxCount::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsPacketRxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsPacketTxCount::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsPacketTxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsPacketTxCount::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsPacketTxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsTxErrCount::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsTxErrCountCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsTxErrCount::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsTxErrCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsCollisionCount::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsCollisionCountCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsCollisionCount::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsCollisionCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsOverrunCount::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsOverrunCountCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsOverrunCount::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsOverrunCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsCarrierDetect::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsCarrierDetectCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsCarrierDetect::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsCarrierDetect::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsTimeSinceReset::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsTimeSinceResetCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsTimeSinceReset::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsTimeSinceReset::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsClusterRevision::OnAttributeResponse)> *
+        onReportEthernetNetworkDiagnosticsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadEthernetNetworkDiagnosticsClusterRevision::OnAttributeResponse)>(
+                ReadEthernetNetworkDiagnosticsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadFixedLabelClusterRevision::OnAttributeResponse)> *
+        onReportFixedLabelClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadFixedLabelClusterRevision::OnAttributeResponse)>(
+                ReadFixedLabelClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadFlowMeasurementMeasuredValue::OnAttributeResponse)> *
+        onReportFlowMeasurementMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadFlowMeasurementMeasuredValue::OnAttributeResponse)>(
+                ReadFlowMeasurementMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadFlowMeasurementMinMeasuredValue::OnAttributeResponse)> *
+        onReportFlowMeasurementMinMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadFlowMeasurementMinMeasuredValue::OnAttributeResponse)>(
+                ReadFlowMeasurementMinMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadFlowMeasurementMaxMeasuredValue::OnAttributeResponse)> *
+        onReportFlowMeasurementMaxMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadFlowMeasurementMaxMeasuredValue::OnAttributeResponse)>(
+                ReadFlowMeasurementMaxMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadFlowMeasurementTolerance::OnAttributeResponse)> *
+        onReportFlowMeasurementToleranceCallback =
+            new chip::Callback::Callback<decltype(&ReadFlowMeasurementTolerance::OnAttributeResponse)>(
+                ReadFlowMeasurementTolerance::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadFlowMeasurementClusterRevision::OnAttributeResponse)> *
+        onReportFlowMeasurementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadFlowMeasurementClusterRevision::OnAttributeResponse)>(
+                ReadFlowMeasurementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralCommissioningBreadcrumb::OnAttributeResponse)> *
+        onReportGeneralCommissioningBreadcrumbCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralCommissioningBreadcrumb::OnAttributeResponse)>(
+                ReadGeneralCommissioningBreadcrumb::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralCommissioningClusterRevision::OnAttributeResponse)> *
+        onReportGeneralCommissioningClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralCommissioningClusterRevision::OnAttributeResponse)>(
+                ReadGeneralCommissioningClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsRebootCount::OnAttributeResponse)> *
+        onReportGeneralDiagnosticsRebootCountCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsRebootCount::OnAttributeResponse)>(
+                ReadGeneralDiagnosticsRebootCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsUpTime::OnAttributeResponse)> *
+        onReportGeneralDiagnosticsUpTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsUpTime::OnAttributeResponse)>(
+                ReadGeneralDiagnosticsUpTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsTotalOperationalHours::OnAttributeResponse)> *
+        onReportGeneralDiagnosticsTotalOperationalHoursCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsTotalOperationalHours::OnAttributeResponse)>(
+                ReadGeneralDiagnosticsTotalOperationalHours::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsBootReasons::OnAttributeResponse)> *
+        onReportGeneralDiagnosticsBootReasonsCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsBootReasons::OnAttributeResponse)>(
+                ReadGeneralDiagnosticsBootReasons::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsClusterRevision::OnAttributeResponse)> *
+        onReportGeneralDiagnosticsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadGeneralDiagnosticsClusterRevision::OnAttributeResponse)>(
+                ReadGeneralDiagnosticsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGroupKeyManagementClusterRevision::OnAttributeResponse)> *
+        onReportGroupKeyManagementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadGroupKeyManagementClusterRevision::OnAttributeResponse)>(
+                ReadGroupKeyManagementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGroupsNameSupport::OnAttributeResponse)> * onReportGroupsNameSupportCallback =
+        new chip::Callback::Callback<decltype(&ReadGroupsNameSupport::OnAttributeResponse)>(
+            ReadGroupsNameSupport::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadGroupsClusterRevision::OnAttributeResponse)> * onReportGroupsClusterRevisionCallback =
+        new chip::Callback::Callback<decltype(&ReadGroupsClusterRevision::OnAttributeResponse)>(
+            ReadGroupsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIdentifyIdentifyTime::OnAttributeResponse)> * onReportIdentifyIdentifyTimeCallback =
+        new chip::Callback::Callback<decltype(&ReadIdentifyIdentifyTime::OnAttributeResponse)>(
+            ReadIdentifyIdentifyTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIdentifyIdentifyType::OnAttributeResponse)> * onReportIdentifyIdentifyTypeCallback =
+        new chip::Callback::Callback<decltype(&ReadIdentifyIdentifyType::OnAttributeResponse)>(
+            ReadIdentifyIdentifyType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIdentifyClusterRevision::OnAttributeResponse)> *
+        onReportIdentifyClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadIdentifyClusterRevision::OnAttributeResponse)>(
+                ReadIdentifyClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementMeasuredValue::OnAttributeResponse)> *
+        onReportIlluminanceMeasurementMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementMeasuredValue::OnAttributeResponse)>(
+                ReadIlluminanceMeasurementMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementMinMeasuredValue::OnAttributeResponse)> *
+        onReportIlluminanceMeasurementMinMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementMinMeasuredValue::OnAttributeResponse)>(
+                ReadIlluminanceMeasurementMinMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementMaxMeasuredValue::OnAttributeResponse)> *
+        onReportIlluminanceMeasurementMaxMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementMaxMeasuredValue::OnAttributeResponse)>(
+                ReadIlluminanceMeasurementMaxMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementTolerance::OnAttributeResponse)> *
+        onReportIlluminanceMeasurementToleranceCallback =
+            new chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementTolerance::OnAttributeResponse)>(
+                ReadIlluminanceMeasurementTolerance::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementLightSensorType::OnAttributeResponse)> *
+        onReportIlluminanceMeasurementLightSensorTypeCallback =
+            new chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementLightSensorType::OnAttributeResponse)>(
+                ReadIlluminanceMeasurementLightSensorType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementClusterRevision::OnAttributeResponse)> *
+        onReportIlluminanceMeasurementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadIlluminanceMeasurementClusterRevision::OnAttributeResponse)>(
+                ReadIlluminanceMeasurementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadKeypadInputClusterRevision::OnAttributeResponse)> *
+        onReportKeypadInputClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadKeypadInputClusterRevision::OnAttributeResponse)>(
+                ReadKeypadInputClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlCurrentLevel::OnAttributeResponse)> *
+        onReportLevelControlCurrentLevelCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlCurrentLevel::OnAttributeResponse)>(
+                ReadLevelControlCurrentLevel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlRemainingTime::OnAttributeResponse)> *
+        onReportLevelControlRemainingTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlRemainingTime::OnAttributeResponse)>(
+                ReadLevelControlRemainingTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlMinLevel::OnAttributeResponse)> * onReportLevelControlMinLevelCallback =
+        new chip::Callback::Callback<decltype(&ReadLevelControlMinLevel::OnAttributeResponse)>(
+            ReadLevelControlMinLevel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlMaxLevel::OnAttributeResponse)> * onReportLevelControlMaxLevelCallback =
+        new chip::Callback::Callback<decltype(&ReadLevelControlMaxLevel::OnAttributeResponse)>(
+            ReadLevelControlMaxLevel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlCurrentFrequency::OnAttributeResponse)> *
+        onReportLevelControlCurrentFrequencyCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlCurrentFrequency::OnAttributeResponse)>(
+                ReadLevelControlCurrentFrequency::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlMinFrequency::OnAttributeResponse)> *
+        onReportLevelControlMinFrequencyCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlMinFrequency::OnAttributeResponse)>(
+                ReadLevelControlMinFrequency::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlMaxFrequency::OnAttributeResponse)> *
+        onReportLevelControlMaxFrequencyCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlMaxFrequency::OnAttributeResponse)>(
+                ReadLevelControlMaxFrequency::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlOptions::OnAttributeResponse)> * onReportLevelControlOptionsCallback =
+        new chip::Callback::Callback<decltype(&ReadLevelControlOptions::OnAttributeResponse)>(
+            ReadLevelControlOptions::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlOnOffTransitionTime::OnAttributeResponse)> *
+        onReportLevelControlOnOffTransitionTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlOnOffTransitionTime::OnAttributeResponse)>(
+                ReadLevelControlOnOffTransitionTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlOnLevel::OnAttributeResponse)> * onReportLevelControlOnLevelCallback =
+        new chip::Callback::Callback<decltype(&ReadLevelControlOnLevel::OnAttributeResponse)>(
+            ReadLevelControlOnLevel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlOnTransitionTime::OnAttributeResponse)> *
+        onReportLevelControlOnTransitionTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlOnTransitionTime::OnAttributeResponse)>(
+                ReadLevelControlOnTransitionTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlOffTransitionTime::OnAttributeResponse)> *
+        onReportLevelControlOffTransitionTimeCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlOffTransitionTime::OnAttributeResponse)>(
+                ReadLevelControlOffTransitionTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlDefaultMoveRate::OnAttributeResponse)> *
+        onReportLevelControlDefaultMoveRateCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlDefaultMoveRate::OnAttributeResponse)>(
+                ReadLevelControlDefaultMoveRate::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlStartUpCurrentLevel::OnAttributeResponse)> *
+        onReportLevelControlStartUpCurrentLevelCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlStartUpCurrentLevel::OnAttributeResponse)>(
+                ReadLevelControlStartUpCurrentLevel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLevelControlClusterRevision::OnAttributeResponse)> *
+        onReportLevelControlClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadLevelControlClusterRevision::OnAttributeResponse)>(
+                ReadLevelControlClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadLowPowerClusterRevision::OnAttributeResponse)> *
+        onReportLowPowerClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadLowPowerClusterRevision::OnAttributeResponse)>(
+                ReadLowPowerClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaInputCurrentMediaInput::OnAttributeResponse)> *
+        onReportMediaInputCurrentMediaInputCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaInputCurrentMediaInput::OnAttributeResponse)>(
+                ReadMediaInputCurrentMediaInput::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaInputClusterRevision::OnAttributeResponse)> *
+        onReportMediaInputClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaInputClusterRevision::OnAttributeResponse)>(
+                ReadMediaInputClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackPlaybackState::OnAttributeResponse)> *
+        onReportMediaPlaybackPlaybackStateCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaPlaybackPlaybackState::OnAttributeResponse)>(
+                ReadMediaPlaybackPlaybackState::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackStartTime::OnAttributeResponse)> * onReportMediaPlaybackStartTimeCallback =
+        new chip::Callback::Callback<decltype(&ReadMediaPlaybackStartTime::OnAttributeResponse)>(
+            ReadMediaPlaybackStartTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackDuration::OnAttributeResponse)> * onReportMediaPlaybackDurationCallback =
+        new chip::Callback::Callback<decltype(&ReadMediaPlaybackDuration::OnAttributeResponse)>(
+            ReadMediaPlaybackDuration::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackPositionUpdatedAt::OnAttributeResponse)> *
+        onReportMediaPlaybackPositionUpdatedAtCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaPlaybackPositionUpdatedAt::OnAttributeResponse)>(
+                ReadMediaPlaybackPositionUpdatedAt::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackPosition::OnAttributeResponse)> * onReportMediaPlaybackPositionCallback =
+        new chip::Callback::Callback<decltype(&ReadMediaPlaybackPosition::OnAttributeResponse)>(
+            ReadMediaPlaybackPosition::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackPlaybackSpeed::OnAttributeResponse)> *
+        onReportMediaPlaybackPlaybackSpeedCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaPlaybackPlaybackSpeed::OnAttributeResponse)>(
+                ReadMediaPlaybackPlaybackSpeed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackSeekRangeEnd::OnAttributeResponse)> *
+        onReportMediaPlaybackSeekRangeEndCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaPlaybackSeekRangeEnd::OnAttributeResponse)>(
+                ReadMediaPlaybackSeekRangeEnd::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackSeekRangeStart::OnAttributeResponse)> *
+        onReportMediaPlaybackSeekRangeStartCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaPlaybackSeekRangeStart::OnAttributeResponse)>(
+                ReadMediaPlaybackSeekRangeStart::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadMediaPlaybackClusterRevision::OnAttributeResponse)> *
+        onReportMediaPlaybackClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadMediaPlaybackClusterRevision::OnAttributeResponse)>(
+                ReadMediaPlaybackClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadModeSelectCurrentMode::OnAttributeResponse)> * onReportModeSelectCurrentModeCallback =
+        new chip::Callback::Callback<decltype(&ReadModeSelectCurrentMode::OnAttributeResponse)>(
+            ReadModeSelectCurrentMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadModeSelectOnMode::OnAttributeResponse)> * onReportModeSelectOnModeCallback =
+        new chip::Callback::Callback<decltype(&ReadModeSelectOnMode::OnAttributeResponse)>(
+            ReadModeSelectOnMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadModeSelectStartUpMode::OnAttributeResponse)> * onReportModeSelectStartUpModeCallback =
+        new chip::Callback::Callback<decltype(&ReadModeSelectStartUpMode::OnAttributeResponse)>(
+            ReadModeSelectStartUpMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadModeSelectDescription::OnAttributeResponse)> * onReportModeSelectDescriptionCallback =
+        new chip::Callback::Callback<decltype(&ReadModeSelectDescription::OnAttributeResponse)>(
+            ReadModeSelectDescription::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadModeSelectClusterRevision::OnAttributeResponse)> *
+        onReportModeSelectClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadModeSelectClusterRevision::OnAttributeResponse)>(
+                ReadModeSelectClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadNetworkCommissioningFeatureMap::OnAttributeResponse)> *
+        onReportNetworkCommissioningFeatureMapCallback =
+            new chip::Callback::Callback<decltype(&ReadNetworkCommissioningFeatureMap::OnAttributeResponse)>(
+                ReadNetworkCommissioningFeatureMap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadNetworkCommissioningClusterRevision::OnAttributeResponse)> *
+        onReportNetworkCommissioningClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadNetworkCommissioningClusterRevision::OnAttributeResponse)>(
+                ReadNetworkCommissioningClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateProviderClusterRevision::OnAttributeResponse)> *
+        onReportOtaSoftwareUpdateProviderClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateProviderClusterRevision::OnAttributeResponse)>(
+                ReadOtaSoftwareUpdateProviderClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateRequestorDefaultOtaProvider::OnAttributeResponse)> *
+        onReportOtaSoftwareUpdateRequestorDefaultOtaProviderCallback =
+            new chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateRequestorDefaultOtaProvider::OnAttributeResponse)>(
+                ReadOtaSoftwareUpdateRequestorDefaultOtaProvider::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateRequestorUpdatePossible::OnAttributeResponse)> *
+        onReportOtaSoftwareUpdateRequestorUpdatePossibleCallback =
+            new chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateRequestorUpdatePossible::OnAttributeResponse)>(
+                ReadOtaSoftwareUpdateRequestorUpdatePossible::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateRequestorClusterRevision::OnAttributeResponse)> *
+        onReportOtaSoftwareUpdateRequestorClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadOtaSoftwareUpdateRequestorClusterRevision::OnAttributeResponse)>(
+                ReadOtaSoftwareUpdateRequestorClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOccupancySensingOccupancy::OnAttributeResponse)> *
+        onReportOccupancySensingOccupancyCallback =
+            new chip::Callback::Callback<decltype(&ReadOccupancySensingOccupancy::OnAttributeResponse)>(
+                ReadOccupancySensingOccupancy::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOccupancySensingOccupancySensorType::OnAttributeResponse)> *
+        onReportOccupancySensingOccupancySensorTypeCallback =
+            new chip::Callback::Callback<decltype(&ReadOccupancySensingOccupancySensorType::OnAttributeResponse)>(
+                ReadOccupancySensingOccupancySensorType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOccupancySensingOccupancySensorTypeBitmap::OnAttributeResponse)> *
+        onReportOccupancySensingOccupancySensorTypeBitmapCallback =
+            new chip::Callback::Callback<decltype(&ReadOccupancySensingOccupancySensorTypeBitmap::OnAttributeResponse)>(
+                ReadOccupancySensingOccupancySensorTypeBitmap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOccupancySensingClusterRevision::OnAttributeResponse)> *
+        onReportOccupancySensingClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadOccupancySensingClusterRevision::OnAttributeResponse)>(
+                ReadOccupancySensingClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffOnOff::OnAttributeResponse)> * onReportOnOffOnOffCallback =
+        new chip::Callback::Callback<decltype(&ReadOnOffOnOff::OnAttributeResponse)>(ReadOnOffOnOff::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffGlobalSceneControl::OnAttributeResponse)> *
+        onReportOnOffGlobalSceneControlCallback =
+            new chip::Callback::Callback<decltype(&ReadOnOffGlobalSceneControl::OnAttributeResponse)>(
+                ReadOnOffGlobalSceneControl::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffOnTime::OnAttributeResponse)> * onReportOnOffOnTimeCallback =
+        new chip::Callback::Callback<decltype(&ReadOnOffOnTime::OnAttributeResponse)>(ReadOnOffOnTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffOffWaitTime::OnAttributeResponse)> * onReportOnOffOffWaitTimeCallback =
+        new chip::Callback::Callback<decltype(&ReadOnOffOffWaitTime::OnAttributeResponse)>(
+            ReadOnOffOffWaitTime::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffStartUpOnOff::OnAttributeResponse)> * onReportOnOffStartUpOnOffCallback =
+        new chip::Callback::Callback<decltype(&ReadOnOffStartUpOnOff::OnAttributeResponse)>(
+            ReadOnOffStartUpOnOff::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffFeatureMap::OnAttributeResponse)> * onReportOnOffFeatureMapCallback =
+        new chip::Callback::Callback<decltype(&ReadOnOffFeatureMap::OnAttributeResponse)>(ReadOnOffFeatureMap::OnAttributeResponse,
+                                                                                          this);
+    chip::Callback::Callback<decltype(&ReadOnOffClusterRevision::OnAttributeResponse)> * onReportOnOffClusterRevisionCallback =
+        new chip::Callback::Callback<decltype(&ReadOnOffClusterRevision::OnAttributeResponse)>(
+            ReadOnOffClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffSwitchConfigurationSwitchType::OnAttributeResponse)> *
+        onReportOnOffSwitchConfigurationSwitchTypeCallback =
+            new chip::Callback::Callback<decltype(&ReadOnOffSwitchConfigurationSwitchType::OnAttributeResponse)>(
+                ReadOnOffSwitchConfigurationSwitchType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffSwitchConfigurationSwitchActions::OnAttributeResponse)> *
+        onReportOnOffSwitchConfigurationSwitchActionsCallback =
+            new chip::Callback::Callback<decltype(&ReadOnOffSwitchConfigurationSwitchActions::OnAttributeResponse)>(
+                ReadOnOffSwitchConfigurationSwitchActions::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOnOffSwitchConfigurationClusterRevision::OnAttributeResponse)> *
+        onReportOnOffSwitchConfigurationClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadOnOffSwitchConfigurationClusterRevision::OnAttributeResponse)>(
+                ReadOnOffSwitchConfigurationClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOperationalCredentialsSupportedFabrics::OnAttributeResponse)> *
+        onReportOperationalCredentialsSupportedFabricsCallback =
+            new chip::Callback::Callback<decltype(&ReadOperationalCredentialsSupportedFabrics::OnAttributeResponse)>(
+                ReadOperationalCredentialsSupportedFabrics::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOperationalCredentialsCommissionedFabrics::OnAttributeResponse)> *
+        onReportOperationalCredentialsCommissionedFabricsCallback =
+            new chip::Callback::Callback<decltype(&ReadOperationalCredentialsCommissionedFabrics::OnAttributeResponse)>(
+                ReadOperationalCredentialsCommissionedFabrics::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOperationalCredentialsCurrentFabricIndex::OnAttributeResponse)> *
+        onReportOperationalCredentialsCurrentFabricIndexCallback =
+            new chip::Callback::Callback<decltype(&ReadOperationalCredentialsCurrentFabricIndex::OnAttributeResponse)>(
+                ReadOperationalCredentialsCurrentFabricIndex::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadOperationalCredentialsClusterRevision::OnAttributeResponse)> *
+        onReportOperationalCredentialsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadOperationalCredentialsClusterRevision::OnAttributeResponse)>(
+                ReadOperationalCredentialsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceStatus::OnAttributeResponse)> * onReportPowerSourceStatusCallback =
+        new chip::Callback::Callback<decltype(&ReadPowerSourceStatus::OnAttributeResponse)>(
+            ReadPowerSourceStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceOrder::OnAttributeResponse)> * onReportPowerSourceOrderCallback =
+        new chip::Callback::Callback<decltype(&ReadPowerSourceOrder::OnAttributeResponse)>(
+            ReadPowerSourceOrder::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceDescription::OnAttributeResponse)> * onReportPowerSourceDescriptionCallback =
+        new chip::Callback::Callback<decltype(&ReadPowerSourceDescription::OnAttributeResponse)>(
+            ReadPowerSourceDescription::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceBatteryVoltage::OnAttributeResponse)> *
+        onReportPowerSourceBatteryVoltageCallback =
+            new chip::Callback::Callback<decltype(&ReadPowerSourceBatteryVoltage::OnAttributeResponse)>(
+                ReadPowerSourceBatteryVoltage::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceBatteryPercentRemaining::OnAttributeResponse)> *
+        onReportPowerSourceBatteryPercentRemainingCallback =
+            new chip::Callback::Callback<decltype(&ReadPowerSourceBatteryPercentRemaining::OnAttributeResponse)>(
+                ReadPowerSourceBatteryPercentRemaining::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceBatteryTimeRemaining::OnAttributeResponse)> *
+        onReportPowerSourceBatteryTimeRemainingCallback =
+            new chip::Callback::Callback<decltype(&ReadPowerSourceBatteryTimeRemaining::OnAttributeResponse)>(
+                ReadPowerSourceBatteryTimeRemaining::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceBatteryChargeLevel::OnAttributeResponse)> *
+        onReportPowerSourceBatteryChargeLevelCallback =
+            new chip::Callback::Callback<decltype(&ReadPowerSourceBatteryChargeLevel::OnAttributeResponse)>(
+                ReadPowerSourceBatteryChargeLevel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceBatteryChargeState::OnAttributeResponse)> *
+        onReportPowerSourceBatteryChargeStateCallback =
+            new chip::Callback::Callback<decltype(&ReadPowerSourceBatteryChargeState::OnAttributeResponse)>(
+                ReadPowerSourceBatteryChargeState::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceFeatureMap::OnAttributeResponse)> * onReportPowerSourceFeatureMapCallback =
+        new chip::Callback::Callback<decltype(&ReadPowerSourceFeatureMap::OnAttributeResponse)>(
+            ReadPowerSourceFeatureMap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPowerSourceClusterRevision::OnAttributeResponse)> *
+        onReportPowerSourceClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadPowerSourceClusterRevision::OnAttributeResponse)>(
+                ReadPowerSourceClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPressureMeasurementMeasuredValue::OnAttributeResponse)> *
+        onReportPressureMeasurementMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadPressureMeasurementMeasuredValue::OnAttributeResponse)>(
+                ReadPressureMeasurementMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPressureMeasurementMinMeasuredValue::OnAttributeResponse)> *
+        onReportPressureMeasurementMinMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadPressureMeasurementMinMeasuredValue::OnAttributeResponse)>(
+                ReadPressureMeasurementMinMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPressureMeasurementMaxMeasuredValue::OnAttributeResponse)> *
+        onReportPressureMeasurementMaxMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadPressureMeasurementMaxMeasuredValue::OnAttributeResponse)>(
+                ReadPressureMeasurementMaxMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPressureMeasurementClusterRevision::OnAttributeResponse)> *
+        onReportPressureMeasurementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadPressureMeasurementClusterRevision::OnAttributeResponse)>(
+                ReadPressureMeasurementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxPressure::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxPressureCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxPressure::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxPressure::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxSpeed::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxSpeedCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxSpeed::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxSpeed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxFlow::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxFlowCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxFlow::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxFlow::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstPressure::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMinConstPressureCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstPressure::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMinConstPressure::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstPressure::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxConstPressureCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstPressure::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxConstPressure::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinCompPressure::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMinCompPressureCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinCompPressure::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMinCompPressure::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxCompPressure::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxCompPressureCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxCompPressure::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxCompPressure::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstSpeed::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMinConstSpeedCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstSpeed::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMinConstSpeed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstSpeed::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxConstSpeedCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstSpeed::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxConstSpeed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstFlow::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMinConstFlowCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstFlow::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMinConstFlow::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstFlow::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxConstFlowCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstFlow::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxConstFlow::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstTemp::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMinConstTempCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMinConstTemp::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMinConstTemp::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstTemp::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlMaxConstTempCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlMaxConstTemp::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlMaxConstTemp::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlPumpStatus::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlPumpStatusCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlPumpStatus::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlPumpStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlEffectiveOperationMode::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlEffectiveOperationModeCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlEffectiveOperationMode::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlEffectiveOperationMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlEffectiveControlMode::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlEffectiveControlModeCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlEffectiveControlMode::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlEffectiveControlMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlCapacity::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlCapacityCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlCapacity::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlCapacity::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlSpeed::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlSpeedCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlSpeed::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlSpeed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlLifetimeRunningHours::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlLifetimeRunningHoursCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlLifetimeRunningHours::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlLifetimeRunningHours::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlPower::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlPowerCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlPower::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlPower::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlLifetimeEnergyConsumed::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlLifetimeEnergyConsumedCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlLifetimeEnergyConsumed::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlLifetimeEnergyConsumed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlOperationMode::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlOperationModeCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlOperationMode::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlOperationMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlControlMode::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlControlModeCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlControlMode::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlControlMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlAlarmMask::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlAlarmMaskCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlAlarmMask::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlAlarmMask::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlFeatureMap::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlFeatureMapCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlFeatureMap::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlFeatureMap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlClusterRevision::OnAttributeResponse)> *
+        onReportPumpConfigurationAndControlClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadPumpConfigurationAndControlClusterRevision::OnAttributeResponse)>(
+                ReadPumpConfigurationAndControlClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementMeasuredValue::OnAttributeResponse)> *
+        onReportRelativeHumidityMeasurementMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementMeasuredValue::OnAttributeResponse)>(
+                ReadRelativeHumidityMeasurementMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementMinMeasuredValue::OnAttributeResponse)> *
+        onReportRelativeHumidityMeasurementMinMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementMinMeasuredValue::OnAttributeResponse)>(
+                ReadRelativeHumidityMeasurementMinMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementMaxMeasuredValue::OnAttributeResponse)> *
+        onReportRelativeHumidityMeasurementMaxMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementMaxMeasuredValue::OnAttributeResponse)>(
+                ReadRelativeHumidityMeasurementMaxMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementTolerance::OnAttributeResponse)> *
+        onReportRelativeHumidityMeasurementToleranceCallback =
+            new chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementTolerance::OnAttributeResponse)>(
+                ReadRelativeHumidityMeasurementTolerance::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementClusterRevision::OnAttributeResponse)> *
+        onReportRelativeHumidityMeasurementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadRelativeHumidityMeasurementClusterRevision::OnAttributeResponse)>(
+                ReadRelativeHumidityMeasurementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadScenesSceneCount::OnAttributeResponse)> * onReportScenesSceneCountCallback =
+        new chip::Callback::Callback<decltype(&ReadScenesSceneCount::OnAttributeResponse)>(
+            ReadScenesSceneCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadScenesCurrentScene::OnAttributeResponse)> * onReportScenesCurrentSceneCallback =
+        new chip::Callback::Callback<decltype(&ReadScenesCurrentScene::OnAttributeResponse)>(
+            ReadScenesCurrentScene::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadScenesCurrentGroup::OnAttributeResponse)> * onReportScenesCurrentGroupCallback =
+        new chip::Callback::Callback<decltype(&ReadScenesCurrentGroup::OnAttributeResponse)>(
+            ReadScenesCurrentGroup::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadScenesSceneValid::OnAttributeResponse)> * onReportScenesSceneValidCallback =
+        new chip::Callback::Callback<decltype(&ReadScenesSceneValid::OnAttributeResponse)>(
+            ReadScenesSceneValid::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadScenesNameSupport::OnAttributeResponse)> * onReportScenesNameSupportCallback =
+        new chip::Callback::Callback<decltype(&ReadScenesNameSupport::OnAttributeResponse)>(
+            ReadScenesNameSupport::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadScenesClusterRevision::OnAttributeResponse)> * onReportScenesClusterRevisionCallback =
+        new chip::Callback::Callback<decltype(&ReadScenesClusterRevision::OnAttributeResponse)>(
+            ReadScenesClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsCurrentHeapFree::OnAttributeResponse)> *
+        onReportSoftwareDiagnosticsCurrentHeapFreeCallback =
+            new chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsCurrentHeapFree::OnAttributeResponse)>(
+                ReadSoftwareDiagnosticsCurrentHeapFree::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsCurrentHeapUsed::OnAttributeResponse)> *
+        onReportSoftwareDiagnosticsCurrentHeapUsedCallback =
+            new chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsCurrentHeapUsed::OnAttributeResponse)>(
+                ReadSoftwareDiagnosticsCurrentHeapUsed::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsCurrentHeapHighWatermark::OnAttributeResponse)> *
+        onReportSoftwareDiagnosticsCurrentHeapHighWatermarkCallback =
+            new chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsCurrentHeapHighWatermark::OnAttributeResponse)>(
+                ReadSoftwareDiagnosticsCurrentHeapHighWatermark::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsClusterRevision::OnAttributeResponse)> *
+        onReportSoftwareDiagnosticsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadSoftwareDiagnosticsClusterRevision::OnAttributeResponse)>(
+                ReadSoftwareDiagnosticsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSwitchNumberOfPositions::OnAttributeResponse)> *
+        onReportSwitchNumberOfPositionsCallback =
+            new chip::Callback::Callback<decltype(&ReadSwitchNumberOfPositions::OnAttributeResponse)>(
+                ReadSwitchNumberOfPositions::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSwitchCurrentPosition::OnAttributeResponse)> * onReportSwitchCurrentPositionCallback =
+        new chip::Callback::Callback<decltype(&ReadSwitchCurrentPosition::OnAttributeResponse)>(
+            ReadSwitchCurrentPosition::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSwitchMultiPressMax::OnAttributeResponse)> * onReportSwitchMultiPressMaxCallback =
+        new chip::Callback::Callback<decltype(&ReadSwitchMultiPressMax::OnAttributeResponse)>(
+            ReadSwitchMultiPressMax::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSwitchFeatureMap::OnAttributeResponse)> * onReportSwitchFeatureMapCallback =
+        new chip::Callback::Callback<decltype(&ReadSwitchFeatureMap::OnAttributeResponse)>(
+            ReadSwitchFeatureMap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadSwitchClusterRevision::OnAttributeResponse)> * onReportSwitchClusterRevisionCallback =
+        new chip::Callback::Callback<decltype(&ReadSwitchClusterRevision::OnAttributeResponse)>(
+            ReadSwitchClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTvChannelTvChannelLineup::OnAttributeResponse)> *
+        onReportTvChannelTvChannelLineupCallback =
+            new chip::Callback::Callback<decltype(&ReadTvChannelTvChannelLineup::OnAttributeResponse)>(
+                ReadTvChannelTvChannelLineup::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTvChannelCurrentTvChannel::OnAttributeResponse)> *
+        onReportTvChannelCurrentTvChannelCallback =
+            new chip::Callback::Callback<decltype(&ReadTvChannelCurrentTvChannel::OnAttributeResponse)>(
+                ReadTvChannelCurrentTvChannel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTvChannelClusterRevision::OnAttributeResponse)> *
+        onReportTvChannelClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadTvChannelClusterRevision::OnAttributeResponse)>(
+                ReadTvChannelClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTargetNavigatorClusterRevision::OnAttributeResponse)> *
+        onReportTargetNavigatorClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadTargetNavigatorClusterRevision::OnAttributeResponse)>(
+                ReadTargetNavigatorClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTemperatureMeasurementMeasuredValue::OnAttributeResponse)> *
+        onReportTemperatureMeasurementMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadTemperatureMeasurementMeasuredValue::OnAttributeResponse)>(
+                ReadTemperatureMeasurementMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTemperatureMeasurementMinMeasuredValue::OnAttributeResponse)> *
+        onReportTemperatureMeasurementMinMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadTemperatureMeasurementMinMeasuredValue::OnAttributeResponse)>(
+                ReadTemperatureMeasurementMinMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTemperatureMeasurementMaxMeasuredValue::OnAttributeResponse)> *
+        onReportTemperatureMeasurementMaxMeasuredValueCallback =
+            new chip::Callback::Callback<decltype(&ReadTemperatureMeasurementMaxMeasuredValue::OnAttributeResponse)>(
+                ReadTemperatureMeasurementMaxMeasuredValue::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTemperatureMeasurementTolerance::OnAttributeResponse)> *
+        onReportTemperatureMeasurementToleranceCallback =
+            new chip::Callback::Callback<decltype(&ReadTemperatureMeasurementTolerance::OnAttributeResponse)>(
+                ReadTemperatureMeasurementTolerance::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTemperatureMeasurementClusterRevision::OnAttributeResponse)> *
+        onReportTemperatureMeasurementClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadTemperatureMeasurementClusterRevision::OnAttributeResponse)>(
+                ReadTemperatureMeasurementClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterBoolean::OnAttributeResponse)> * onReportTestClusterBooleanCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterBoolean::OnAttributeResponse)>(
+            ReadTestClusterBoolean::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterBitmap8::OnAttributeResponse)> * onReportTestClusterBitmap8Callback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterBitmap8::OnAttributeResponse)>(
+            ReadTestClusterBitmap8::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterBitmap16::OnAttributeResponse)> * onReportTestClusterBitmap16Callback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterBitmap16::OnAttributeResponse)>(
+            ReadTestClusterBitmap16::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterBitmap32::OnAttributeResponse)> * onReportTestClusterBitmap32Callback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterBitmap32::OnAttributeResponse)>(
+            ReadTestClusterBitmap32::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterBitmap64::OnAttributeResponse)> * onReportTestClusterBitmap64Callback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterBitmap64::OnAttributeResponse)>(
+            ReadTestClusterBitmap64::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt8u::OnAttributeResponse)> * onReportTestClusterInt8uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt8u::OnAttributeResponse)>(
+            ReadTestClusterInt8u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt16u::OnAttributeResponse)> * onReportTestClusterInt16uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt16u::OnAttributeResponse)>(
+            ReadTestClusterInt16u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt24u::OnAttributeResponse)> * onReportTestClusterInt24uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt24u::OnAttributeResponse)>(
+            ReadTestClusterInt24u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt32u::OnAttributeResponse)> * onReportTestClusterInt32uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt32u::OnAttributeResponse)>(
+            ReadTestClusterInt32u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt40u::OnAttributeResponse)> * onReportTestClusterInt40uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt40u::OnAttributeResponse)>(
+            ReadTestClusterInt40u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt48u::OnAttributeResponse)> * onReportTestClusterInt48uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt48u::OnAttributeResponse)>(
+            ReadTestClusterInt48u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt56u::OnAttributeResponse)> * onReportTestClusterInt56uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt56u::OnAttributeResponse)>(
+            ReadTestClusterInt56u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt64u::OnAttributeResponse)> * onReportTestClusterInt64uCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt64u::OnAttributeResponse)>(
+            ReadTestClusterInt64u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt8s::OnAttributeResponse)> * onReportTestClusterInt8sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt8s::OnAttributeResponse)>(
+            ReadTestClusterInt8s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt16s::OnAttributeResponse)> * onReportTestClusterInt16sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt16s::OnAttributeResponse)>(
+            ReadTestClusterInt16s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt24s::OnAttributeResponse)> * onReportTestClusterInt24sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt24s::OnAttributeResponse)>(
+            ReadTestClusterInt24s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt32s::OnAttributeResponse)> * onReportTestClusterInt32sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt32s::OnAttributeResponse)>(
+            ReadTestClusterInt32s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt40s::OnAttributeResponse)> * onReportTestClusterInt40sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt40s::OnAttributeResponse)>(
+            ReadTestClusterInt40s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt48s::OnAttributeResponse)> * onReportTestClusterInt48sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt48s::OnAttributeResponse)>(
+            ReadTestClusterInt48s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt56s::OnAttributeResponse)> * onReportTestClusterInt56sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt56s::OnAttributeResponse)>(
+            ReadTestClusterInt56s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterInt64s::OnAttributeResponse)> * onReportTestClusterInt64sCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterInt64s::OnAttributeResponse)>(
+            ReadTestClusterInt64s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterEnum8::OnAttributeResponse)> * onReportTestClusterEnum8Callback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterEnum8::OnAttributeResponse)>(
+            ReadTestClusterEnum8::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterEnum16::OnAttributeResponse)> * onReportTestClusterEnum16Callback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterEnum16::OnAttributeResponse)>(
+            ReadTestClusterEnum16::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterFloatSingle::OnAttributeResponse)> * onReportTestClusterFloatSingleCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterFloatSingle::OnAttributeResponse)>(
+            ReadTestClusterFloatSingle::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterFloatDouble::OnAttributeResponse)> * onReportTestClusterFloatDoubleCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterFloatDouble::OnAttributeResponse)>(
+            ReadTestClusterFloatDouble::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterOctetString::OnAttributeResponse)> * onReportTestClusterOctetStringCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterOctetString::OnAttributeResponse)>(
+            ReadTestClusterOctetString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterLongOctetString::OnAttributeResponse)> *
+        onReportTestClusterLongOctetStringCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterLongOctetString::OnAttributeResponse)>(
+                ReadTestClusterLongOctetString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterCharString::OnAttributeResponse)> * onReportTestClusterCharStringCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterCharString::OnAttributeResponse)>(
+            ReadTestClusterCharString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterLongCharString::OnAttributeResponse)> *
+        onReportTestClusterLongCharStringCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterLongCharString::OnAttributeResponse)>(
+                ReadTestClusterLongCharString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterEpochUs::OnAttributeResponse)> * onReportTestClusterEpochUsCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterEpochUs::OnAttributeResponse)>(
+            ReadTestClusterEpochUs::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterEpochS::OnAttributeResponse)> * onReportTestClusterEpochSCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterEpochS::OnAttributeResponse)>(
+            ReadTestClusterEpochS::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterVendorId::OnAttributeResponse)> * onReportTestClusterVendorIdCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterVendorId::OnAttributeResponse)>(
+            ReadTestClusterVendorId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt8u::OnAttributeResponse)> *
+        onReportTestClusterRangeRestrictedInt8uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt8u::OnAttributeResponse)>(
+                ReadTestClusterRangeRestrictedInt8u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt8s::OnAttributeResponse)> *
+        onReportTestClusterRangeRestrictedInt8sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt8s::OnAttributeResponse)>(
+                ReadTestClusterRangeRestrictedInt8s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt16u::OnAttributeResponse)> *
+        onReportTestClusterRangeRestrictedInt16uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt16u::OnAttributeResponse)>(
+                ReadTestClusterRangeRestrictedInt16u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt16s::OnAttributeResponse)> *
+        onReportTestClusterRangeRestrictedInt16sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterRangeRestrictedInt16s::OnAttributeResponse)>(
+                ReadTestClusterRangeRestrictedInt16s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterUnsupported::OnAttributeResponse)> * onReportTestClusterUnsupportedCallback =
+        new chip::Callback::Callback<decltype(&ReadTestClusterUnsupported::OnAttributeResponse)>(
+            ReadTestClusterUnsupported::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableBoolean::OnAttributeResponse)> *
+        onReportTestClusterNullableBooleanCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableBoolean::OnAttributeResponse)>(
+                ReadTestClusterNullableBoolean::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap8::OnAttributeResponse)> *
+        onReportTestClusterNullableBitmap8Callback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap8::OnAttributeResponse)>(
+                ReadTestClusterNullableBitmap8::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap16::OnAttributeResponse)> *
+        onReportTestClusterNullableBitmap16Callback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap16::OnAttributeResponse)>(
+                ReadTestClusterNullableBitmap16::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap32::OnAttributeResponse)> *
+        onReportTestClusterNullableBitmap32Callback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap32::OnAttributeResponse)>(
+                ReadTestClusterNullableBitmap32::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap64::OnAttributeResponse)> *
+        onReportTestClusterNullableBitmap64Callback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableBitmap64::OnAttributeResponse)>(
+                ReadTestClusterNullableBitmap64::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt8u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt8uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt8u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt8u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt16u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt16uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt16u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt16u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt24u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt24uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt24u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt24u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt32u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt32uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt32u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt32u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt40u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt40uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt40u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt40u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt48u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt48uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt48u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt48u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt56u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt56uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt56u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt56u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt64u::OnAttributeResponse)> *
+        onReportTestClusterNullableInt64uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt64u::OnAttributeResponse)>(
+                ReadTestClusterNullableInt64u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt8s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt8sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt8s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt8s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt16s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt16sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt16s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt16s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt24s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt24sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt24s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt24s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt32s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt32sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt32s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt32s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt40s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt40sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt40s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt40s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt48s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt48sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt48s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt48s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt56s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt56sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt56s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt56s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableInt64s::OnAttributeResponse)> *
+        onReportTestClusterNullableInt64sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableInt64s::OnAttributeResponse)>(
+                ReadTestClusterNullableInt64s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableEnum8::OnAttributeResponse)> *
+        onReportTestClusterNullableEnum8Callback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableEnum8::OnAttributeResponse)>(
+                ReadTestClusterNullableEnum8::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableEnum16::OnAttributeResponse)> *
+        onReportTestClusterNullableEnum16Callback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableEnum16::OnAttributeResponse)>(
+                ReadTestClusterNullableEnum16::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableFloatSingle::OnAttributeResponse)> *
+        onReportTestClusterNullableFloatSingleCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableFloatSingle::OnAttributeResponse)>(
+                ReadTestClusterNullableFloatSingle::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableFloatDouble::OnAttributeResponse)> *
+        onReportTestClusterNullableFloatDoubleCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableFloatDouble::OnAttributeResponse)>(
+                ReadTestClusterNullableFloatDouble::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableOctetString::OnAttributeResponse)> *
+        onReportTestClusterNullableOctetStringCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableOctetString::OnAttributeResponse)>(
+                ReadTestClusterNullableOctetString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableCharString::OnAttributeResponse)> *
+        onReportTestClusterNullableCharStringCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableCharString::OnAttributeResponse)>(
+                ReadTestClusterNullableCharString::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt8u::OnAttributeResponse)> *
+        onReportTestClusterNullableRangeRestrictedInt8uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt8u::OnAttributeResponse)>(
+                ReadTestClusterNullableRangeRestrictedInt8u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt8s::OnAttributeResponse)> *
+        onReportTestClusterNullableRangeRestrictedInt8sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt8s::OnAttributeResponse)>(
+                ReadTestClusterNullableRangeRestrictedInt8s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt16u::OnAttributeResponse)> *
+        onReportTestClusterNullableRangeRestrictedInt16uCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt16u::OnAttributeResponse)>(
+                ReadTestClusterNullableRangeRestrictedInt16u::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt16s::OnAttributeResponse)> *
+        onReportTestClusterNullableRangeRestrictedInt16sCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterNullableRangeRestrictedInt16s::OnAttributeResponse)>(
+                ReadTestClusterNullableRangeRestrictedInt16s::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadTestClusterClusterRevision::OnAttributeResponse)> *
+        onReportTestClusterClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadTestClusterClusterRevision::OnAttributeResponse)>(
+                ReadTestClusterClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatLocalTemperature::OnAttributeResponse)> *
+        onReportThermostatLocalTemperatureCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatLocalTemperature::OnAttributeResponse)>(
+                ReadThermostatLocalTemperature::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatAbsMinHeatSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatAbsMinHeatSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatAbsMinHeatSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatAbsMinHeatSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatAbsMaxHeatSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatAbsMaxHeatSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatAbsMaxHeatSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatAbsMaxHeatSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatAbsMinCoolSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatAbsMinCoolSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatAbsMinCoolSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatAbsMinCoolSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatAbsMaxCoolSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatAbsMaxCoolSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatAbsMaxCoolSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatAbsMaxCoolSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatOccupiedCoolingSetpoint::OnAttributeResponse)> *
+        onReportThermostatOccupiedCoolingSetpointCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatOccupiedCoolingSetpoint::OnAttributeResponse)>(
+                ReadThermostatOccupiedCoolingSetpoint::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatOccupiedHeatingSetpoint::OnAttributeResponse)> *
+        onReportThermostatOccupiedHeatingSetpointCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatOccupiedHeatingSetpoint::OnAttributeResponse)>(
+                ReadThermostatOccupiedHeatingSetpoint::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatMinHeatSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatMinHeatSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatMinHeatSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatMinHeatSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatMaxHeatSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatMaxHeatSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatMaxHeatSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatMaxHeatSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatMinCoolSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatMinCoolSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatMinCoolSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatMinCoolSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatMaxCoolSetpointLimit::OnAttributeResponse)> *
+        onReportThermostatMaxCoolSetpointLimitCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatMaxCoolSetpointLimit::OnAttributeResponse)>(
+                ReadThermostatMaxCoolSetpointLimit::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatMinSetpointDeadBand::OnAttributeResponse)> *
+        onReportThermostatMinSetpointDeadBandCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatMinSetpointDeadBand::OnAttributeResponse)>(
+                ReadThermostatMinSetpointDeadBand::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatControlSequenceOfOperation::OnAttributeResponse)> *
+        onReportThermostatControlSequenceOfOperationCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatControlSequenceOfOperation::OnAttributeResponse)>(
+                ReadThermostatControlSequenceOfOperation::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatSystemMode::OnAttributeResponse)> * onReportThermostatSystemModeCallback =
+        new chip::Callback::Callback<decltype(&ReadThermostatSystemMode::OnAttributeResponse)>(
+            ReadThermostatSystemMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatStartOfWeek::OnAttributeResponse)> * onReportThermostatStartOfWeekCallback =
+        new chip::Callback::Callback<decltype(&ReadThermostatStartOfWeek::OnAttributeResponse)>(
+            ReadThermostatStartOfWeek::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatNumberOfWeeklyTransitions::OnAttributeResponse)> *
+        onReportThermostatNumberOfWeeklyTransitionsCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatNumberOfWeeklyTransitions::OnAttributeResponse)>(
+                ReadThermostatNumberOfWeeklyTransitions::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatNumberOfDailyTransitions::OnAttributeResponse)> *
+        onReportThermostatNumberOfDailyTransitionsCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatNumberOfDailyTransitions::OnAttributeResponse)>(
+                ReadThermostatNumberOfDailyTransitions::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatFeatureMap::OnAttributeResponse)> * onReportThermostatFeatureMapCallback =
+        new chip::Callback::Callback<decltype(&ReadThermostatFeatureMap::OnAttributeResponse)>(
+            ReadThermostatFeatureMap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatClusterRevision::OnAttributeResponse)> *
+        onReportThermostatClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatClusterRevision::OnAttributeResponse)>(
+                ReadThermostatClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)> *
+        onReportThermostatUserInterfaceConfigurationTemperatureDisplayModeCallback = new chip::Callback::Callback<decltype(
+            &ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)>(
+            ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse)> *
+        onReportThermostatUserInterfaceConfigurationKeypadLockoutCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse)>(
+                ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(
+        &ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)> *
+        onReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCallback = new chip::Callback::Callback<decltype(
+            &ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)>(
+            ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationClusterRevision::OnAttributeResponse)> *
+        onReportThermostatUserInterfaceConfigurationClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationClusterRevision::OnAttributeResponse)>(
+                ReadThermostatUserInterfaceConfigurationClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsChannel::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsChannelCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsChannel::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsChannel::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRoutingRole::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRoutingRoleCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRoutingRole::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRoutingRole::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsNetworkName::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsNetworkNameCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsNetworkName::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsNetworkName::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPanId::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsPanIdCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPanId::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsPanId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsExtendedPanId::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsExtendedPanIdCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsExtendedPanId::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsExtendedPanId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsMeshLocalPrefix::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsMeshLocalPrefixCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsMeshLocalPrefix::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsMeshLocalPrefix::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsOverrunCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsOverrunCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsOverrunCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsOverrunCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPartitionId::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsPartitionIdCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPartitionId::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsPartitionId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsWeighting::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsWeightingCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsWeighting::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsWeighting::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsDataVersion::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsDataVersionCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsDataVersion::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsDataVersion::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsStableDataVersion::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsStableDataVersionCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsStableDataVersion::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsStableDataVersion::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsLeaderRouterId::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsLeaderRouterIdCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsLeaderRouterId::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsLeaderRouterId::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsDetachedRoleCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsDetachedRoleCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsDetachedRoleCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsDetachedRoleCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsChildRoleCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsChildRoleCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsChildRoleCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsChildRoleCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRouterRoleCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRouterRoleCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRouterRoleCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRouterRoleCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsLeaderRoleCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsLeaderRoleCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsLeaderRoleCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsLeaderRoleCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsAttachAttemptCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsAttachAttemptCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsAttachAttemptCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsAttachAttemptCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsPartitionIdChangeCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCallback = new chip::Callback::Callback<decltype(
+            &ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)>(
+            ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsParentChangeCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsParentChangeCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsParentChangeCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsParentChangeCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxTotalCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxTotalCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxTotalCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxTotalCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxUnicastCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxUnicastCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxUnicastCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxUnicastCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxBroadcastCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxBroadcastCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxBroadcastCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxBroadcastCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxAckRequestedCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxAckRequestedCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxAckRequestedCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxAckRequestedCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxAckedCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxAckedCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxAckedCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxAckedCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxNoAckRequestedCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxNoAckRequestedCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxNoAckRequestedCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxNoAckRequestedCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxDataCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxDataCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxDataCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxDataCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxDataPollCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxDataPollCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxDataPollCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxDataPollCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxBeaconCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxBeaconCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxBeaconCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxBeaconCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxBeaconRequestCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxBeaconRequestCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxBeaconRequestCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxBeaconRequestCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxOtherCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxOtherCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxOtherCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxOtherCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxRetryCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxRetryCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxRetryCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxRetryCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxErrCcaCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxErrCcaCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxErrCcaCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxErrCcaCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxErrAbortCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxErrAbortCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxErrAbortCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxErrAbortCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxErrBusyChannelCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsTxErrBusyChannelCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsTxErrBusyChannelCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsTxErrBusyChannelCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxTotalCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxTotalCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxTotalCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxTotalCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxUnicastCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxUnicastCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxUnicastCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxUnicastCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxBroadcastCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxBroadcastCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxBroadcastCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxBroadcastCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDataCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxDataCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDataCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxDataCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDataPollCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxDataPollCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDataPollCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxDataPollCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxBeaconCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxBeaconCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxBeaconCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxBeaconCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxBeaconRequestCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxBeaconRequestCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxBeaconRequestCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxBeaconRequestCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxOtherCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxOtherCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxOtherCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxOtherCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxAddressFilteredCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxAddressFilteredCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxAddressFilteredCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxAddressFilteredCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxDestAddrFilteredCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDuplicatedCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxDuplicatedCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxDuplicatedCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxDuplicatedCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrNoFrameCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxErrNoFrameCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrNoFrameCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxErrNoFrameCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxErrUnknownNeighborCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxErrInvalidSrcAddrCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrSecCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxErrSecCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrSecCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxErrSecCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrFcsCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxErrFcsCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrFcsCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxErrFcsCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrOtherCount::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsRxErrOtherCountCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsRxErrOtherCount::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsRxErrOtherCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsActiveTimestamp::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsActiveTimestampCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsActiveTimestamp::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsActiveTimestamp::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPendingTimestamp::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsPendingTimestampCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPendingTimestamp::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsPendingTimestamp::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsDelay::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsDelayCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsDelay::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsDelay::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsChannelMask::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsChannelMaskCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsChannelMask::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsChannelMask::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsClusterRevision::OnAttributeResponse)> *
+        onReportThreadNetworkDiagnosticsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsClusterRevision::OnAttributeResponse)>(
+                ReadThreadNetworkDiagnosticsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWakeOnLanWakeOnLanMacAddress::OnAttributeResponse)> *
+        onReportWakeOnLanWakeOnLanMacAddressCallback =
+            new chip::Callback::Callback<decltype(&ReadWakeOnLanWakeOnLanMacAddress::OnAttributeResponse)>(
+                ReadWakeOnLanWakeOnLanMacAddress::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWakeOnLanClusterRevision::OnAttributeResponse)> *
+        onReportWakeOnLanClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadWakeOnLanClusterRevision::OnAttributeResponse)>(
+                ReadWakeOnLanClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsBssid::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsBssidCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsBssid::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsBssid::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsSecurityType::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsSecurityTypeCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsSecurityType::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsSecurityType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsWiFiVersion::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsWiFiVersionCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsWiFiVersion::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsWiFiVersion::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsChannelNumber::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsChannelNumberCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsChannelNumber::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsChannelNumber::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsRssi::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsRssiCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsRssi::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsRssi::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsBeaconLostCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsBeaconLostCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsBeaconLostCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsBeaconLostCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsBeaconRxCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsBeaconRxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsBeaconRxCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsBeaconRxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketMulticastRxCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsPacketMulticastRxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketMulticastRxCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsPacketMulticastRxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketMulticastTxCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsPacketMulticastTxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketMulticastTxCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsPacketMulticastTxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketUnicastRxCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsPacketUnicastRxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketUnicastRxCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsPacketUnicastRxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketUnicastTxCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsPacketUnicastTxCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsPacketUnicastTxCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsPacketUnicastTxCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsCurrentMaxRate::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsCurrentMaxRateCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsCurrentMaxRate::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsCurrentMaxRate::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsOverrunCount::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsOverrunCountCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsOverrunCount::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsOverrunCount::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsClusterRevision::OnAttributeResponse)> *
+        onReportWiFiNetworkDiagnosticsClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadWiFiNetworkDiagnosticsClusterRevision::OnAttributeResponse)>(
+                ReadWiFiNetworkDiagnosticsClusterRevision::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringType::OnAttributeResponse)> * onReportWindowCoveringTypeCallback =
+        new chip::Callback::Callback<decltype(&ReadWindowCoveringType::OnAttributeResponse)>(
+            ReadWindowCoveringType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionLift::OnAttributeResponse)> *
+        onReportWindowCoveringCurrentPositionLiftCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionLift::OnAttributeResponse)>(
+                ReadWindowCoveringCurrentPositionLift::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionTilt::OnAttributeResponse)> *
+        onReportWindowCoveringCurrentPositionTiltCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionTilt::OnAttributeResponse)>(
+                ReadWindowCoveringCurrentPositionTilt::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringConfigStatus::OnAttributeResponse)> *
+        onReportWindowCoveringConfigStatusCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringConfigStatus::OnAttributeResponse)>(
+                ReadWindowCoveringConfigStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionLiftPercentage::OnAttributeResponse)> *
+        onReportWindowCoveringCurrentPositionLiftPercentageCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionLiftPercentage::OnAttributeResponse)>(
+                ReadWindowCoveringCurrentPositionLiftPercentage::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionTiltPercentage::OnAttributeResponse)> *
+        onReportWindowCoveringCurrentPositionTiltPercentageCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionTiltPercentage::OnAttributeResponse)>(
+                ReadWindowCoveringCurrentPositionTiltPercentage::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringOperationalStatus::OnAttributeResponse)> *
+        onReportWindowCoveringOperationalStatusCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringOperationalStatus::OnAttributeResponse)>(
+                ReadWindowCoveringOperationalStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringTargetPositionLiftPercent100ths::OnAttributeResponse)> *
+        onReportWindowCoveringTargetPositionLiftPercent100thsCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringTargetPositionLiftPercent100ths::OnAttributeResponse)>(
+                ReadWindowCoveringTargetPositionLiftPercent100ths::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringTargetPositionTiltPercent100ths::OnAttributeResponse)> *
+        onReportWindowCoveringTargetPositionTiltPercent100thsCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringTargetPositionTiltPercent100ths::OnAttributeResponse)>(
+                ReadWindowCoveringTargetPositionTiltPercent100ths::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringEndProductType::OnAttributeResponse)> *
+        onReportWindowCoveringEndProductTypeCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringEndProductType::OnAttributeResponse)>(
+                ReadWindowCoveringEndProductType::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionLiftPercent100ths::OnAttributeResponse)> *
+        onReportWindowCoveringCurrentPositionLiftPercent100thsCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionLiftPercent100ths::OnAttributeResponse)>(
+                ReadWindowCoveringCurrentPositionLiftPercent100ths::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionTiltPercent100ths::OnAttributeResponse)> *
+        onReportWindowCoveringCurrentPositionTiltPercent100thsCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringCurrentPositionTiltPercent100ths::OnAttributeResponse)>(
+                ReadWindowCoveringCurrentPositionTiltPercent100ths::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledOpenLimitLift::OnAttributeResponse)> *
+        onReportWindowCoveringInstalledOpenLimitLiftCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledOpenLimitLift::OnAttributeResponse)>(
+                ReadWindowCoveringInstalledOpenLimitLift::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledClosedLimitLift::OnAttributeResponse)> *
+        onReportWindowCoveringInstalledClosedLimitLiftCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledClosedLimitLift::OnAttributeResponse)>(
+                ReadWindowCoveringInstalledClosedLimitLift::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledOpenLimitTilt::OnAttributeResponse)> *
+        onReportWindowCoveringInstalledOpenLimitTiltCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledOpenLimitTilt::OnAttributeResponse)>(
+                ReadWindowCoveringInstalledOpenLimitTilt::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledClosedLimitTilt::OnAttributeResponse)> *
+        onReportWindowCoveringInstalledClosedLimitTiltCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringInstalledClosedLimitTilt::OnAttributeResponse)>(
+                ReadWindowCoveringInstalledClosedLimitTilt::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringMode::OnAttributeResponse)> * onReportWindowCoveringModeCallback =
+        new chip::Callback::Callback<decltype(&ReadWindowCoveringMode::OnAttributeResponse)>(
+            ReadWindowCoveringMode::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringSafetyStatus::OnAttributeResponse)> *
+        onReportWindowCoveringSafetyStatusCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringSafetyStatus::OnAttributeResponse)>(
+                ReadWindowCoveringSafetyStatus::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringFeatureMap::OnAttributeResponse)> *
+        onReportWindowCoveringFeatureMapCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringFeatureMap::OnAttributeResponse)>(
+                ReadWindowCoveringFeatureMap::OnAttributeResponse, this);
+    chip::Callback::Callback<decltype(&ReadWindowCoveringClusterRevision::OnAttributeResponse)> *
+        onReportWindowCoveringClusterRevisionCallback =
+            new chip::Callback::Callback<decltype(&ReadWindowCoveringClusterRevision::OnAttributeResponse)>(
+                ReadWindowCoveringClusterRevision::OnAttributeResponse, this);
 };
 
 void registerCommandsReporting(Commands & commands)

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -36,38 +36,6 @@ namespace Controller {
 
 // AccessControl Cluster Commands
 // AccessControl Cluster Attributes
-CHIP_ERROR AccessControlCluster::ReadAttributeAcl(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             AccessControlClusterAclListAttributeFilter);
-}
-
-CHIP_ERROR AccessControlCluster::ReadAttributeExtension(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             AccessControlClusterExtensionListAttributeFilter);
-}
-
-CHIP_ERROR AccessControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
 
 // AccountLogin Cluster Commands
 CHIP_ERROR AccountLoginCluster::GetSetupPIN(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -155,17 +123,6 @@ exit:
 }
 
 // AccountLogin Cluster Attributes
-CHIP_ERROR AccountLoginCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR AccountLoginCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -323,17 +280,6 @@ exit:
 }
 
 // AdministratorCommissioning Cluster Attributes
-CHIP_ERROR AdministratorCommissioningCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR AdministratorCommissioningCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                                 Callback::Cancelable * onFailureCallback,
                                                                                 uint16_t minInterval, uint16_t maxInterval)
@@ -394,17 +340,6 @@ exit:
 }
 
 // ApplicationBasic Cluster Attributes
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeVendorName(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeVendorName(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -420,17 +355,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeVendorName(Callback::Cancelab
 {
     return RequestAttributeReporting(ApplicationBasic::Attributes::VendorName::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeVendorId(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeVendorId(Callback::Cancelable * onSuccessCallback,
@@ -450,17 +374,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeVendorId(Callback::Cancelable
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeApplicationName(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeApplicationName(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -476,17 +389,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeApplicationName(Callback::Can
 {
     return RequestAttributeReporting(ApplicationBasic::Attributes::ApplicationName::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeProductId(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeProductId(Callback::Cancelable * onSuccessCallback,
@@ -506,17 +408,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeProductId(Callback::Cancelabl
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeApplicationId(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeApplicationId(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -532,17 +423,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeApplicationId(Callback::Cance
 {
     return RequestAttributeReporting(ApplicationBasic::Attributes::ApplicationId::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback,
@@ -562,17 +442,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeCatalogVendorId(Callback::Can
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeApplicationStatus(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeApplicationStatus(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -588,17 +457,6 @@ CHIP_ERROR ApplicationBasicCluster::ReportAttributeApplicationStatus(Callback::C
 {
     return RequestAttributeReporting(ApplicationBasic::Attributes::ApplicationStatus::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ApplicationBasicCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ApplicationBasicCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -665,28 +523,6 @@ exit:
 }
 
 // ApplicationLauncher Cluster Attributes
-CHIP_ERROR ApplicationLauncherCluster::ReadAttributeApplicationLauncherList(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ApplicationLauncherClusterApplicationLauncherListListAttributeFilter);
-}
-
-CHIP_ERROR ApplicationLauncherCluster::ReadAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ApplicationLauncherCluster::SubscribeAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -704,17 +540,6 @@ CHIP_ERROR ApplicationLauncherCluster::ReportAttributeCatalogVendorId(Callback::
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ApplicationLauncherCluster::ReadAttributeApplicationId(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ApplicationLauncherCluster::SubscribeAttributeApplicationId(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -730,17 +555,6 @@ CHIP_ERROR ApplicationLauncherCluster::ReportAttributeApplicationId(Callback::Ca
 {
     return RequestAttributeReporting(ApplicationLauncher::Attributes::ApplicationId::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ApplicationLauncherCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ApplicationLauncherCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -846,28 +660,6 @@ exit:
 }
 
 // AudioOutput Cluster Attributes
-CHIP_ERROR AudioOutputCluster::ReadAttributeAudioOutputList(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             AudioOutputClusterAudioOutputListListAttributeFilter);
-}
-
-CHIP_ERROR AudioOutputCluster::ReadAttributeCurrentAudioOutput(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR AudioOutputCluster::SubscribeAttributeCurrentAudioOutput(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -883,17 +675,6 @@ CHIP_ERROR AudioOutputCluster::ReportAttributeCurrentAudioOutput(Callback::Cance
 {
     return RequestAttributeReporting(AudioOutput::Attributes::CurrentAudioOutput::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR AudioOutputCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR AudioOutputCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -996,17 +777,6 @@ exit:
 }
 
 // BarrierControl Cluster Attributes
-CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierMovingState(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR BarrierControlCluster::SubscribeAttributeBarrierMovingState(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -1022,17 +792,6 @@ CHIP_ERROR BarrierControlCluster::ReportAttributeBarrierMovingState(Callback::Ca
 {
     return RequestAttributeReporting(BarrierControl::Attributes::BarrierMovingState::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierSafetyStatus(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BarrierControlCluster::SubscribeAttributeBarrierSafetyStatus(Callback::Cancelable * onSuccessCallback,
@@ -1052,17 +811,6 @@ CHIP_ERROR BarrierControlCluster::ReportAttributeBarrierSafetyStatus(Callback::C
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierCapabilities(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR BarrierControlCluster::SubscribeAttributeBarrierCapabilities(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -1080,17 +828,6 @@ CHIP_ERROR BarrierControlCluster::ReportAttributeBarrierCapabilities(Callback::C
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierPosition(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR BarrierControlCluster::SubscribeAttributeBarrierPosition(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -1106,17 +843,6 @@ CHIP_ERROR BarrierControlCluster::ReportAttributeBarrierPosition(Callback::Cance
 {
     return RequestAttributeReporting(BarrierControl::Attributes::BarrierPosition::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR BarrierControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BarrierControlCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -1176,17 +902,6 @@ exit:
 }
 
 // Basic Cluster Attributes
-CHIP_ERROR BasicCluster::ReadAttributeInteractionModelVersion(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeInteractionModelVersion(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -1202,16 +917,6 @@ CHIP_ERROR BasicCluster::ReportAttributeInteractionModelVersion(Callback::Cancel
 {
     return RequestAttributeReporting(Basic::Attributes::InteractionModelVersion::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeVendorName(Callback::Cancelable * onSuccessCallback,
@@ -1231,16 +936,6 @@ CHIP_ERROR BasicCluster::ReportAttributeVendorName(Callback::Cancelable * onRepo
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeVendorID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeVendorID(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval)
@@ -1256,17 +951,6 @@ CHIP_ERROR BasicCluster::ReportAttributeVendorID(Callback::Cancelable * onReport
 {
     return RequestAttributeReporting(Basic::Attributes::VendorID::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeProductName(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeProductName(Callback::Cancelable * onSuccessCallback,
@@ -1286,16 +970,6 @@ CHIP_ERROR BasicCluster::ReportAttributeProductName(Callback::Cancelable * onRep
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeProductID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeProductID(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval)
@@ -1311,16 +985,6 @@ CHIP_ERROR BasicCluster::ReportAttributeProductID(Callback::Cancelable * onRepor
 {
     return RequestAttributeReporting(Basic::Attributes::ProductID::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeNodeLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeNodeLabel(Callback::Cancelable * onSuccessCallback,
@@ -1340,16 +1004,6 @@ CHIP_ERROR BasicCluster::ReportAttributeNodeLabel(Callback::Cancelable * onRepor
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeLocation(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval)
@@ -1365,17 +1019,6 @@ CHIP_ERROR BasicCluster::ReportAttributeLocation(Callback::Cancelable * onReport
 {
     return RequestAttributeReporting(Basic::Attributes::Location::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback,
@@ -1395,17 +1038,6 @@ CHIP_ERROR BasicCluster::ReportAttributeHardwareVersion(Callback::Cancelable * o
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -1421,17 +1053,6 @@ CHIP_ERROR BasicCluster::ReportAttributeHardwareVersionString(Callback::Cancelab
 {
     return RequestAttributeReporting(Basic::Attributes::HardwareVersionString::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeSoftwareVersion(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeSoftwareVersion(Callback::Cancelable * onSuccessCallback,
@@ -1451,17 +1072,6 @@ CHIP_ERROR BasicCluster::ReportAttributeSoftwareVersion(Callback::Cancelable * o
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -1477,17 +1087,6 @@ CHIP_ERROR BasicCluster::ReportAttributeSoftwareVersionString(Callback::Cancelab
 {
     return RequestAttributeReporting(Basic::Attributes::SoftwareVersionString::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback,
@@ -1507,16 +1106,6 @@ CHIP_ERROR BasicCluster::ReportAttributeManufacturingDate(Callback::Cancelable *
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributePartNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributePartNumber(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval)
@@ -1532,16 +1121,6 @@ CHIP_ERROR BasicCluster::ReportAttributePartNumber(Callback::Cancelable * onRepo
 {
     return RequestAttributeReporting(Basic::Attributes::PartNumber::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeProductURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeProductURL(Callback::Cancelable * onSuccessCallback,
@@ -1561,17 +1140,6 @@ CHIP_ERROR BasicCluster::ReportAttributeProductURL(Callback::Cancelable * onRepo
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeProductLabel(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeProductLabel(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -1587,17 +1155,6 @@ CHIP_ERROR BasicCluster::ReportAttributeProductLabel(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(Basic::Attributes::ProductLabel::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeSerialNumber(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeSerialNumber(Callback::Cancelable * onSuccessCallback,
@@ -1617,17 +1174,6 @@ CHIP_ERROR BasicCluster::ReportAttributeSerialNumber(Callback::Cancelable * onRe
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -1645,16 +1191,6 @@ CHIP_ERROR BasicCluster::ReportAttributeLocalConfigDisabled(Callback::Cancelable
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR BasicCluster::ReadAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR BasicCluster::SubscribeAttributeReachable(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval)
@@ -1670,27 +1206,6 @@ CHIP_ERROR BasicCluster::ReportAttributeReachable(Callback::Cancelable * onRepor
 {
     return RequestAttributeReporting(Basic::Attributes::Reachable::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeUniqueID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BasicCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BasicCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -1712,17 +1227,6 @@ CHIP_ERROR BasicCluster::ReportAttributeClusterRevision(Callback::Cancelable * o
 
 // BinaryInputBasic Cluster Commands
 // BinaryInputBasic Cluster Attributes
-CHIP_ERROR BinaryInputBasicCluster::ReadAttributeOutOfService(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000051;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR BinaryInputBasicCluster::SubscribeAttributeOutOfService(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -1738,17 +1242,6 @@ CHIP_ERROR BinaryInputBasicCluster::ReportAttributeOutOfService(Callback::Cancel
 {
     return RequestAttributeReporting(BinaryInputBasic::Attributes::OutOfService::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR BinaryInputBasicCluster::ReadAttributePresentValue(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000055;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR BinaryInputBasicCluster::SubscribeAttributePresentValue(Callback::Cancelable * onSuccessCallback,
@@ -1768,17 +1261,6 @@ CHIP_ERROR BinaryInputBasicCluster::ReportAttributePresentValue(Callback::Cancel
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR BinaryInputBasicCluster::ReadAttributeStatusFlags(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000006F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR BinaryInputBasicCluster::SubscribeAttributeStatusFlags(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -1794,17 +1276,6 @@ CHIP_ERROR BinaryInputBasicCluster::ReportAttributeStatusFlags(Callback::Cancela
 {
     return RequestAttributeReporting(BinaryInputBasic::Attributes::StatusFlags::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR BinaryInputBasicCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BinaryInputBasicCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -1921,17 +1392,6 @@ exit:
 }
 
 // Binding Cluster Attributes
-CHIP_ERROR BindingCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR BindingCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -1951,17 +1411,6 @@ CHIP_ERROR BindingCluster::ReportAttributeClusterRevision(Callback::Cancelable *
 
 // BooleanState Cluster Commands
 // BooleanState Cluster Attributes
-CHIP_ERROR BooleanStateCluster::ReadAttributeStateValue(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR BooleanStateCluster::SubscribeAttributeStateValue(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -1977,17 +1426,6 @@ CHIP_ERROR BooleanStateCluster::ReportAttributeStateValue(Callback::Cancelable *
 {
     return RequestAttributeReporting(BooleanState::Attributes::StateValue::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR BooleanStateCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BooleanStateCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -2545,39 +1983,6 @@ exit:
 }
 
 // BridgedActions Cluster Attributes
-CHIP_ERROR BridgedActionsCluster::ReadAttributeActionList(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BridgedActionsClusterActionListListAttributeFilter);
-}
-
-CHIP_ERROR BridgedActionsCluster::ReadAttributeEndpointList(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BridgedActionsClusterEndpointListListAttributeFilter);
-}
-
-CHIP_ERROR BridgedActionsCluster::ReadAttributeSetupUrl(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR BridgedActionsCluster::SubscribeAttributeSetupUrl(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -2593,17 +1998,6 @@ CHIP_ERROR BridgedActionsCluster::ReportAttributeSetupUrl(Callback::Cancelable *
 {
     return RequestAttributeReporting(BridgedActions::Attributes::SetupUrl::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR BridgedActionsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR BridgedActionsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -2625,17 +2019,6 @@ CHIP_ERROR BridgedActionsCluster::ReportAttributeClusterRevision(Callback::Cance
 
 // BridgedDeviceBasic Cluster Commands
 // BridgedDeviceBasic Cluster Attributes
-CHIP_ERROR BridgedDeviceBasicCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR BridgedDeviceBasicCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -3598,17 +2981,6 @@ exit:
 }
 
 // ColorControl Cluster Attributes
-CHIP_ERROR ColorControlCluster::ReadAttributeCurrentHue(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentHue(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -3624,17 +2996,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentHue(Callback::Cancelable *
 {
     return RequestAttributeReporting(ColorControl::Attributes::CurrentHue::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
@@ -3654,17 +3015,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentSaturation(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeRemainingTime(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeRemainingTime(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -3680,17 +3030,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeRemainingTime(Callback::Cancelabl
 {
     return RequestAttributeReporting(ColorControl::Attributes::RemainingTime::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeCurrentX(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentX(Callback::Cancelable * onSuccessCallback,
@@ -3710,17 +3049,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentX(Callback::Cancelable * o
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeCurrentY(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentY(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -3736,17 +3064,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentY(Callback::Cancelable * o
 {
     return RequestAttributeReporting(ColorControl::Attributes::CurrentY::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeDriftCompensation(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeDriftCompensation(Callback::Cancelable * onSuccessCallback,
@@ -3766,17 +3083,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeDriftCompensation(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeCompensationText(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeCompensationText(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -3792,17 +3098,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCompensationText(Callback::Cancel
 {
     return RequestAttributeReporting(ColorControl::Attributes::CompensationText::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -3822,17 +3117,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorTemperature(Callback::Cancel
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorMode(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorMode(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -3848,17 +3132,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorMode(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback,
@@ -3878,17 +3151,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorControlOptions(Callback::Can
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeNumberOfPrimaries(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeNumberOfPrimaries(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -3904,17 +3166,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeNumberOfPrimaries(Callback::Cance
 {
     return RequestAttributeReporting(ColorControl::Attributes::NumberOfPrimaries::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary1X(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary1X(Callback::Cancelable * onSuccessCallback,
@@ -3934,17 +3185,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary1X(Callback::Cancelable * 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary1Y(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary1Y(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -3960,17 +3200,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary1Y(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary1Y::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary1Intensity(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary1Intensity(Callback::Cancelable * onSuccessCallback,
@@ -3990,17 +3219,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary1Intensity(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary2X(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000015;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary2X(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -4016,17 +3234,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary2X(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary2X::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary2Y(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000016;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary2Y(Callback::Cancelable * onSuccessCallback,
@@ -4046,17 +3253,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary2Y(Callback::Cancelable * 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary2Intensity(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary2Intensity(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -4072,17 +3268,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary2Intensity(Callback::Cance
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary2Intensity::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary3X(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000019;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary3X(Callback::Cancelable * onSuccessCallback,
@@ -4102,17 +3287,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary3X(Callback::Cancelable * 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary3Y(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary3Y(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -4128,17 +3302,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary3Y(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary3Y::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary3Intensity(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary3Intensity(Callback::Cancelable * onSuccessCallback,
@@ -4158,17 +3321,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary3Intensity(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary4X(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000020;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary4X(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -4184,17 +3336,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary4X(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary4X::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary4Y(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000021;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary4Y(Callback::Cancelable * onSuccessCallback,
@@ -4214,17 +3355,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary4Y(Callback::Cancelable * 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary4Intensity(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000022;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary4Intensity(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -4240,17 +3370,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary4Intensity(Callback::Cance
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary4Intensity::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary5X(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000024;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary5X(Callback::Cancelable * onSuccessCallback,
@@ -4270,17 +3389,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary5X(Callback::Cancelable * 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary5Y(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000025;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary5Y(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -4296,17 +3404,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary5Y(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary5Y::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary5Intensity(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000026;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary5Intensity(Callback::Cancelable * onSuccessCallback,
@@ -4326,17 +3423,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary5Intensity(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary6X(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000028;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary6X(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -4352,17 +3438,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary6X(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary6X::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary6Y(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000029;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary6Y(Callback::Cancelable * onSuccessCallback,
@@ -4382,17 +3457,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary6Y(Callback::Cancelable * 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributePrimary6Intensity(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributePrimary6Intensity(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -4408,17 +3472,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributePrimary6Intensity(Callback::Cance
 {
     return RequestAttributeReporting(ColorControl::Attributes::Primary6Intensity::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointX(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000030;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeWhitePointX(Callback::Cancelable * onSuccessCallback,
@@ -4438,17 +3491,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeWhitePointX(Callback::Cancelable 
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointY(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000031;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeWhitePointY(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                               uint16_t maxInterval)
@@ -4464,17 +3506,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeWhitePointY(Callback::Cancelable 
 {
     return RequestAttributeReporting(ColorControl::Attributes::WhitePointY::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRX(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000032;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointRX(Callback::Cancelable * onSuccessCallback,
@@ -4494,17 +3525,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointRX(Callback::Cancelable
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRY(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000033;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointRY(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -4520,17 +3540,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointRY(Callback::Cancelable
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorPointRY::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000034;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
@@ -4550,17 +3559,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointRIntensity(Callback::Ca
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGX(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000036;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointGX(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -4576,17 +3574,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointGX(Callback::Cancelable
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorPointGX::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGY(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000037;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointGY(Callback::Cancelable * onSuccessCallback,
@@ -4606,17 +3593,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointGY(Callback::Cancelable
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000038;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -4632,17 +3608,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointGIntensity(Callback::Ca
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorPointGIntensity::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBX(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointBX(Callback::Cancelable * onSuccessCallback,
@@ -4662,17 +3627,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointBX(Callback::Cancelable
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBY(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointBY(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -4688,17 +3642,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointBY(Callback::Cancelable
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorPointBY::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
@@ -4718,17 +3661,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorPointBIntensity(Callback::Ca
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeEnhancedCurrentHue(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeEnhancedCurrentHue(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -4744,17 +3676,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeEnhancedCurrentHue(Callback::Canc
 {
     return RequestAttributeReporting(ColorControl::Attributes::EnhancedCurrentHue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeEnhancedColorMode(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeEnhancedColorMode(Callback::Cancelable * onSuccessCallback,
@@ -4774,17 +3695,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeEnhancedColorMode(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopActive(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorLoopActive(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -4800,17 +3710,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorLoopActive(Callback::Cancela
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorLoopActive::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopDirection(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorLoopDirection(Callback::Cancelable * onSuccessCallback,
@@ -4830,17 +3729,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorLoopDirection(Callback::Canc
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopTime(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorLoopTime(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -4856,17 +3744,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorLoopTime(Callback::Cancelabl
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorLoopTime::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopStartEnhancedHue(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorLoopStartEnhancedHue(Callback::Cancelable * onSuccessCallback,
@@ -4886,17 +3763,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorLoopStartEnhancedHue(Callbac
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopStoredEnhancedHue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorLoopStoredEnhancedHue(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -4912,17 +3778,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorLoopStoredEnhancedHue(Callba
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorLoopStoredEnhancedHue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorCapabilities(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000400A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorCapabilities(Callback::Cancelable * onSuccessCallback,
@@ -4942,17 +3797,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorCapabilities(Callback::Cance
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeColorTempPhysicalMin(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000400B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorTempPhysicalMin(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -4968,17 +3812,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorTempPhysicalMin(Callback::Ca
 {
     return RequestAttributeReporting(ColorControl::Attributes::ColorTempPhysicalMin::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeColorTempPhysicalMax(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000400C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeColorTempPhysicalMax(Callback::Cancelable * onSuccessCallback,
@@ -4998,17 +3831,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorTempPhysicalMax(Callback::Ca
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeCoupleColorTempToLevelMinMireds(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000400D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeCoupleColorTempToLevelMinMireds(Callback::Cancelable * onSuccessCallback,
                                                                                   Callback::Cancelable * onFailureCallback,
                                                                                   uint16_t minInterval, uint16_t maxInterval)
@@ -5026,17 +3848,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCoupleColorTempToLevelMinMireds(C
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ColorControlCluster::ReadAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ColorControlCluster::SubscribeAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
                                                                                 Callback::Cancelable * onFailureCallback,
                                                                                 uint16_t minInterval, uint16_t maxInterval)
@@ -5052,17 +3863,6 @@ CHIP_ERROR ColorControlCluster::ReportAttributeStartUpColorTemperatureMireds(Cal
 {
     return RequestAttributeReporting(ColorControl::Attributes::StartUpColorTemperatureMireds::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ColorControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ColorControlCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -5170,39 +3970,6 @@ exit:
 }
 
 // ContentLauncher Cluster Attributes
-CHIP_ERROR ContentLauncherCluster::ReadAttributeAcceptsHeaderList(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ContentLauncherClusterAcceptsHeaderListListAttributeFilter);
-}
-
-CHIP_ERROR ContentLauncherCluster::ReadAttributeSupportedStreamingTypes(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ContentLauncherClusterSupportedStreamingTypesListAttributeFilter);
-}
-
-CHIP_ERROR ContentLauncherCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ContentLauncherCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -5222,61 +3989,6 @@ CHIP_ERROR ContentLauncherCluster::ReportAttributeClusterRevision(Callback::Canc
 
 // Descriptor Cluster Commands
 // Descriptor Cluster Attributes
-CHIP_ERROR DescriptorCluster::ReadAttributeDeviceList(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             DescriptorClusterDeviceListListAttributeFilter);
-}
-
-CHIP_ERROR DescriptorCluster::ReadAttributeServerList(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             DescriptorClusterServerListListAttributeFilter);
-}
-
-CHIP_ERROR DescriptorCluster::ReadAttributeClientList(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             DescriptorClusterClientListListAttributeFilter);
-}
-
-CHIP_ERROR DescriptorCluster::ReadAttributePartsList(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             DescriptorClusterPartsListListAttributeFilter);
-}
-
-CHIP_ERROR DescriptorCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR DescriptorCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -6333,17 +5045,6 @@ exit:
 }
 
 // DoorLock Cluster Attributes
-CHIP_ERROR DoorLockCluster::ReadAttributeActuatorEnabled(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR DoorLockCluster::SubscribeAttributeActuatorEnabled(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                               uint16_t maxInterval)
@@ -6359,17 +5060,6 @@ CHIP_ERROR DoorLockCluster::ReportAttributeActuatorEnabled(Callback::Cancelable 
 {
     return RequestAttributeReporting(DoorLock::Attributes::ActuatorEnabled::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR DoorLockCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR DoorLockCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -6391,17 +5081,6 @@ CHIP_ERROR DoorLockCluster::ReportAttributeClusterRevision(Callback::Cancelable 
 
 // ElectricalMeasurement Cluster Commands
 // ElectricalMeasurement Cluster Attributes
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeMeasurementType(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeMeasurementType(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -6417,17 +5096,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeMeasurementType(Callback
 {
     return RequestAttributeReporting(ElectricalMeasurement::Attributes::MeasurementType::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeTotalActivePower(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000304;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32sAttributeCallback>);
 }
 
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeTotalActivePower(Callback::Cancelable * onSuccessCallback,
@@ -6447,17 +5115,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeTotalActivePower(Callbac
                                      BasicAttributeFilter<Int32sAttributeCallback>);
 }
 
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeRmsVoltage(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000505;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeRmsVoltage(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -6473,17 +5130,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeRmsVoltage(Callback::Can
 {
     return RequestAttributeReporting(ElectricalMeasurement::Attributes::RmsVoltage::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeRmsVoltageMin(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000506;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeRmsVoltageMin(Callback::Cancelable * onSuccessCallback,
@@ -6503,17 +5149,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeRmsVoltageMin(Callback::
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeRmsVoltageMax(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000507;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeRmsVoltageMax(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -6529,17 +5164,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeRmsVoltageMax(Callback::
 {
     return RequestAttributeReporting(ElectricalMeasurement::Attributes::RmsVoltageMax::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeRmsCurrent(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000508;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeRmsCurrent(Callback::Cancelable * onSuccessCallback,
@@ -6559,17 +5183,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeRmsCurrent(Callback::Can
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeRmsCurrentMin(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000509;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeRmsCurrentMin(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -6585,17 +5198,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeRmsCurrentMin(Callback::
 {
     return RequestAttributeReporting(ElectricalMeasurement::Attributes::RmsCurrentMin::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeRmsCurrentMax(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000050A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeRmsCurrentMax(Callback::Cancelable * onSuccessCallback,
@@ -6615,17 +5217,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeRmsCurrentMax(Callback::
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeActivePower(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000050B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeActivePower(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -6641,17 +5232,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeActivePower(Callback::Ca
 {
     return RequestAttributeReporting(ElectricalMeasurement::Attributes::ActivePower::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeActivePowerMin(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000050C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeActivePowerMin(Callback::Cancelable * onSuccessCallback,
@@ -6671,17 +5251,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeActivePowerMin(Callback:
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeActivePowerMax(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000050D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeActivePowerMax(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -6697,17 +5266,6 @@ CHIP_ERROR ElectricalMeasurementCluster::ReportAttributeActivePowerMax(Callback:
 {
     return RequestAttributeReporting(ElectricalMeasurement::Attributes::ActivePowerMax::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ElectricalMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ElectricalMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -6769,17 +5327,6 @@ exit:
 }
 
 // EthernetNetworkDiagnostics Cluster Attributes
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributePHYRate(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributePHYRate(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -6795,17 +5342,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributePHYRate(Callback::C
 {
     return RequestAttributeReporting(EthernetNetworkDiagnostics::Attributes::PHYRate::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeFullDuplex(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeFullDuplex(Callback::Cancelable * onSuccessCallback,
@@ -6825,17 +5361,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeFullDuplex(Callback
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributePacketRxCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributePacketRxCount(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -6851,17 +5376,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributePacketRxCount(Callb
 {
     return RequestAttributeReporting(EthernetNetworkDiagnostics::Attributes::PacketRxCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributePacketTxCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributePacketTxCount(Callback::Cancelable * onSuccessCallback,
@@ -6881,17 +5395,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributePacketTxCount(Callb
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeTxErrCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeTxErrCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -6907,17 +5410,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeTxErrCount(Callback
 {
     return RequestAttributeReporting(EthernetNetworkDiagnostics::Attributes::TxErrCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeCollisionCount(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeCollisionCount(Callback::Cancelable * onSuccessCallback,
@@ -6937,17 +5429,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeCollisionCount(Call
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeOverrunCount(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeOverrunCount(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -6963,17 +5444,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeOverrunCount(Callba
 {
     return RequestAttributeReporting(EthernetNetworkDiagnostics::Attributes::OverrunCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeCarrierDetect(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeCarrierDetect(Callback::Cancelable * onSuccessCallback,
@@ -6993,17 +5463,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeCarrierDetect(Callb
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeTimeSinceReset(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeTimeSinceReset(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -7019,28 +5478,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeTimeSinceReset(Call
 {
     return RequestAttributeReporting(EthernetNetworkDiagnostics::Attributes::TimeSinceReset::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR EthernetNetworkDiagnosticsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -7062,28 +5499,6 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ReportAttributeClusterRevision(Cal
 
 // FixedLabel Cluster Commands
 // FixedLabel Cluster Attributes
-CHIP_ERROR FixedLabelCluster::ReadAttributeLabelList(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             FixedLabelClusterLabelListListAttributeFilter);
-}
-
-CHIP_ERROR FixedLabelCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR FixedLabelCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -7103,17 +5518,6 @@ CHIP_ERROR FixedLabelCluster::ReportAttributeClusterRevision(Callback::Cancelabl
 
 // FlowMeasurement Cluster Commands
 // FlowMeasurement Cluster Attributes
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -7129,17 +5533,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancel
 {
     return RequestAttributeReporting(FlowMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -7159,17 +5552,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMinMeasuredValue(Callback::Can
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -7187,17 +5569,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMaxMeasuredValue(Callback::Can
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -7213,17 +5584,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeTolerance(Callback::Cancelable
 {
     return RequestAttributeReporting(FlowMeasurement::Attributes::Tolerance::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -7380,17 +5740,6 @@ exit:
 }
 
 // GeneralCommissioning Cluster Attributes
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR GeneralCommissioningCluster::SubscribeAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -7406,50 +5755,6 @@ CHIP_ERROR GeneralCommissioningCluster::ReportAttributeBreadcrumb(Callback::Canc
 {
     return RequestAttributeReporting(GeneralCommissioning::Attributes::Breadcrumb::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeBasicCommissioningInfoList(Callback::Cancelable * onSuccessCallback,
-                                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GeneralCommissioningClusterBasicCommissioningInfoListListAttributeFilter);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeLocationCapability(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -7471,28 +5776,6 @@ CHIP_ERROR GeneralCommissioningCluster::ReportAttributeClusterRevision(Callback:
 
 // GeneralDiagnostics Cluster Commands
 // GeneralDiagnostics Cluster Attributes
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeNetworkInterfaces(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GeneralDiagnosticsClusterNetworkInterfacesListAttributeFilter);
-}
-
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeRebootCount(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR GeneralDiagnosticsCluster::SubscribeAttributeRebootCount(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -7508,17 +5791,6 @@ CHIP_ERROR GeneralDiagnosticsCluster::ReportAttributeRebootCount(Callback::Cance
 {
     return RequestAttributeReporting(GeneralDiagnostics::Attributes::RebootCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeUpTime(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR GeneralDiagnosticsCluster::SubscribeAttributeUpTime(Callback::Cancelable * onSuccessCallback,
@@ -7538,17 +5810,6 @@ CHIP_ERROR GeneralDiagnosticsCluster::ReportAttributeUpTime(Callback::Cancelable
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeTotalOperationalHours(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR GeneralDiagnosticsCluster::SubscribeAttributeTotalOperationalHours(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -7566,17 +5827,6 @@ CHIP_ERROR GeneralDiagnosticsCluster::ReportAttributeTotalOperationalHours(Callb
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeBootReasons(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR GeneralDiagnosticsCluster::SubscribeAttributeBootReasons(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -7592,50 +5842,6 @@ CHIP_ERROR GeneralDiagnosticsCluster::ReportAttributeBootReasons(Callback::Cance
 {
     return RequestAttributeReporting(GeneralDiagnostics::Attributes::BootReasons::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeActiveHardwareFaults(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GeneralDiagnosticsClusterActiveHardwareFaultsListAttributeFilter);
-}
-
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeActiveRadioFaults(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GeneralDiagnosticsClusterActiveRadioFaultsListAttributeFilter);
-}
-
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeActiveNetworkFaults(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GeneralDiagnosticsClusterActiveNetworkFaultsListAttributeFilter);
-}
-
-CHIP_ERROR GeneralDiagnosticsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR GeneralDiagnosticsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -7657,39 +5863,6 @@ CHIP_ERROR GeneralDiagnosticsCluster::ReportAttributeClusterRevision(Callback::C
 
 // GroupKeyManagement Cluster Commands
 // GroupKeyManagement Cluster Attributes
-CHIP_ERROR GroupKeyManagementCluster::ReadAttributeGroups(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GroupKeyManagementClusterGroupsListAttributeFilter);
-}
-
-CHIP_ERROR GroupKeyManagementCluster::ReadAttributeGroupKeys(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GroupKeyManagementClusterGroupKeysListAttributeFilter);
-}
-
-CHIP_ERROR GroupKeyManagementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR GroupKeyManagementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -7956,17 +6129,6 @@ exit:
 }
 
 // Groups Cluster Attributes
-CHIP_ERROR GroupsCluster::ReadAttributeNameSupport(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR GroupsCluster::SubscribeAttributeNameSupport(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -7982,17 +6144,6 @@ CHIP_ERROR GroupsCluster::ReportAttributeNameSupport(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(Groups::Attributes::NameSupport::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR GroupsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR GroupsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -8136,17 +6287,6 @@ exit:
 }
 
 // Identify Cluster Attributes
-CHIP_ERROR IdentifyCluster::ReadAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR IdentifyCluster::SubscribeAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -8164,17 +6304,6 @@ CHIP_ERROR IdentifyCluster::ReportAttributeIdentifyTime(Callback::Cancelable * o
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR IdentifyCluster::ReadAttributeIdentifyType(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR IdentifyCluster::SubscribeAttributeIdentifyType(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -8190,17 +6319,6 @@ CHIP_ERROR IdentifyCluster::ReportAttributeIdentifyType(Callback::Cancelable * o
 {
     return RequestAttributeReporting(Identify::Attributes::IdentifyType::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR IdentifyCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR IdentifyCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -8222,17 +6340,6 @@ CHIP_ERROR IdentifyCluster::ReportAttributeClusterRevision(Callback::Cancelable 
 
 // IlluminanceMeasurement Cluster Commands
 // IlluminanceMeasurement Cluster Attributes
-CHIP_ERROR IlluminanceMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR IlluminanceMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -8248,17 +6355,6 @@ CHIP_ERROR IlluminanceMeasurementCluster::ReportAttributeMeasuredValue(Callback:
 {
     return RequestAttributeReporting(IlluminanceMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR IlluminanceMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR IlluminanceMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -8278,17 +6374,6 @@ CHIP_ERROR IlluminanceMeasurementCluster::ReportAttributeMinMeasuredValue(Callba
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR IlluminanceMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR IlluminanceMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -8304,17 +6389,6 @@ CHIP_ERROR IlluminanceMeasurementCluster::ReportAttributeMaxMeasuredValue(Callba
 {
     return RequestAttributeReporting(IlluminanceMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR IlluminanceMeasurementCluster::ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR IlluminanceMeasurementCluster::SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback,
@@ -8334,17 +6408,6 @@ CHIP_ERROR IlluminanceMeasurementCluster::ReportAttributeTolerance(Callback::Can
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR IlluminanceMeasurementCluster::ReadAttributeLightSensorType(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR IlluminanceMeasurementCluster::SubscribeAttributeLightSensorType(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
                                                                             uint16_t minInterval, uint16_t maxInterval)
@@ -8360,17 +6423,6 @@ CHIP_ERROR IlluminanceMeasurementCluster::ReportAttributeLightSensorType(Callbac
 {
     return RequestAttributeReporting(IlluminanceMeasurement::Attributes::LightSensorType::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR IlluminanceMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR IlluminanceMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -8433,17 +6485,6 @@ exit:
 }
 
 // KeypadInput Cluster Attributes
-CHIP_ERROR KeypadInputCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR KeypadInputCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -8820,17 +6861,6 @@ exit:
 }
 
 // LevelControl Cluster Attributes
-CHIP_ERROR LevelControlCluster::ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -8846,17 +6876,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeCurrentLevel(Callback::Cancelable
 {
     return RequestAttributeReporting(LevelControl::Attributes::CurrentLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeRemainingTime(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeRemainingTime(Callback::Cancelable * onSuccessCallback,
@@ -8876,17 +6895,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeRemainingTime(Callback::Cancelabl
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeMinLevel(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeMinLevel(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -8902,17 +6910,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeMinLevel(Callback::Cancelable * o
 {
     return RequestAttributeReporting(LevelControl::Attributes::MinLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeMaxLevel(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeMaxLevel(Callback::Cancelable * onSuccessCallback,
@@ -8932,17 +6929,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeMaxLevel(Callback::Cancelable * o
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeCurrentFrequency(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeCurrentFrequency(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -8958,17 +6944,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeCurrentFrequency(Callback::Cancel
 {
     return RequestAttributeReporting(LevelControl::Attributes::CurrentFrequency::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeMinFrequency(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeMinFrequency(Callback::Cancelable * onSuccessCallback,
@@ -8988,17 +6963,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeMinFrequency(Callback::Cancelable
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeMaxFrequency(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeMaxFrequency(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -9014,17 +6978,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeMaxFrequency(Callback::Cancelable
 {
     return RequestAttributeReporting(LevelControl::Attributes::MaxFrequency::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeOptions(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeOptions(Callback::Cancelable * onSuccessCallback,
@@ -9044,17 +6997,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeOptions(Callback::Cancelable * on
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeOnOffTransitionTime(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeOnOffTransitionTime(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -9070,17 +7012,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeOnOffTransitionTime(Callback::Can
 {
     return RequestAttributeReporting(LevelControl::Attributes::OnOffTransitionTime::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeOnLevel(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeOnLevel(Callback::Cancelable * onSuccessCallback,
@@ -9100,17 +7031,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeOnLevel(Callback::Cancelable * on
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeOnTransitionTime(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeOnTransitionTime(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -9126,17 +7046,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeOnTransitionTime(Callback::Cancel
 {
     return RequestAttributeReporting(LevelControl::Attributes::OnTransitionTime::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeOffTransitionTime(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeOffTransitionTime(Callback::Cancelable * onSuccessCallback,
@@ -9156,17 +7065,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeOffTransitionTime(Callback::Cance
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeDefaultMoveRate(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000014;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeDefaultMoveRate(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -9184,17 +7082,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeDefaultMoveRate(Callback::Cancela
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR LevelControlCluster::ReadAttributeStartUpCurrentLevel(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeStartUpCurrentLevel(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -9210,17 +7097,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeStartUpCurrentLevel(Callback::Can
 {
     return RequestAttributeReporting(LevelControl::Attributes::StartUpCurrentLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -9280,17 +7156,6 @@ exit:
 }
 
 // LowPower Cluster Attributes
-CHIP_ERROR LowPowerCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR LowPowerCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                               uint16_t maxInterval)
@@ -9470,28 +7335,6 @@ exit:
 }
 
 // MediaInput Cluster Attributes
-CHIP_ERROR MediaInputCluster::ReadAttributeMediaInputList(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             MediaInputClusterMediaInputListListAttributeFilter);
-}
-
-CHIP_ERROR MediaInputCluster::ReadAttributeCurrentMediaInput(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR MediaInputCluster::SubscribeAttributeCurrentMediaInput(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -9507,17 +7350,6 @@ CHIP_ERROR MediaInputCluster::ReportAttributeCurrentMediaInput(Callback::Cancela
 {
     return RequestAttributeReporting(MediaInput::Attributes::CurrentMediaInput::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR MediaInputCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR MediaInputCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -9967,17 +7799,6 @@ exit:
 }
 
 // MediaPlayback Cluster Attributes
-CHIP_ERROR MediaPlaybackCluster::ReadAttributePlaybackState(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributePlaybackState(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -9993,17 +7814,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributePlaybackState(Callback::Cancelab
 {
     return RequestAttributeReporting(MediaPlayback::Attributes::PlaybackState::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR MediaPlaybackCluster::ReadAttributeStartTime(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributeStartTime(Callback::Cancelable * onSuccessCallback,
@@ -10023,17 +7833,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributeStartTime(Callback::Cancelable *
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR MediaPlaybackCluster::ReadAttributeDuration(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributeDuration(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -10049,17 +7848,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributeDuration(Callback::Cancelable * 
 {
     return RequestAttributeReporting(MediaPlayback::Attributes::Duration::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR MediaPlaybackCluster::ReadAttributePositionUpdatedAt(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributePositionUpdatedAt(Callback::Cancelable * onSuccessCallback,
@@ -10079,17 +7867,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributePositionUpdatedAt(Callback::Canc
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR MediaPlaybackCluster::ReadAttributePosition(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributePosition(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -10105,17 +7882,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributePosition(Callback::Cancelable * 
 {
     return RequestAttributeReporting(MediaPlayback::Attributes::Position::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR MediaPlaybackCluster::ReadAttributePlaybackSpeed(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributePlaybackSpeed(Callback::Cancelable * onSuccessCallback,
@@ -10135,17 +7901,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributePlaybackSpeed(Callback::Cancelab
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR MediaPlaybackCluster::ReadAttributeSeekRangeEnd(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributeSeekRangeEnd(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -10163,17 +7918,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributeSeekRangeEnd(Callback::Cancelabl
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR MediaPlaybackCluster::ReadAttributeSeekRangeStart(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributeSeekRangeStart(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -10189,17 +7933,6 @@ CHIP_ERROR MediaPlaybackCluster::ReportAttributeSeekRangeStart(Callback::Cancela
 {
     return RequestAttributeReporting(MediaPlayback::Attributes::SeekRangeStart::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR MediaPlaybackCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR MediaPlaybackCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -10262,17 +7995,6 @@ exit:
 }
 
 // ModeSelect Cluster Attributes
-CHIP_ERROR ModeSelectCluster::ReadAttributeCurrentMode(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ModeSelectCluster::SubscribeAttributeCurrentMode(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -10288,28 +8010,6 @@ CHIP_ERROR ModeSelectCluster::ReportAttributeCurrentMode(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ModeSelect::Attributes::CurrentMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ModeSelectCluster::ReadAttributeSupportedModes(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ModeSelectClusterSupportedModesListAttributeFilter);
-}
-
-CHIP_ERROR ModeSelectCluster::ReadAttributeOnMode(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ModeSelectCluster::SubscribeAttributeOnMode(Callback::Cancelable * onSuccessCallback,
@@ -10329,17 +8029,6 @@ CHIP_ERROR ModeSelectCluster::ReportAttributeOnMode(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ModeSelectCluster::ReadAttributeStartUpMode(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ModeSelectCluster::SubscribeAttributeStartUpMode(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -10357,17 +8046,6 @@ CHIP_ERROR ModeSelectCluster::ReportAttributeStartUpMode(Callback::Cancelable * 
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ModeSelectCluster::ReadAttributeDescription(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR ModeSelectCluster::SubscribeAttributeDescription(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -10383,17 +8061,6 @@ CHIP_ERROR ModeSelectCluster::ReportAttributeDescription(Callback::Cancelable * 
 {
     return RequestAttributeReporting(ModeSelect::Attributes::Description::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR ModeSelectCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ModeSelectCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -10793,17 +8460,6 @@ exit:
 }
 
 // NetworkCommissioning Cluster Attributes
-CHIP_ERROR NetworkCommissioningCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR NetworkCommissioningCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -10819,17 +8475,6 @@ CHIP_ERROR NetworkCommissioningCluster::ReportAttributeFeatureMap(Callback::Canc
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR NetworkCommissioningCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -11000,17 +8645,6 @@ exit:
 }
 
 // OtaSoftwareUpdateProvider Cluster Attributes
-CHIP_ERROR OtaSoftwareUpdateProviderCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR OtaSoftwareUpdateProviderCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -11080,17 +8714,6 @@ exit:
 }
 
 // OtaSoftwareUpdateRequestor Cluster Attributes
-CHIP_ERROR OtaSoftwareUpdateRequestorCluster::ReadAttributeDefaultOtaProvider(Callback::Cancelable * onSuccessCallback,
-                                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR OtaSoftwareUpdateRequestorCluster::SubscribeAttributeDefaultOtaProvider(Callback::Cancelable * onSuccessCallback,
                                                                                    Callback::Cancelable * onFailureCallback,
                                                                                    uint16_t minInterval, uint16_t maxInterval)
@@ -11108,17 +8731,6 @@ CHIP_ERROR OtaSoftwareUpdateRequestorCluster::ReportAttributeDefaultOtaProvider(
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
 }
 
-CHIP_ERROR OtaSoftwareUpdateRequestorCluster::ReadAttributeUpdatePossible(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR OtaSoftwareUpdateRequestorCluster::SubscribeAttributeUpdatePossible(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -11134,17 +8746,6 @@ CHIP_ERROR OtaSoftwareUpdateRequestorCluster::ReportAttributeUpdatePossible(Call
 {
     return RequestAttributeReporting(OtaSoftwareUpdateRequestor::Attributes::UpdatePossible::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR OtaSoftwareUpdateRequestorCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OtaSoftwareUpdateRequestorCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -11166,17 +8767,6 @@ CHIP_ERROR OtaSoftwareUpdateRequestorCluster::ReportAttributeClusterRevision(Cal
 
 // OccupancySensing Cluster Commands
 // OccupancySensing Cluster Attributes
-CHIP_ERROR OccupancySensingCluster::ReadAttributeOccupancy(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OccupancySensingCluster::SubscribeAttributeOccupancy(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -11192,17 +8782,6 @@ CHIP_ERROR OccupancySensingCluster::ReportAttributeOccupancy(Callback::Cancelabl
 {
     return RequestAttributeReporting(OccupancySensing::Attributes::Occupancy::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OccupancySensingCluster::ReadAttributeOccupancySensorType(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR OccupancySensingCluster::SubscribeAttributeOccupancySensorType(Callback::Cancelable * onSuccessCallback,
@@ -11222,17 +8801,6 @@ CHIP_ERROR OccupancySensingCluster::ReportAttributeOccupancySensorType(Callback:
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR OccupancySensingCluster::ReadAttributeOccupancySensorTypeBitmap(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OccupancySensingCluster::SubscribeAttributeOccupancySensorTypeBitmap(Callback::Cancelable * onSuccessCallback,
                                                                                 Callback::Cancelable * onFailureCallback,
                                                                                 uint16_t minInterval, uint16_t maxInterval)
@@ -11248,17 +8816,6 @@ CHIP_ERROR OccupancySensingCluster::ReportAttributeOccupancySensorTypeBitmap(Cal
 {
     return RequestAttributeReporting(OccupancySensing::Attributes::OccupancySensorTypeBitmap::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OccupancySensingCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OccupancySensingCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -11520,16 +9077,6 @@ exit:
 }
 
 // OnOff Cluster Attributes
-CHIP_ERROR OnOffCluster::ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval)
 {
@@ -11544,17 +9091,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Cancelable * onReportCal
 {
     return RequestAttributeReporting(OnOff::Attributes::OnOff::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback,
@@ -11574,16 +9110,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeGlobalSceneControl(Callback::Cancelable 
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR OnOffCluster::ReadAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeOnTime(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval)
@@ -11599,17 +9125,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOnTime(Callback::Cancelable * onReportCa
 {
     return RequestAttributeReporting(OnOff::Attributes::OnTime::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback,
@@ -11629,17 +9144,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOffWaitTime(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR OnOffCluster::ReadAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -11657,16 +9161,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeStartUpOnOff(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR OnOffCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval)
@@ -11682,17 +9176,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeFeatureMap(Callback::Cancelable * onRepo
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -11714,17 +9197,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeClusterRevision(Callback::Cancelable * o
 
 // OnOffSwitchConfiguration Cluster Commands
 // OnOffSwitchConfiguration Cluster Attributes
-CHIP_ERROR OnOffSwitchConfigurationCluster::ReadAttributeSwitchType(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffSwitchConfigurationCluster::SubscribeAttributeSwitchType(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -11742,17 +9214,6 @@ CHIP_ERROR OnOffSwitchConfigurationCluster::ReportAttributeSwitchType(Callback::
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR OnOffSwitchConfigurationCluster::ReadAttributeSwitchActions(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffSwitchConfigurationCluster::SubscribeAttributeSwitchActions(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
                                                                             uint16_t minInterval, uint16_t maxInterval)
@@ -11768,17 +9229,6 @@ CHIP_ERROR OnOffSwitchConfigurationCluster::ReportAttributeSwitchActions(Callbac
 {
     return RequestAttributeReporting(OnOffSwitchConfiguration::Attributes::SwitchActions::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OnOffSwitchConfigurationCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OnOffSwitchConfigurationCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -12191,28 +9641,6 @@ exit:
 }
 
 // OperationalCredentials Cluster Attributes
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             OperationalCredentialsClusterFabricsListListAttributeFilter);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -12228,17 +9656,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeSupportedFabrics(Callba
 {
     return RequestAttributeReporting(OperationalCredentials::Attributes::SupportedFabrics::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback,
@@ -12258,28 +9675,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeCommissionedFabrics(Cal
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeTrustedRootCertificates(Callback::Cancelable * onSuccessCallback,
-                                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -12295,17 +9690,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeCurrentFabricIndex(Call
 {
     return RequestAttributeReporting(OperationalCredentials::Attributes::CurrentFabricIndex::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -12327,17 +9711,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeClusterRevision(Callbac
 
 // PowerSource Cluster Commands
 // PowerSource Cluster Attributes
-CHIP_ERROR PowerSourceCluster::ReadAttributeStatus(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeStatus(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -12353,17 +9726,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeStatus(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(PowerSource::Attributes::Status::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PowerSourceCluster::ReadAttributeOrder(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeOrder(Callback::Cancelable * onSuccessCallback,
@@ -12383,17 +9745,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeOrder(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR PowerSourceCluster::ReadAttributeDescription(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeDescription(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -12409,17 +9760,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeDescription(Callback::Cancelable *
 {
     return RequestAttributeReporting(PowerSource::Attributes::Description::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR PowerSourceCluster::ReadAttributeBatteryVoltage(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeBatteryVoltage(Callback::Cancelable * onSuccessCallback,
@@ -12439,17 +9779,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeBatteryVoltage(Callback::Cancelabl
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR PowerSourceCluster::ReadAttributeBatteryPercentRemaining(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeBatteryPercentRemaining(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -12465,17 +9794,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeBatteryPercentRemaining(Callback::
 {
     return RequestAttributeReporting(PowerSource::Attributes::BatteryPercentRemaining::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PowerSourceCluster::ReadAttributeBatteryTimeRemaining(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeBatteryTimeRemaining(Callback::Cancelable * onSuccessCallback,
@@ -12495,17 +9813,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeBatteryTimeRemaining(Callback::Can
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR PowerSourceCluster::ReadAttributeBatteryChargeLevel(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeBatteryChargeLevel(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                     uint16_t maxInterval)
@@ -12521,28 +9828,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeBatteryChargeLevel(Callback::Cance
 {
     return RequestAttributeReporting(PowerSource::Attributes::BatteryChargeLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PowerSourceCluster::ReadAttributeActiveBatteryFaults(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             PowerSourceClusterActiveBatteryFaultsListAttributeFilter);
-}
-
-CHIP_ERROR PowerSourceCluster::ReadAttributeBatteryChargeState(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeBatteryChargeState(Callback::Cancelable * onSuccessCallback,
@@ -12562,17 +9847,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeBatteryChargeState(Callback::Cance
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR PowerSourceCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -12588,17 +9862,6 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeFeatureMap(Callback::Cancelable * 
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR PowerSourceCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PowerSourceCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -12620,41 +9883,9 @@ CHIP_ERROR PowerSourceCluster::ReportAttributeClusterRevision(Callback::Cancelab
 
 // PowerSourceConfiguration Cluster Commands
 // PowerSourceConfiguration Cluster Attributes
-CHIP_ERROR PowerSourceConfigurationCluster::ReadAttributeSources(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             PowerSourceConfigurationClusterSourcesListAttributeFilter);
-}
-
-CHIP_ERROR PowerSourceConfigurationCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
 
 // PressureMeasurement Cluster Commands
 // PressureMeasurement Cluster Attributes
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -12670,17 +9901,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Ca
 {
     return RequestAttributeReporting(PressureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -12700,17 +9920,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMinMeasuredValue(Callback:
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -12726,17 +9935,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMaxMeasuredValue(Callback:
 {
     return RequestAttributeReporting(PressureMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -12758,17 +9956,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeClusterRevision(Callback::
 
 // PumpConfigurationAndControl Cluster Commands
 // PumpConfigurationAndControl Cluster Attributes
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxPressure(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxPressure(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -12784,17 +9971,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxPressure(Callba
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxPressure::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback,
@@ -12814,17 +9990,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxSpeed(Callback:
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxFlow(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxFlow(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -12840,17 +10005,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxFlow(Callback::
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxFlow::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMinConstPressure(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMinConstPressure(Callback::Cancelable * onSuccessCallback,
@@ -12870,17 +10024,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMinConstPressure(C
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxConstPressure(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxConstPressure(Callback::Cancelable * onSuccessCallback,
                                                                                   Callback::Cancelable * onFailureCallback,
                                                                                   uint16_t minInterval, uint16_t maxInterval)
@@ -12896,17 +10039,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxConstPressure(C
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxConstPressure::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMinCompPressure(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMinCompPressure(Callback::Cancelable * onSuccessCallback,
@@ -12926,17 +10058,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMinCompPressure(Ca
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxCompPressure(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxCompPressure(Callback::Cancelable * onSuccessCallback,
                                                                                  Callback::Cancelable * onFailureCallback,
                                                                                  uint16_t minInterval, uint16_t maxInterval)
@@ -12952,17 +10073,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxCompPressure(Ca
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxCompPressure::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMinConstSpeed(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMinConstSpeed(Callback::Cancelable * onSuccessCallback,
@@ -12982,17 +10092,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMinConstSpeed(Call
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxConstSpeed(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxConstSpeed(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -13008,17 +10107,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxConstSpeed(Call
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxConstSpeed::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMinConstFlow(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMinConstFlow(Callback::Cancelable * onSuccessCallback,
@@ -13038,17 +10126,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMinConstFlow(Callb
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxConstFlow(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxConstFlow(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -13064,17 +10141,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxConstFlow(Callb
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxConstFlow::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMinConstTemp(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMinConstTemp(Callback::Cancelable * onSuccessCallback,
@@ -13094,17 +10160,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMinConstTemp(Callb
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxConstTemp(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxConstTemp(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -13120,17 +10175,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxConstTemp(Callb
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxConstTemp::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributePumpStatus(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributePumpStatus(Callback::Cancelable * onSuccessCallback,
@@ -13150,17 +10194,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributePumpStatus(Callbac
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
                                                                                         Callback::Cancelable * onFailureCallback,
                                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -13176,17 +10209,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeEffectiveOperation
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::EffectiveOperationMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
-                                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
@@ -13206,17 +10228,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeEffectiveControlMo
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeCapacity(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeCapacity(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -13232,17 +10243,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeCapacity(Callback:
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::Capacity::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeSpeed(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000014;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeSpeed(Callback::Cancelable * onSuccessCallback,
@@ -13262,17 +10262,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeSpeed(Callback::Ca
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeLifetimeRunningHours(Callback::Cancelable * onSuccessCallback,
-                                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000015;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeLifetimeRunningHours(Callback::Cancelable * onSuccessCallback,
                                                                                       Callback::Cancelable * onFailureCallback,
                                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -13288,17 +10277,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeLifetimeRunningHou
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::LifetimeRunningHours::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributePower(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000016;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributePower(Callback::Cancelable * onSuccessCallback,
@@ -13318,17 +10296,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributePower(Callback::Ca
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeLifetimeEnergyConsumed(Callback::Cancelable * onSuccessCallback,
-                                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeLifetimeEnergyConsumed(Callback::Cancelable * onSuccessCallback,
                                                                                         Callback::Cancelable * onFailureCallback,
                                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -13344,17 +10311,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeLifetimeEnergyCons
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000020;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeOperationMode(Callback::Cancelable * onSuccessCallback,
@@ -13374,17 +10330,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeOperationMode(Call
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeControlMode(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000021;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeControlMode(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -13400,17 +10345,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeControlMode(Callba
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::ControlMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeAlarmMask(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000022;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeAlarmMask(Callback::Cancelable * onSuccessCallback,
@@ -13430,17 +10364,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeAlarmMask(Callback
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
                                                                             uint16_t minInterval, uint16_t maxInterval)
@@ -13456,17 +10379,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeFeatureMap(Callbac
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -13488,17 +10400,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeClusterRevision(Ca
 
 // RelativeHumidityMeasurement Cluster Commands
 // RelativeHumidityMeasurement Cluster Attributes
-CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR RelativeHumidityMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -13514,17 +10415,6 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ReportAttributeMeasuredValue(Call
 {
     return RequestAttributeReporting(RelativeHumidityMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR RelativeHumidityMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -13544,17 +10434,6 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ReportAttributeMinMeasuredValue(C
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR RelativeHumidityMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                                   Callback::Cancelable * onFailureCallback,
                                                                                   uint16_t minInterval, uint16_t maxInterval)
@@ -13572,17 +10451,6 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ReportAttributeMaxMeasuredValue(C
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR RelativeHumidityMeasurementCluster::SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -13598,17 +10466,6 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ReportAttributeTolerance(Callback
 {
     return RequestAttributeReporting(RelativeHumidityMeasurement::Attributes::Tolerance::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR RelativeHumidityMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -13940,17 +10797,6 @@ exit:
 }
 
 // Scenes Cluster Attributes
-CHIP_ERROR ScenesCluster::ReadAttributeSceneCount(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ScenesCluster::SubscribeAttributeSceneCount(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval)
@@ -13966,17 +10812,6 @@ CHIP_ERROR ScenesCluster::ReportAttributeSceneCount(Callback::Cancelable * onRep
 {
     return RequestAttributeReporting(Scenes::Attributes::SceneCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ScenesCluster::ReadAttributeCurrentScene(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ScenesCluster::SubscribeAttributeCurrentScene(Callback::Cancelable * onSuccessCallback,
@@ -13996,17 +10831,6 @@ CHIP_ERROR ScenesCluster::ReportAttributeCurrentScene(Callback::Cancelable * onR
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ScenesCluster::ReadAttributeCurrentGroup(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ScenesCluster::SubscribeAttributeCurrentGroup(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval)
@@ -14022,17 +10846,6 @@ CHIP_ERROR ScenesCluster::ReportAttributeCurrentGroup(Callback::Cancelable * onR
 {
     return RequestAttributeReporting(Scenes::Attributes::CurrentGroup::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ScenesCluster::ReadAttributeSceneValid(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR ScenesCluster::SubscribeAttributeSceneValid(Callback::Cancelable * onSuccessCallback,
@@ -14052,17 +10865,6 @@ CHIP_ERROR ScenesCluster::ReportAttributeSceneValid(Callback::Cancelable * onRep
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR ScenesCluster::ReadAttributeNameSupport(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ScenesCluster::SubscribeAttributeNameSupport(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -14078,17 +10880,6 @@ CHIP_ERROR ScenesCluster::ReportAttributeNameSupport(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(Scenes::Attributes::NameSupport::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ScenesCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ScenesCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -14150,28 +10941,6 @@ exit:
 }
 
 // SoftwareDiagnostics Cluster Attributes
-CHIP_ERROR SoftwareDiagnosticsCluster::ReadAttributeThreadMetrics(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             SoftwareDiagnosticsClusterThreadMetricsListAttributeFilter);
-}
-
-CHIP_ERROR SoftwareDiagnosticsCluster::ReadAttributeCurrentHeapFree(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR SoftwareDiagnosticsCluster::SubscribeAttributeCurrentHeapFree(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -14187,17 +10956,6 @@ CHIP_ERROR SoftwareDiagnosticsCluster::ReportAttributeCurrentHeapFree(Callback::
 {
     return RequestAttributeReporting(SoftwareDiagnostics::Attributes::CurrentHeapFree::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR SoftwareDiagnosticsCluster::ReadAttributeCurrentHeapUsed(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR SoftwareDiagnosticsCluster::SubscribeAttributeCurrentHeapUsed(Callback::Cancelable * onSuccessCallback,
@@ -14217,17 +10975,6 @@ CHIP_ERROR SoftwareDiagnosticsCluster::ReportAttributeCurrentHeapUsed(Callback::
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR SoftwareDiagnosticsCluster::ReadAttributeCurrentHeapHighWatermark(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR SoftwareDiagnosticsCluster::SubscribeAttributeCurrentHeapHighWatermark(Callback::Cancelable * onSuccessCallback,
                                                                                   Callback::Cancelable * onFailureCallback,
                                                                                   uint16_t minInterval, uint16_t maxInterval)
@@ -14243,28 +10990,6 @@ CHIP_ERROR SoftwareDiagnosticsCluster::ReportAttributeCurrentHeapHighWatermark(C
 {
     return RequestAttributeReporting(SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR SoftwareDiagnosticsCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR SoftwareDiagnosticsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR SoftwareDiagnosticsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -14286,17 +11011,6 @@ CHIP_ERROR SoftwareDiagnosticsCluster::ReportAttributeClusterRevision(Callback::
 
 // Switch Cluster Commands
 // Switch Cluster Attributes
-CHIP_ERROR SwitchCluster::ReadAttributeNumberOfPositions(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR SwitchCluster::SubscribeAttributeNumberOfPositions(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                               uint16_t maxInterval)
@@ -14312,17 +11026,6 @@ CHIP_ERROR SwitchCluster::ReportAttributeNumberOfPositions(Callback::Cancelable 
 {
     return RequestAttributeReporting(Switch::Attributes::NumberOfPositions::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR SwitchCluster::ReadAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR SwitchCluster::SubscribeAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback,
@@ -14342,17 +11045,6 @@ CHIP_ERROR SwitchCluster::ReportAttributeCurrentPosition(Callback::Cancelable * 
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR SwitchCluster::ReadAttributeMultiPressMax(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR SwitchCluster::SubscribeAttributeMultiPressMax(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval)
@@ -14370,17 +11062,6 @@ CHIP_ERROR SwitchCluster::ReportAttributeMultiPressMax(Callback::Cancelable * on
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR SwitchCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR SwitchCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval)
@@ -14396,17 +11077,6 @@ CHIP_ERROR SwitchCluster::ReportAttributeFeatureMap(Callback::Cancelable * onRep
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR SwitchCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR SwitchCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -14554,28 +11224,6 @@ exit:
 }
 
 // TvChannel Cluster Attributes
-CHIP_ERROR TvChannelCluster::ReadAttributeTvChannelList(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TvChannelClusterTvChannelListListAttributeFilter);
-}
-
-CHIP_ERROR TvChannelCluster::ReadAttributeTvChannelLineup(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR TvChannelCluster::SubscribeAttributeTvChannelLineup(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -14593,17 +11241,6 @@ CHIP_ERROR TvChannelCluster::ReportAttributeTvChannelLineup(Callback::Cancelable
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
 }
 
-CHIP_ERROR TvChannelCluster::ReadAttributeCurrentTvChannel(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR TvChannelCluster::SubscribeAttributeCurrentTvChannel(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -14619,17 +11256,6 @@ CHIP_ERROR TvChannelCluster::ReportAttributeCurrentTvChannel(Callback::Cancelabl
 {
     return RequestAttributeReporting(TvChannel::Attributes::CurrentTvChannel::Id, onReportCallback,
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
-CHIP_ERROR TvChannelCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TvChannelCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -14694,28 +11320,6 @@ exit:
 }
 
 // TargetNavigator Cluster Attributes
-CHIP_ERROR TargetNavigatorCluster::ReadAttributeTargetNavigatorList(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TargetNavigatorClusterTargetNavigatorListListAttributeFilter);
-}
-
-CHIP_ERROR TargetNavigatorCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TargetNavigatorCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -14735,17 +11339,6 @@ CHIP_ERROR TargetNavigatorCluster::ReportAttributeClusterRevision(Callback::Canc
 
 // TemperatureMeasurement Cluster Commands
 // TemperatureMeasurement Cluster Attributes
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -14761,17 +11354,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback:
 {
     return RequestAttributeReporting(TemperatureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -14791,17 +11373,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMinMeasuredValue(Callba
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -14819,17 +11390,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMaxMeasuredValue(Callba
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -14845,17 +11405,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeTolerance(Callback::Can
 {
     return RequestAttributeReporting(TemperatureMeasurement::Attributes::Tolerance::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -15640,17 +12189,6 @@ exit:
 }
 
 // TestCluster Cluster Attributes
-CHIP_ERROR TestClusterCluster::ReadAttributeBoolean(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeBoolean(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval)
@@ -15666,17 +12204,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeBoolean(Callback::Cancelable * onR
 {
     return RequestAttributeReporting(TestCluster::Attributes::Boolean::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeBitmap8(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeBitmap8(Callback::Cancelable * onSuccessCallback,
@@ -15696,17 +12223,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeBitmap8(Callback::Cancelable * onR
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeBitmap16(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeBitmap16(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval)
@@ -15722,17 +12238,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeBitmap16(Callback::Cancelable * on
 {
     return RequestAttributeReporting(TestCluster::Attributes::Bitmap16::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeBitmap32(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeBitmap32(Callback::Cancelable * onSuccessCallback,
@@ -15752,17 +12257,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeBitmap32(Callback::Cancelable * on
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeBitmap64(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeBitmap64(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval)
@@ -15778,17 +12272,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeBitmap64(Callback::Cancelable * on
 {
     return RequestAttributeReporting(TestCluster::Attributes::Bitmap64::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt8u(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt8u(Callback::Cancelable * onSuccessCallback,
@@ -15808,17 +12291,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt8u(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt16u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt16u(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -15834,17 +12306,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt16u(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int16u::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt24u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt24u(Callback::Cancelable * onSuccessCallback,
@@ -15864,17 +12325,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt24u(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt32u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt32u(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -15890,17 +12340,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt32u(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int32u::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt40u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt40u(Callback::Cancelable * onSuccessCallback,
@@ -15920,17 +12359,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt40u(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt48u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt48u(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -15946,17 +12374,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt48u(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int48u::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt56u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt56u(Callback::Cancelable * onSuccessCallback,
@@ -15976,17 +12393,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt56u(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt64u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt64u(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16002,17 +12408,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt64u(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int64u::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt8s(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt8s(Callback::Cancelable * onSuccessCallback,
@@ -16032,17 +12427,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt8s(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt16s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt16s(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16058,17 +12442,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt16s(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int16s::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt24s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt24s(Callback::Cancelable * onSuccessCallback,
@@ -16088,17 +12461,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt24s(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int32sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt32s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt32s(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16114,17 +12476,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt32s(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int32s::Id, onReportCallback,
                                      BasicAttributeFilter<Int32sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt40s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt40s(Callback::Cancelable * onSuccessCallback,
@@ -16144,17 +12495,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt40s(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt48s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt48s(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16170,17 +12510,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt48s(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int48s::Id, onReportCallback,
                                      BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeInt56s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt56s(Callback::Cancelable * onSuccessCallback,
@@ -16200,17 +12529,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt56s(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeInt64s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000014;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeInt64s(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16226,17 +12544,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeInt64s(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Int64s::Id, onReportCallback,
                                      BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeEnum8(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000015;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeEnum8(Callback::Cancelable * onSuccessCallback,
@@ -16256,17 +12563,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeEnum8(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeEnum16(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000016;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeEnum16(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16282,17 +12578,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeEnum16(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::Enum16::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeFloatSingle(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<FloatAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeFloatSingle(Callback::Cancelable * onSuccessCallback,
@@ -16312,17 +12597,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeFloatSingle(Callback::Cancelable *
                                      BasicAttributeFilter<FloatAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeFloatDouble(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000018;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<DoubleAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeFloatDouble(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -16338,17 +12612,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeFloatDouble(Callback::Cancelable *
 {
     return RequestAttributeReporting(TestCluster::Attributes::FloatDouble::Id, onReportCallback,
                                      BasicAttributeFilter<DoubleAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeOctetString(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000019;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeOctetString(Callback::Cancelable * onSuccessCallback,
@@ -16368,50 +12631,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeOctetString(Callback::Cancelable *
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeListInt8u(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TestClusterClusterListInt8uListAttributeFilter);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeListOctetString(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TestClusterClusterListOctetStringListAttributeFilter);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeListStructOctetString(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TestClusterClusterListStructOctetStringListAttributeFilter);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeLongOctetString(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeLongOctetString(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -16427,17 +12646,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeLongOctetString(Callback::Cancelab
 {
     return RequestAttributeReporting(TestCluster::Attributes::LongOctetString::Id, onReportCallback,
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeCharString(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeCharString(Callback::Cancelable * onSuccessCallback,
@@ -16457,17 +12665,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeCharString(Callback::Cancelable * 
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeLongCharString(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeLongCharString(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -16483,17 +12680,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeLongCharString(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::LongCharString::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeEpochUs(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000020;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeEpochUs(Callback::Cancelable * onSuccessCallback,
@@ -16513,17 +12699,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeEpochUs(Callback::Cancelable * onR
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeEpochS(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000021;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeEpochS(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -16539,17 +12714,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeEpochS(Callback::Cancelable * onRe
 {
     return RequestAttributeReporting(TestCluster::Attributes::EpochS::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeVendorId(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000022;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeVendorId(Callback::Cancelable * onSuccessCallback,
@@ -16569,28 +12733,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeVendorId(Callback::Cancelable * on
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeListNullablesAndOptionalsStruct(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000023;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TestClusterClusterListNullablesAndOptionalsStructListAttributeFilter);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000026;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -16606,17 +12748,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeRangeRestrictedInt8u(Callback::Can
 {
     return RequestAttributeReporting(TestCluster::Attributes::RangeRestrictedInt8u::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000027;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
@@ -16636,17 +12767,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeRangeRestrictedInt8s(Callback::Can
                                      BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000028;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -16662,17 +12782,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeRangeRestrictedInt16u(Callback::Ca
 {
     return RequestAttributeReporting(TestCluster::Attributes::RangeRestrictedInt16u::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000029;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
@@ -16692,39 +12801,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeRangeRestrictedInt16s(Callback::Ca
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeListLongOctetString(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             TestClusterClusterListLongOctetStringListAttributeFilter);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeTimedWriteBoolean(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000030;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeUnsupported(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x000000FF;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeUnsupported(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval)
@@ -16740,17 +12816,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeUnsupported(Callback::Cancelable *
 {
     return RequestAttributeReporting(TestCluster::Attributes::Unsupported::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableBoolean(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableBoolean(Callback::Cancelable * onSuccessCallback,
@@ -16770,17 +12835,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableBoolean(Callback::Cancelab
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableBitmap8(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableBitmap8(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -16796,17 +12850,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableBitmap8(Callback::Cancelab
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableBitmap8::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableBitmap16(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableBitmap16(Callback::Cancelable * onSuccessCallback,
@@ -16826,17 +12869,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableBitmap16(Callback::Cancela
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableBitmap32(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableBitmap32(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -16852,17 +12884,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableBitmap32(Callback::Cancela
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableBitmap32::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableBitmap64(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableBitmap64(Callback::Cancelable * onSuccessCallback,
@@ -16882,17 +12903,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableBitmap64(Callback::Cancela
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt8u(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt8u(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -16908,17 +12918,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt8u(Callback::Cancelable
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt8u::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt16u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt16u(Callback::Cancelable * onSuccessCallback,
@@ -16938,17 +12937,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt16u(Callback::Cancelabl
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt24u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt24u(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -16964,17 +12952,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt24u(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt24u::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt32u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt32u(Callback::Cancelable * onSuccessCallback,
@@ -16994,17 +12971,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt32u(Callback::Cancelabl
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt40u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt40u(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -17020,17 +12986,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt40u(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt40u::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt48u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000800A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt48u(Callback::Cancelable * onSuccessCallback,
@@ -17050,17 +13005,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt48u(Callback::Cancelabl
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt56u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000800B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt56u(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -17076,17 +13020,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt56u(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt56u::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt64u(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000800C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt64u(Callback::Cancelable * onSuccessCallback,
@@ -17106,17 +13039,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt64u(Callback::Cancelabl
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt8s(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000800D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt8s(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -17132,17 +13054,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt8s(Callback::Cancelable
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt8s::Id, onReportCallback,
                                      BasicAttributeFilter<Int8sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt16s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000800E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt16s(Callback::Cancelable * onSuccessCallback,
@@ -17162,17 +13073,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt16s(Callback::Cancelabl
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt24s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000800F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt24s(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -17188,17 +13088,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt24s(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt24s::Id, onReportCallback,
                                      BasicAttributeFilter<Int32sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt32s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt32s(Callback::Cancelable * onSuccessCallback,
@@ -17218,17 +13107,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt32s(Callback::Cancelabl
                                      BasicAttributeFilter<Int32sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt40s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt40s(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -17244,17 +13122,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt40s(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt40s::Id, onReportCallback,
                                      BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt48s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt48s(Callback::Cancelable * onSuccessCallback,
@@ -17274,17 +13141,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt48s(Callback::Cancelabl
                                      BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt56s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt56s(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                 uint16_t maxInterval)
@@ -17300,17 +13156,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt56s(Callback::Cancelabl
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableInt56s::Id, onReportCallback,
                                      BasicAttributeFilter<Int64sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableInt64s(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008014;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableInt64s(Callback::Cancelable * onSuccessCallback,
@@ -17330,17 +13175,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableInt64s(Callback::Cancelabl
                                      BasicAttributeFilter<Int64sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableEnum8(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008015;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableEnum8(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -17356,17 +13190,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableEnum8(Callback::Cancelable
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableEnum8::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableEnum16(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008016;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableEnum16(Callback::Cancelable * onSuccessCallback,
@@ -17386,17 +13209,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableEnum16(Callback::Cancelabl
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableFloatSingle(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<FloatAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableFloatSingle(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -17412,17 +13224,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableFloatSingle(Callback::Canc
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableFloatSingle::Id, onReportCallback,
                                      BasicAttributeFilter<FloatAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableFloatDouble(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008018;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<DoubleAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableFloatDouble(Callback::Cancelable * onSuccessCallback,
@@ -17442,17 +13243,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableFloatDouble(Callback::Canc
                                      BasicAttributeFilter<DoubleAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableOctetString(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008019;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableOctetString(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -17468,17 +13258,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableOctetString(Callback::Canc
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableOctetString::Id, onReportCallback,
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableCharString(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000801E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableCharString(Callback::Cancelable * onSuccessCallback,
@@ -17498,17 +13277,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableCharString(Callback::Cance
                                      BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008026;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -17524,17 +13292,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableRangeRestrictedInt8u(Callb
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008027;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
@@ -17554,17 +13311,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableRangeRestrictedInt8s(Callb
                                      BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008028;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -17582,17 +13328,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableRangeRestrictedInt16u(Call
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR TestClusterCluster::ReadAttributeNullableRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00008029;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TestClusterCluster::SubscribeAttributeNullableRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -17608,17 +13343,6 @@ CHIP_ERROR TestClusterCluster::ReportAttributeNullableRangeRestrictedInt16s(Call
 {
     return RequestAttributeReporting(TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TestClusterCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TestClusterCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -17851,17 +13575,6 @@ exit:
 }
 
 // Thermostat Cluster Attributes
-CHIP_ERROR ThermostatCluster::ReadAttributeLocalTemperature(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeLocalTemperature(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -17877,17 +13590,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeLocalTemperature(Callback::Cancelab
 {
     return RequestAttributeReporting(Thermostat::Attributes::LocalTemperature::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeAbsMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeAbsMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
@@ -17907,17 +13609,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeAbsMinHeatSetpointLimit(Callback::C
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeAbsMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeAbsMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -17933,17 +13624,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeAbsMaxHeatSetpointLimit(Callback::C
 {
     return RequestAttributeReporting(Thermostat::Attributes::AbsMaxHeatSetpointLimit::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeAbsMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeAbsMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
@@ -17963,17 +13643,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeAbsMinCoolSetpointLimit(Callback::C
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeAbsMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeAbsMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -17989,17 +13658,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeAbsMaxCoolSetpointLimit(Callback::C
 {
     return RequestAttributeReporting(Thermostat::Attributes::AbsMaxCoolSetpointLimit::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeOccupiedCoolingSetpoint(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeOccupiedCoolingSetpoint(Callback::Cancelable * onSuccessCallback,
@@ -18019,17 +13677,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeOccupiedCoolingSetpoint(Callback::C
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -18045,17 +13692,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeOccupiedHeatingSetpoint(Callback::C
 {
     return RequestAttributeReporting(Thermostat::Attributes::OccupiedHeatingSetpoint::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000015;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
@@ -18075,17 +13711,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeMinHeatSetpointLimit(Callback::Canc
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000016;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -18101,17 +13726,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeMaxHeatSetpointLimit(Callback::Canc
 {
     return RequestAttributeReporting(Thermostat::Attributes::MaxHeatSetpointLimit::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
@@ -18131,17 +13745,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeMinCoolSetpointLimit(Callback::Canc
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000018;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -18157,17 +13760,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeMaxCoolSetpointLimit(Callback::Canc
 {
     return RequestAttributeReporting(Thermostat::Attributes::MaxCoolSetpointLimit::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeMinSetpointDeadBand(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000019;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeMinSetpointDeadBand(Callback::Cancelable * onSuccessCallback,
@@ -18187,17 +13779,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeMinSetpointDeadBand(Callback::Cance
                                      BasicAttributeFilter<Int8sAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeControlSequenceOfOperation(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeControlSequenceOfOperation(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -18213,17 +13794,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeControlSequenceOfOperation(Callback
 {
     return RequestAttributeReporting(Thermostat::Attributes::ControlSequenceOfOperation::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeSystemMode(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeSystemMode(Callback::Cancelable * onSuccessCallback,
@@ -18243,17 +13813,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeSystemMode(Callback::Cancelable * o
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeStartOfWeek(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000020;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeStartOfWeek(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval)
@@ -18269,17 +13828,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeStartOfWeek(Callback::Cancelable * 
 {
     return RequestAttributeReporting(Thermostat::Attributes::StartOfWeek::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeNumberOfWeeklyTransitions(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000021;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeNumberOfWeeklyTransitions(Callback::Cancelable * onSuccessCallback,
@@ -18299,17 +13847,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeNumberOfWeeklyTransitions(Callback:
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeNumberOfDailyTransitions(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000022;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeNumberOfDailyTransitions(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -18327,17 +13864,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeNumberOfDailyTransitions(Callback::
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ThermostatCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -18353,17 +13879,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeFeatureMap(Callback::Cancelable * o
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -18385,18 +13900,6 @@ CHIP_ERROR ThermostatCluster::ReportAttributeClusterRevision(Callback::Cancelabl
 
 // ThermostatUserInterfaceConfiguration Cluster Commands
 // ThermostatUserInterfaceConfiguration Cluster Attributes
-CHIP_ERROR
-ThermostatUserInterfaceConfigurationCluster::ReadAttributeTemperatureDisplayMode(Callback::Cancelable * onSuccessCallback,
-                                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::SubscribeAttributeTemperatureDisplayMode(
     Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval)
 {
@@ -18412,17 +13915,6 @@ ThermostatUserInterfaceConfigurationCluster::ReportAttributeTemperatureDisplayMo
 {
     return RequestAttributeReporting(ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::ReadAttributeKeypadLockout(Callback::Cancelable * onSuccessCallback,
-                                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::SubscribeAttributeKeypadLockout(Callback::Cancelable * onSuccessCallback,
@@ -18442,18 +13934,6 @@ CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::ReportAttributeKeypadLoc
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR
-ThermostatUserInterfaceConfigurationCluster::ReadAttributeScheduleProgrammingVisibility(Callback::Cancelable * onSuccessCallback,
-                                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::SubscribeAttributeScheduleProgrammingVisibility(
     Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval)
 {
@@ -18469,17 +13949,6 @@ ThermostatUserInterfaceConfigurationCluster::ReportAttributeScheduleProgrammingV
 {
     return RequestAttributeReporting(ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::Id,
                                      onReportCallback, BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -18542,17 +14011,6 @@ exit:
 }
 
 // ThreadNetworkDiagnostics Cluster Attributes
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeChannel(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeChannel(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -18568,17 +14026,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeChannel(Callback::Can
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::Channel::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRoutingRole(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRoutingRole(Callback::Cancelable * onSuccessCallback,
@@ -18598,17 +14045,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRoutingRole(Callback:
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeNetworkName(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeNetworkName(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -18624,17 +14060,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeNetworkName(Callback:
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::NetworkName::Id, onReportCallback,
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributePanId(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributePanId(Callback::Cancelable * onSuccessCallback,
@@ -18654,17 +14079,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributePanId(Callback::Cance
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeExtendedPanId(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeExtendedPanId(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
                                                                             uint16_t minInterval, uint16_t maxInterval)
@@ -18680,17 +14094,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeExtendedPanId(Callbac
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::ExtendedPanId::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeMeshLocalPrefix(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeMeshLocalPrefix(Callback::Cancelable * onSuccessCallback,
@@ -18710,17 +14113,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeMeshLocalPrefix(Callb
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeOverrunCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeOverrunCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -18736,39 +14128,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeOverrunCount(Callback
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::OverrunCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeNeighborTableList(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ThreadNetworkDiagnosticsClusterNeighborTableListListAttributeFilter);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRouteTableList(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ThreadNetworkDiagnosticsClusterRouteTableListListAttributeFilter);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributePartitionId(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributePartitionId(Callback::Cancelable * onSuccessCallback,
@@ -18788,17 +14147,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributePartitionId(Callback:
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeWeighting(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeWeighting(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -18814,17 +14162,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeWeighting(Callback::C
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::Weighting::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeDataVersion(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeDataVersion(Callback::Cancelable * onSuccessCallback,
@@ -18844,17 +14181,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeDataVersion(Callback:
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeStableDataVersion(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeStableDataVersion(Callback::Cancelable * onSuccessCallback,
                                                                                 Callback::Cancelable * onFailureCallback,
                                                                                 uint16_t minInterval, uint16_t maxInterval)
@@ -18870,17 +14196,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeStableDataVersion(Cal
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::StableDataVersion::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeLeaderRouterId(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeLeaderRouterId(Callback::Cancelable * onSuccessCallback,
@@ -18900,17 +14215,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeLeaderRouterId(Callba
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeDetachedRoleCount(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeDetachedRoleCount(Callback::Cancelable * onSuccessCallback,
                                                                                 Callback::Cancelable * onFailureCallback,
                                                                                 uint16_t minInterval, uint16_t maxInterval)
@@ -18926,17 +14230,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeDetachedRoleCount(Cal
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeChildRoleCount(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeChildRoleCount(Callback::Cancelable * onSuccessCallback,
@@ -18956,17 +14249,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeChildRoleCount(Callba
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRouterRoleCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRouterRoleCount(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -18982,17 +14264,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRouterRoleCount(Callb
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RouterRoleCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeLeaderRoleCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeLeaderRoleCount(Callback::Cancelable * onSuccessCallback,
@@ -19012,17 +14283,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeLeaderRoleCount(Callb
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeAttachAttemptCount(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeAttachAttemptCount(Callback::Cancelable * onSuccessCallback,
                                                                                  Callback::Cancelable * onFailureCallback,
                                                                                  uint16_t minInterval, uint16_t maxInterval)
@@ -19038,17 +14298,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeAttachAttemptCount(Ca
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributePartitionIdChangeCount(Callback::Cancelable * onSuccessCallback,
-                                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributePartitionIdChangeCount(Callback::Cancelable * onSuccessCallback,
@@ -19068,17 +14317,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributePartitionIdChangeCoun
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeBetterPartitionAttachAttemptCount(Callback::Cancelable * onSuccessCallback,
-                                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000014;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeBetterPartitionAttachAttemptCount(
     Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval)
 {
@@ -19094,17 +14332,6 @@ ThreadNetworkDiagnosticsCluster::ReportAttributeBetterPartitionAttachAttemptCoun
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeParentChangeCount(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000015;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeParentChangeCount(Callback::Cancelable * onSuccessCallback,
@@ -19124,17 +14351,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeParentChangeCount(Cal
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxTotalCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000016;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxTotalCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -19150,17 +14366,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxTotalCount(Callback
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxTotalCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxUnicastCount(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxUnicastCount(Callback::Cancelable * onSuccessCallback,
@@ -19180,17 +14385,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxUnicastCount(Callba
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxBroadcastCount(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000018;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxBroadcastCount(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -19206,17 +14400,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxBroadcastCount(Call
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxAckRequestedCount(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000019;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxAckRequestedCount(Callback::Cancelable * onSuccessCallback,
@@ -19236,17 +14419,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxAckRequestedCount(C
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxAckedCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxAckedCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -19262,17 +14434,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxAckedCount(Callback
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxAckedCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxNoAckRequestedCount(Callback::Cancelable * onSuccessCallback,
-                                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxNoAckRequestedCount(Callback::Cancelable * onSuccessCallback,
@@ -19292,17 +14453,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxNoAckRequestedCount
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxDataCount(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxDataCount(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -19318,17 +14468,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxDataCount(Callback:
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxDataCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxDataPollCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxDataPollCount(Callback::Cancelable * onSuccessCallback,
@@ -19348,17 +14487,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxDataPollCount(Callb
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxBeaconCount(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxBeaconCount(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
                                                                             uint16_t minInterval, uint16_t maxInterval)
@@ -19374,17 +14502,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxBeaconCount(Callbac
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxBeaconCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
-                                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
@@ -19404,17 +14521,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxBeaconRequestCount(
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxOtherCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000020;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxOtherCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -19432,17 +14538,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxOtherCount(Callback
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxRetryCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000021;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxRetryCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -19458,17 +14553,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxRetryCount(Callback
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxRetryCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxDirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
-                                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000022;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxDirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
@@ -19489,17 +14573,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxDirectMaxRetryExpir
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxIndirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
-                                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000023;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxIndirectMaxRetryExpiryCount(
     Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval)
 {
@@ -19514,17 +14587,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxIndirectMaxRetryExp
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxErrCcaCount(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000024;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxErrCcaCount(Callback::Cancelable * onSuccessCallback,
@@ -19544,17 +14606,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxErrCcaCount(Callbac
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxErrAbortCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000025;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxErrAbortCount(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -19570,17 +14621,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxErrAbortCount(Callb
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeTxErrBusyChannelCount(Callback::Cancelable * onSuccessCallback,
-                                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000026;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeTxErrBusyChannelCount(Callback::Cancelable * onSuccessCallback,
@@ -19600,17 +14640,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeTxErrBusyChannelCount
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxTotalCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000027;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxTotalCount(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -19626,17 +14655,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxTotalCount(Callback
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxTotalCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxUnicastCount(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000028;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxUnicastCount(Callback::Cancelable * onSuccessCallback,
@@ -19656,17 +14674,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxUnicastCount(Callba
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxBroadcastCount(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000029;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxBroadcastCount(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -19682,17 +14689,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxBroadcastCount(Call
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxDataCount(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxDataCount(Callback::Cancelable * onSuccessCallback,
@@ -19712,17 +14708,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxDataCount(Callback:
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxDataPollCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxDataPollCount(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -19738,17 +14723,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxDataPollCount(Callb
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxDataPollCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxBeaconCount(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxBeaconCount(Callback::Cancelable * onSuccessCallback,
@@ -19768,17 +14742,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxBeaconCount(Callbac
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
-                                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
                                                                                    Callback::Cancelable * onFailureCallback,
                                                                                    uint16_t minInterval, uint16_t maxInterval)
@@ -19794,17 +14757,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxBeaconRequestCount(
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxOtherCount(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxOtherCount(Callback::Cancelable * onSuccessCallback,
@@ -19824,17 +14776,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxOtherCount(Callback
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxAddressFilteredCount(Callback::Cancelable * onSuccessCallback,
-                                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000002F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxAddressFilteredCount(Callback::Cancelable * onSuccessCallback,
                                                                                      Callback::Cancelable * onFailureCallback,
                                                                                      uint16_t minInterval, uint16_t maxInterval)
@@ -19850,17 +14791,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxAddressFilteredCoun
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxDestAddrFilteredCount(Callback::Cancelable * onSuccessCallback,
-                                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000030;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxDestAddrFilteredCount(Callback::Cancelable * onSuccessCallback,
@@ -19880,17 +14810,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxDestAddrFilteredCou
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxDuplicatedCount(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000031;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxDuplicatedCount(Callback::Cancelable * onSuccessCallback,
                                                                                 Callback::Cancelable * onFailureCallback,
                                                                                 uint16_t minInterval, uint16_t maxInterval)
@@ -19906,17 +14825,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxDuplicatedCount(Cal
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxErrNoFrameCount(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000032;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxErrNoFrameCount(Callback::Cancelable * onSuccessCallback,
@@ -19936,17 +14844,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxErrNoFrameCount(Cal
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxErrUnknownNeighborCount(Callback::Cancelable * onSuccessCallback,
-                                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000033;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxErrUnknownNeighborCount(Callback::Cancelable * onSuccessCallback,
                                                                                         Callback::Cancelable * onFailureCallback,
                                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -19962,17 +14859,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxErrUnknownNeighborC
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxErrInvalidSrcAddrCount(Callback::Cancelable * onSuccessCallback,
-                                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000034;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxErrInvalidSrcAddrCount(Callback::Cancelable * onSuccessCallback,
@@ -19992,17 +14878,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxErrInvalidSrcAddrCo
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxErrSecCount(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000035;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxErrSecCount(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
                                                                             uint16_t minInterval, uint16_t maxInterval)
@@ -20018,17 +14893,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxErrSecCount(Callbac
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxErrSecCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxErrFcsCount(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000036;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxErrFcsCount(Callback::Cancelable * onSuccessCallback,
@@ -20048,17 +14912,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxErrFcsCount(Callbac
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeRxErrOtherCount(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000037;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeRxErrOtherCount(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
                                                                               uint16_t minInterval, uint16_t maxInterval)
@@ -20074,17 +14927,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeRxErrOtherCount(Callb
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeActiveTimestamp(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000038;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeActiveTimestamp(Callback::Cancelable * onSuccessCallback,
@@ -20104,17 +14946,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeActiveTimestamp(Callb
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributePendingTimestamp(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000039;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributePendingTimestamp(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -20130,17 +14961,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributePendingTimestamp(Call
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::PendingTimestamp::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeDelay(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeDelay(Callback::Cancelable * onSuccessCallback,
@@ -20160,28 +14980,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeDelay(Callback::Cance
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeSecurityPolicy(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ThreadNetworkDiagnosticsClusterSecurityPolicyListAttributeFilter);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeChannelMask(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeChannelMask(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -20197,50 +14995,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeChannelMask(Callback:
 {
     return RequestAttributeReporting(ThreadNetworkDiagnostics::Attributes::ChannelMask::Id, onReportCallback,
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeOperationalDatasetComponents(Callback::Cancelable * onSuccessCallback,
-                                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ThreadNetworkDiagnosticsClusterOperationalDatasetComponentsListAttributeFilter);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeActiveNetworkFaultsList(Callback::Cancelable * onSuccessCallback,
-                                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000003E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             ThreadNetworkDiagnosticsClusterActiveNetworkFaultsListListAttributeFilter);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR ThreadNetworkDiagnosticsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -20262,17 +15016,6 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ReportAttributeClusterRevision(Callb
 
 // WakeOnLan Cluster Commands
 // WakeOnLan Cluster Attributes
-CHIP_ERROR WakeOnLanCluster::ReadAttributeWakeOnLanMacAddress(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
 CHIP_ERROR WakeOnLanCluster::SubscribeAttributeWakeOnLanMacAddress(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -20288,17 +15031,6 @@ CHIP_ERROR WakeOnLanCluster::ReportAttributeWakeOnLanMacAddress(Callback::Cancel
 {
     return RequestAttributeReporting(WakeOnLan::Attributes::WakeOnLanMacAddress::Id, onReportCallback,
                                      BasicAttributeFilter<CharStringAttributeCallback>);
-}
-
-CHIP_ERROR WakeOnLanCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WakeOnLanCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -20359,17 +15091,6 @@ exit:
 }
 
 // WiFiNetworkDiagnostics Cluster Attributes
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeBssid(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeBssid(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval)
@@ -20385,17 +15106,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeBssid(Callback::Cancela
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::Bssid::Id, onReportCallback,
                                      BasicAttributeFilter<OctetStringAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeSecurityType(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeSecurityType(Callback::Cancelable * onSuccessCallback,
@@ -20415,17 +15125,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeSecurityType(Callback::
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeWiFiVersion(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeWiFiVersion(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -20441,17 +15140,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeWiFiVersion(Callback::C
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::WiFiVersion::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeChannelNumber(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeChannelNumber(Callback::Cancelable * onSuccessCallback,
@@ -20471,17 +15159,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeChannelNumber(Callback:
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeRssi(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8sAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeRssi(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval)
@@ -20497,17 +15174,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeRssi(Callback::Cancelab
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::Rssi::Id, onReportCallback,
                                      BasicAttributeFilter<Int8sAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeBeaconLostCount(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeBeaconLostCount(Callback::Cancelable * onSuccessCallback,
@@ -20527,17 +15193,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeBeaconLostCount(Callbac
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeBeaconRxCount(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000006;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeBeaconRxCount(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -20553,17 +15208,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeBeaconRxCount(Callback:
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::BeaconRxCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributePacketMulticastRxCount(Callback::Cancelable * onSuccessCallback,
-                                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributePacketMulticastRxCount(Callback::Cancelable * onSuccessCallback,
@@ -20583,17 +15227,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributePacketMulticastRxCount(
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributePacketMulticastTxCount(Callback::Cancelable * onSuccessCallback,
-                                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributePacketMulticastTxCount(Callback::Cancelable * onSuccessCallback,
                                                                                    Callback::Cancelable * onFailureCallback,
                                                                                    uint16_t minInterval, uint16_t maxInterval)
@@ -20609,17 +15242,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributePacketMulticastTxCount(
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::PacketMulticastTxCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributePacketUnicastRxCount(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributePacketUnicastRxCount(Callback::Cancelable * onSuccessCallback,
@@ -20639,17 +15261,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributePacketUnicastRxCount(Ca
                                      BasicAttributeFilter<Int32uAttributeCallback>);
 }
 
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributePacketUnicastTxCount(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributePacketUnicastTxCount(Callback::Cancelable * onSuccessCallback,
                                                                                  Callback::Cancelable * onFailureCallback,
                                                                                  uint16_t minInterval, uint16_t maxInterval)
@@ -20665,17 +15276,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributePacketUnicastTxCount(Ca
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::PacketUnicastTxCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeCurrentMaxRate(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeCurrentMaxRate(Callback::Cancelable * onSuccessCallback,
@@ -20695,17 +15295,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeCurrentMaxRate(Callback
                                      BasicAttributeFilter<Int64uAttributeCallback>);
 }
 
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeOverrunCount(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeOverrunCount(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -20721,28 +15310,6 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReportAttributeOverrunCount(Callback::
 {
     return RequestAttributeReporting(WiFiNetworkDiagnostics::Attributes::OverrunCount::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR WiFiNetworkDiagnosticsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WiFiNetworkDiagnosticsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -21048,17 +15615,6 @@ exit:
 }
 
 // WindowCovering Cluster Attributes
-CHIP_ERROR WindowCoveringCluster::ReadAttributeType(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeType(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval)
@@ -21074,17 +15630,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeType(Callback::Cancelable * onR
 {
     return RequestAttributeReporting(WindowCovering::Attributes::Type::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionLift(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionLift(Callback::Cancelable * onSuccessCallback,
@@ -21104,17 +15649,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionLift(Callback::C
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionTilt(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionTilt(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback,
                                                                         uint16_t minInterval, uint16_t maxInterval)
@@ -21130,17 +15664,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionTilt(Callback::C
 {
     return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionTilt::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeConfigStatus(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000007;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeConfigStatus(Callback::Cancelable * onSuccessCallback,
@@ -21160,17 +15683,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeConfigStatus(Callback::Cancelab
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000008;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onSuccessCallback,
                                                                                   Callback::Cancelable * onFailureCallback,
                                                                                   uint16_t minInterval, uint16_t maxInterval)
@@ -21186,17 +15698,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionLiftPercentage(C
 {
     return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionLiftPercentage::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onSuccessCallback,
-                                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000009;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onSuccessCallback,
@@ -21216,17 +15717,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionTiltPercentage(C
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeOperationalStatus(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeOperationalStatus(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -21242,17 +15732,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeOperationalStatus(Callback::Can
 {
     return RequestAttributeReporting(WindowCovering::Attributes::OperationalStatus::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000B;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
@@ -21272,17 +15751,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeTargetPositionLiftPercent100ths
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000C;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
                                                                                     Callback::Cancelable * onFailureCallback,
                                                                                     uint16_t minInterval, uint16_t maxInterval)
@@ -21298,17 +15766,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeTargetPositionTiltPercent100ths
 {
     return RequestAttributeReporting(WindowCovering::Attributes::TargetPositionTiltPercent100ths::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeEndProductType(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000D;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeEndProductType(Callback::Cancelable * onSuccessCallback,
@@ -21328,17 +15785,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeEndProductType(Callback::Cancel
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000E;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
                                                                                      Callback::Cancelable * onFailureCallback,
                                                                                      uint16_t minInterval, uint16_t maxInterval)
@@ -21354,17 +15800,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionLiftPercent100th
 {
     return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000000F;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
@@ -21384,17 +15819,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionTiltPercent100th
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeInstalledOpenLimitLift(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000010;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeInstalledOpenLimitLift(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -21410,17 +15834,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeInstalledOpenLimitLift(Callback
 {
     return RequestAttributeReporting(WindowCovering::Attributes::InstalledOpenLimitLift::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeInstalledClosedLimitLift(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeInstalledClosedLimitLift(Callback::Cancelable * onSuccessCallback,
@@ -21440,17 +15853,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeInstalledClosedLimitLift(Callba
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeInstalledOpenLimitTilt(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeInstalledOpenLimitTilt(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback,
                                                                            uint16_t minInterval, uint16_t maxInterval)
@@ -21466,17 +15868,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeInstalledOpenLimitTilt(Callback
 {
     return RequestAttributeReporting(WindowCovering::Attributes::InstalledOpenLimitTilt::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeInstalledClosedLimitTilt(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeInstalledClosedLimitTilt(Callback::Cancelable * onSuccessCallback,
@@ -21496,17 +15887,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeInstalledClosedLimitTilt(Callba
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeMode(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000017;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeMode(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval)
@@ -21522,17 +15902,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeMode(Callback::Cancelable * onR
 {
     return RequestAttributeReporting(WindowCovering::Attributes::Mode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000001A;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback,
@@ -21552,17 +15921,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeSafetyStatus(Callback::Cancelab
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -21578,17 +15936,6 @@ CHIP_ERROR WindowCoveringCluster::ReportAttributeFeatureMap(Callback::Cancelable
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR WindowCoveringCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR WindowCoveringCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -37,9 +37,6 @@ public:
     ~AccessControlCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeAcl(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeExtension(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 };
 
 class DLL_EXPORT AccountLoginCluster : public ClusterBase
@@ -55,7 +52,6 @@ public:
                      chip::CharSpan tempAccountIdentifier, chip::CharSpan setupPIN);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -78,7 +74,6 @@ public:
     CHIP_ERROR RevokeCommissioning(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -96,36 +91,28 @@ public:
     CHIP_ERROR ChangeStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t status);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeVendorName(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeVendorId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeApplicationName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeApplicationName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeApplicationName(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeProductId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeProductId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeProductId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeApplicationId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeApplicationId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeApplicationId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCatalogVendorId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeApplicationStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeApplicationStatus(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeApplicationStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -144,17 +131,12 @@ public:
                          uint16_t catalogVendorId, chip::CharSpan applicationId);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeApplicationLauncherList(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCatalogVendorId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeApplicationId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeApplicationId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeApplicationId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -174,13 +156,10 @@ public:
     CHIP_ERROR SelectOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t index);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeAudioOutputList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeCurrentAudioOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentAudioOutput(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentAudioOutput(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -200,26 +179,21 @@ public:
     CHIP_ERROR BarrierControlStop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeBarrierMovingState(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBarrierMovingState(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBarrierMovingState(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBarrierSafetyStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBarrierSafetyStatus(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBarrierSafetyStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBarrierCapabilities(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBarrierCapabilities(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBarrierCapabilities(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBarrierPosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBarrierPosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBarrierPosition(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -237,88 +211,65 @@ public:
     CHIP_ERROR MfgSpecificPing(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeInteractionModelVersion(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInteractionModelVersion(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInteractionModelVersion(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeVendorName(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeVendorID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeVendorID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeVendorID(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeProductName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeProductName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeProductName(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeProductID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeProductID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeProductID(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNodeLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNodeLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNodeLabel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLocation(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeHardwareVersion(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeHardwareVersionString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSoftwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSoftwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSoftwareVersion(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSoftwareVersionString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeManufacturingDate(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePartNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePartNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePartNumber(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeProductURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeProductURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeProductURL(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeProductLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeProductLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeProductLabel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSerialNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSerialNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSerialNumber(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLocalConfigDisabled(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeReachable(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeUniqueID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -333,19 +284,15 @@ public:
     ~BinaryInputBasicCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeOutOfService(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOutOfService(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOutOfService(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePresentValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePresentValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePresentValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStatusFlags(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStatusFlags(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStatusFlags(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -364,7 +311,6 @@ public:
                       chip::GroupId groupId, chip::EndpointId endpointId, chip::ClusterId clusterId);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -379,11 +325,9 @@ public:
     ~BooleanStateCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeStateValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStateValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStateValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -422,13 +366,9 @@ public:
                           uint32_t invokeID);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeActionList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeEndpointList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeSetupUrl(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSetupUrl(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSetupUrl(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -443,7 +383,6 @@ public:
     ~BridgedDeviceBasicCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -503,249 +442,187 @@ public:
                             uint8_t optionsOverride);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeCurrentHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentHue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentSaturation(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRemainingTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRemainingTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRemainingTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentX(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentY(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDriftCompensation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDriftCompensation(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDriftCompensation(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCompensationText(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCompensationText(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCompensationText(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorTemperature(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorTemperature(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorControlOptions(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNumberOfPrimaries(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNumberOfPrimaries(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNumberOfPrimaries(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary1X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary1X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary1X(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary1Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary1Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary1Y(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary1Intensity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary1Intensity(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary1Intensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary2X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary2X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary2X(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary2Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary2Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary2Y(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary2Intensity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary2Intensity(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary2Intensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary3X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary3X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary3X(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary3Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary3Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary3Y(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary3Intensity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary3Intensity(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary3Intensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary4X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary4X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary4X(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary4Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary4Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary4Y(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary4Intensity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary4Intensity(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary4Intensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary5X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary5X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary5X(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary5Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary5Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary5Y(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary5Intensity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary5Intensity(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary5Intensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary6X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary6X(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary6X(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary6Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary6Y(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary6Y(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePrimary6Intensity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePrimary6Intensity(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePrimary6Intensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeWhitePointX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeWhitePointX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeWhitePointX(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeWhitePointY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeWhitePointY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeWhitePointY(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointRX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointRX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointRX(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointRY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointRY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointRY(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointRIntensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointGX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointGX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointGX(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointGY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointGY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointGY(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointGIntensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointBX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointBX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointBX(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointBY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointBY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointBY(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorPointBIntensity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEnhancedCurrentHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEnhancedCurrentHue(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEnhancedCurrentHue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEnhancedColorMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEnhancedColorMode(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEnhancedColorMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorLoopActive(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorLoopActive(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorLoopActive(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorLoopDirection(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorLoopDirection(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorLoopDirection(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorLoopTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorLoopTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorLoopTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorLoopStartEnhancedHue(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorLoopStartEnhancedHue(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorLoopStartEnhancedHue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorLoopStoredEnhancedHue(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorLoopStoredEnhancedHue(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorLoopStoredEnhancedHue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorCapabilities(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorCapabilities(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorCapabilities(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorTempPhysicalMin(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorTempPhysicalMin(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorTempPhysicalMin(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeColorTempPhysicalMax(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeColorTempPhysicalMax(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeColorTempPhysicalMax(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCoupleColorTempToLevelMinMireds(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCoupleColorTempToLevelMinMireds(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCoupleColorTempToLevelMinMireds(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -766,10 +643,6 @@ public:
                          chip::CharSpan contentURL, chip::CharSpan displayString);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeAcceptsHeaderList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeSupportedStreamingTypes(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -784,11 +657,6 @@ public:
     ~DescriptorCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeDeviceList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeServerList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClientList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributePartsList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -858,11 +726,9 @@ public:
                                  uint16_t timeout, chip::ByteSpan pinCode);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeActuatorEnabled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeActuatorEnabled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeActuatorEnabled(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -877,52 +743,40 @@ public:
     ~ElectricalMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasurementType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasurementType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasurementType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTotalActivePower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTotalActivePower(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTotalActivePower(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRmsVoltage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRmsVoltage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRmsVoltage(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRmsVoltageMin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRmsVoltageMin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRmsVoltageMin(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRmsVoltageMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRmsVoltageMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRmsVoltageMax(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRmsCurrent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRmsCurrent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRmsCurrent(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRmsCurrentMin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRmsCurrentMin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRmsCurrentMin(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRmsCurrentMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRmsCurrentMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRmsCurrentMax(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeActivePower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeActivePower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeActivePower(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeActivePowerMin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeActivePowerMin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeActivePowerMin(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeActivePowerMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeActivePowerMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeActivePowerMax(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -938,44 +792,33 @@ public:
     CHIP_ERROR ResetCounts(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributePHYRate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePHYRate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePHYRate(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFullDuplex(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFullDuplex(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFullDuplex(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePacketRxCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePacketRxCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePacketRxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePacketTxCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePacketTxCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePacketTxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxErrCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxErrCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxErrCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCollisionCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCollisionCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCollisionCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOverrunCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOverrunCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOverrunCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCarrierDetect(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCarrierDetect(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCarrierDetect(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTimeSinceReset(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTimeSinceReset(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTimeSinceReset(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -990,8 +833,6 @@ public:
     ~FixedLabelCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeLabelList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1004,25 +845,20 @@ public:
     ~FlowMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTolerance(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1042,15 +878,9 @@ public:
                                    uint8_t location, chip::CharSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBreadcrumb(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBasicCommissioningInfoList(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeRegulatoryConfig(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeLocationCapability(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1065,30 +895,19 @@ public:
     ~GeneralDiagnosticsCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeNetworkInterfaces(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeRebootCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRebootCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRebootCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeUpTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeUpTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeUpTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTotalOperationalHours(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTotalOperationalHours(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTotalOperationalHours(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBootReasons(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBootReasons(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBootReasons(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeActiveHardwareFaults(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeActiveRadioFaults(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeActiveNetworkFaults(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1101,9 +920,6 @@ public:
     ~GroupKeyManagementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeGroups(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeGroupKeys(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1127,11 +943,9 @@ public:
     CHIP_ERROR ViewGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t groupId);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeNameSupport(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNameSupport(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNameSupport(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1152,15 +966,12 @@ public:
                              uint8_t effectIdentifier, uint8_t effectVariant);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeIdentifyTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeIdentifyType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeIdentifyType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeIdentifyType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1175,29 +986,23 @@ public:
     ~IlluminanceMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTolerance(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLightSensorType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLightSensorType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLightSensorType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1213,7 +1018,6 @@ public:
     CHIP_ERROR SendKey(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t keyCode);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1245,68 +1049,53 @@ public:
     CHIP_ERROR StopWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRemainingTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRemainingTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRemainingTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentFrequency(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentFrequency(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentFrequency(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinFrequency(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinFrequency(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinFrequency(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxFrequency(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxFrequency(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxFrequency(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOptions(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOptions(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOptions(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOnOffTransitionTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnOffTransitionTime(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnOffTransitionTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOnLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOnTransitionTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnTransitionTime(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnTransitionTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOffTransitionTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOffTransitionTime(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOffTransitionTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDefaultMoveRate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDefaultMoveRate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDefaultMoveRate(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartUpCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartUpCurrentLevel(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartUpCurrentLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1324,7 +1113,6 @@ public:
     CHIP_ERROR Sleep(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1346,13 +1134,10 @@ public:
     CHIP_ERROR ShowInputStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMediaInputList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeCurrentMediaInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentMediaInput(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentMediaInput(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1382,40 +1167,31 @@ public:
     CHIP_ERROR MediaStop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributePlaybackState(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePlaybackState(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePlaybackState(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDuration(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDuration(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDuration(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePositionUpdatedAt(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePositionUpdatedAt(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributePositionUpdatedAt(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePosition(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePlaybackSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePlaybackSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePlaybackSpeed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSeekRangeEnd(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSeekRangeEnd(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSeekRangeEnd(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSeekRangeStart(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSeekRangeStart(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSeekRangeStart(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1433,24 +1209,18 @@ public:
     CHIP_ERROR ChangeToMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t newMode);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeCurrentMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSupportedModes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeOnMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartUpMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartUpMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartUpMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDescription(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDescription(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDescription(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1483,11 +1253,9 @@ public:
                                  chip::ByteSpan ssid, chip::ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1512,7 +1280,6 @@ public:
                           chip::ByteSpan metadataForProvider);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1532,16 +1299,13 @@ public:
                                    chip::ByteSpan metadataForNode);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeDefaultOtaProvider(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDefaultOtaProvider(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDefaultOtaProvider(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeUpdatePossible(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeUpdatePossible(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeUpdatePossible(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1556,22 +1320,17 @@ public:
     ~OccupancySensingCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeOccupancy(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOccupancy(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOccupancy(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOccupancySensorType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOccupancySensorType(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOccupancySensorType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOccupancySensorTypeBitmap(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOccupancySensorTypeBitmap(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOccupancySensorTypeBitmap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1594,32 +1353,25 @@ public:
     CHIP_ERROR Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnOff(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeGlobalSceneControl(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOffWaitTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartUpOnOff(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1634,15 +1386,12 @@ public:
     ~OnOffSwitchConfigurationCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeSwitchType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSwitchType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSwitchType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSwitchActions(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSwitchActions(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSwitchActions(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1675,25 +1424,18 @@ public:
                          chip::ByteSpan NOCValue, chip::ByteSpan ICACValue);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSupportedFabrics(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCommissionedFabrics(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTrustedRootCertificates(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentFabricIndex(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1708,50 +1450,37 @@ public:
     ~PowerSourceCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOrder(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOrder(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOrder(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDescription(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDescription(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDescription(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBatteryVoltage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBatteryVoltage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBatteryVoltage(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBatteryPercentRemaining(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBatteryPercentRemaining(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBatteryPercentRemaining(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBatteryTimeRemaining(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBatteryTimeRemaining(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBatteryTimeRemaining(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBatteryChargeLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBatteryChargeLevel(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBatteryChargeLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeActiveBatteryFaults(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeBatteryChargeState(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBatteryChargeState(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBatteryChargeState(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1764,8 +1493,6 @@ public:
     ~PowerSourceConfigurationCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeSources(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 };
 
 class DLL_EXPORT PressureMeasurementCluster : public ClusterBase
@@ -1775,21 +1502,17 @@ public:
     ~PressureMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1802,117 +1525,87 @@ public:
     ~PumpConfigurationAndControlCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMaxPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxPressure(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxSpeed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxFlow(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinConstPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinConstPressure(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinConstPressure(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxConstPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxConstPressure(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxConstPressure(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinCompPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinCompPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinCompPressure(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxCompPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxCompPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxCompPressure(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinConstSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinConstSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinConstSpeed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxConstSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxConstSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxConstSpeed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinConstFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinConstFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinConstFlow(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxConstFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxConstFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxConstFlow(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinConstTemp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinConstTemp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinConstTemp(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxConstTemp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxConstTemp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxConstTemp(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePumpStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePumpStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePumpStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEffectiveOperationMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEffectiveControlMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCapacity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCapacity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCapacity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSpeed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLifetimeRunningHours(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLifetimeRunningHours(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLifetimeRunningHours(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePower(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLifetimeEnergyConsumed(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLifetimeEnergyConsumed(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLifetimeEnergyConsumed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOperationMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOperationMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOperationMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeControlMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeControlMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeControlMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeAlarmMask(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeAlarmMask(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeAlarmMask(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1925,25 +1618,20 @@ public:
     ~RelativeHumidityMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTolerance(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -1973,27 +1661,21 @@ public:
                          uint8_t sceneId);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeSceneCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSceneCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSceneCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentScene(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentGroup(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSceneValid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSceneValid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSceneValid(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNameSupport(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNameSupport(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNameSupport(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2011,23 +1693,16 @@ public:
     CHIP_ERROR ResetWatermarks(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeThreadMetrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeCurrentHeapFree(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentHeapFree(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentHeapFree(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentHeapUsed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentHeapUsed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentHeapUsed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentHeapHighWatermark(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentHeapHighWatermark(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentHeapHighWatermark(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2042,24 +1717,19 @@ public:
     ~SwitchCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeNumberOfPositions(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNumberOfPositions(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNumberOfPositions(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPosition(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMultiPressMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMultiPressMax(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMultiPressMax(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2079,17 +1749,13 @@ public:
     CHIP_ERROR SkipChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t count);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeTvChannelList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeTvChannelLineup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTvChannelLineup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTvChannelLineup(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentTvChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentTvChannel(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentTvChannel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2108,8 +1774,6 @@ public:
                               chip::CharSpan data);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeTargetNavigatorList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2124,25 +1788,20 @@ public:
     ~TemperatureMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTolerance(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTolerance(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2191,310 +1850,225 @@ public:
     CHIP_ERROR TimedInvokeRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeBoolean(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBoolean(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBoolean(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBitmap8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBitmap8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBitmap8(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBitmap16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBitmap16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBitmap16(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBitmap32(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBitmap32(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBitmap32(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBitmap64(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBitmap64(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBitmap64(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt8u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt8u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt8u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt16u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt16u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt16u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt24u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt24u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt24u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt32u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt32u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt32u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt40u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt40u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt40u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt48u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt48u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt48u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt56u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt56u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt56u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt64u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt64u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt64u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt8s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt8s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt8s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt16s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt16s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt16s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt24s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt24s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt24s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt32s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt32s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt32s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt40s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt40s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt40s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt48s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt48s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt48s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt56s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt56s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt56s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInt64s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInt64s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInt64s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEnum8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEnum8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEnum8(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEnum16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEnum16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEnum16(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFloatSingle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFloatSingle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFloatSingle(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFloatDouble(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFloatDouble(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFloatDouble(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOctetString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeListInt8u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeListOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeListStructOctetString(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeLongOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLongOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLongOctetString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCharString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLongCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLongCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLongCharString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEpochUs(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEpochUs(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEpochUs(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEpochS(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEpochS(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEpochS(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeVendorId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeListNullablesAndOptionalsStruct(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRangeRestrictedInt8u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRangeRestrictedInt8s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRangeRestrictedInt16u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRangeRestrictedInt16s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeListLongOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeTimedWriteBoolean(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeUnsupported(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeUnsupported(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeUnsupported(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableBoolean(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableBoolean(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableBoolean(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableBitmap8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableBitmap8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableBitmap8(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableBitmap16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableBitmap16(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableBitmap16(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableBitmap32(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableBitmap32(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableBitmap32(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableBitmap64(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableBitmap64(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableBitmap64(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt8u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt8u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt8u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt16u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt16u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt16u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt24u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt24u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt24u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt32u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt32u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt32u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt40u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt40u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt40u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt48u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt48u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt48u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt56u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt56u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt56u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt64u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt64u(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt64u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt8s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt8s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt8s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt16s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt16s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt16s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt24s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt24s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt24s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt32s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt32s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt32s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt40s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt40s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt40s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt48s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt48s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt48s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt56s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt56s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt56s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableInt64s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableInt64s(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableInt64s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableEnum8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableEnum8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableEnum8(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableEnum16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableEnum16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableEnum16(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableFloatSingle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableFloatSingle(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableFloatSingle(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableFloatDouble(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableFloatDouble(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableFloatDouble(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableOctetString(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableOctetString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableCharString(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableCharString(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableRangeRestrictedInt8u(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                               uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableRangeRestrictedInt8u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableRangeRestrictedInt8s(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                               uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableRangeRestrictedInt8s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableRangeRestrictedInt16u(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableRangeRestrictedInt16u(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNullableRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNullableRangeRestrictedInt16s(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNullableRangeRestrictedInt16s(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2520,107 +2094,75 @@ public:
                                   int8_t amount);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeLocalTemperature(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLocalTemperature(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLocalTemperature(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeAbsMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeAbsMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeAbsMinHeatSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeAbsMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeAbsMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeAbsMaxHeatSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeAbsMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeAbsMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeAbsMinCoolSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeAbsMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeAbsMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeAbsMaxCoolSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOccupiedCoolingSetpoint(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOccupiedCoolingSetpoint(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOccupiedCoolingSetpoint(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinHeatSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxHeatSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxHeatSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinCoolSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxCoolSetpointLimit(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxCoolSetpointLimit(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinSetpointDeadBand(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinSetpointDeadBand(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinSetpointDeadBand(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeControlSequenceOfOperation(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeControlSequenceOfOperation(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                             uint16_t maxInterval);
     CHIP_ERROR ReportAttributeControlSequenceOfOperation(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSystemMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSystemMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSystemMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartOfWeek(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartOfWeek(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartOfWeek(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNumberOfWeeklyTransitions(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNumberOfWeeklyTransitions(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNumberOfWeeklyTransitions(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNumberOfDailyTransitions(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNumberOfDailyTransitions(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNumberOfDailyTransitions(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2635,23 +2177,17 @@ public:
     ~ThermostatUserInterfaceConfigurationCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeTemperatureDisplayMode(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTemperatureDisplayMode(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTemperatureDisplayMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeKeypadLockout(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeKeypadLockout(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeKeypadLockout(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeScheduleProgrammingVisibility(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeScheduleProgrammingVisibility(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeScheduleProgrammingVisibility(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2667,281 +2203,202 @@ public:
     CHIP_ERROR ResetCounts(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeChannel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRoutingRole(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRoutingRole(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRoutingRole(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNetworkName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeNetworkName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeNetworkName(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePanId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePanId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePanId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeExtendedPanId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeExtendedPanId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeExtendedPanId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMeshLocalPrefix(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeshLocalPrefix(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeshLocalPrefix(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOverrunCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOverrunCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOverrunCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeNeighborTableList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeRouteTableList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributePartitionId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePartitionId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePartitionId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeWeighting(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeWeighting(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeWeighting(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDataVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDataVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDataVersion(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStableDataVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStableDataVersion(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStableDataVersion(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLeaderRouterId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLeaderRouterId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLeaderRouterId(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDetachedRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDetachedRoleCount(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDetachedRoleCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeChildRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeChildRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeChildRoleCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRouterRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRouterRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRouterRoleCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeLeaderRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeLeaderRoleCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLeaderRoleCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeAttachAttemptCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeAttachAttemptCount(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeAttachAttemptCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePartitionIdChangeCount(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePartitionIdChangeCount(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributePartitionIdChangeCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBetterPartitionAttachAttemptCount(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBetterPartitionAttachAttemptCount(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBetterPartitionAttachAttemptCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeParentChangeCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeParentChangeCount(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeParentChangeCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxTotalCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxTotalCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxTotalCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxUnicastCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxUnicastCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxUnicastCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxBroadcastCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxBroadcastCount(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxBroadcastCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxAckRequestedCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxAckRequestedCount(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxAckRequestedCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxAckedCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxAckedCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxAckedCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxNoAckRequestedCount(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxNoAckRequestedCount(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxNoAckRequestedCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxDataCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxDataCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxDataCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxDataPollCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxDataPollCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxDataPollCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxBeaconCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxBeaconCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxBeaconCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxBeaconRequestCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxOtherCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxOtherCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxOtherCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxRetryCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxRetryCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxRetryCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxDirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxDirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                              uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxDirectMaxRetryExpiryCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxIndirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxIndirectMaxRetryExpiryCount(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxIndirectMaxRetryExpiryCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxErrCcaCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxErrCcaCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxErrCcaCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxErrAbortCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxErrAbortCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxErrAbortCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTxErrBusyChannelCount(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTxErrBusyChannelCount(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                        uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTxErrBusyChannelCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxTotalCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxTotalCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxTotalCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxUnicastCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxUnicastCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxUnicastCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxBroadcastCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxBroadcastCount(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxBroadcastCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxDataCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxDataCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxDataCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxDataPollCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxDataPollCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxDataPollCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxBeaconCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxBeaconCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxBeaconCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxBeaconRequestCount(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxBeaconRequestCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxOtherCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxOtherCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxOtherCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxAddressFilteredCount(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxAddressFilteredCount(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxAddressFilteredCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxDestAddrFilteredCount(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxDestAddrFilteredCount(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                          uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxDestAddrFilteredCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxDuplicatedCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxDuplicatedCount(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxDuplicatedCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxErrNoFrameCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxErrNoFrameCount(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxErrNoFrameCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxErrUnknownNeighborCount(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxErrUnknownNeighborCount(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxErrUnknownNeighborCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxErrInvalidSrcAddrCount(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxErrInvalidSrcAddrCount(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxErrInvalidSrcAddrCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxErrSecCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxErrSecCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxErrSecCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxErrFcsCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxErrFcsCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxErrFcsCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRxErrOtherCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRxErrOtherCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRxErrOtherCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeActiveTimestamp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeActiveTimestamp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeActiveTimestamp(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePendingTimestamp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePendingTimestamp(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributePendingTimestamp(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeDelay(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeDelay(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeDelay(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSecurityPolicy(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeChannelMask(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeChannelMask(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeChannelMask(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOperationalDatasetComponents(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeActiveNetworkFaultsList(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2956,12 +2413,10 @@ public:
     ~WakeOnLanCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeWakeOnLanMacAddress(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeWakeOnLanMacAddress(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeWakeOnLanMacAddress(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -2977,68 +2432,49 @@ public:
     CHIP_ERROR ResetCounts(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeBssid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBssid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBssid(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSecurityType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSecurityType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSecurityType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeWiFiVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeWiFiVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeWiFiVersion(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeChannelNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeChannelNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeChannelNumber(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeRssi(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeRssi(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeRssi(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBeaconLostCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBeaconLostCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBeaconLostCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBeaconRxCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBeaconRxCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBeaconRxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePacketMulticastRxCount(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePacketMulticastRxCount(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributePacketMulticastRxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePacketMulticastTxCount(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePacketMulticastTxCount(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributePacketMulticastTxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePacketUnicastRxCount(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePacketUnicastRxCount(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributePacketUnicastRxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributePacketUnicastTxCount(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributePacketUnicastTxCount(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributePacketUnicastTxCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentMaxRate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentMaxRate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentMaxRate(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOverrunCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOverrunCount(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOverrunCount(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -3066,106 +2502,76 @@ public:
     CHIP_ERROR UpOrOpen(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPositionLift(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPositionLift(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPositionLift(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPositionTilt(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPositionTilt(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPositionTilt(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeConfigStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeConfigStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeConfigStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOperationalStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOperationalStatus(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                    uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOperationalStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                  uint16_t maxInterval);
     CHIP_ERROR ReportAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEndProductType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEndProductType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                 uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEndProductType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInstalledOpenLimitLift(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInstalledOpenLimitLift(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInstalledOpenLimitLift(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInstalledClosedLimitLift(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInstalledClosedLimitLift(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInstalledClosedLimitLift(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInstalledOpenLimitTilt(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInstalledOpenLimitTilt(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInstalledOpenLimitTilt(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeInstalledClosedLimitTilt(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeInstalledClosedLimitTilt(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeInstalledClosedLimitTilt(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSafetyStatus(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/lighting-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/lighting-app/zap-generated/CHIPClusters.cpp
@@ -188,16 +188,6 @@ exit:
 
 // OnOff Cluster Commands
 // OnOff Cluster Attributes
-CHIP_ERROR OnOffCluster::ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval)
 {
@@ -212,17 +202,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Cancelable * onReportCal
 {
     return RequestAttributeReporting(OnOff::Attributes::OnOff::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback,
@@ -242,16 +221,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeGlobalSceneControl(Callback::Cancelable 
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
-CHIP_ERROR OnOffCluster::ReadAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeOnTime(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval)
@@ -267,17 +236,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOnTime(Callback::Cancelable * onReportCa
 {
     return RequestAttributeReporting(OnOff::Attributes::OnTime::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback,
@@ -297,17 +255,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOffWaitTime(Callback::Cancelable * onRep
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR OnOffCluster::ReadAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00004003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval)
@@ -325,16 +272,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeStartUpOnOff(Callback::Cancelable * onRe
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR OnOffCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval)
@@ -350,17 +287,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeFeatureMap(Callback::Cancelable * onRepo
 {
     return RequestAttributeReporting(Globals::Attributes::FeatureMap::Id, onReportCallback,
                                      BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/zzz_generated/lighting-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/lighting-app/zap-generated/CHIPClusters.h
@@ -58,32 +58,25 @@ public:
     ~OnOffCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnOff(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeGlobalSceneControl(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeGlobalSceneControl(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOffWaitTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStartUpOnOff(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeFeatureMap(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
@@ -185,17 +185,6 @@ exit:
 }
 
 // OtaSoftwareUpdateProvider Cluster Attributes
-CHIP_ERROR OtaSoftwareUpdateProviderCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR OtaSoftwareUpdateProviderCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.h
@@ -47,7 +47,6 @@ public:
                           chip::ByteSpan metadataForProvider);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/pump-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-app/zap-generated/CHIPClusters.cpp
@@ -36,17 +36,6 @@ namespace Controller {
 
 // FlowMeasurement Cluster Commands
 // FlowMeasurement Cluster Attributes
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -62,17 +51,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancel
 {
     return RequestAttributeReporting(FlowMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -92,17 +70,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMinMeasuredValue(Callback::Can
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -118,17 +85,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMaxMeasuredValue(Callback::Can
 {
     return RequestAttributeReporting(FlowMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -150,17 +106,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeClusterRevision(Callback::Canc
 
 // PressureMeasurement Cluster Commands
 // PressureMeasurement Cluster Attributes
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -176,17 +121,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Ca
 {
     return RequestAttributeReporting(PressureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -206,17 +140,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMinMeasuredValue(Callback:
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -232,17 +155,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMaxMeasuredValue(Callback:
 {
     return RequestAttributeReporting(PressureMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -264,17 +176,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeClusterRevision(Callback::
 
 // TemperatureMeasurement Cluster Commands
 // TemperatureMeasurement Cluster Attributes
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -290,17 +191,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback:
 {
     return RequestAttributeReporting(TemperatureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -320,17 +210,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMinMeasuredValue(Callba
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -346,17 +225,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMaxMeasuredValue(Callba
 {
     return RequestAttributeReporting(TemperatureMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/zzz_generated/pump-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/pump-app/zap-generated/CHIPClusters.h
@@ -37,21 +37,17 @@ public:
     ~FlowMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -64,21 +60,17 @@ public:
     ~PressureMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -91,21 +83,17 @@ public:
     ~TemperatureMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
@@ -36,17 +36,6 @@ namespace Controller {
 
 // FlowMeasurement Cluster Commands
 // FlowMeasurement Cluster Attributes
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                    uint16_t maxInterval)
@@ -62,17 +51,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancel
 {
     return RequestAttributeReporting(FlowMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -92,17 +70,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMinMeasuredValue(Callback::Can
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -118,17 +85,6 @@ CHIP_ERROR FlowMeasurementCluster::ReportAttributeMaxMeasuredValue(Callback::Can
 {
     return RequestAttributeReporting(FlowMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR FlowMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -507,17 +463,6 @@ exit:
 }
 
 // LevelControl Cluster Attributes
-CHIP_ERROR LevelControlCluster::ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR LevelControlCluster::SubscribeAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                uint16_t maxInterval)
@@ -533,17 +478,6 @@ CHIP_ERROR LevelControlCluster::ReportAttributeCurrentLevel(Callback::Cancelable
 {
     return RequestAttributeReporting(LevelControl::Attributes::CurrentLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR LevelControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR LevelControlCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -679,16 +613,6 @@ exit:
 }
 
 // OnOff Cluster Attributes
-CHIP_ERROR OnOffCluster::ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
 CHIP_ERROR OnOffCluster::SubscribeAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval)
 {
@@ -703,17 +627,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Cancelable * onReportCal
 {
     return RequestAttributeReporting(OnOff::Attributes::OnOff::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
-}
-
-CHIP_ERROR OnOffCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OnOffCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -735,17 +648,6 @@ CHIP_ERROR OnOffCluster::ReportAttributeClusterRevision(Callback::Cancelable * o
 
 // PressureMeasurement Cluster Commands
 // PressureMeasurement Cluster Attributes
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
                                                                        uint16_t minInterval, uint16_t maxInterval)
@@ -761,17 +663,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Ca
 {
     return RequestAttributeReporting(PressureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -791,17 +682,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMinMeasuredValue(Callback:
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -817,17 +697,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeMaxMeasuredValue(Callback:
 {
     return RequestAttributeReporting(PressureMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PressureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -849,17 +718,6 @@ CHIP_ERROR PressureMeasurementCluster::ReportAttributeClusterRevision(Callback::
 
 // PumpConfigurationAndControl Cluster Commands
 // PumpConfigurationAndControl Cluster Attributes
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxPressure(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxPressure(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -875,17 +733,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxPressure(Callba
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxPressure::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback,
@@ -905,17 +752,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxSpeed(Callback:
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeMaxFlow(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeMaxFlow(Callback::Cancelable * onSuccessCallback,
                                                                          Callback::Cancelable * onFailureCallback,
                                                                          uint16_t minInterval, uint16_t maxInterval)
@@ -931,17 +767,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeMaxFlow(Callback::
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::MaxFlow::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000011;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
@@ -961,17 +786,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeEffectiveOperation
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
-                                                                                 Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000012;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
                                                                                       Callback::Cancelable * onFailureCallback,
                                                                                       uint16_t minInterval, uint16_t maxInterval)
@@ -987,17 +801,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeEffectiveControlMo
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::EffectiveControlMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeCapacity(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000013;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeCapacity(Callback::Cancelable * onSuccessCallback,
@@ -1017,17 +820,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeCapacity(Callback:
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000020;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeOperationMode(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -1043,17 +835,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeOperationMode(Call
 {
     return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::OperationMode::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                            Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -1075,17 +856,6 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeClusterRevision(Ca
 
 // TemperatureMeasurement Cluster Commands
 // TemperatureMeasurement Cluster Attributes
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -1101,17 +871,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback:
 {
     return RequestAttributeReporting(TemperatureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -1131,17 +890,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMinMeasuredValue(Callba
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -1157,17 +905,6 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMaxMeasuredValue(Callba
 {
     return RequestAttributeReporting(TemperatureMeasurement::Attributes::MaxMeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
-}
-
-CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.h
@@ -37,21 +37,17 @@ public:
     ~FlowMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -81,11 +77,9 @@ public:
     CHIP_ERROR StopWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -105,11 +99,9 @@ public:
     CHIP_ERROR Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnOff(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -124,21 +116,17 @@ public:
     ~PressureMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -151,39 +139,29 @@ public:
     ~PumpConfigurationAndControlCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMaxPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxPressure(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxPressure(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxSpeed(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxSpeed(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxFlow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxFlow(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEffectiveOperationMode(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                         uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEffectiveOperationMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
-                                                 Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeEffectiveControlMode(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeEffectiveControlMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCapacity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCapacity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCapacity(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeOperationMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeOperationMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOperationMode(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -196,21 +174,17 @@ public:
     ~TemperatureMeasurementCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMinMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeMaxMeasuredValue(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/thermostat/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/thermostat/zap-generated/CHIPClusters.cpp
@@ -115,17 +115,6 @@ exit:
 }
 
 // Identify Cluster Attributes
-CHIP_ERROR IdentifyCluster::ReadAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR IdentifyCluster::SubscribeAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -143,17 +132,6 @@ CHIP_ERROR IdentifyCluster::ReportAttributeIdentifyTime(Callback::Cancelable * o
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR IdentifyCluster::ReadAttributeIdentifyType(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR IdentifyCluster::SubscribeAttributeIdentifyType(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                            uint16_t maxInterval)
@@ -169,17 +147,6 @@ CHIP_ERROR IdentifyCluster::ReportAttributeIdentifyType(Callback::Cancelable * o
 {
     return RequestAttributeReporting(Identify::Attributes::IdentifyType::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR IdentifyCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR IdentifyCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/zzz_generated/thermostat/zap-generated/CHIPClusters.h
+++ b/zzz_generated/thermostat/zap-generated/CHIPClusters.h
@@ -41,15 +41,12 @@ public:
     CHIP_ERROR IdentifyQuery(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeIdentifyTime(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeIdentifyType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeIdentifyType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeIdentifyType(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
@@ -171,17 +171,6 @@ exit:
 }
 
 // GeneralCommissioning Cluster Attributes
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000000;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
 CHIP_ERROR GeneralCommissioningCluster::SubscribeAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                                      uint16_t maxInterval)
@@ -197,61 +186,6 @@ CHIP_ERROR GeneralCommissioningCluster::ReportAttributeBreadcrumb(Callback::Canc
 {
     return RequestAttributeReporting(GeneralCommissioning::Attributes::Breadcrumb::Id, onReportCallback,
                                      BasicAttributeFilter<Int64uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeBasicCommissioningInfoList(Callback::Cancelable * onSuccessCallback,
-                                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             GeneralCommissioningClusterBasicCommissioningInfoListListAttributeFilter);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
-                                                                      Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeLocationCapability(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR GeneralCommissioningCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -458,28 +392,6 @@ exit:
 }
 
 // NetworkCommissioning Cluster Attributes
-CHIP_ERROR NetworkCommissioningCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFC;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int32uAttributeCallback>);
-}
-
-CHIP_ERROR NetworkCommissioningCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                     Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
-}
-
 CHIP_ERROR NetworkCommissioningCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
                                                                           uint16_t minInterval, uint16_t maxInterval)
@@ -803,28 +715,6 @@ exit:
 }
 
 // OperationalCredentials Cluster Attributes
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000001;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             OperationalCredentialsClusterFabricsListListAttributeFilter);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000002;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback,
                                                                              uint16_t minInterval, uint16_t maxInterval)
@@ -840,17 +730,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeSupportedFabrics(Callba
 {
     return RequestAttributeReporting(OperationalCredentials::Attributes::SupportedFabrics::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000003;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback,
@@ -870,28 +749,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeCommissionedFabrics(Cal
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeTrustedRootCertificates(Callback::Cancelable * onSuccessCallback,
-                                                                               Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000004;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback,
-                                                                          Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x00000005;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
                                                                                uint16_t minInterval, uint16_t maxInterval)
@@ -907,17 +764,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReportAttributeCurrentFabricIndex(Call
 {
     return RequestAttributeReporting(OperationalCredentials::Attributes::CurrentFabricIndex::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
-}
-
-CHIP_ERROR OperationalCredentialsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback)
-{
-    app::AttributePathParams attributePath;
-    attributePath.mEndpointId  = mEndpoint;
-    attributePath.mClusterId   = mClusterId;
-    attributePath.mAttributeId = 0x0000FFFD;
-    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.h
@@ -44,16 +44,9 @@ public:
                                    uint8_t location, chip::CharSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeBreadcrumb(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeBasicCommissioningInfoList(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeRegulatoryConfig(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeLocationCapability(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -78,8 +71,6 @@ public:
                             uint64_t breadcrumb, uint32_t timeoutMs);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);
@@ -110,25 +101,18 @@ public:
                                  chip::CharSpan label);
 
     // Cluster Attributes
-    CHIP_ERROR ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                   uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSupportedFabrics(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                      uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCommissionedFabrics(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeTrustedRootCertificates(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback);
-    CHIP_ERROR ReadAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeCurrentFabricIndex(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback, uint16_t minInterval,
                                                     uint16_t maxInterval);
     CHIP_ERROR ReportAttributeCurrentFabricIndex(Callback::Cancelable * onReportCallback);
-    CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SubscribeAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeClusterRevision(Callback::Cancelable * onReportCallback);


### PR DESCRIPTION
They were unused except by chip-tool.  chip-tool is switched to use
the type-safe read API.

#### Problem
Command-line chip-tool can't read nullable attributes properly (i.e. if the value is null).  And it's using the CHIPClusters APIs that nothing else uses.

#### Change overview
See above.

#### Testing
Manually tested a read of a null-valued attribute by hacking chip-tool to write a null value to it (which does not work normally work).  Tested some reads of non-null attributes as well.