### PR TITLE
Integrate IM eventing with platform for diagnostic clusters

### DIFF
--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
 #include <platform/ConnectivityManager.h>
@@ -211,6 +212,34 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
         ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnHardwareFaultsDetected");
 
         ReportAttributeOnAllEndpoints(GeneralDiagnostics::Attributes::ActiveHardwareFaults::Id);
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::ActiveHardwareFaults::Id);
+
+                    // Record HardwareFault event
+                    EventNumber eventNumber;
+                    DataModel::List<const HardwareFaultType> currentList = DataModel::List<const HardwareFaultType>(
+                        reinterpret_cast<const HardwareFaultType *>(current.data()), current.size());
+                    DataModel::List<const HardwareFaultType> previousList = DataModel::List<const HardwareFaultType>(
+                        reinterpret_cast<const HardwareFaultType *>(previous.data()), previous.size());
+                    Events::HardwareFaultChange::Type event{ currentList, previousList };
+
+                    if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber, EventOptions::Type::kUrgent))
+                    {
+                        ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record HardwareFault event");
+                    }
+                }
+            }
+        }
     }
 
     // Get called when the Node detects a radio fault has been raised.
@@ -219,6 +248,34 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
         ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnHardwareFaultsDetected");
 
         ReportAttributeOnAllEndpoints(GeneralDiagnostics::Attributes::ActiveRadioFaults::Id);
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::ActiveRadioFaults::Id);
+
+                    // Record RadioFault event
+                    EventNumber eventNumber;
+                    DataModel::List<const RadioFaultType> currentList = DataModel::List<const RadioFaultType>(
+                        reinterpret_cast<const RadioFaultType *>(current.data()), current.size());
+                    DataModel::List<const RadioFaultType> previousList = DataModel::List<const RadioFaultType>(
+                        reinterpret_cast<const RadioFaultType *>(previous.data()), previous.size());
+                    Events::RadioFaultChange::Type event{ currentList, previousList };
+
+                    if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber, EventOptions::Type::kUrgent))
+                    {
+                        ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record RadioFault event");
+                    }
+                }
+            }
+        }
     }
 
     // Get called when the Node detects a network fault has been raised.
@@ -227,6 +284,34 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
         ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnHardwareFaultsDetected");
 
         ReportAttributeOnAllEndpoints(GeneralDiagnostics::Attributes::ActiveNetworkFaults::Id);
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::ActiveNetworkFaults::Id);
+
+                    // Record NetworkFault event
+                    EventNumber eventNumber;
+                    DataModel::List<const NetworkFaultType> currentList = DataModel::List<const NetworkFaultType>(
+                        reinterpret_cast<const NetworkFaultType *>(current.data()), current.size());
+                    DataModel::List<const NetworkFaultType> previousList = DataModel::List<const NetworkFaultType>(
+                        reinterpret_cast<const NetworkFaultType *>(previous.data()), previous.size());
+                    Events::NetworkFaultChange::Type event{ currentList, previousList };
+
+                    if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber, EventOptions::Type::kUrgent))
+                    {
+                        ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record NetworkFault event");
+                    }
+                }
+            }
+        }
     }
 };
 

--- a/src/include/platform/GeneralFaults.h
+++ b/src/include/platform/GeneralFaults.h
@@ -56,7 +56,7 @@ public:
     CHIP_ERROR add(const uint8_t value);
 
     uint8_t * data() { return mData; }
-    int size() const;
+    size_t size() const;
     uint8_t operator[](int index) const;
 
     Iterator begin() const;
@@ -85,9 +85,9 @@ inline CHIP_ERROR GeneralFaults<N>::add(const uint8_t value)
 }
 
 template <size_t N>
-inline int GeneralFaults<N>::size() const
+inline size_t GeneralFaults<N>::size() const
 {
-    return mSize;
+    return static_cast<size_t>(mSize);
 }
 
 template <size_t N>


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* All IM event server support has landed, we can integrate evening on IM with platform now. 
* This PR is only focus on diagnostic event integration.

Fixes #12524

#### Change overview
Record events when diagnostic events occurs on platform side

#### Testing
How was this tested? (at least one bullet point required)
* Connect Node to the access-point
* Change WiFi password on Access Point which will trigger disconnection on the Node.
* Confirm corresponding WiFi diagnostic events are recorded on the device from log.

```
[1638937064.073887][468062:468065] CHIP:DL: wpa_supplicant:PropertiesChanged:key:DisconnectReason -> -4
[1638937064.106144][468062:468065] CHIP:DL: wpa_supplicant:PropertiesChanged:key:State -> 'disconnected'
[1638937064.106224][468062:468065] CHIP:ZCL: WiFiDiagnosticsDelegate: OnDisconnectionDetected
[1638937064.106326][468062:468065] CHIP:EVL: LogEvent event number: 0x0000000000000001 schema priority: 1, endpoint id:  0x0 cluster id: 0x0000_0036 event id: 0x0 Sys timestamp: 0x000000001FA9A9D3
[1638937064.106380][468062:468065] CHIP:ZCL: WiFiDiagnosticsDelegate: OnConnectionStatusChanged
[1638937064.106450][468062:468065] CHIP:EVL: LogEvent event number: 0x0000000000000002 schema priority: 1, endpoint id:  0x0 cluster id: 0x0000_0036 event id: 0x2 Sys timestamp: 0x000000001FA9A9D3

```

