### PR TITLE
Added additional AttestationVerificationResult values

### DIFF
--- a/src/credentials/DeviceAttestationVerifier.h
+++ b/src/credentials/DeviceAttestationVerifier.h
@@ -34,21 +34,24 @@ enum class AttestationVerificationResult : uint16_t
     kPaaSignatureInvalid = 103,
     kPaaRevoked          = 104,
     kPaaFormatInvalid    = 105,
+    kPaaArgumentInvalid  = 106,
 
     kPaiExpired           = 200,
     kPaiSignatureInvalid  = 201,
     kPaiRevoked           = 202,
     kPaiFormatInvalid     = 203,
-    kPaiVendorIdMismatch  = 204,
-    kPaiAuthorityNotFound = 205,
+    kPaiArgumentInvalid   = 204,
+    kPaiVendorIdMismatch  = 205,
+    kPaiAuthorityNotFound = 206,
 
     kDacExpired           = 300,
     kDacSignatureInvalid  = 301,
     kDacRevoked           = 302,
     kDacFormatInvalid     = 303,
-    kDacVendorIdMismatch  = 304,
-    kDacProductIdMismatch = 305,
-    kDacAuthorityNotFound = 306,
+    kDacArgumentInvalid   = 304,
+    kDacVendorIdMismatch  = 305,
+    kDacProductIdMismatch = 306,
+    kDacAuthorityNotFound = 307,
 
     kFirmwareInformationMismatch = 400,
     kFirmwareInformationMissing  = 401,
@@ -68,6 +71,8 @@ enum class AttestationVerificationResult : uint16_t
     kNoMemory = 700,
 
     kInvalidArgument = 800,
