### PR TITLE
Fix efr32 builds (detected by cloudbuild, now added to CI)

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -76,7 +76,7 @@ jobs:
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                      efr32 BRD4161A lighting-app \
-                     out/efr32-brd4161a-light/chip-all-clusters-app.elf \
+                     out/efr32-brd4161a-light/chip-efr32-lighting-example.out \
                      /tmp/bloat_reports/
             - name: Build example EFR32 Lighting App for BRD4161A with RPCs
               timeout-minutes: 10

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -61,18 +61,23 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Build example EFR32 Lock App for BRD4161A
-              timeout-minutes: 10
+
+             - name: Build some BRD4161A variants
+              timeout-minutes: 30
               run: |
-                  scripts/examples/gn_efr32_example.sh examples/lock-app/efr32/ out/lock_app_debug BRD4161A
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A lock-app \
-                    out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out /tmp/bloat_reports/
-            - name: Build example EFR32 Lighting App for BRD4161A
-              timeout-minutes: 10
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --enable-flashbundle \
+                        --target-glob '*-brd4161a-{lock,light,unit-test}' \
+                        build \
+                        --copy-artifacts-to out/artifacts \
+                     "
+            - name: Prepare bloat report for light app
               run: |
-                  scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/lighting_app_debug BRD4161A
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A lighting-app \
-                    out/lighting_app_debug/BRD4161A/chip-efr32-lighting-example.out /tmp/bloat_reports/
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                     efr32 BRD4161A lighting-app \
+                     out/efr32-brd4161a-light/chip-all-clusters-app.elf \
+                     /tmp/bloat_reports/
             - name: Build example EFR32 Lighting App for BRD4161A with RPCs
               timeout-minutes: 10
               run: |

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -62,7 +62,7 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
 
-             - name: Build some BRD4161A variants
+            - name: Build some BRD4161A variants
               timeout-minutes: 30
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -129,9 +129,9 @@ class Efr32Builder(GnBuilder):
 
         if self.app == Efr32App.UNIT_TEST:
             # Include test runner python wheels
-            items["chip_nl_test_runner_wheels"] = os.path.join(
-                self.output_dir, 'chip_nl_test_runner_wheels')
-
+            for root, dirs, files in os.walk(os.path.join(self.output_dir, 'chip_nl_test_runner_wheels')):
+                for file in files:
+                    items["chip_nl_test_runner_wheels/" + file] = os.path.join(root, file)
         # Figure out flash bundle files and build accordingly
         with open(os.path.join(self.output_dir, self.app.FlashBundleName())) as f:
             for line in f.readlines():

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -131,7 +131,8 @@ class Efr32Builder(GnBuilder):
             # Include test runner python wheels
             for root, dirs, files in os.walk(os.path.join(self.output_dir, 'chip_nl_test_runner_wheels')):
                 for file in files:
-                    items["chip_nl_test_runner_wheels/" + file] = os.path.join(root, file)
+                    items["chip_nl_test_runner_wheels/" +
+                          file] = os.path.join(root, file)
         # Figure out flash bundle files and build accordingly
         with open(os.path.join(self.output_dir, self.app.FlashBundleName())) as f:
             for line in f.readlines():

--- a/scripts/build/builders/mbed.py
+++ b/scripts/build/builders/mbed.py
@@ -15,9 +15,7 @@
 import logging
 import os
 import platform
-import glob
 import shlex
-import pathlib
 
 from enum import Enum, auto
 from .builder import Builder

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -135,7 +135,7 @@ void TestGetVendor(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 123);
 
     // overflow a uint16
-    strcpy(vp, "%" PRIu32 "+456", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(vp, "%" PRIu32 "+456", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 0);
 }
 
@@ -146,7 +146,7 @@ void TestGetLongDiscriminator(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetLongDiscriminator(GetSpan(ld)) == 1234);
 
     // overflow a uint16
