### PR TITLE
Add support to chip-tool for sending the null value for nullable arguments.

### DIFF
--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -79,7 +79,16 @@ struct Argument
     int64_t min;
     uint64_t max;
     void * value;
-    bool optional;
+    uint8_t flags;
+
+    enum
+    {
+        kOptional = (1 << 0),
+        kNullable = (1 << 1),
+    };
+
+    bool isOptional() const { return flags & kOptional; }
+    bool isNullable() const { return flags & kNullable; }
 };
 
 class Command
@@ -97,11 +106,11 @@ public:
     const char * GetName(void) const { return mName; }
     const char * GetAttribute(void) const;
     const char * GetArgumentName(size_t index) const;
-    bool GetArgumentIsOptional(size_t index) const { return mArgs[index].optional; }
+    bool GetArgumentIsOptional(size_t index) const { return mArgs[index].isOptional(); }
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
 
     bool InitArguments(int argc, char ** argv);
-    size_t AddArgument(const char * name, const char * value, bool optional = false);
+    size_t AddArgument(const char * name, const char * value, uint8_t flags = 0);
     /**
      * @brief
      *   Add a char string command argument
@@ -110,106 +119,100 @@ public:
      * @param value A pointer to a `char *` where the argv value will be stored
      * @returns The number of arguments currently added to the command
      */
-    size_t AddArgument(const char * name, char ** value, bool optional = false);
+    size_t AddArgument(const char * name, char ** value, uint8_t flags = 0);
+
     /**
      * Add an octet string command argument
      */
-    size_t AddArgument(const char * name, chip::ByteSpan * value, bool optional = false);
-    size_t AddArgument(const char * name, chip::Span<const char> * value, bool optional = false);
-    size_t AddArgument(const char * name, AddressWithInterface * out, bool optional = false);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, bool optional = false)
+    size_t AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags = 0);
+    size_t AddArgument(const char * name, chip::Span<const char> * value, uint8_t flags = 0);
+    size_t AddArgument(const char * name, AddressWithInterface * out, uint8_t flags = 0);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, optional);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, flags);
     }
 
-    size_t AddArgument(const char * name, float min, float max, float * out, bool optional = false);
-    size_t AddArgument(const char * name, double min, double max, double * out, bool optional = false);
+    size_t AddArgument(const char * name, float min, float max, float * out, uint8_t flags = 0);
+    size_t AddArgument(const char * name, double min, double max, double * out, uint8_t flags = 0);
 
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), optional);
+        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), flags);
     }
 
     template <typename T>
     size_t AddArgument(const char * name, chip::Optional<T> * value)
     {
-        return AddArgument(name, reinterpret_cast<T *>(value), true);
+        return AddArgument(name, reinterpret_cast<T *>(value), Argument::kOptional);
     }
 
     template <typename T>
     size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<T> * value)
     {
-        return AddArgument(name, min, max, reinterpret_cast<T *>(value), true);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(value), Argument::kOptional);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, bool optional = false)
+    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0)
     {
-        // We always require our args to be provided for the moment.
-        return AddArgument(name, &value->SetNonNull(), optional);
+        return AddArgument(name, reinterpret_cast<T *>(value), flags | Argument::kNullable);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value,
-                       bool optional = false)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0)
     {
-        // We always require our args to be provided for the moment.
-        return AddArgument(name, min, max, &value->SetNonNull(), optional);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(value), flags | Argument::kNullable);
     }
 
-    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value,
-                       bool optional = false)
+    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value, uint8_t flags = 0)
     {
-        // We always require our args to be provided for the moment.
-        return AddArgument(name, min, max, &value->SetNonNull(), optional);
+        return AddArgument(name, min, max, reinterpret_cast<float *>(value), flags | Argument::kNullable);
     }
 
-    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value,
-                       bool optional = false)
+    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value, uint8_t flags = 0)
     {
-        // We always require our args to be provided for the moment.
-        return AddArgument(name, min, max, &value->SetNonNull(), optional);
+        return AddArgument(name, min, max, reinterpret_cast<double *>(value), flags | Argument::kNullable);
     }
 
     virtual CHIP_ERROR Run() = 0;
 
 private:
     bool InitArgument(size_t argIndex, char * argValue);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, bool optional);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, bool optional);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags);
 
     /**
      * Add the Argument to our list.  This preserves the property that all


### PR DESCRIPTION
It's represented as "null" on the command line.

Warning: this might make it difficult to send the string value "null"
for a nullable char string.

#### Problem
Can't set attributes to null via chip-tool command line, or set null for nullable command arguments.

#### Change overview
See above.

#### Testing
Manually tested that I can set the nullable-boolean and nullable-char-string attributes of TestCluster to both null and non-null values.