### PR TITLE
Add trace messages for automation

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/src/lib/core/core.gni")
 
 assert(chip_build_tools)
 
@@ -68,5 +69,13 @@ executable("chip-tool") {
     "${chip_root}/zzz_generated/chip-tool",
   ]
 
+  if (chip_enable_transport_trace) {
+    deps += [ "${chip_root}/examples/common/tracing:trace_handlers" ]
+  }
+
   output_dir = root_out_dir
+}
+
+group("default") {
+  deps = [ ":chip-tool" ]
 }

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -29,6 +29,28 @@ scripts/examples/gn_build_example.sh examples/chip-tool SOME-PATH/
 
 which puts the binary at `SOME-PATH/chip-tool`.
 
+### Building with message tracing
+
+Message tracing allows capture of the secure messages which can be used for test
+automation.
+
+```
+gn gen out/with_trace/ --args='import("//with_pw_trace.gni")'
+ninja -C out/with_trace chip-tool
+```
+
+This enables tracing and adds additional flags to chip-tool to control where the
+traces should go:
+
+-   --trace_file <file> Outputs trace data to the specified file.
+-   --trace_log Outputs trace data to the chip log stream.
+
+For example:
+
+```
+out/with_trace/chip-tool --trace_file trace.log pairing <pairing_args>
+```
+
 ## Using the Client to commission a device
 
 In order to send commands to a device, it must be commissioned with the client.

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -31,7 +31,8 @@ public:
     int Run(int argc, char ** argv);
 
 private:
-    CHIP_ERROR RunCommand(int argc, char ** argv);
+    CHIP_ERROR RunCommand();
+
     std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);
     Command * GetGlobalCommand(CommandsVector & commands, std::string commandName, std::string attributeName);

--- a/examples/chip-tool/with_pw_trace.gni
+++ b/examples/chip-tool/with_pw_trace.gni
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# add this gni as import in your build args to use pigweed in the example
+# 'import("//with_pw_rpc.gni")'
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/config/standalone/args.gni")
+
+import("//build_overrides/pigweed.gni")
+
+cpp_standard = "gnu++17"
+
+pw_trace_BACKEND = "${chip_root}/examples/platform/linux/pw_trace_chip"
+
+chip_enable_transport_trace = true

--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/pigweed.gni")
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("$dir_pw_build/target_types.gni")
+import("${chip_root}/src/lib/lib.gni")
+
+config("default_config") {
+  include_dirs = [ "." ]
+}
+
+source_set("trace_handlers") {
+  sources = [ "TraceHandlers.cpp" ]
+
+  deps = [
+    "$dir_pw_trace",
+    "${chip_root}/src/lib",
+  ]
+
+  public_configs = [ ":default_config" ]
+}

--- a/examples/common/tracing/README.md
+++ b/examples/common/tracing/README.md
@@ -1,0 +1,5 @@
+# Trace Handlers
+
+These are trace message handlers which get registered with pw_trace_chip and
+interpret the different CHIP messages to extract the useful information required
+for test automation.

