### PR TITLE
Remove ObjectPool leak flag from GroupDataProviderImpl::mKeySetIterators

### DIFF
--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -160,7 +160,7 @@ private:
     BitMapObjectPool<GroupMappingIteratorImpl, kIteratorsMax> mEndpointGroupsIterators;
     BitMapObjectPool<AllStatesIterator, kIteratorsMax> mAllStatesIterators;
     BitMapObjectPool<FabricStatesIterator, kIteratorsMax> mFabricStatesIterators;
-    BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode> mKeySetIterators;
+    BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax> mKeySetIterators;
 };
 
 } // namespace Credentials


### PR DESCRIPTION
#### Problem

The `ObjectPool` leak reported in #12503 _ObjectPool leaks in GroupDataProviderImpl_ is no longer reproducable; possibly fixed by d25a3ef9.

#### Change overview

Remove the ‘allow leaks’ flag from `GroupDataProviderImpl::mKeySetIterators`.

#### Testing

CI.
