### PR TITLE
Small cleanups

### DIFF
--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -437,7 +437,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         mTxLength = mTxBuf->DataLength();
 
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send whole message:");
-        PrintBufDebug(data);
+        PrintBufDebug(mTxBuf);
 
         // Determine fragment header size.
         uint8_t header_size =
@@ -493,7 +493,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
 
         characteristic[0] = headerFlags.Raw();
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send first fragment:");
-        PrintBufDebug(data);
+        PrintBufDebug(mTxBuf);
     }
     else if (mTxState == kState_InProgress)
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -492,9 +492,14 @@ public:
      *
      * @param[in] remoteDeviceId        The remote device Id.
      * @param[in] rendezvousParams      The Rendezvous connection parameters
-     * @param[in] commssioningParams    The commissioning parameters (uses defualt if not supplied)
      */
     CHIP_ERROR PairDevice(NodeId remoteDeviceId, RendezvousParameters & rendezvousParams);
+    /**
+     * @overload
+     * @param[in] remoteDeviceId        The remote device Id.
+     * @param[in] rendezvousParams      The Rendezvous connection parameters
+     * @param[in] commissioningParams    The commissioning parameters (uses default if not supplied)
+     */
     CHIP_ERROR PairDevice(NodeId remoteDeviceId, RendezvousParameters & rendezvousParams,
                           CommissioningParameters & commissioningParams);
 
@@ -514,7 +519,7 @@ public:
      *   OnPairingComplete will be called with an error.
      *
      * @param[in] remoteDeviceId        The remote device Id.
-     * @param[in] rendezvousParams      The Rendezvous connection parameters
+     * @param[in] params                The Rendezvous connection parameters
      */
     CHIP_ERROR EstablishPASEConnection(NodeId remoteDeviceId, RendezvousParameters & params);
 

--- a/src/platform/cc13x2_26x2/ble_user_config.c
+++ b/src/platform/cc13x2_26x2/ble_user_config.c
@@ -17,8 +17,8 @@
  */
 
 /**
- * @file  This file contains user configurable variables for the BLE
- *      Application.
+ * @file
+ *  This file contains user configurable variables for the BLE Application.
  *
  */
 

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -44,7 +44,7 @@ public:
     /**
      * Allocates a new secure session out of the internal resource pool.
      *
-     * @param sessionType secure session type
+     * @param secureSessionType secure session type
      * @param localSessionId represents the encryption key ID assigned by local node
      * @param peerNodeId represents peer Node's ID
      * @param peerCATs represents peer CASE Authenticated Tags

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -111,19 +111,12 @@ public:
 
     bool operator!=(const PeerAddress & other) const { return !(*this == other); }
 
-    /// Maximum size of an Inet address ToString format, that can hold both IPV6 and IPV4 addresses.
-#ifdef INET6_ADDRSTRLEN
-    static constexpr size_t kInetMaxAddrLen = INET6_ADDRSTRLEN;
-#else
-    static constexpr size_t kInetMaxAddrLen = INET_ADDRSTRLEN;
-#endif
-
     /// Maximum size of the string outputes by ToString. Format is of the form:
     /// "UDP:<ip>:<port>"
     static constexpr size_t kMaxToStringSize = 3 // type: UDP/TCP/BLE
         + 1                                      // splitter :
         + 2                                      // brackets around address
-        + kInetMaxAddrLen                        // address
+        + Inet::IPAddress::kMaxStringLength      // address
         + 1                                      // splitter %
         + Inet::InterfaceId::kMaxIfNameLength    // interface
         + 1                                      // splitter :
@@ -138,7 +131,7 @@ public:
 
     void ToString(char * buf, size_t bufSize) const
     {
-        char ip_addr[kInetMaxAddrLen];
+        char ip_addr[Inet::IPAddress::kMaxStringLength];
 
         char interface[Inet::InterfaceId::kMaxIfNameLength + 1] = {}; // +1 to prepend '%'
         if (mInterface.IsPresent())


### PR DESCRIPTION
- Fix debug logging in `src/ble/BtpEngine.cpp`.

- Fix `Transport::PeerAddress::kMaxToStringSize` to use `Inet::IPAddress::kMaxStringLength` for the result of `Inet::IPAddress::ToString()`.

- Fix some Doxygen.
