### PR TITLE
Add missing Humidity sensor device type definition and fix typo in Contact sensor definition

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1290,7 +1290,7 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
-        <name>MA-comtactsensor</name>
+        <name>MA-contactsensor</name>
         <domain>CHIP</domain>
         <typeName>Matter Contact Sensor</typeName>
         <profileId editable="false">0x0103</profileId>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1531,6 +1531,45 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
+        <name>MA-humiditysensor</name>
+        <domain>CHIP</domain>
+        <typeName>Matter Humidity Sensor</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0307</deviceId>
+        <clusters lockOthers="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>IDENTIFY_TIME</requireAttribute>
+                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
+                <requireCommand>Identify</requireCommand>
+                <requireCommand>IdentifyQuery</requireCommand>
+                <requireCommand>TriggerEffect</requireCommand>
+            </include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
+                <requireAttribute>SERVER_LIST</requireAttribute>
+                <requireAttribute>CLIENT_LIST</requireAttribute>
+                <requireAttribute>PARTS_LIST</requireAttribute>
+            </include>
+            <include cluster="Binding" client="true" server="false" clientLocked="false" serverLocked="true">
+                <requireAttribute>BINDING</requireAttribute>
+            </include>
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+                <requireCommand>AddGroup</requireCommand>
+                <requireCommand>AddGroupResponse</requireCommand>
+                <requireCommand>ViewGroup</requireCommand>
+                <requireCommand>ViewGroupResponse</requireCommand>
+                <requireCommand>GetGroupMembership</requireCommand>
+                <requireCommand>GetGroupMembershipResponse</requireCommand>
+                <requireCommand>RemoveGroup</requireCommand>
+                <requireCommand>RemoveGroupResponse</requireCommand>
+                <requireCommand>RemoveAllGroups</requireCommand>
+                <requireCommand>AddGroupIfIdentifying</requireCommand>
+            </include>
+            <include cluster="Relative Humidity Measurement" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+        </clusters>
+    </deviceType>
+    <deviceType>
         <name>MA-onoffsensor</name>
         <domain>CHIP</domain>
         <typeName>Matter On/Off Sensor</typeName>

--- a/zzz_generated/chip-tool/zap-generated/reporting/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/reporting/Commands.h
@@ -3090,17 +3090,17 @@ private:
             new chip::Callback::Callback<decltype(&ReadThermostatClusterRevision::OnAttributeResponse)>(
                 ReadThermostatClusterRevision::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)> *
-        onReportThermostatUserInterfaceConfigurationTemperatureDisplayModeCallback = new chip::Callback::Callback<
-            decltype(&ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)>(
+        onReportThermostatUserInterfaceConfigurationTemperatureDisplayModeCallback = new chip::Callback::Callback<decltype(
+            &ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)>(
             ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse)> *
         onReportThermostatUserInterfaceConfigurationKeypadLockoutCallback =
             new chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse)>(
                 ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse, this);
-    chip::Callback::Callback<
-        decltype(&ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)> *
-        onReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCallback = new chip::Callback::Callback<
-            decltype(&ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)>(
+    chip::Callback::Callback<decltype(
+        &ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)> *
+        onReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCallback = new chip::Callback::Callback<decltype(
+            &ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)>(
             ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationClusterRevision::OnAttributeResponse)> *
         onReportThermostatUserInterfaceConfigurationClusterRevisionCallback =
@@ -3179,8 +3179,8 @@ private:
             new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse)>(
                 ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)> *
-        onReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCallback = new chip::Callback::Callback<
-            decltype(&ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)>(
+        onReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCallback = new chip::Callback::Callback<decltype(
+            &ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)>(
             ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsParentChangeCount::OnAttributeResponse)> *
         onReportThreadNetworkDiagnosticsParentChangeCountCallback =

--- a/zzz_generated/chip-tool/zap-generated/reporting/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/reporting/Commands.h
@@ -3090,17 +3090,17 @@ private:
             new chip::Callback::Callback<decltype(&ReadThermostatClusterRevision::OnAttributeResponse)>(
                 ReadThermostatClusterRevision::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)> *
-        onReportThermostatUserInterfaceConfigurationTemperatureDisplayModeCallback = new chip::Callback::Callback<decltype(
-            &ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)>(
+        onReportThermostatUserInterfaceConfigurationTemperatureDisplayModeCallback = new chip::Callback::Callback<
+            decltype(&ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse)>(
             ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse)> *
         onReportThermostatUserInterfaceConfigurationKeypadLockoutCallback =
             new chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse)>(
                 ReadThermostatUserInterfaceConfigurationKeypadLockout::OnAttributeResponse, this);
-    chip::Callback::Callback<decltype(
-        &ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)> *
-        onReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCallback = new chip::Callback::Callback<decltype(
-            &ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)>(
+    chip::Callback::Callback<
+        decltype(&ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)> *
+        onReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCallback = new chip::Callback::Callback<
+            decltype(&ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse)>(
             ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThermostatUserInterfaceConfigurationClusterRevision::OnAttributeResponse)> *
         onReportThermostatUserInterfaceConfigurationClusterRevisionCallback =
@@ -3179,8 +3179,8 @@ private:
             new chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse)>(
                 ReadThreadNetworkDiagnosticsPartitionIdChangeCount::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)> *
-        onReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCallback = new chip::Callback::Callback<decltype(
-            &ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)>(
+        onReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCountCallback = new chip::Callback::Callback<
+            decltype(&ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse)>(
             ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount::OnAttributeResponse, this);
     chip::Callback::Callback<decltype(&ReadThreadNetworkDiagnosticsParentChangeCount::OnAttributeResponse)> *
         onReportThreadNetworkDiagnosticsParentChangeCountCallback =


### PR DESCRIPTION
#### Problem
* Missing Humidity sensor device type definition 
* Typo error in contact sensor device type

#### Change overview
* Added Humidity sensor definition
* Fixed typo

#### Testing
This does not affect any existing code as the contact sensor device type doesn't exist in any example application. 