-    strcpy(ld, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(ld, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     printf("ld = %s\n", ld);
     NL_TEST_ASSERT(inSuite, GetLongDiscriminator(GetSpan(ld)) == 0);
 }
@@ -175,7 +175,7 @@ void TestGetDeviceType(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetDeviceType(GetSpan(dt)) == 1234);
 
     // overflow a uint16
-    strcpy(dt, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(dt, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetDeviceType(GetSpan(dt)) == 0);
 }
 
@@ -602,7 +602,7 @@ void TestIsDeviceSleepyActive(nlTestSuite * inSuite, void * inContext)
 
     // If the interval is the default value, the device is not sleepy
     sprintf(key, "CRA");
-    sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count());
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count()));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -19,6 +19,7 @@
 #include <lib/dnssd/TxtFields.h>
 
 #include <limits>
+#include <stdio.h>
 #include <string.h>
 
 #include <lib/dnssd/Resolver.h>

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -43,57 +43,57 @@ ByteSpan GetSpan(char * key)
 void TestGetTxtFieldKey(nlTestSuite * inSuite, void * inContext)
 {
     char key[4];
-    sprintf(key, "D");
+    strcpy(key, "D");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kLongDiscriminator);
 
-    sprintf(key, "VP");
+    strcpy(key, "VP");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kVendorProduct);
 
-    sprintf(key, "CM");
+    strcpy(key, "CM");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kCommissioningMode);
 
-    sprintf(key, "DT");
+    strcpy(key, "DT");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kDeviceType);
 
-    sprintf(key, "DN");
+    strcpy(key, "DN");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kDeviceName);
 
-    sprintf(key, "RI");
+    strcpy(key, "RI");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kRotatingDeviceId);
 
-    sprintf(key, "PI");
+    strcpy(key, "PI");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kPairingInstruction);
 
-    sprintf(key, "PH");
+    strcpy(key, "PH");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kPairingHint);
 
-    sprintf(key, "CRI");
+    strcpy(key, "CRI");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kMrpRetryIntervalIdle);
 
-    sprintf(key, "CRA");
+    strcpy(key, "CRA");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kMrpRetryIntervalActive);
 
-    sprintf(key, "T");
+    strcpy(key, "T");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kTcpSupport);
 
-    sprintf(key, "XX");
+    strcpy(key, "XX");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kUnknown);
 }
 
 void TestGetTxtFieldKeyCaseInsensitive(nlTestSuite * inSuite, void * inContext)
 {
     char key[3];
-    sprintf(key, "d");
+    strcpy(key, "d");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kLongDiscriminator);
 
-    sprintf(key, "vp");
+    strcpy(key, "vp");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kVendorProduct);
-    sprintf(key, "Vp");
+    strcpy(key, "Vp");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kVendorProduct);
-    sprintf(key, "vP");
+    strcpy(key, "vP");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kVendorProduct);
 
-    sprintf(key, "Xx");
+    strcpy(key, "Xx");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kUnknown);
 }
 
@@ -101,16 +101,16 @@ void TestGetProduct(nlTestSuite * inSuite, void * inContext)
 {
     // Product and vendor are given as part of the same key, on either side of a + sign. Product is after the +
     char vp[64];
-    sprintf(vp, "123+456");
+    strcpy(vp, "123+456");
     NL_TEST_ASSERT(inSuite, GetProduct(GetSpan(vp)) == 456);
 
-    sprintf(vp, "123+");
+    strcpy(vp, "123+");
     NL_TEST_ASSERT(inSuite, GetProduct(GetSpan(vp)) == 0);
 
-    sprintf(vp, "+456");
+    strcpy(vp, "+456");
     NL_TEST_ASSERT(inSuite, GetProduct(GetSpan(vp)) == 456);
 
-    sprintf(vp, "123");
+    strcpy(vp, "123");
     NL_TEST_ASSERT(inSuite, GetProduct(GetSpan(vp)) == 0);
 
     // overflow a uint16
@@ -121,31 +121,31 @@ void TestGetVendor(nlTestSuite * inSuite, void * inContext)
 {
     // Product and vendor are given as part of the same key, on either side of a + sign. Vendor is first
     char vp[64];
-    sprintf(vp, "123+456");
+    strcpy(vp, "123+456");
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 123);
 
-    sprintf(vp, "123+");
+    strcpy(vp, "123+");
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 123);
 
