### PR TITLE
Fix arm cross compile error: default copy constructor deprecated if manual copy operator defined

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -59,7 +59,7 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Build Some samples
-              timeout-minutes: 5
+              timeout-minutes: 20 
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -1,0 +1,92 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build example - Linux ARM
+
+on:
+    push:
+    pull_request:
+
+concurrency:
+    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    arm_crosscompile:
+        name: Linux ARM Cross compile
+        timeout-minutes: 70
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-crosscompile:0.5.33
+            volumes:
+                - "/tmp/bloat_reports:/tmp/bloat_reports"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
+              env:
+                  GH_CONTEXT: ${{ toJson(github) }}
+              run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
+
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
+            - name: Build Some samples
+              timeout-minutes: 5
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-arm64-all-clusters \
+                        --target linux-arm64-chip-tool-ipv6only \
+                        --target linux-arm64-minmdns \
+                        --target linux-arm64-thermostat-no-ble \
+                        build \
+                     "
+            - name: Bloat report - chip-tool
+              timeout-minutes: 5
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    linux arm64 chip-tool-ipv6only \
+                    out/linux-arm64-chip-tool-ipv6only/chip-tool \
+                    /tmp/bloat_reports/
+            - name: Bloat report - thermostat
+              timeout-minutes: 5
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    linux arm64 thermostat-no-ble \
+                    out/linux-arm64-chip-thermostat-no-ble/chip-thermostat \
+                    /tmp/bloat_reports/
+            - name: Uploading Size Reports
+              uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
+              with:
+                  name: Size,Linux-Examples,${{ env.GH_EVENT_PR }},${{ env.GH_EVENT_HASH }},${{ env.GH_EVENT_PARENT }}
+                  path: |
+                      /tmp/bloat_reports/

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -81,7 +81,7 @@ jobs:
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux arm64 thermostat-no-ble \
-                    out/linux-arm64-chip-thermostat-no-ble/chip-thermostat \
+                    out/linux-arm64-thermostat-no-ble/thermostat-app \
                     /tmp/bloat_reports/
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/src/app/ConcreteEventPath.h
+++ b/src/app/ConcreteEventPath.h
@@ -34,16 +34,8 @@ struct ConcreteEventPath
 
     ConcreteEventPath() {}
 
-    ConcreteEventPath & operator=(const ConcreteEventPath & other)
-    {
-        if (&other == this)
-            return *this;
-
-        mEndpointId = other.mEndpointId;
-        mClusterId  = other.mClusterId;
-        mEventId    = other.mEventId;
-        return *this;
-    }
+    ConcreteEventPath(const ConcreteEventPath & other) = default;
+    ConcreteEventPath & operator=(const ConcreteEventPath & other) = default;
 
     bool operator==(const ConcreteEventPath & other) const
     {


### PR DESCRIPTION
#### Problem
```
2021-12-08 04:23:40 INFO    clang++ -MMD -MF obj/third_party/connectedhomeip/src/app/clusters/test-cluster-server/all-clusters-common.test-cluster-server.cpp.o.d -Wconversion --target=aarch64-linux-gnu -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wimplicit-fallthrough -Wheader-hygiene -Wformat-type-confusion -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-missing-field-initializers -Wno-unused-parameter -fdiagnostics-color --sysroot=/opt/ubuntu-21.04-aarch64-sysroot -fno-strict-aliasing -D_REENTRANT -I/opt/ubuntu-21.04-aarch64-sysroot/usr/include/gio-unix-2.0 -I/opt/ubuntu-21.04-aarch64-sysroot/usr/include/libmount -I/opt/ubuntu-21.04-aarch64-sysroot/usr/include/blkid -I/opt/ubuntu-21.04-aarch64-sysroot/usr/include/glib-2.0 -I/opt/ubuntu-21.04-aarch64-sysroot/usr/lib/aarch64-linux-gnu/glib-2.0/include -std=gnu++14 -fno-rtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -DCHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT=1 -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/zzz_generated/all-clusters-app -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/include -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/src -Igen/include -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/zzz_generated/app-common -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/config/standalone -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/third_party/nlassert/repo/include -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/third_party/nlio/repo/include -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/third_party/mbedtls/repo/include -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/third_party/inipp/repo/inipp -I../../examples/all-clusters-app/linux/third_party/connectedhomeip/zzz_generated -c ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/clusters/test-cluster-server/test-cluster-server.cpp -o obj/third_party/connectedhomeip/src/app/clusters/test-cluster-server/all-clusters-common.test-cluster-server.cpp.o
2021-12-08 04:23:40 INFO    In file included from ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/clusters/test-cluster-server/test-cluster-server.cpp:23:
2021-12-08 04:23:40 INFO    In file included from ../../examples/all-clusters-app/linux/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h:26:
2021-12-08 04:23:40 INFO    In file included from ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/EventLoggingTypes.h:20:
2021-12-08 04:23:40 INFO    In file included from ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/ClusterInfo.h:22:
2021-12-08 04:23:40 INFO    ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/ConcreteEventPath.h:37:25: error: definition of implicit copy constructor for 'ConcreteEventPath' is deprecated because it has a user-provided copy assignment operator [-Werror,-Wdeprecated-copy-with-user-provided-copy]
2021-12-08 04:23:40 INFO        ConcreteEventPath & operator=(const ConcreteEventPath & other)
2021-12-08 04:23:40 INFO                            ^
2021-12-08 04:23:40 INFO    ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/EventLoggingTypes.h:125:7: note: in implicit copy constructor for 'chip::app::ConcreteEventPath' first required here
2021-12-08 04:23:40 INFO    class EventOptions
2021-12-08 04:23:40 INFO          ^
2021-12-08 04:23:40 INFO    ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/app/clusters/test-cluster-server/test-cluster-server.cpp:460:67: note: in implicit copy constructor for 'chip::app::EventOptions' first required here
2021-12-08 04:23:40 INFO        if (CHIP_NO_ERROR != LogEvent(event, commandPath.mEndpointId, eventOptions, responseData.value))
2021-12-08 04:23:40 INFO   
```

#### Change overview
- Add CI step to compile arm64
- Replace the manual copy constructor implementation with just = default, explicitly allowing both constructor and operator=

#### Testing
Using ACT locally
CI will also validate this