### PR TITLE
Send/Extract optional MRP parameters in CASE messages

### DIFF
--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -90,7 +90,9 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR ListenForSessionEstablishment(uint16_t mySessionId, FabricTable * fabrics, SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR ListenForSessionEstablishment(uint16_t mySessionId, FabricTable * fabrics, SessionEstablishmentDelegate * delegate,
+                                             Optional<ReliableMessageProtocolConfig> mrpConfig =
+                                             Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
      * @brief
@@ -107,7 +109,8 @@ public:
      */
     CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId,
                                 uint16_t mySessionId, Messaging::ExchangeContext * exchangeCtxt,
-                                SessionEstablishmentDelegate * delegate);
+                                SessionEstablishmentDelegate * delegate, Optional<ReliableMessageProtocolConfig> mrpConfig =
+                                Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
      * Parse a sigma1 message.  This function will return success only if the
@@ -127,10 +130,9 @@ public:
      * and the  resumptionID and initiatorResumeMIC outparams will be set to
      * valid values, or the resumptionRequested outparam will be set to false.
      */
-    static CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ByteSpan & initiatorRandom,
-                                  uint16_t & initiatorSessionId, ByteSpan & destinationId, ByteSpan & initiatorEphPubKey,
-                                  // TODO: MRP param parsing
-                                  bool & resumptionRequested, ByteSpan & resumptionId, ByteSpan & initiatorResumeMIC);
+    CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ByteSpan & initiatorRandom,
+                           uint16_t & initiatorSessionId, ByteSpan & destinationId, ByteSpan & initiatorEphPubKey,
+                           bool & resumptionRequested, ByteSpan & resumptionId, ByteSpan & initiatorResumeMIC);
 
     /**
      * @brief
@@ -260,6 +262,8 @@ private:
 
     uint8_t mLocalFabricIndex       = 0;
     uint64_t mSessionSetupTimeStamp = 0;
+
+    Optional<ReliableMessageProtocolConfig> mLocalMRPConfig;
 
 protected:
     bool mCASESessionEstablished = false;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -90,9 +90,9 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR ListenForSessionEstablishment(uint16_t mySessionId, FabricTable * fabrics, SessionEstablishmentDelegate * delegate,
-                                             Optional<ReliableMessageProtocolConfig> mrpConfig =
-                                             Optional<ReliableMessageProtocolConfig>::Missing());
+    CHIP_ERROR ListenForSessionEstablishment(
+        uint16_t mySessionId, FabricTable * fabrics, SessionEstablishmentDelegate * delegate,
+        Optional<ReliableMessageProtocolConfig> mrpConfig = Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
      * @brief
@@ -107,10 +107,10 @@ public:
      *
      * @return CHIP_ERROR      The result of initialization
      */
-    CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId,
-                                uint16_t mySessionId, Messaging::ExchangeContext * exchangeCtxt,
-                                SessionEstablishmentDelegate * delegate, Optional<ReliableMessageProtocolConfig> mrpConfig =
-                                Optional<ReliableMessageProtocolConfig>::Missing());
+    CHIP_ERROR
+    EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId, uint16_t mySessionId,
+                     Messaging::ExchangeContext * exchangeCtxt, SessionEstablishmentDelegate * delegate,
+                     Optional<ReliableMessageProtocolConfig> mrpConfig = Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
      * Parse a sigma1 message.  This function will return success only if the
@@ -130,9 +130,9 @@ public:
      * and the  resumptionID and initiatorResumeMIC outparams will be set to
      * valid values, or the resumptionRequested outparam will be set to false.
      */
-    CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ByteSpan & initiatorRandom,
-                           uint16_t & initiatorSessionId, ByteSpan & destinationId, ByteSpan & initiatorEphPubKey,
-                           bool & resumptionRequested, ByteSpan & resumptionId, ByteSpan & initiatorResumeMIC);
+    CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ByteSpan & initiatorRandom, uint16_t & initiatorSessionId,
+                           ByteSpan & destinationId, ByteSpan & initiatorEphPubKey, bool & resumptionRequested,
+                           ByteSpan & resumptionId, ByteSpan & initiatorResumeMIC);
 
     /**
      * @brief

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -484,8 +484,9 @@ static CHIP_ERROR EncodeSigma1(MutableByteSpan & buf)
         bool resumptionRequested;                                                                                                  \
         ByteSpan resumptionId;                                                                                                     \
         ByteSpan initiatorResumeMIC;                                                                                               \
-        err = CASESession::ParseSigma1(reader, initiatorRandom, initiatorSessionId, destinationId, initiatorEphPubKey,             \
-                                       resumptionRequested, resumptionId, initiatorResumeMIC);                                     \
+        CASESession session;                                                                                                       \
+        err = session.ParseSigma1(reader, initiatorRandom, initiatorSessionId, destinationId, initiatorEphPubKey,                  \
+                                  resumptionRequested, resumptionId, initiatorResumeMIC);                                          \
         NL_TEST_ASSERT(inSuite, (err == CHIP_NO_ERROR) == params::expectSuccess);                                                  \
         if (params::expectSuccess)                                                                                                 \
         {                                                                                                                          \


### PR DESCRIPTION
#### Problem
* Fixes - https://github.com/project-chip/connectedhomeip/issues/10019

#### Change overview
Optional MRP parameters will be extracted from and/or provided in session messages when available.

#### Testing
Covered by existing tests.