-    sprintf(vp, "+456");
+    strcpy(vp, "+456");
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 0);
 
-    sprintf(vp, "123");
+    strcpy(vp, "123");
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 123);
 
     // overflow a uint16
-    sprintf(vp, "%" PRIu32 "+456", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    strcpy(vp, "%" PRIu32 "+456", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 0);
 }
 
 void TestGetLongDiscriminator(nlTestSuite * inSuite, void * inContext)
 {
     char ld[64];
-    sprintf(ld, "1234");
+    strcpy(ld, "1234");
     NL_TEST_ASSERT(inSuite, GetLongDiscriminator(GetSpan(ld)) == 1234);
 
     // overflow a uint16
-    sprintf(ld, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    strcpy(ld, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     printf("ld = %s\n", ld);
     NL_TEST_ASSERT(inSuite, GetLongDiscriminator(GetSpan(ld)) == 0);
 }
@@ -153,13 +153,13 @@ void TestGetLongDiscriminator(nlTestSuite * inSuite, void * inContext)
 void TestGetCommissioningMode(nlTestSuite * inSuite, void * inContext)
 {
     char cm[64];
-    sprintf(cm, "0");
+    strcpy(cm, "0");
     NL_TEST_ASSERT(inSuite, GetCommissioningMode(GetSpan(cm)) == 0);
 
-    sprintf(cm, "1");
+    strcpy(cm, "1");
     NL_TEST_ASSERT(inSuite, GetCommissioningMode(GetSpan(cm)) == 1);
 
-    sprintf(cm, "2");
+    strcpy(cm, "2");
     NL_TEST_ASSERT(inSuite, GetCommissioningMode(GetSpan(cm)) == 2);
 
     // overflow a uint8
@@ -170,11 +170,11 @@ void TestGetCommissioningMode(nlTestSuite * inSuite, void * inContext)
 void TestGetDeviceType(nlTestSuite * inSuite, void * inContext)
 {
     char dt[64];
-    sprintf(dt, "1234");
+    strcpy(dt, "1234");
     NL_TEST_ASSERT(inSuite, GetDeviceType(GetSpan(dt)) == 1234);
 
     // overflow a uint16
-    sprintf(dt, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    strcpy(dt, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetDeviceType(GetSpan(dt)) == 0);
 }
 
@@ -183,7 +183,7 @@ void TestGetDeviceName(nlTestSuite * inSuite, void * inContext)
     char name[kMaxDeviceNameLen + 1] = "";
     char val[kMaxDeviceNameLen + 2];
 
-    sprintf(val, "testname");
+    strcpy(val, "testname");
     GetDeviceName(GetSpan(val), name);
     NL_TEST_ASSERT(inSuite, strcmp(name, "testname") == 0);
 
@@ -204,7 +204,7 @@ void TestGetRotatingDeviceId(nlTestSuite * inSuite, void * inContext)
     uint8_t id[kMaxRotatingIdLen];
     size_t len;
 
-    sprintf(ri, "0A1B");
+    strcpy(ri, "0A1B");
     GetRotatingDeviceId(GetSpan(ri), id, &len);
     printf("id[0] = %x\n", id[0]);
     NL_TEST_ASSERT(inSuite, id[0] == 0x0A);
@@ -212,23 +212,23 @@ void TestGetRotatingDeviceId(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, len == 2);
 
     // odd number of characters can't be parsed.
-    sprintf(ri, "0A1BC");
+    strcpy(ri, "0A1BC");
     GetRotatingDeviceId(GetSpan(ri), id, &len);
     NL_TEST_ASSERT(inSuite, len == 0);
 
     // non-hex characters can't be parsed
-    sprintf(ri, "0ATT");
+    strcpy(ri, "0ATT");
     GetRotatingDeviceId(GetSpan(ri), id, &len);
     NL_TEST_ASSERT(inSuite, len == 0);
 
     // Lower case should work on SDK even though devices shouldn't be sending that.
-    sprintf(ri, "0a1b");
+    strcpy(ri, "0a1b");
     GetRotatingDeviceId(GetSpan(ri), id, &len);
     NL_TEST_ASSERT(inSuite, id[0] == 0x0A);
     NL_TEST_ASSERT(inSuite, id[1] == 0x1B);
     NL_TEST_ASSERT(inSuite, len == 2);
 
-    sprintf(ri, "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031");
+    strcpy(ri, "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031");
     GetRotatingDeviceId(GetSpan(ri), id, &len);
     NL_TEST_ASSERT(inSuite, len == sizeof(id));
     for (uint8_t i = 0; i < sizeof(id); ++i)
@@ -240,10 +240,10 @@ void TestGetRotatingDeviceId(nlTestSuite * inSuite, void * inContext)
 void TestGetPairingHint(nlTestSuite * inSuite, void * inContext)
 {
     char ph[64];
-    sprintf(ph, "0");
+    strcpy(ph, "0");
     NL_TEST_ASSERT(inSuite, GetPairingHint(GetSpan(ph)) == 0);
 
-    sprintf(ph, "9");
+    strcpy(ph, "9");
     NL_TEST_ASSERT(inSuite, GetPairingHint(GetSpan(ph)) == 9);
 
     // overflow a uint16
@@ -256,7 +256,7 @@ void TestGetPairingInstruction(nlTestSuite * inSuite, void * inContext)
     char data[kMaxPairingInstructionLen + 2];
     char ret[kMaxPairingInstructionLen + 1] = "";
 
-    sprintf(data, "something");
+    strcpy(data, "something");
     GetPairingInstruction(GetSpan(data), ret);
     NL_TEST_ASSERT(inSuite, strcmp(ret, "something") == 0);
 
@@ -308,16 +308,16 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     DiscoveredNodeData filled;
 
     // Long discriminator
-    sprintf(key, "D");
-    sprintf(val, "840");
+    strcpy(key, "D");
+    strcpy(val, "840");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.longDiscriminator == 840);
     filled.longDiscriminator = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // vendor and product
-    sprintf(key, "VP");
-    sprintf(val, "123+456");
+    strcpy(key, "VP");
+    strcpy(val, "123+456");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.vendorId == 123);
     NL_TEST_ASSERT(inSuite, filled.productId == 456);
@@ -326,32 +326,32 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Commissioning mode
-    sprintf(key, "CM");
-    sprintf(val, "1");
+    strcpy(key, "CM");
+    strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.commissioningMode == 1);
     filled.commissioningMode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Device type
-    sprintf(key, "DT");
-    sprintf(val, "1");
+    strcpy(key, "DT");
+    strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.deviceType == 1);
     filled.deviceType = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Device name
-    sprintf(key, "DN");
-    sprintf(val, "abc");
+    strcpy(key, "DN");
+    strcpy(val, "abc");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, strcmp(filled.deviceName, "abc") == 0);
     memset(filled.deviceName, 0, sizeof(filled.deviceName));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Rotating device id
