### PR TITLE
RPC: Fix EFR light & lock rpc examples.

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -70,7 +70,10 @@ efr32_sdk("sdk") {
   ]
 
   if (chip_enable_pw_rpc) {
-    defines += [ "HAL_VCOM_ENABLE=1" ]
+    defines += [
+      "HAL_VCOM_ENABLE=1",
+      "PW_RPC_ENABLED",
+    ]
   }
 }
 

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -67,7 +67,10 @@ efr32_sdk("sdk") {
   ]
 
   if (chip_enable_pw_rpc) {
-    defines += [ "HAL_VCOM_ENABLE=1" ]
+    defines += [
+      "HAL_VCOM_ENABLE=1",
+      "PW_RPC_ENABLED",
+    ]
   }
 }
 


### PR DESCRIPTION
#### Problem
Missing a define which was causing RPCs to not start. 

#### Change overview
Add missing define.

#### Testing
Built RPC versions for both examples and tested with rpc console.
