### PR TITLE
[Inet] InetIterator::GetHardwareAddress for LwIP

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -172,7 +172,12 @@ CHIP_ERROR InterfaceIterator::GetInterfaceType(InterfaceType & type)
 
 CHIP_ERROR InterfaceIterator::GetHardwareAddress(uint8_t * addressBuffer, uint8_t & addressSize, uint8_t addressBufferSize)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    VerifyOrReturnError(addressBuffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(addressSize >= mCurNetif->hwaddr_len, CHIP_ERROR_BUFFER_TOO_SMALL);
+    addressSize = mCurNetif->hwaddr_len;
+    memcpy(addressBuffer, mCurNetif->hwaddr, addressSize);
+    return CHIP_NO_ERROR;
 }
 
 bool InterfaceAddressIterator::HasCurrent()

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -174,7 +174,7 @@ CHIP_ERROR InterfaceIterator::GetHardwareAddress(uint8_t * addressBuffer, uint8_
 {
     VerifyOrReturnError(addressBuffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(addressSize >= mCurNetif->hwaddr_len, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(addressBufferSize >= mCurNetif->hwaddr_len, CHIP_ERROR_BUFFER_TOO_SMALL);
     addressSize = mCurNetif->hwaddr_len;
     memcpy(addressBuffer, mCurNetif->hwaddr, addressSize);
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem

1b2413793424 (#12552) added `InetIterator::GetHardwareAddress()`,
with an implementation for Zephyr and stubs for other builds.

#### Change overview

Implement `GetHardwareAddress()` for LwIP builds.

(For sockets builds, there is no cross-platform access to the
hardware MAC. Linux could use `SIOCGIFHWADDR`.)

#### Testing

CI (test from #12552)
