### PR TITLE
Fix minimal mDNS ResolvedNodeData::mAddress overflow

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -178,6 +178,10 @@ void PacketDataReporter::OnOperationalIPAddress(const chip::Inet::IPAddress & ad
     // This code assumes that all entries in the mDNS packet relate to the
     // same entity. This may not be correct if multiple servers are reported
     // (if multi-admin decides to use unique ports for every ecosystem).
+    if (mNodeData.mNumIPs >= ResolvedNodeData::kMaxIPAddresses)
+    {
+        return;
+    }
     mNodeData.mAddress[mNodeData.mNumIPs++] = addr;
     mNodeData.mInterfaceId                  = mInterfaceId;
     mHasIP                                  = true;


### PR DESCRIPTION
#### Problem
ResolvedNodeData::mAddress buffer overflow

#### Change overview
Limit the array size when assign

Follow ups: #11695 use pool for it.

#### Testing
Verified using unit-tests