### PR TITLE
added PartNumber, ProductURL, ProductLabel and UniqueID for basic cluster on android tv server

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -37,7 +37,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetNodeLabel(nodeLabel, sizeof(nodeLabel)) == CHIP_NO_ERROR)
     {
         status = Attributes::NodeLabel::Set(endpoint, chip::CharSpan(nodeLabel, strlen(nodeLabel)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Node Label: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Node Label: 0x%02x", status));
     }
 
     char location[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1];
@@ -45,42 +45,42 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR)
     {
         status = Attributes::Location::Set(endpoint, chip::CharSpan(location, strlen(location)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
     }
 
     char vendorName[DeviceLayer::ConfigurationManager::kMaxVendorNameLength + 1];
     if (ConfigurationMgr().GetVendorName(vendorName, sizeof(vendorName)) == CHIP_NO_ERROR)
     {
         status = Attributes::VendorName::Set(endpoint, chip::CharSpan(vendorName, strlen(vendorName)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Name: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Name: 0x%02x", status));
     }
 
     uint16_t vendorId;
     if (ConfigurationMgr().GetVendorId(vendorId) == CHIP_NO_ERROR)
     {
         status = Attributes::VendorID::Set(endpoint, vendorId);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Id: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Id: 0x%02x", status));
     }
 
     char productName[DeviceLayer::ConfigurationManager::kMaxProductNameLength + 1];
     if (ConfigurationMgr().GetProductName(productName, sizeof(productName)) == CHIP_NO_ERROR)
     {
         status = Attributes::ProductName::Set(endpoint, chip::CharSpan(productName, strlen(productName)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Name: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Name: 0x%02x", status));
     }
 
     uint16_t productId;
     if (ConfigurationMgr().GetProductId(productId) == CHIP_NO_ERROR)
     {
         status = Attributes::ProductID::Set(endpoint, productId);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Id: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Id: 0x%02x", status));
     }
 
     char hardwareVersionString[DeviceLayer::ConfigurationManager::kMaxHardwareVersionStringLength + 1];
     if (ConfigurationMgr().GetHardwareVersionString(hardwareVersionString, sizeof(hardwareVersionString)) == CHIP_NO_ERROR)
     {
         status = Attributes::HardwareVersionString::Set(endpoint, CharSpan(hardwareVersionString, strlen(hardwareVersionString)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
                        ChipLogError(Zcl, "Error setting Hardware Version String: 0x%02x", status));
     }
 
@@ -88,14 +88,14 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetHardwareVersion(hardwareVersion) == CHIP_NO_ERROR)
     {
         status = Attributes::HardwareVersion::Set(endpoint, hardwareVersion);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Hardware Version: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Hardware Version: 0x%02x", status));
     }
 
     char softwareVersionString[DeviceLayer::ConfigurationManager::kMaxSoftwareVersionLength + 1];
     if (ConfigurationMgr().GetSoftwareVersionString(softwareVersionString, sizeof(softwareVersionString)) == CHIP_NO_ERROR)
     {
         status = Attributes::SoftwareVersionString::Set(endpoint, CharSpan(softwareVersionString, strlen(softwareVersionString)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
                        ChipLogError(Zcl, "Error setting Software Version String: 0x%02x", status));
     }
 
@@ -103,14 +103,14 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetSoftwareVersion(softwareVersion) == CHIP_NO_ERROR)
     {
         status = Attributes::SoftwareVersion::Set(endpoint, softwareVersion);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version: 0x%02x", status));
     }
 
     char serialNumberString[DeviceLayer::ConfigurationManager::kMaxSerialNumberLength + 1];
     if (ConfigurationMgr().GetSerialNumber(serialNumberString, sizeof(serialNumberString)) == CHIP_NO_ERROR)
     {
         status = Attributes::SerialNumber::Set(endpoint, CharSpan(serialNumberString, strlen(serialNumberString)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Serial Number String: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Serial Number String: 0x%02x", status));
     }
 
     char manufacturingDateString[DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength + 1];
@@ -122,7 +122,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
         snprintf(manufacturingDateString, sizeof(manufacturingDateString), "%04" PRIu16 "-%02" PRIu16 "-%02" PRIu16,
                  manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
         status = Attributes::ManufacturingDate::Set(endpoint, CharSpan(manufacturingDateString, strlen(manufacturingDateString)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
                        ChipLogError(Zcl, "Error setting Manufacturing Date String: 0x%02x", status));
     }
 
@@ -130,28 +130,28 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetPartNumber(partNumber, sizeof(partNumber)) == CHIP_NO_ERROR)
     {
         status = Attributes::PartNumber::Set(endpoint, CharSpan(partNumber, strlen(partNumber)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Part Number: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Part Number: 0x%02x", status));
     }
 
     char productURL[DeviceLayer::ConfigurationManager::kMaxProductURLLength + 1];
     if (ConfigurationMgr().GetProductURL(productURL, sizeof(productURL)) == CHIP_NO_ERROR)
     {
         status = Attributes::ProductURL::Set(endpoint, CharSpan(productURL, strlen(productURL)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product URL: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product URL: 0x%02x", status));
     }
 
     char productLabel[DeviceLayer::ConfigurationManager::kMaxProductURLLength + 1];
     if (ConfigurationMgr().GetProductLabel(productLabel, sizeof(productLabel)) == CHIP_NO_ERROR)
     {
         status = Attributes::ProductLabel::Set(endpoint, CharSpan(productLabel, strlen(productLabel)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Label: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Label: 0x%02x", status));
     }
 
     bool localConfigDisabled;
     if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
     {
         status = Attributes::LocalConfigDisabled::Set(endpoint, localConfigDisabled);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
                        ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
     }
 
@@ -159,14 +159,14 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetReachable(reachable) == CHIP_NO_ERROR)
     {
         status = Attributes::Reachable::Set(endpoint, reachable);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Reachable: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Reachable: 0x%02x", status));
     }
 
     char uniqueId[DeviceLayer::ConfigurationManager::kMaxUniqueIDLength + 1];
     if (ConfigurationMgr().GetUniqueId(uniqueId, sizeof(uniqueId)) == CHIP_NO_ERROR)
     {
         status = Attributes::UniqueID::Set(endpoint, CharSpan(uniqueId, strlen(uniqueId)));
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Unique Id: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Unique Id: 0x%02x", status));
     }
 }
 

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -80,8 +80,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetHardwareVersionString(hardwareVersionString, sizeof(hardwareVersionString)) == CHIP_NO_ERROR)
     {
         status = Attributes::HardwareVersionString::Set(endpoint, CharSpan(hardwareVersionString, strlen(hardwareVersionString)));
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
-                       ChipLogError(Zcl, "Error setting Hardware Version String: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Hardware Version String: 0x%02x", status));
     }
 
     uint16_t hardwareVersion;
@@ -95,8 +94,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetSoftwareVersionString(softwareVersionString, sizeof(softwareVersionString)) == CHIP_NO_ERROR)
     {
         status = Attributes::SoftwareVersionString::Set(endpoint, CharSpan(softwareVersionString, strlen(softwareVersionString)));
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
-                       ChipLogError(Zcl, "Error setting Software Version String: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version String: 0x%02x", status));
     }
 
     uint16_t softwareVersion;
@@ -123,7 +121,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
                  manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
         status = Attributes::ManufacturingDate::Set(endpoint, CharSpan(manufacturingDateString, strlen(manufacturingDateString)));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
-                       ChipLogError(Zcl, "Error setting Manufacturing Date String: 0x%02x", status));
+                   ChipLogError(Zcl, "Error setting Manufacturing Date String: 0x%02x", status));
     }
 
     char partNumber[DeviceLayer::ConfigurationManager::kMaxPartNumberLength + 1];
@@ -151,8 +149,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
     {
         status = Attributes::LocalConfigDisabled::Set(endpoint, localConfigDisabled);
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
-                       ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
     }
 
     bool reachable;

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -19,6 +19,7 @@
 #include "basic.h"
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <cstddef>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/ConfigurationManager.h>
 
@@ -31,6 +32,21 @@ using namespace chip::DeviceLayer;
 void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
 {
     EmberAfStatus status;
+
+    char nodeLabel[DeviceLayer::ConfigurationManager::kMaxNodeLabelLength + 1];
+    if (ConfigurationMgr().GetNodeLabel(nodeLabel, sizeof(nodeLabel)) == CHIP_NO_ERROR)
+    {
+        status = Attributes::NodeLabel::Set(endpoint, chip::CharSpan(nodeLabel, strlen(nodeLabel)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Node Label: 0x%02x", status));
+    }
+
+    char location[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1];
+    size_t codeLen = 0;
+    if (ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR)
+    {
+        status = Attributes::Location::Set(endpoint, chip::CharSpan(location, strlen(location)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
+    }
 
     char vendorName[DeviceLayer::ConfigurationManager::kMaxVendorNameLength + 1];
     if (ConfigurationMgr().GetVendorName(vendorName, sizeof(vendorName)) == CHIP_NO_ERROR)
@@ -108,6 +124,48 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
         status = Attributes::ManufacturingDate::Set(endpoint, CharSpan(manufacturingDateString, strlen(manufacturingDateString)));
         VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
                        ChipLogError(Zcl, "Error setting Manufacturing Date String: 0x%02x", status));
+    }
+
+    char partNumber[DeviceLayer::ConfigurationManager::kMaxPartNumberLength + 1];
+    if (ConfigurationMgr().GetPartNumber(partNumber, sizeof(partNumber)) == CHIP_NO_ERROR)
+    {
+        status = Attributes::PartNumber::Set(endpoint, CharSpan(partNumber, strlen(partNumber)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Part Number: 0x%02x", status));
+    }
+
+    char productURL[DeviceLayer::ConfigurationManager::kMaxProductURLLength + 1];
+    if (ConfigurationMgr().GetProductURL(productURL, sizeof(productURL)) == CHIP_NO_ERROR)
+    {
+        status = Attributes::ProductURL::Set(endpoint, CharSpan(productURL, strlen(productURL)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product URL: 0x%02x", status));
+    }
+
+    char productLabel[DeviceLayer::ConfigurationManager::kMaxProductURLLength + 1];
+    if (ConfigurationMgr().GetProductLabel(productLabel, sizeof(productLabel)) == CHIP_NO_ERROR)
+    {
+        status = Attributes::ProductLabel::Set(endpoint, CharSpan(productLabel, strlen(productLabel)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Label: 0x%02x", status));
+    }
+
+    bool localConfigDisabled;
+    if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
+    {
+        status = Attributes::LocalConfigDisabled::Set(endpoint, localConfigDisabled);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
+    }
+
+    bool reachable;
+    if (ConfigurationMgr().GetReachable(reachable) == CHIP_NO_ERROR)
+    {
+        status = Attributes::Reachable::Set(endpoint, reachable);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Reachable: 0x%02x", status));
+    }
+
+    char uniqueId[DeviceLayer::ConfigurationManager::kMaxUniqueIDLength + 1];
+    if (ConfigurationMgr().GetUniqueId(uniqueId, sizeof(uniqueId)) == CHIP_NO_ERROR)
+    {
+        status = Attributes::UniqueID::Set(endpoint, CharSpan(uniqueId, strlen(uniqueId)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Unique Id: 0x%02x", status));
     }
 }
 

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -151,7 +151,8 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
     {
         status = Attributes::LocalConfigDisabled::Set(endpoint, localConfigDisabled);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+                       ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
     }
 
     bool reachable;

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -116,6 +116,14 @@ public:
     virtual CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours)      = 0;
     virtual CHIP_ERROR GetBootReason(uint32_t & bootReason)                            = 0;
     virtual CHIP_ERROR StoreBootReason(uint32_t bootReason)                            = 0;
+    virtual CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize)                                     = 0;
+    virtual CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize)                             = 0;
+    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize)                                    = 0;
+    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                                    = 0;
+    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                                  = 0;
+    virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                                      = 0;
+    virtual CHIP_ERROR GetReachable(bool & disabled)                                             = 0;
+    virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                                   = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -122,7 +122,7 @@ public:
     virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                       = 0;
     virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                     = 0;
     virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                         = 0;
-    virtual CHIP_ERROR GetReachable(bool & disabled)                                   = 0;
+    virtual CHIP_ERROR GetReachable(bool & reachable)                                   = 0;
     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -116,14 +116,14 @@ public:
     virtual CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours)      = 0;
     virtual CHIP_ERROR GetBootReason(uint32_t & bootReason)                            = 0;
     virtual CHIP_ERROR StoreBootReason(uint32_t bootReason)                            = 0;
-    virtual CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize)                                     = 0;
-    virtual CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize)                             = 0;
-    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize)                                    = 0;
-    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                                    = 0;
-    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                                  = 0;
-    virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                                      = 0;
-    virtual CHIP_ERROR GetReachable(bool & disabled)                                             = 0;
-    virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                                   = 0;
+    virtual CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize)                        = 0;
+    virtual CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize)                = 0;
+    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize)                       = 0;
+    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                       = 0;
+    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                     = 0;
+    virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                         = 0;
+    virtual CHIP_ERROR GetReachable(bool & disabled)                                   = 0;
+    virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -122,7 +122,7 @@ public:
     virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                       = 0;
     virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                     = 0;
     virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                         = 0;
-    virtual CHIP_ERROR GetReachable(bool & reachable)                                   = 0;
+    virtual CHIP_ERROR GetReachable(bool & reachable)                                  = 0;
     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -417,7 +417,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetLocalConfigDisabled(
 }
 
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetReachable(bool & disabled)
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetReachable(bool & reachable)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -423,7 +423,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetReachable(bool & dis
 }
 
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf, size_t bufSize) 
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf, size_t bufSize)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -381,6 +381,54 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreBootReason(uint32_t 
 }
 
 template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetNodeLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreNodeLabel(const char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductURL(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetLocalConfigDisabled(bool & disabled)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetReachable(bool & disabled)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf, size_t bufSize) 
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -100,6 +100,14 @@ public:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override;
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
+    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
+    CHIP_ERROR GetReachable(bool & disabled) override;
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR RunUnitTests(void) override;
     bool IsFullyProvisioned() override;
     void InitiateFactoryReset() override;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -106,7 +106,7 @@ public:
     CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
-    CHIP_ERROR GetReachable(bool & disabled) override;
+    CHIP_ERROR GetReachable(bool & reachable) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR RunUnitTests(void) override;
     bool IsFullyProvisioned() override;

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -576,7 +576,7 @@ inline void chipDie(void)
  *
  *  @param[in]  expr        A Boolean expression to be evaluated.
  */
-#define VerifyOrdo(expr, ...)                                                                                                  \
+#define VerifyOrdo(expr, ...)                                                                                                      \
     do                                                                                                                             \
     {                                                                                                                              \
         if (!(expr))                                                                                                               \

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -562,6 +562,29 @@ inline void chipDie(void)
         }                                                                                                                          \
     } while (false)
 
+/**
+ *  @def VerifyOrdo(expr, ...)
+ *
+ *  @brief
+ *    do something if expression evaluates to false
+ *
+ *  Example usage:
+ *
+ * @code
+ *    VerifyOrdo(param != nullptr, LogError("param is nullptr"));
+ *  @endcode
+ *
+ *  @param[in]  expr        A Boolean expression to be evaluated.
+ */
+#define VerifyOrdo(expr, ...)                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(expr))                                                                                                               \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+        }                                                                                                                          \
+    } while (false)
+
 #if (__cplusplus >= 201103L)
 
 #ifndef __FINAL

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -71,6 +71,13 @@ const AndroidConfig::Key AndroidConfig::kConfigKey_ProductId             = { kCo
 const AndroidConfig::Key AndroidConfig::kConfigKey_ProductName           = { kConfigNamespace_ChipFactory, "product-name" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_SoftwareVersion       = { kConfigNamespace_ChipFactory, "software-version" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_SoftwareVersionString = { kConfigNamespace_ChipFactory, "software-version-str" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_NodeLabel = { kConfigNamespace_ChipFactory, "node-label" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_PartNumber = { kConfigNamespace_ChipFactory, "part-number" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_ProductURL = { kConfigNamespace_ChipFactory, "product-url" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_ProductLabel = { kConfigNamespace_ChipFactory, "product-label" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_LocalConfigDisabled = { kConfigNamespace_ChipFactory, "local-config-disabled" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_Reachable = { kConfigNamespace_ChipFactory, "reachable" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_UniqueId = { kConfigNamespace_ChipFactory, "uniqueId" };
 
 // Keys stored in the Chip-config namespace
 const AndroidConfig::Key AndroidConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -71,13 +71,13 @@ const AndroidConfig::Key AndroidConfig::kConfigKey_ProductId             = { kCo
 const AndroidConfig::Key AndroidConfig::kConfigKey_ProductName           = { kConfigNamespace_ChipFactory, "product-name" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_SoftwareVersion       = { kConfigNamespace_ChipFactory, "software-version" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_SoftwareVersionString = { kConfigNamespace_ChipFactory, "software-version-str" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_NodeLabel = { kConfigNamespace_ChipFactory, "node-label" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_PartNumber = { kConfigNamespace_ChipFactory, "part-number" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_ProductURL = { kConfigNamespace_ChipFactory, "product-url" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_ProductLabel = { kConfigNamespace_ChipFactory, "product-label" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_NodeLabel             = { kConfigNamespace_ChipFactory, "node-label" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_PartNumber            = { kConfigNamespace_ChipFactory, "part-number" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_ProductURL            = { kConfigNamespace_ChipFactory, "product-url" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_ProductLabel          = { kConfigNamespace_ChipFactory, "product-label" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_LocalConfigDisabled = { kConfigNamespace_ChipFactory, "local-config-disabled" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_Reachable = { kConfigNamespace_ChipFactory, "reachable" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_UniqueId = { kConfigNamespace_ChipFactory, "uniqueId" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_Reachable           = { kConfigNamespace_ChipFactory, "reachable" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_UniqueId            = { kConfigNamespace_ChipFactory, "uniqueId" };
 
 // Keys stored in the Chip-config namespace
 const AndroidConfig::Key AndroidConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -79,6 +79,13 @@ public:
     static const Key kConfigKey_ProductName;
     static const Key kConfigKey_SoftwareVersion;
     static const Key kConfigKey_SoftwareVersionString;
+    static const Key kConfigKey_NodeLabel;
+    static const Key kConfigKey_PartNumber;
+    static const Key kConfigKey_ProductURL;
+    static const Key kConfigKey_ProductLabel;
+    static const Key kConfigKey_LocalConfigDisabled;
+    static const Key kConfigKey_Reachable;
+    static const Key kConfigKey_UniqueId;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -276,9 +276,9 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocalConfigDisabled(bool & disabled)
     return ReadConfigValue(AndroidConfig::kConfigKey_LocalConfigDisabled, disabled);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetReachable(bool & disabled)
+CHIP_ERROR ConfigurationManagerImpl::GetReachable(bool & reachable)
 {
-    return ReadConfigValue(AndroidConfig::kConfigKey_Reachable, disabled);
+    return ReadConfigValue(AndroidConfig::kConfigKey_Reachable, reachable);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -281,7 +281,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetReachable(bool & disabled)
     return ReadConfigValue(AndroidConfig::kConfigKey_Reachable, disabled);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize) 
+CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
 {
     size_t dateLen;
     return ReadConfigValueStr(AndroidConfig::kConfigKey_UniqueId, buf, bufSize, dateLen);

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -242,5 +242,50 @@ CHIP_ERROR ConfigurationManagerImpl::GetHardwareVersionString(char * buf, size_t
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetNodeLabel(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return ReadConfigValueStr(AndroidConfig::kConfigKey_NodeLabel, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreNodeLabel(const char * buf, size_t bufSize)
+{
+    return WriteConfigValueStr(AndroidConfig::kConfigKey_NodeLabel, buf, bufSize);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetPartNumber(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return ReadConfigValueStr(AndroidConfig::kConfigKey_PartNumber, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetProductURL(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return ReadConfigValueStr(AndroidConfig::kConfigKey_ProductURL, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetProductLabel(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return ReadConfigValueStr(AndroidConfig::kConfigKey_ProductLabel, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetLocalConfigDisabled(bool & disabled)
+{
+    return ReadConfigValue(AndroidConfig::kConfigKey_LocalConfigDisabled, disabled);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetReachable(bool & disabled)
+{
+    return ReadConfigValue(AndroidConfig::kConfigKey_Reachable, disabled);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize) 
+{
+    size_t dateLen;
+    return ReadConfigValueStr(AndroidConfig::kConfigKey_UniqueId, buf, bufSize, dateLen);
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -51,7 +51,7 @@ public:
     CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
-    CHIP_ERROR GetReachable(bool & disabled) override;
+    CHIP_ERROR GetReachable(bool & reachable) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
 
 private:

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -45,6 +45,14 @@ public:
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSoftwareVersion(uint16_t & softwareVer) override;
+    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
+    CHIP_ERROR GetReachable(bool & disabled) override;
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -39,6 +39,13 @@ public interface ConfigurationManager {
   String kConfigKey_ProductName = "product-name";
   String kConfigKey_SoftwareVersion = "software-version";
   String kConfigKey_SoftwareVersionString = "software-version-str";
+  String kConfigKey_NodeLabel = "node-label";
+  String kConfigKey_PartNumber = "part-number";
+  String kConfigKey_ProductURL = "product-url";
+  String kConfigKey_ProductLabel = "product-label";
+  String kConfigKey_LocalConfigDisabled = "local-config-disabled";
+  String kConfigKey_Reachable = "reachable";
+  String kConfigKey_UniqueId = "uniqueId";
 
   // Keys stored in the Chip-config namespace
   String kConfigKey_FabricId = "fabric-id";

--- a/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
@@ -22,6 +22,7 @@ import android.content.SharedPreferences;
 import android.util.Log;
 import java.util.Base64;
 import java.util.Map;
+import java.util.UUID;
 
 /** Java interface for ConfigurationManager */
 public class PreferencesConfigurationManager implements ConfigurationManager {
@@ -32,6 +33,15 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
 
   public PreferencesConfigurationManager(Context context) {
     preferences = context.getSharedPreferences(PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
+
+    try {
+      String keyUniqueId = getKey(kConfigNamespace_ChipFactory,kConfigKey_UniqueId);
+      if (!preferences.contains(keyUniqueId)) {
+        preferences.edit().putString(keyUniqueId, UUID.randomUUID().toString().replaceAll("-","")).apply();
+      }
+    } catch (AndroidChipPlatformException e) {
+      e.printStackTrace();
+    }
   }
 
   @Override
@@ -136,6 +146,25 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
          */
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_SerialNum:
         return "TEST_ANDROID_SN";
+
+      /**
+       * The PartNumber attribute SHALL specify a human-readable (displayable) vendor assigned part number for the Node whose meaning and numbering scheme is vendor defined.
+       * Multiple products (and hence PartNumbers) can share a ProductID. For instance, there may be different packaging (with different PartNumbers) for different regions; also different colors of a product might share the ProductID but may have a different PartNumber.
+       */
+      case kConfigNamespace_ChipFactory + ":" + kConfigKey_PartNumber:
+        return "TEST_ANDROID_PRODUCT_BLUE";
+
+      /**
+       * The ProductURL attribute SHALL specify a link to a product specific web page. The syntax of the ProductURL attribute SHALL follow the syntax as specified in RFC 3986. The specified URL SHOULD resolve to a maintained web page available for the lifetime of the product. The maximum length of the ProductUrl attribute is 256 ASCII characters.
+       */
+      case kConfigNamespace_ChipFactory + ":" + kConfigKey_ProductURL:
+        return "https://buildwithmatter.com/";
+
+      /**
+       * The ProductLabel attribute SHALL specify a vendor specific human readable (displayable) product label. The ProductLabel attribute MAY be used to provide a more user-friendly value than that represented by the ProductName attribute. The ProductLabel attribute SHOULD NOT include the name of the vendor as defined within the VendorName attribute.
+       */
+      case kConfigNamespace_ChipFactory + ":" + kConfigKey_ProductLabel:
+        return "X10";
     }
 
     if (preferences.contains(key)) {

--- a/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
@@ -35,9 +35,12 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
     preferences = context.getSharedPreferences(PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
 
     try {
-      String keyUniqueId = getKey(kConfigNamespace_ChipFactory,kConfigKey_UniqueId);
+      String keyUniqueId = getKey(kConfigNamespace_ChipFactory, kConfigKey_UniqueId);
       if (!preferences.contains(keyUniqueId)) {
-        preferences.edit().putString(keyUniqueId, UUID.randomUUID().toString().replaceAll("-","")).apply();
+        preferences
+            .edit()
+            .putString(keyUniqueId, UUID.randomUUID().toString().replaceAll("-", ""))
+            .apply();
       }
     } catch (AndroidChipPlatformException e) {
       e.printStackTrace();
@@ -147,22 +150,31 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_SerialNum:
         return "TEST_ANDROID_SN";
 
-      /**
-       * The PartNumber attribute SHALL specify a human-readable (displayable) vendor assigned part number for the Node whose meaning and numbering scheme is vendor defined.
-       * Multiple products (and hence PartNumbers) can share a ProductID. For instance, there may be different packaging (with different PartNumbers) for different regions; also different colors of a product might share the ProductID but may have a different PartNumber.
-       */
+        /**
+         * The PartNumber attribute SHALL specify a human-readable (displayable) vendor assigned
+         * part number for the Node whose meaning and numbering scheme is vendor defined. Multiple
+         * products (and hence PartNumbers) can share a ProductID. For instance, there may be
+         * different packaging (with different PartNumbers) for different regions; also different
+         * colors of a product might share the ProductID but may have a different PartNumber.
+         */
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_PartNumber:
         return "TEST_ANDROID_PRODUCT_BLUE";
 
-      /**
-       * The ProductURL attribute SHALL specify a link to a product specific web page. The syntax of the ProductURL attribute SHALL follow the syntax as specified in RFC 3986. The specified URL SHOULD resolve to a maintained web page available for the lifetime of the product. The maximum length of the ProductUrl attribute is 256 ASCII characters.
-       */
+        /**
+         * The ProductURL attribute SHALL specify a link to a product specific web page. The syntax
+         * of the ProductURL attribute SHALL follow the syntax as specified in RFC 3986. The
+         * specified URL SHOULD resolve to a maintained web page available for the lifetime of the
+         * product. The maximum length of the ProductUrl attribute is 256 ASCII characters.
+         */
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_ProductURL:
         return "https://buildwithmatter.com/";
 
-      /**
-       * The ProductLabel attribute SHALL specify a vendor specific human readable (displayable) product label. The ProductLabel attribute MAY be used to provide a more user-friendly value than that represented by the ProductName attribute. The ProductLabel attribute SHOULD NOT include the name of the vendor as defined within the VendorName attribute.
-       */
+        /**
+         * The ProductLabel attribute SHALL specify a vendor specific human readable (displayable)
+         * product label. The ProductLabel attribute MAY be used to provide a more user-friendly
+         * value than that represented by the ProductName attribute. The ProductLabel attribute
+         * SHOULD NOT include the name of the vendor as defined within the VendorName attribute.
+         */
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_ProductLabel:
         return "X10";
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* PartNumber, ProductURL, ProductLabel and UniqueID for basic cluster are not implemented on android tv server

#### Change overview
* Added these Attributes

#### Testing
* /chip-tool basic read *