### PR TITLE
Fix inifinte loop in esp32 RIO handling.

### DIFF
--- a/examples/platform/esp32/route_hook/esp_route_hook.c
+++ b/examples/platform/esp32/route_hook/esp_route_hook.c
@@ -94,7 +94,7 @@ static void ra_recv_handler(struct netif * netif, const uint8_t * icmp_payload, 
             uint8_t rio_data_len     = opt_len - sizeof(rio_header_t);
 
             ESP_LOGI(TAG, "Received RIO");
-            for (; rio_data_len >= prefix_len_bytes; rio_data_len -= prefix_len_bytes, rio_data += prefix_len_bytes)
+            if (rio_data_len >= prefix_len_bytes)
             {
                 ip6_addr_t prefix;
                 esp_route_entry_t route;


### PR DESCRIPTION
#### Problem
If the router is advertising a default prefix (::/0), the route
handler is going into an infinite loop.

Route information options can only have one prefix anyway, so the
loop here is overkill and likely to introduce bad routes. 

#### Change overview
Change for loop to a simple check that the size is sufficient.

#### Testing
Configured radvd to advertise a default route, saw infinite loop on upstream, no problems with this code. Regular routes are being processed correctly.
