### PR TITLE
Implement event support for basic information cluster

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -28,6 +28,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
@@ -228,6 +229,20 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%" PRIu8 " was deleted from fabric storage.", fabricId);
         fabricListChanged();
+
+        // The Leave event SHOULD be emitted by a Node prior to permanently leaving the Fabric.
+        ForAllEndpointsWithServerCluster(Basic::Id, [](EndpointId endpoint, intptr_t context) -> Loop {
+            // If Basic cluster is implemented on this endpoint
+            Basic::Events::Leave::Type event;
+            EventNumber eventNumber;
+
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+            {
+                ChipLogError(Zcl, "OpCredsFabricTableDelegate: Failed to record Leave event");
+            }
+
+            return Loop::Continue;
+        });
     }
 
     // Gets called when a fabric is loaded into the FabricTable from KVS store.

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -67,6 +67,28 @@ class GenericThreadStackManagerImpl_OpenThread_LwIP;
 } // namespace Internal
 
 /**
+ * Defines the delegate class of Platform Manager to notify platform updates.
+ */
+class PlatformManagerDelegate
+{
+public:
+    virtual ~PlatformManagerDelegate() {}
+
+    /**
+     * @brief
+     *   Called by the current Node after completing a boot or reboot process.
+     */
+    virtual void OnStartUp(uint32_t softwareVersion) {}
+
+    /**
+     * @brief
+     *   Called by the current Node prior to any orderly shutdown sequence on a
+     *   best-effort basis.
+     */
+    virtual void OnShutDown() {}
+};
+
+/**
  * Provides features for initializing and interacting with the chip network
  * stack on a chip-enabled device.
  */
@@ -88,6 +110,8 @@ public:
     CHIP_ERROR InitChipStack();
     CHIP_ERROR AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
     void RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
+    void SetDelegate(PlatformManagerDelegate * delegate) { mDelegate = delegate; }
+    PlatformManagerDelegate * GetDelegate() const { return mDelegate; }
 
     /**
      * ScheduleWork can be called after InitChipStack has been called.  Calls
@@ -156,7 +180,8 @@ public:
 #endif
 
 private:
-    bool mInitialized = false;
+    bool mInitialized                   = false;
+    PlatformManagerDelegate * mDelegate = nullptr;
 
     // ===== Members for internal use by the following friends.
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we only have event defined in basic information cluster, the basic cluster events are not emitted when the event actually occurs. 

#### Change overview
Implement event support for basic information cluster

#### Testing
* Reboot device and make sure StartUp event was properly logged.

```
[1638986330.816387][515903:515903] CHIP:ZCL: PlatformMgrDelegate: OnStartUp
[1638986330.816401][515903:515903] CHIP:EVL: LogEvent event number: 0x0000000000000001 schema priority: 2, endpoint id:  0x0 cluster id: 0x0000_0028 event id: 0x0 Sys timestamp: 0x00000000229969E9

```