-    sprintf(key, "RI");
-    sprintf(val, "1A2B");
+    strcpy(key, "RI");
+    strcpy(val, "1A2B");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.rotatingId[0] == 0x1A);
     NL_TEST_ASSERT(inSuite, filled.rotatingId[1] == 0x2B);
@@ -361,16 +361,16 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Pairing instruction
-    sprintf(key, "PI");
-    sprintf(val, "hint");
+    strcpy(key, "PI");
+    strcpy(val, "hint");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, strcmp(filled.pairingInstruction, "hint") == 0);
     memset(filled.pairingInstruction, 0, sizeof(filled.pairingInstruction));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Pairing hint
-    sprintf(key, "PH");
-    sprintf(val, "1");
+    strcpy(key, "PH");
+    strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.pairingHint == 1);
     filled.pairingHint = 0;
@@ -412,15 +412,15 @@ void TxtFieldMrpRetryIntervalIdle(nlTestSuite * inSuite, void * inContext)
     NodeData nodeData;
 
     // Minimum
-    sprintf(key, "CRI");
-    sprintf(val, "1");
+    strcpy(key, "CRI");
+    strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalIdle().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalIdle().Value() == 1_ms32);
 
     // Maximum
-    sprintf(key, "CRI");
-    sprintf(val, "3600000");
+    strcpy(key, "CRI");
+    strcpy(val, "3600000");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalIdle().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalIdle().Value() == 3600000_ms32);
@@ -430,38 +430,38 @@ void TxtFieldMrpRetryIntervalIdle(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
 
     // Invalid CRI - negative value
-    sprintf(key, "CRI");
-    sprintf(val, "-1");
+    strcpy(key, "CRI");
+    strcpy(val, "-1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid CRI - greater than maximum
-    sprintf(key, "CRI");
-    sprintf(val, "3600001");
+    strcpy(key, "CRI");
+    strcpy(val, "3600001");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid CRI - much greater than maximum
-    sprintf(key, "CRI");
-    sprintf(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
+    strcpy(key, "CRI");
+    strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid CRI - hexadecimal value
-    sprintf(key, "CRI");
-    sprintf(val, "0x20");
+    strcpy(key, "CRI");
+    strcpy(val, "0x20");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid CRI - leading zeros
-    sprintf(key, "CRI");
-    sprintf(val, "0700");
+    strcpy(key, "CRI");
+    strcpy(val, "0700");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid CRI - text at the end
-    sprintf(key, "CRI");
-    sprintf(val, "123abc");
+    strcpy(key, "CRI");
+    strcpy(val, "123abc");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalIdle().HasValue());
 }
@@ -475,15 +475,15 @@ void TxtFieldMrpRetryIntervalActive(nlTestSuite * inSuite, void * inContext)
     NodeData nodeData;
 
     // Minimum
-    sprintf(key, "CRA");
-    sprintf(val, "1");
+    strcpy(key, "CRA");
+    strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalActive().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalActive().Value() == 1_ms32);
 
     // Maximum