--- a/examples/common/tracing/TraceHandlers.cpp
+++ b/examples/common/tracing/TraceHandlers.cpp
@@ -1,0 +1,115 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#include "TraceHandlers.h"
+
+#include <mutex>
+#include <stdint.h>
+#include <string>
+
+#include "pw_trace/trace.h"
+#include "pw_trace_chip/trace_chip.h"
+#include "transport/TraceMessage.h"
+#include <lib/support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace trace {
+
+namespace {
+
+// Handles the output from the trace handlers.
+class TraceOutput
+{
+public:
+    ~TraceOutput() { DeleteStream(); }
+
+    void SetStream(TraceStream * stream)
+    {
+        std::lock_guard<std::mutex> guard(mLock);
+        if (mStream)
+        {
+            delete mStream;
+            mStream = nullptr;
+        }
+        mStream = stream;
+    }
+
+    void DeleteStream() { SetStream(nullptr); }
+
+    void Stream(const std::string & tag, const std::string & data)
+    {
+        std::lock_guard<std::mutex> guard(mLock);
+        if (mStream)
+        {
+            mStream->Stream(tag, data);
+        }
+    }
+
+    void Handler(const std::string & label)
+    {
+        std::lock_guard<std::mutex> guard(mLock);
+        if (mStream)
+        {
+            mStream->Handler(label);
+        }
+    }
+
+private:
+    std::mutex mLock;
+    TraceStream * mStream = nullptr;
+};
+
+TraceOutput output;
+
+// TODO: Framework this into a registry of handlers for different message types.
+bool TraceDefaultHandler(const TraceEventFields & trace)
+{
+    if (strcmp(trace.dataFormat, kTraceSecureMessageDataFormat) != 0 || trace.dataSize != sizeof(TraceSecureMessageData))
+    {
+        return false;
+    }
+
+    const TraceSecureMessageData * msg = reinterpret_cast<const TraceSecureMessageData *>(trace.dataBuffer);
+    output.Handler("Default");
+    output.Stream("ExchangeId", std::to_string(msg->payloadHeader->GetExchangeID()));
+    output.Stream("MsgType", std::to_string(msg->payloadHeader->GetMessageType()));
+    output.Stream("MessageCounter", std::to_string(msg->packetHeader->GetMessageCounter()));
+    output.Stream("PacketSize", std::to_string(msg->packetSize));
+
+    return true;
+}
+
+} // namespace
+
+void SetTraceStream(TraceStream * stream)
+{
+    output.SetStream(stream);
+}
+
+void InitTrace()
+{
+    RegisterTraceHandler(TraceDefaultHandler);
+}
+
+void DeInitTrace()
+{
+    UnregisterAllTraceHandlers();
+    output.DeleteStream();
+}
+
+} // namespace trace
+} // namespace chip

--- a/examples/common/tracing/TraceHandlers.h
+++ b/examples/common/tracing/TraceHandlers.h
@@ -1,0 +1,80 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include <fstream>
+#include <iostream>
+#include <lib/support/logging/CHIPLogging.h>
+#include <string>
+#include <sys/time.h>
+
+namespace chip {
+namespace trace {
+
+class TraceStream
+{
+public:
+    virtual ~TraceStream()                                                 = default;
+    virtual void Stream(const std::string & tag, const std::string & data) = 0;
+    virtual void Handler(const std::string & label)                        = 0;
+};
+
+class TraceStreamLog : public TraceStream
+{
+public:
+    void Stream(const std::string & tag, const std::string & data) override
+    {
+        ChipLogAutomation("    %s: %s", tag.data(), data.data());
+    }
+    void Handler(const std::string & label) override { ChipLogAutomation("%s", label.data()); }
+};
+
+class TraceStreamFile : public TraceStream
+{
+public:
+    TraceStreamFile(const char * fileName) { mFile.open(fileName); }
+    ~TraceStreamFile() { mFile.close(); }
+
+    void Stream(const std::string & tag, const std::string & data) override
+    {
+        if (mFile.is_open())
+        {
+            mFile << "    " << tag.data() << ": " << data.data() << "\n";
+            mFile.flush();
+        }
+    }
+    void Handler(const std::string & label) override
+    {
+        if (mFile.is_open())
+        {
+            struct timeval tv;
+            gettimeofday(&tv, nullptr);
+            mFile << label << " [" << tv.tv_sec << "." << tv.tv_usec << "]\n";
+            mFile.flush();
+        }
+    }
+
+private:
+    std::ofstream mFile;
+};
+
+void SetTraceStream(TraceStream * stream);
+void InitTrace();
+void DeInitTrace();
+
+} // namespace trace
+} // namespace chip

