### PR TITLE
Fix timer list empty bug

### DIFF
--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -160,7 +160,7 @@ public:
     /**
      * Test whether there are any timers.
      */
-    bool Empty() const { return mEarliestTimer != nullptr; }
+    bool Empty() const { return mEarliestTimer == nullptr; }
 
     /**
      * Remove and return all timers that expire before the given time @a t.


### PR DESCRIPTION
#### Problem
The `TimerList::Empty()` returns wrong value.

#### Change overview
A small bug fix.
