### PR TITLE
src/app/ConcreteEventPath.h:37:25: error: definition of implicit copy…

### DIFF
--- a/src/app/ConcreteEventPath.h
+++ b/src/app/ConcreteEventPath.h
@@ -34,6 +34,8 @@ struct ConcreteEventPath
 
     ConcreteEventPath() {}
 
+    ConcreteEventPath(const ConcreteEventPath & other) = default;
+
     ConcreteEventPath & operator=(const ConcreteEventPath & other)
     {
         if (&other == this)


### PR DESCRIPTION
… constructor for 'ConcreteEventPath' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]

#### Problem

Build is failing locally for me with: `src/app/ConcreteEventPath.h:37:25: error: definition of implicit copy constructor for 'ConcreteEventPath' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy`