### PR TITLE
Revert "Add tracing service to example/platform/esp rpc (#12386)"

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -227,7 +227,6 @@ target_compile_options(${COMPONENT_LIB} PRIVATE
                        "-DPW_RPC_BUTTON_SERVICE=1"
                        "-DPW_RPC_DEVICE_SERVICE=1"
                        "-DPW_RPC_LIGHTING_SERVICE=1"
-                       "-DPW_RPC_LOCKING_SERVICE=1"
-                       "-DPW_RPC_TRACING_SERVICE=1")
+                       "-DPW_RPC_LOCKING_SERVICE=1")
 
 endif (CONFIG_ENABLE_PW_RPC)

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -52,23 +52,6 @@
 #include "pigweed/rpc_services/Locking.h"
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
-#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-#include "pw_trace/trace.h"
-#include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
-
-// Define trace time for pw_trace
-PW_TRACE_TIME_TYPE pw_trace_GetTraceTime()
-{
-    return (PW_TRACE_TIME_TYPE) chip::System::SystemClock().GetMonotonicMicroseconds64().count();
-}
-// Microsecond time source
-size_t pw_trace_GetTraceTimeTicksPerSecond()
-{
-    return 1000000;
-}
-
-#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-
 namespace chip {
 namespace rpc {
 
@@ -139,10 +122,6 @@ Lighting lighting_service;
 Locking locking;
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
-#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-pw::trace::TraceService trace_service;
-#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-
 void RegisterServices(pw::rpc::Server & server)
 {
 #if defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE
@@ -164,10 +143,6 @@ void RegisterServices(pw::rpc::Server & server)
 #if defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
     server.RegisterService(locking);
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
-
-#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-    server.RegisterService(trace_service);
-#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 }
 
 } // namespace


### PR DESCRIPTION
This reverts commit 59ca4148ad864ce20b7b1841f571b5461508d87b.

#### Problem
Cloud build failures on M5stack:

```
Step #1 - "ESP32": 2021-12-03 17:27:54 INFO    /opt/espressif/tools/tools/xtensa-esp32-elf/esp-2021r2-8.4.0/xtensa-esp32-elf/bin/../lib/gcc/xtensa-esp32-elf/8.4.0/../../../../xtensa-esp32-elf/bin/ld: third_party/connectedhomeip/third_party/pigweed/repo/pw_trace_tokenized/libpw_trace_tokenized.trace_buffer.a(trace_buffer.cc.obj): in function `pw::trace::(anonymous namespace)::TraceBuffer::TraceBuffer()':
Step #1 - "ESP32": 2021-12-03 17:27:54 INFO    /workspace/examples/all-clusters-app/esp32/third_party/connectedhomeip/third_party/pigweed/repo/pw_trace_tokenized/trace_buffer.cc:34: undefined reference to `pw::trace::CallbacksImpl::RegisterSink(void (*)(void*, unsigned int), void (*)(void*, void const*, unsigned int), void (*)(void*), void*, unsigned int*)'
Step #1 - "ESP32": 2021-12-03 17:27:54 INFO    collect2: error: ld returned 1 exit status
```

#### Change overview
Reverts a PR

