### PR TITLE
Improve LogEvent API

### DIFF
--- a/src/app/EventLogging.h
+++ b/src/app/EventLogging.h
@@ -54,23 +54,25 @@ private:
  * `ClusterID` and `EventId`.
  *
  * @param[in] apDelegate The EventLoggingDelegate to serialize the event data
- *
- * @param[in] aEventOptions    The options for the event metadata.
- *
+ * @param[in] aEndpoint    The current cluster's Endpoint Id
+ * @param[in] aUrgent    The EventOption Type, kUrgent or kNotUrgent
  * @param[out] aEventNumber The event Number if the event was written to the
  *                         log, 0 otherwise. The Event number is expected to monotonically increase.
  *
  * @return CHIP_ERROR  CHIP Error Code
  */
 template <typename T>
-CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventOptions aEventOptions, EventNumber & aEventNumber)
+CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber,
+                    EventOptions::Type aUrgent = EventOptions::Type::kNotUrgent)
 {
     EventLogger<T> eventData(aEventData);
     ConcreteEventPath path(aEndpoint, aEventData.GetClusterId(), aEventData.GetEventId());
     EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
-    aEventOptions.mPath       = path;
-    aEventOptions.mPriority   = aEventData.GetPriorityLevel();
-    return logMgmt.LogEvent(&eventData, aEventOptions, aEventNumber);
+    EventOptions eventOptions;
+    eventOptions.mUrgent   = aUrgent;
+    eventOptions.mPath     = path;
+    eventOptions.mPriority = aEventData.GetPriorityLevel();
+    return logMgmt.LogEvent(&eventData, eventOptions, aEventNumber);
 }
 
 } // namespace app

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -452,12 +452,11 @@ bool emberAfTestClusterClusterTestEmitTestEventRequestCallback(
     Structs::SimpleStruct::Type arg4;
     DataModel::List<const Structs::SimpleStruct::Type> arg5;
     DataModel::List<const SimpleEnum> arg6;
-    EventOptions eventOptions;
 
     // TODO:  Add code to pull arg4, arg5 and arg6 from the arguments of the command
     Events::TestEvent::Type event{ commandData.arg1, commandData.arg2, commandData.arg3, arg4, arg5, arg6 };
 
-    if (CHIP_NO_ERROR != LogEvent(event, commandPath.mEndpointId, eventOptions, responseData.value))
+    if (CHIP_NO_ERROR != LogEvent(event, commandPath.mEndpointId, responseData.value))
     {
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return true;


### PR DESCRIPTION
#### Problem
Remove EventOptions parameter from LogEvent API and Add isUrgent parameter in LogEventAPI so that Cluster Event implementation would not be confused by things in EventOptions

#### Change overview
See above

#### Testing
Existing test covers