--- a/examples/platform/linux/pw_trace_chip/BUILD.gn
+++ b/examples/platform/linux/pw_trace_chip/BUILD.gn
@@ -1,0 +1,38 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("$dir_pw_build/target_types.gni")
+
+config("public_include_path") {
+  include_dirs = [ "public" ]
+}
+
+config("backend_config") {
+  include_dirs = [ "public_overrides" ]
+}
+
+pw_source_set("pw_trace_chip") {
+  public_configs = [
+    ":backend_config",
+    ":public_include_path",
+  ]
+  include_dirs = [ "${chip_root}/src" ]
+  public_deps = [ "$dir_pw_status" ]
+  deps = [ "$dir_pw_trace:facade" ]
+  sources = [ "trace.cc" ]
+  public = [ "public_overrides/pw_trace_backend/trace_backend.h" ]
+}

--- a/examples/platform/linux/pw_trace_chip/public/pw_trace_chip/trace_chip.h
+++ b/examples/platform/linux/pw_trace_chip/public/pw_trace_chip/trace_chip.h
@@ -1,0 +1,92 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Enable these trace types
+#define PW_TRACE_TYPE_INSTANT ::chip::trace::PW_TRACE_EVENT_TYPE_INSTANT
+#define PW_TRACE_TYPE_INSTANT_GROUP ::chip::trace::PW_TRACE_EVENT_TYPE_INSTANT_GROUP
+
+#define PW_TRACE_TYPE_DURATION_START ::chip::trace::PW_TRACE_EVENT_TYPE_DURATION_START
+#define PW_TRACE_TYPE_DURATION_END ::chip::trace::PW_TRACE_EVENT_TYPE_DURATION_END
+
+#define PW_TRACE_TYPE_DURATION_GROUP_START ::chip::trace::PW_TRACE_EVENT_TYPE_DURATION_GROUP_START
+#define PW_TRACE_TYPE_DURATION_GROUP_END ::chip::trace::PW_TRACE_EVENT_TYPE_DURATION_GROUP_END
+
+#define PW_TRACE_TYPE_ASYNC_START ::chip::trace::PW_TRACE_EVENT_TYPE_ASYNC_START
+#define PW_TRACE_TYPE_ASYNC_INSTANT ::chip::trace::PW_TRACE_EVENT_TYPE_ASYNC_STEP
+#define PW_TRACE_TYPE_ASYNC_END ::chip::trace::PW_TRACE_EVENT_TYPE_ASYNC_END
+
+namespace chip {
+namespace trace {
+
+typedef enum
+{
+    PW_TRACE_EVENT_TYPE_INVALID              = 0,
+    PW_TRACE_EVENT_TYPE_INSTANT              = 1,
+    PW_TRACE_EVENT_TYPE_INSTANT_GROUP        = 2,
+    PW_TRACE_EVENT_TYPE_ASYNC_START          = 3,
+    PW_TRACE_EVENT_TYPE_ASYNC_STEP           = 4,
+    PW_TRACE_EVENT_TYPE_ASYNC_END            = 5,
+    PW_TRACE_EVENT_TYPE_DURATION_START       = 6,
+    PW_TRACE_EVENT_TYPE_DURATION_END         = 7,
+    PW_TRACE_EVENT_TYPE_DURATION_GROUP_START = 8,
+    PW_TRACE_EVENT_TYPE_DURATION_GROUP_END   = 9,
+} TraceEventType;
+
+// This should not be called directly, instead use the PW_TRACE_* macros.
+void TraceEvent(const char * module, const char * label, TraceEventType eventType, const char * group, uint32_t traceId,
+                uint8_t flags, const char * dataFormat, const void * dataBuffer, size_t dataSize);
+
+struct TraceEventFields
+{
+    const char * module;
+    const char * label;
+    TraceEventType eventType;
+    const char * group;
+    uint32_t traceId;
+    uint8_t flags;
+    const char * dataFormat;
+    const void * dataBuffer;
+    size_t dataSize;
+};
+
+typedef bool (*TraceHandlerCallback)(const TraceEventFields & trace);
+
+// Register a trace handler which gets called for all data trace events.
+void RegisterTraceHandler(TraceHandlerCallback callback);
+void UnregisterAllTraceHandlers();
+
+// These are what the facade actually calls.
+#define PW_TRACE(eventType, flags, label, group, traceId)                                                                          \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ::chip::trace::TraceEvent(PW_TRACE_MODULE_NAME, label, eventType, group, traceId, flags, NULL, NULL, 0);                   \
+    } while (0)
+
+#define PW_TRACE_DATA(eventType, flags, label, group, traceId, dataFormat, data, size)                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ::chip::trace::TraceEvent(PW_TRACE_MODULE_NAME, label, eventType, group, traceId, flags, dataFormat, data, size);          \
+    } while (0)
+
+} // namespace trace
+} // namespace chip