+
+    kInternalError = 900,
 
     kNotImplemented = 0xFFFFU,
 

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1208,8 +1208,29 @@ CHIP_ERROR LoadCertFromPKCS7(const char * pkcs7, X509DerCertificate * x509list, 
 
 CHIP_ERROR GetNumberOfCertsFromPKCS7(const char * pkcs7, uint32_t * n_certs);
 
+enum class CertificateChainValidationResult
+{
+    kSuccess = 0,
+
+    kRootFormatInvalid   = 100,
+    kRootArgumentInvalid = 101,
+
+    kICAFormatInvalid   = 200,
+    kICAArgumentInvalid = 201,
+
+    kLeafFormatInvalid   = 300,
+    kLeafArgumentInvalid = 301,
+
+    kChainInvalid = 400,
+
+    kNoMemory = 500,
+
+    kInternalFrameworkError = 600,
+};
+
 CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t rootCertificateLen, const uint8_t * caCertificate,
-                                    size_t caCertificateLen, const uint8_t * leafCertificate, size_t leafCertificateLen);
+                                    size_t caCertificateLen, const uint8_t * leafCertificate, size_t leafCertificateLen,
+                                    CertificateChainValidationResult & result);
 
 /**
  * @brief Validate timestamp of a certificate (toBeEvaluatedCertificate) in comparison with other certificate's

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1661,6 +1661,8 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
     X509 * x509CACertificate   = nullptr;
     X509 * x509LeafCertificate = nullptr;
 
+    result = CertificateChainValidationResult::kInternalFrameworkError;
+
     VerifyOrReturnError(rootCertificate != nullptr && rootCertificateLen != 0,
                         (result = CertificateChainValidationResult::kRootArgumentInvalid, CHIP_ERROR_INVALID_ARGUMENT));
     VerifyOrReturnError(caCertificate != nullptr && caCertificateLen != 0,

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -1227,6 +1227,8 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
     int mbedResult;
     uint32_t flags;
 
+    result = CertificateChainValidationResult::kInternalFrameworkError;
+
     VerifyOrReturnError(rootCertificate != nullptr && rootCertificateLen != 0,
                         (result = CertificateChainValidationResult::kRootArgumentInvalid, CHIP_ERROR_INVALID_ARGUMENT));
     VerifyOrReturnError(caCertificate != nullptr && caCertificateLen != 0,
@@ -1282,6 +1284,7 @@ exit:
     (void) caCertificateLen;
     (void) leafCertificate;
     (void) leafCertificateLen;
+    (void) result;
     CHIP_ERROR error = CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // defined(MBEDTLS_X509_CRT_PARSE_C)
 

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1853,19 +1853,11 @@ static void TestX509_CertChainValidation(nlTestSuite * inSuite, void * inContext
     err = GetTestCert(TestCert::kNode01_01, TestCertLoadFlags::kDERForm, leaf_cert);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
+    CertificateChainValidationResult chainValidationResult;
     err = ValidateCertificateChain(root_cert.data(), root_cert.size(), ica_cert.data(), ica_cert.size(), leaf_cert.data(),
-                                   leaf_cert.size());
+                                   leaf_cert.size(), chainValidationResult);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    // Now test chain without ICA certificate
-    err = GetTestCert(TestCert::kRoot01, TestCertLoadFlags::kDERForm, root_cert);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    err = GetTestCert(TestCert::kNode01_02, TestCertLoadFlags::kDERForm, leaf_cert);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    err = ValidateCertificateChain(root_cert.data(), root_cert.size(), nullptr, 0, leaf_cert.data(), leaf_cert.size());
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, chainValidationResult == CertificateChainValidationResult::kSuccess);
 }
 
 static void TestX509_IssuingTimestampValidation(nlTestSuite * inSuite, void * inContext)

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1858,6 +1858,32 @@ static void TestX509_CertChainValidation(nlTestSuite * inSuite, void * inContext
                                    leaf_cert.size(), chainValidationResult);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, chainValidationResult == CertificateChainValidationResult::kSuccess);
+
+    // Now test for invalid arguments.
+    err = ValidateCertificateChain(nullptr, 0, ica_cert.data(), ica_cert.size(), leaf_cert.data(), leaf_cert.size(),
+                                   chainValidationResult);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, chainValidationResult == CertificateChainValidationResult::kRootArgumentInvalid);
+
+    err = ValidateCertificateChain(root_cert.data(), root_cert.size(), nullptr, 0, leaf_cert.data(), leaf_cert.size(),
+                                   chainValidationResult);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, chainValidationResult == CertificateChainValidationResult::kICAArgumentInvalid);
+
+    err = ValidateCertificateChain(root_cert.data(), root_cert.size(), ica_cert.data(), ica_cert.size(), nullptr, 0,
+                                   chainValidationResult);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, chainValidationResult == CertificateChainValidationResult::kLeafArgumentInvalid);
+
+    // Now test with an ICA certificate that does not correspond to the chain
+    ByteSpan wrong_ica_cert;
+    err = GetTestCert(TestCert::kICA02, TestCertLoadFlags::kDERForm, wrong_ica_cert);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ValidateCertificateChain(root_cert.data(), root_cert.size(), wrong_ica_cert.data(), wrong_ica_cert.size(),
+                                   leaf_cert.data(), leaf_cert.size(), chainValidationResult);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_TRUSTED);
+    NL_TEST_ASSERT(inSuite, chainValidationResult == CertificateChainValidationResult::kChainInvalid);
 }
 
 static void TestX509_IssuingTimestampValidation(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem
Current `VerifyAttestationInformation` does simplified processing that will return `AttestationVerificationResult::kDacSignatureInvalid` for *any* failure of the certificate chain validation, event if not related to DAC signature. This is because there is only a bool result used and we do not expose the internal outcome of the certificate chain validation that would expose the true error, such as validity period expiration, malformed certs, missing extensions.

Reference: Issue #11918

#### Change overview
* Added new entries to AttestationVerificationResult enum.
* Added new method that maps `CertificateChainValidationResult` to `AttestationVerificationResult` (DAC Verifier Example).
* Added new enum (`CertificateChainValidationResult`) to show detailed error codes during Certificate Chain Validation.
* Updated ValidateCertificateChain method w/ new parameter - CertificateChainValidationResult enum.
* Made ICA mandatory in ValidateCertificateChain method.
* Updated both OpenSSL/mbedTLS methods to give a more detailed failure result using new parameter.
* Removed test case that didn't use ICA certificate.
* Updated test case to use new `CertificateChainValidationResult` parameter.

#### Testing
* Matter Unit Tests