### PR TITLE
[Android]-Custom CommissioningFlow - Redirect back to ChipTool after commissioning 

### DIFF
--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.chip.chiptool">
 
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -30,12 +31,18 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="mt" /><!-- Process Matter URIs -->
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="mt" android:host="modelinfo" /> <!-- Process Redirect URIs -->
+            </intent-filter>
         </activity>
     </application>
 
     <queries>
         <intent>
-            <action android:name="chip.intent.action.ATTESTATION"/>
+            <action android:name="chip.intent.action.ATTESTATION" />
         </intent>
     </queries>
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -231,13 +231,24 @@ class CHIPToolActivity :
   private fun onReturnIntent(intent: Intent) {
     val appLinkData = intent.data
     // Require URI schema "mt:"
-    if (!appLinkData?.scheme.equals("mt")) return
+    if (!appLinkData?.scheme.equals("mt", true)) {
+      Log.d(TAG, "Unrecognized URI schema : ${appLinkData?.scheme}")
+      return
+    }
     // Require URI host "modelinfo"
-    if (!appLinkData?.host.equals("modelinfo")) return
+    if (!appLinkData?.host.equals("modelinfo", true)) {
+      Log.d(TAG, "Unrecognized URI host : ${appLinkData?.host}")
+      return
+    }
 
     // parse payload
     try {
       val payloadBase64String = appLinkData?.getQueryParameter("payload")
+      if (payloadBase64String.isNullOrEmpty()) {
+        Log.d(TAG, "Unrecognized payload")
+        return
+      }
+
       val decodeBytes = Base64.decode(payloadBase64String, Base64.DEFAULT)
       val payloadString = String(decodeBytes)
       val payload = JSONObject(payloadString)

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -22,6 +22,7 @@ import android.net.Uri
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
 import android.os.Bundle
+import android.util.Base64
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -44,6 +45,7 @@ import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceDetailsFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
 import com.google.chip.chiptool.setuppayloadscanner.CHIPLedgerDetailsFragment
+import org.json.JSONObject
 
 class CHIPToolActivity :
     AppCompatActivity(),
@@ -72,6 +74,10 @@ class CHIPToolActivity :
 
     if (intent?.action == NfcAdapter.ACTION_NDEF_DISCOVERED)
       onNfcIntent(intent)
+
+    if(Intent.ACTION_VIEW == intent?.action) {
+      onReturnIntent(intent)
+    }
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
@@ -220,6 +226,54 @@ class CHIPToolActivity :
         }
         .create()
         .show()
+  }
+
+  private fun onReturnIntent(intent: Intent) {
+    val appLinkData = intent.data
+    // Require URI schema "mt:"
+    if (!appLinkData?.scheme.equals("mt")) return
+    // Require URI host "modelinfo"
+    if (!appLinkData?.host.equals("modelinfo")) return
+
+    // parse payload
+    try {
+      val payloadBase64String = appLinkData?.getQueryParameter("payload")
+      val decodeBytes = Base64.decode(payloadBase64String, Base64.DEFAULT)
+      val payloadString = String(decodeBytes)
+      val payload = JSONObject(payloadString)
+
+      // parse payload from JSON
+      val setupPayload = SetupPayload()
+      // set defaults
+      setupPayload.discoveryCapabilities = setOf()
+      setupPayload.optionalQRCodeInfo = mapOf()
+
+      // read from payload
+      setupPayload.version = payload.getInt("version")
+      setupPayload.vendorId = payload.getInt("vendorId")
+      setupPayload.productId = payload.getInt("productId")
+      setupPayload.commissioningFlow = payload.getInt("commissioningFlow")
+      setupPayload.discriminator = payload.getInt("discriminator")
+      setupPayload.setupPinCode = payload.getLong("setupPinCode")
+
+      val deviceInfo = CHIPDeviceInfo.fromSetupPayload(setupPayload)
+      val buttons = arrayOf(
+        getString(R.string.nfc_tag_action_show)
+      )
+
+      AlertDialog.Builder(this)
+        .setTitle(R.string.provision_custom_flow_alert_title)
+        .setItems(buttons) { _, _ ->
+          onCHIPDeviceInfoReceived(deviceInfo)
+        }
+        .create()
+        .show()
+
+    } catch (ex: UnrecognizedQrCodeException) {
+      Log.e(TAG, "Unrecognized Payload", ex)
+      Toast.makeText(this, "Unrecognized Setup Payload", Toast.LENGTH_SHORT).show()
+      return
+    }
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -75,7 +75,7 @@ class CHIPToolActivity :
     if (intent?.action == NfcAdapter.ACTION_NDEF_DISCOVERED)
       onNfcIntent(intent)
 
-    if(Intent.ACTION_VIEW == intent?.action) {
+    if (Intent.ACTION_VIEW == intent?.action) {
       onReturnIntent(intent)
     }
   }

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -141,10 +141,11 @@
     <string name="chip_ledger_info_commissioning_flow_url_text">Loading...</string>
     <string name="chip_ledge_info_redirect_btn_text">Redirect</string>
     <string name="chip_ledger_info_commissioning_flow_url_not_available">Not available</string>
+    <string name="provision_custom_flow_alert_title">Commissioning flow Completed.</string>
 
     <string name="dcl_api_root_url">https://dcl.dev.dsr-corporation.com/api/modelinfo/models</string>
     <string name="dcl_response_key">result</string>
     <string name="dcl_custom_flow_url_key">custom</string>
-    <string name="custom_flow_return_url"></string>
+    <string name="custom_flow_return_url">mt://modelinfo</string>
     <string name="retrieve_endpoint_list">Retrieve Endpoint List</string>
 </resources>


### PR DESCRIPTION
Custom CommissioningFlow - Redirect back to ChipTool after commissioning 

#### Change overview
This PR defines a URI to the android app, such that 3P apps can redirect back the users to ChipTool as part of Custom CommissioningFlow Implementation.

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, using the following URI - mt://modelinfo?payload=eyJjb21taXNzaW9uaW5nRmxvdyI6MCwiZGlzY292ZXJ5Q2FwYWJpbGl0aWVzIjpbIkJMRSJdLCJk aXNjcmltaW5hdG9yIjozODQwLCJvcHRpb25hbFFyQ29kZUluZm9NYXAiOnt9LCJwcm9kdWN0SWQi OjY1Mjc5LCJzZXR1cFBpbkNvZGUiOjIwMjAyMDIxLCJ2ZW5kb3JJZCI6OTA1MCwidmVyc2lvbiI6 MH0=

Screenshots
* Landing page when redirected using the URI
<img width="200" alt="Landing" src="https://user-images.githubusercontent.com/26148162/145152799-a529df21-4ab9-46f5-8bb6-7392af72db63.png">
* Device Info page (Payload parsed from the URI)
<img width="200" alt="DeviceInfo" src="https://user-images.githubusercontent.com/26148162/145152802-00fd1d5a-eab9-497d-9411-e0e8bc6fb997.png">