--- a/examples/platform/linux/pw_trace_chip/public_overrides/pw_trace_backend/trace_backend.h
+++ b/examples/platform/linux/pw_trace_chip/public_overrides/pw_trace_backend/trace_backend.h
@@ -1,0 +1,20 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#pragma once
+
+#include "pw_trace_chip/trace_chip.h"

--- a/examples/platform/linux/pw_trace_chip/trace.cc
+++ b/examples/platform/linux/pw_trace_chip/trace.cc
@@ -1,0 +1,62 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include <mutex>
+#include <vector>
+
+#include "pw_trace_chip/trace_chip.h"
+
+#include "pw_trace/trace.h"
+
+namespace chip {
+namespace trace {
+namespace {
+
+std::mutex handlerLock;
+std::vector<TraceHandlerCallback> traceHandlers;
+
+} // namespace
+
+void TraceEvent(const char * module, const char * label, TraceEventType eventType, const char * group, uint32_t traceId,
+                uint8_t flags, const char * dataFormat, const void * dataBuffer, size_t dataSize)
+{
+    TraceEventFields fields = { module, label, eventType, group, traceId, flags, dataFormat, dataBuffer, dataSize };
+    std::lock_guard<std::mutex> guard(handlerLock);
+    for (const auto & handler : traceHandlers)
+    {
+        if (handler(fields))
+        {
+            return;
+        }
+    }
+}
+
+void RegisterTraceHandler(TraceHandlerCallback callback)
+{
+    std::lock_guard<std::mutex> guard(handlerLock);
+    traceHandlers.push_back(callback);
+}
+
+void UnregisterAllTraceHandlers()
+{
+    std::lock_guard<std::mutex> guard(handlerLock);
+    traceHandlers.clear();
+}
+
+} // namespace trace
+} // namespace chip

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -60,6 +60,7 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_CONFIG_MEMORY_DEBUG_CHECKS=${chip_config_memory_debug_checks}",
     "CHIP_CONFIG_MEMORY_DEBUG_DMALLOC=${chip_config_memory_debug_dmalloc}",
     "CHIP_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES=false",
