### PR TITLE
Rename ActionStatusEnum to ActionStateEnum.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/bridged-actions-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/bridged-actions-cluster.xml
@@ -39,7 +39,7 @@ limitations under the License.
     <item value="1" name="interrupted"/>
   </enum>
 
-  <enum name="ActionStatusEnum" type="ENUM8">
+  <enum name="ActionStateEnum" type="ENUM8">
     <cluster code="0x0025"/>
     <item value="0" name="Inactive"/>
     <item value="1" name="Active"/>
@@ -72,7 +72,7 @@ limitations under the License.
     <item name="Type"              type="ActionTypeEnum"/>
     <item name="EndpointListID"    type="INT16U"/>
     <item name="SupportedCommands" type="INT16U"/>
-    <item name="Status"            type="ActionStatusEnum"/>
+    <item name="Status"            type="ActionStateEnum"/>
   </struct>
 
   <struct name="EndpointListStruct">
@@ -176,14 +176,14 @@ limitations under the License.
       <description>This event SHALL be generated when there is a change in the Status of an ActionID.</description>
       <field id="0" name="ActionID" type="INT16U" />
       <field id="1" name="InvokeID" type="INT32U" />
-      <field id="2" name="NewState" type="ActionStatusEnum" />
+      <field id="2" name="NewState" type="ActionStateEnum" />
     </event>
 
     <event side="server" code="0x01" priority="info" name="ActionFailed" optional="false">
       <description>This event SHALL be generated when there is some error which prevents the action from its normal planned execution.</description>
       <field id="0" name="ActionID" type="INT16U" />
       <field id="1" name="InvokeID" type="INT32U" />
-      <field id="2" name="NewState" type="ActionStatusEnum" />
+      <field id="2" name="NewState" type="ActionStateEnum" />
       <field id="3" name="Error"    type="ActionErrorEnum" />
     </event>
 

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -1362,7 +1362,7 @@ void CHIPBridgedActionsActionListAttributeCallback::CallbackFn(
         bool statusNull     = false;
         bool statusHasValue = true;
 
-        chip::app::Clusters::BridgedActions::ActionStatusEnum statusValue = entry.status;
+        chip::app::Clusters::BridgedActions::ActionStateEnum statusValue = entry.status;
 
         jobject status = nullptr;
         if (!statusNull && statusHasValue)

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -4761,7 +4761,7 @@ class BridgedActions(Cluster):
             kUnknown = 0x00
             kInterrupted = 0x01
 
-        class ActionStatusEnum(IntEnum):
+        class ActionStateEnum(IntEnum):
             kInactive = 0x00
             kActive = 0x01
             kPaused = 0x02
@@ -4794,7 +4794,7 @@ class BridgedActions(Cluster):
                             ClusterObjectFieldDescriptor(Label="type", Tag=3, Type=BridgedActions.Enums.ActionTypeEnum),
                             ClusterObjectFieldDescriptor(Label="endpointListID", Tag=4, Type=uint),
                             ClusterObjectFieldDescriptor(Label="supportedCommands", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="status", Tag=6, Type=BridgedActions.Enums.ActionStatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=6, Type=BridgedActions.Enums.ActionStateEnum),
                     ])
 
             actionID: 'uint' = 0
@@ -4802,7 +4802,7 @@ class BridgedActions(Cluster):
             type: 'BridgedActions.Enums.ActionTypeEnum' = 0
             endpointListID: 'uint' = 0
             supportedCommands: 'uint' = 0
-            status: 'BridgedActions.Enums.ActionStatusEnum' = 0
+            status: 'BridgedActions.Enums.ActionStateEnum' = 0
 
         @dataclass
         class EndpointListStruct(ClusterObject):
@@ -5133,12 +5133,12 @@ class BridgedActions(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="actionID", Tag=0, Type=uint),
                             ClusterObjectFieldDescriptor(Label="invokeID", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="newState", Tag=2, Type=BridgedActions.Enums.ActionStatusEnum),
+                            ClusterObjectFieldDescriptor(Label="newState", Tag=2, Type=BridgedActions.Enums.ActionStateEnum),
                     ])
 
             actionID: 'uint' = 0
             invokeID: 'uint' = 0
-            newState: 'BridgedActions.Enums.ActionStatusEnum' = 0
+            newState: 'BridgedActions.Enums.ActionStateEnum' = 0
 
         @dataclass
         class ActionFailed(ClusterEventDescriptor):
@@ -5151,13 +5151,13 @@ class BridgedActions(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="actionID", Tag=0, Type=uint),
                             ClusterObjectFieldDescriptor(Label="invokeID", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="newState", Tag=2, Type=BridgedActions.Enums.ActionStatusEnum),
+                            ClusterObjectFieldDescriptor(Label="newState", Tag=2, Type=BridgedActions.Enums.ActionStateEnum),
                             ClusterObjectFieldDescriptor(Label="error", Tag=3, Type=BridgedActions.Enums.ActionErrorEnum),
                     ])
 
             actionID: 'uint' = 0
             invokeID: 'uint' = 0
-            newState: 'BridgedActions.Enums.ActionStatusEnum' = 0
+            newState: 'BridgedActions.Enums.ActionStateEnum' = 0
             error: 'BridgedActions.Enums.ActionErrorEnum' = 0
 
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -6249,8 +6249,8 @@ enum class ActionErrorEnum : uint8_t
     kUnknown     = 0x00,
     kInterrupted = 0x01,
 };
-// Enum for ActionStatusEnum
-enum class ActionStatusEnum : uint8_t
+// Enum for ActionStateEnum
+enum class ActionStateEnum : uint8_t
 {
     kInactive = 0x00,
     kActive   = 0x01,
@@ -6313,7 +6313,7 @@ public:
     ActionTypeEnum type;
     uint16_t endpointListID;
     uint16_t supportedCommands;
-    ActionStatusEnum status;
+    ActionStateEnum status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -6941,7 +6941,7 @@ public:
 
     uint16_t actionID;
     uint32_t invokeID;
-    ActionStatusEnum newState;
+    ActionStateEnum newState;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6955,7 +6955,7 @@ public:
 
     uint16_t actionID;
     uint32_t invokeID;
-    ActionStatusEnum newState;
+    ActionStateEnum newState;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -6981,7 +6981,7 @@ public:
 
     uint16_t actionID;
     uint32_t invokeID;
-    ActionStatusEnum newState;
+    ActionStateEnum newState;
     ActionErrorEnum error;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -6996,7 +6996,7 @@ public:
 
     uint16_t actionID;
     uint32_t invokeID;
-    ActionStatusEnum newState;
+    ActionStateEnum newState;
     ActionErrorEnum error;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);


### PR DESCRIPTION
It's called ActionStateEnum in the spec.

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes; this is unused for now.