### PR TITLE
[gitignore] Add `*~` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/html
 
 # compilation database for VSCode and other Ides
 compile_commands.json
+
+# backup files, usually created by the ZAP tool
+*~


### PR DESCRIPTION
#### Problem

Seeing lots of files ends with `~` after updating ZAP,  add them to the gitignore.

This is a common pattern of backup files on Linux.

#### Change overview

Add `*~` to git ignore.

#### Testing
git nolonger lists *~