+    "CHIP_CONFIG_TRANSPORT_TRACE_ENABLED=${chip_enable_transport_trace}",
   ]
 }
 

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -47,6 +47,9 @@ declare_args() {
 
   # Memory management debug option: use dmalloc
   chip_config_memory_debug_dmalloc = false
+
+  # When enabled traces messages using pw_trace.
+  chip_enable_transport_trace = false
 }
 
 if (chip_target_style == "") {

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -14,7 +14,9 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/nlio.gni")
+import("//build_overrides/pigweed.gni")
 import("${chip_root}/src/ble/ble.gni")
+import("${chip_root}/src/lib/core/core.gni")
 
 static_library("transport") {
   output_name = "libTransportLayer"
@@ -51,6 +53,7 @@ static_library("transport") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:chip_buildconfig",
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
@@ -58,4 +61,8 @@ static_library("transport") {
     "${chip_root}/src/transport/raw",
     "${nlio_root}:nlio",
   ]
+
+  if (chip_enable_transport_trace) {
+    deps = [ "$dir_pw_trace" ]
+  }
 }

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -29,6 +29,8 @@
 #include <lib/support/SafeInt.h>
 #include <transport/SecureMessageCodec.h>
 
+#include "transport/TraceMessage.h"
+
 namespace chip {
 
 using System::PacketBuffer;
@@ -59,6 +61,8 @@ CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
 
     uint8_t * data    = msgBuf->Start();
     uint16_t totalLen = msgBuf->TotalLength();
+
+    CHIP_TRACE_MESSAGE(payloadHeader, packetHeader, data, totalLen);
 
     MessageAuthenticationCode mac;
     ReturnErrorOnFailure(state->EncryptBeforeSend(data, totalLen, data, packetHeader, mac));

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPBuildConfig.h>
+#include <transport/raw/MessageHeader.h>
+
+#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+#include "pw_trace/trace.h"
+
+#define CHIP_TRACE_MESSAGE(payloadHeader, packetHeader, data, dataLen)                                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        ::chip::trace::TraceSecureMessageData _trace_data{ &payloadHeader, &packetHeader, data, dataLen };                         \
+        PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceSecureMessageDataFormat,                                           \
+                              reinterpret_cast<const char *>(&_trace_data), sizeof(_trace_data));                                  \
+    } while (0)
+#else
+#define CHIP_TRACE_MESSAGE(payloadHeader, packetHeader, data, dataLen)                                                             \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
+
+#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+
+namespace chip {
+namespace trace {
+
+constexpr const char * kTraceSecureMessageDataFormat = "SecMsg";
+
+struct TraceSecureMessageData
+{
+    PayloadHeader * payloadHeader;
+    PacketHeader * packetHeader;
+    uint8_t * packetPayload;
+    size_t packetSize;
+};
+
+} // namespace trace
+} // namespace chip


### PR DESCRIPTION

#### Problem
Specific data from messages are needed for test validation, it is desirable to have a simple and flexible way to extract this data without requiring logging wrapped in macros directly in the protocols #11510, #11553, #11552.

#### Change overview
Add a trace backend to chip-tool which provides a simple and flexible way to trace chip messages. The backend provides handlers, which can be registered to handle the different types of messages and extract the relevant data needed for test automation.

Added additional optional flags to chip-tool which allows turning on these traces and piping them either to a log or file. These flags and tracing are only enabled when tracing is enabled at compile time. Include trace compile with:
```
gn gen out/with_trace/ --args='import("//with_pw_trace.gni")'
```

The trace point is before the encrypt in SecureMessageCodec and only enabled when `PW_TRACE_CHIP_ENABLED` is defined at compile time and a pw_trace backend is configured.

**Note**: This is just adding the plumbing to get the message data in a centralized spot with a framework to write and register handlers which can interpret the messages. Writing these handlers for the different messages will be the next step.

#### Testing
Compiled chip-tool with and without tracing enabled, piped tracing to log and to file and commissioned a device:
```
out/with_trace/chip-tool --trace_file trace.log pairing ble-wifi $node_id $ssid $pass 112233 20202021 3840
```
Which generated the following trace.log file:
```
Default [1638910356.471590]
    ExchangeId: 64510
    MsgType: 8
    MessageCounter: 1
    PacketSize: 35
Default [1638910356.658687]
    ExchangeId: 64511
    MsgType: 8
    MessageCounter: 2
    PacketSize: 35
Default [1638910356.839889]
    ExchangeId: 64512
    MsgType: 8
    MessageCounter: 3
    PacketSize: 67
Default [1638910357.600516]
    ExchangeId: 64513
    MsgType: 8
    MessageCounter: 4
    PacketSize: 67
Default [1638910358.902744]
    ExchangeId: 64514
    MsgType: 8
    MessageCounter: 5
    PacketSize: 272
Default [1638910359.127382]
    ExchangeId: 64515
    MsgType: 8
    MessageCounter: 6
    PacketSize: 539
Default [1638910362.97414]
    ExchangeId: 64516
    MsgType: 8
    MessageCounter: 7
    PacketSize: 60
Default [1638910362.233414]
    ExchangeId: 64517
    MsgType: 8
    MessageCounter: 8
    PacketSize: 48
```