-    sprintf(key, "CRA");
-    sprintf(val, "3600000");
+    strcpy(key, "CRA");
+    strcpy(val, "3600000");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalActive().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.GetMrpRetryIntervalActive().Value() == 3600000_ms32);
@@ -493,38 +493,38 @@ void TxtFieldMrpRetryIntervalActive(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
 
     // Invalid CRA - negative value
-    sprintf(key, "CRA");
-    sprintf(val, "-1");
+    strcpy(key, "CRA");
+    strcpy(val, "-1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid CRA - greater than maximum
-    sprintf(key, "CRA");
-    sprintf(val, "3600001");
+    strcpy(key, "CRA");
+    strcpy(val, "3600001");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid CRA - much greater than maximum
-    sprintf(key, "CRA");
-    sprintf(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
+    strcpy(key, "CRA");
+    strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid CRA - hexadecimal value
-    sprintf(key, "CRA");
-    sprintf(val, "0x20");
+    strcpy(key, "CRA");
+    strcpy(val, "0x20");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid CRA - leading zeros
-    sprintf(key, "CRA");
-    sprintf(val, "0700");
+    strcpy(key, "CRA");
+    strcpy(val, "0700");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid CRA - text at the end
-    sprintf(key, "CRA");
-    sprintf(val, "123abc");
+    strcpy(key, "CRA");
+    strcpy(val, "123abc");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.GetMrpRetryIntervalActive().HasValue());
 }
@@ -538,8 +538,8 @@ void TxtFieldTcpSupport(nlTestSuite * inSuite, void * inContext)
     NodeData nodeData;
 
     // True
-    sprintf(key, "T");
-    sprintf(val, "1");
+    strcpy(key, "T");
+    strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.*supportsTcp);
 
@@ -548,14 +548,14 @@ void TxtFieldTcpSupport(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
 
     // False
-    sprintf(key, "T");
-    sprintf(val, "0");
+    strcpy(key, "T");
+    strcpy(val, "0");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.*supportsTcp == false);
 
     // Invalid value, stil false
-    sprintf(key, "T");
-    sprintf(val, "asdf");
+    strcpy(key, "T");
+    strcpy(val, "asdf");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.*supportsTcp == false);
 }
