### PR TITLE
Fix Darwin test compilation error on Xcode 13.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -53,7 +53,7 @@ void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue
                  }];
 }
 
-CHIPDevice * GetConnectedDevice()
+CHIPDevice * GetConnectedDevice(void)
 {
     XCTAssertNotNil(mConnectedDevice);
     return mConnectedDevice;

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -70,7 +70,7 @@ void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue
                  }];
 }
 
-CHIPDevice * GetConnectedDevice()
+CHIPDevice * GetConnectedDevice(void)
 {
     XCTAssertNotNil(mConnectedDevice);
     return mConnectedDevice;


### PR DESCRIPTION
#### Problem
Ending up with `-Wstrict-prototypes` warnings on Xcode 13.  Matter CI runs Xcode 12, but the free tier is now on 13 and this is causing build failures for people.

This used to be a problem all along, but we recently enabled `-Werror` for the Darwin tests files.

#### Change overview
Fix the warning that triggers the error.

#### Testing
Verified this fixes the build in my fork's CI.