@@ -574,14 +574,14 @@ void TestIsDeviceSleepyIdle(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is the default value, the device is not sleepy
-    sprintf(key, "CRI");
-    sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count());
+    strcpy(key, "CRI");
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count()));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     sprintf(key, "CRI");
-    sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count() + 1);
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count() + 1));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
@@ -606,8 +606,8 @@ void TestIsDeviceSleepyActive(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
-    sprintf(key, "CRA");
-    sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count() + 1);
+    strcpy(key, "CRA");
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count() + 1));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
     NL_TEST_ASSERT(inSuite, nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }


### PR DESCRIPTION
#### Problem
Test builds give:

```
2021-12-07 22:51:19 INFO    arm-none-eabi-g++ -MMD -MF obj/third_party/connectedhomeip/src/lib/dnssd/tests/libMdnsTests.TestTxtFields.cpp.o.d -Wconversion -march=armv7e-m -mcpu=cortex-m4 -mabi=aapcs -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb -Og -g2 -fno-common -ffunction-sections -fdata-sections --specs=nosys.specs --specs=nano.specs -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -Wall -Werror -Wstack-usage=8192 -Wextra -Wshadow -Wunreachable-code -Wvla -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wno-cast-function-type -fdiagnostics-color -fno-strict-aliasing -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/kit/common/bsp -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/board/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/driver/memlcd/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/driver/memlcd/src/ls013b7dh03 -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/matter/efr32 -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/matter/efr32/efr32mg12/BRD4161A -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/bootloader -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/CMSIS/Include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/CMSIS/RTOS2/Include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/common/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/driver/button/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/driver/leddrv/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/common/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/gpiointerrupt/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/uartdrv/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/uartdrv/config -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/dmadrv/config -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/dmadrv/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/nvm3/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emdrv/rtcdrv/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/emlib/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/halconfig/inc/hal-config -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/peripheral/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/common -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/chip/efr32 -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/chip/efr32/rf/common/cortex -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/hal -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/hal/efr32 -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/protocol/ieee802154 -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/plugin/pa-conversions -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/plugin/rail_util_pti -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/plugin/rail_util_rf_path -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/device_init/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/hfxo_manager/config/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/hfxo_manager/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/hfxo_manager/src -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/mpu/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/power_manager/config/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/power_manager/inc/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/power_manager/src/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/sleeptimer/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/sleeptimer/config -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/system/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/service/udelay/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/middleware/glib -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/middleware/glib/glib -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/middleware/glib/dmd -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/base/hal/plugin/psstore -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/base/hal/plugin/antenna -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/protocol/bluetooth/inc/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/plugin/plugin-common/fem-control -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/silicon_labs/silabs_core/graphics -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/mbedtls/include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/mbedtls/include/psa -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/mbedtls/library -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/sl_alt/include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/sl_protocol_crypto/src -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/sl_mbedtls_support/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/sl_mbedtls_support/config/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/sl_psa_driver/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/se_manager/inc -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/crypto/sl_component/se_manager/src/ -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/cmsis/Include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/kernel/include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/driver/memlcd/inc/memlcd_usart -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/driver/mx25_flash_shutdown/inc/sl_mx25_flash_shutdown_usart -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/hardware/kit/EFR32MG12_BRD4161A/config -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/Device/SiliconLabs/EFR32MG12P/Include -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/chip/efr32/efr32xg1x -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F -isystem../../src/test_driver/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/config -Wno-maybe-uninitialized -Wno-shadow -std=gnu++17 -fno-rtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -DMBEDTLS_CONFIG_FILE=\"efr32-chip-mbedtls-config.h\" -DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=\"efr32-mbedtls-psa-crypto-config.h\" -D__STARTUP_CLEAR_BSS -DHARD_FAULT_LOG_ENABLE -DCORTEXM3_EFM32_MICRO -DEFR32_LOG_ENABLED=1 -DNVM3_DEFAULT_NVM_SIZE=40960 -DEFR32_OPENTHREAD_API -DPHY=EMBER_PHY_RAIL -DCORTEXM3 -DMICRO=EMBER_MICRO_CORTEXM3_EFR32 -DPLAT=EMBER_PLATFORM_CORTEXM3 -DEFR32MG12P432F1024GL125=1 -DBRD4161A=1 -DSL_SUPRESS_DEPRECATION_WARNINGS_SDK_3_1 -DCHIP_KVS_BASE_SECTOR_INDEX=\(\(FLASH_SIZE/FLASH_PAGE_SIZE\)-\(CHIP_KVS_SECTOR_COUNT\)\) -DCHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI=1 -D__HEAP_SIZE=0 -DSL_CATALOG_FREERTOS_KERNEL_PRESENT=1 -DMBEDTLS_THREADING_C=1 -DMBEDTLS_THREADING_ALT=1 -DSL_THREADING_ALT=1 -DEFR32MG12 -DCHIP_KVS_SECTOR_COUNT=6 -DBOARD_ID=BRD4161A -DPW_RPC_ENABLED -I../../src/test_driver/efr32/third_party/connectedhomeip/src/include -I../../src/test_driver/efr32/third_party/connectedhomeip/src -Igen/include -I../../src/test_driver/efr32/third_party/connectedhomeip/zzz_generated/app-common -I../../src/test_driver/efr32/third_party/connectedhomeip/src/lwip/efr32 -I../../src/test_driver/efr32/third_party/connectedhomeip/src/lwip/freertos -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/lwip/repo/lwip/src/include -I../../src/test_driver/efr32/third_party/connectedhomeip/src/platform/EFR32 -I../../src/test_driver/efr32/third_party/connectedhomeip/src/test_driver/efr32/include -I../../src/test_driver/efr32/third_party/connectedhomeip/examples/platform/efr32 -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/jlink/segger_rtt/RTT -Igen/include/RTT -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/nlassert/repo/include -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/nlio/repo/include -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/nlfaultinjection/repo/include -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_checksum/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/public_overrides -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/standard_library_public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_span/public_overrides -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_span/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_bytes/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_preprocessor/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_status/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log/public_overrides -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_log/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic/public_overrides -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_containers/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_string/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/pigweed/repo/pw_result/public -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/openthread/repo/include -I../../src/test_driver/efr32/third_party/connectedhomeip/third_party/nlunit-test/repo/src -c ../../src/test_driver/efr32/third_party/connectedhomeip/src/lib/dnssd/tests/TestTxtFields.cpp -o obj/third_party/connectedhomeip/src/lib/dnssd/tests/libMdnsTests.TestTxtFields.cpp.o
2021-12-07 22:51:19 INFO    ../../src/test_driver/efr32/third_party/connectedhomeip/src/lib/dnssd/tests/TestTxtFields.cpp: In instantiation of 'void {anonymous}::TestIsDeviceSleepyIdle(nlTestSuite*, void*) [with NodeData = chip::Dnssd::DiscoveredNodeData; nlTestSuite = _nlTestSuite]':
2021-12-07 22:51:19 INFO    ../../src/test_driver/efr32/third_party/connectedhomeip/src/lib/dnssd/tests/TestTxtFields.cpp:639:1:   required from here
2021-12-07 22:51:19 INFO    ../../src/test_driver/efr32/third_party/connectedhomeip/src/lib/dnssd/tests/TestTxtFields.cpp:578:20: error: format '%d' expects argument of type 'int', but argument 3 has type 'std::chrono::duration<long unsigned int, std::ratio<1, 1000> >::rep' {aka 'long unsigned int'} [-Werror=format=]
2021-12-07 22:51:19 INFO      578 |     sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count());
2021-12-07 22:51:19 INFO          |                   ~^
2021-12-07 22:51:19 INFO          |                    |
2021-12-07 22:51:19 INFO          |                    int
2021-12-07 22:51:19 INFO          |                   %ld
```


#### Change overview
- fix compile issues by casting
- cleanup code converting many sprintf to strcpy
- Add build_examples CI step that would have caught this issue
- fix efr32 atrifact copy after wheels updates

#### Testing
Locally using act
CI will validate this as well