### PR TITLE
Add unit tests for SystemTimer.h

### DIFF
--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR LayerImplLwIP::StartTimer(Clock::Timeout delay, TimerCompleteCallback
 
     CancelTimer(onComplete, appState);
 
-    TimerList::Node * timer = mTimerPool.Create(*this, delay, onComplete, appState);
+    TimerList::Node * timer = mTimerPool.Create(*this, SystemClock().GetMonotonicTimestamp() + delay, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
     if (mTimerList.Add(timer) == timer)
@@ -87,7 +87,7 @@ CHIP_ERROR LayerImplLwIP::ScheduleWork(TimerCompleteCallback onComplete, void * 
 {
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    TimerList::Node * timer = mTimerPool.Create(*this, System::Clock::kZero, onComplete, appState);
+    TimerList::Node * timer = mTimerPool.Create(*this, SystemClock().GetMonotonicTimestamp(), onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
     return ScheduleLambda([this, timer] { this->mTimerPool.Invoke(timer); });

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR LayerImplSelect::StartTimer(Clock::Timeout delay, TimerCompleteCallba
 
     CancelTimer(onComplete, appState);
 
-    TimerList::Node * timer = mTimerPool.Create(*this, delay, onComplete, appState);
+    TimerList::Node * timer = mTimerPool.Create(*this, SystemClock().GetMonotonicTimestamp() + delay, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
@@ -186,7 +186,7 @@ CHIP_ERROR LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, void 
 
     CancelTimer(onComplete, appState);
 
-    TimerList::Node * timer = mTimerPool.Create(*this, Clock::kZero, onComplete, appState);
+    TimerList::Node * timer = mTimerPool.Create(*this, SystemClock().GetMonotonicTimestamp(), onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -67,29 +67,30 @@ TimerList::Node * TimerList::Add(TimerList::Node * add)
 
 TimerList::Node * TimerList::Remove(TimerList::Node * remove)
 {
-    VerifyOrDie(mEarliestTimer != nullptr);
-
-    if (remove == mEarliestTimer)
+    if (mEarliestTimer != nullptr && remove != nullptr)
     {
-        mEarliestTimer = remove->mNextTimer;
-    }
-    else
-    {
-        TimerList::Node * lTimer = mEarliestTimer;
-
-        while (lTimer->mNextTimer)
+        if (remove == mEarliestTimer)
         {
-            if (remove == lTimer->mNextTimer)
-            {
-                lTimer->mNextTimer = remove->mNextTimer;
-                break;
-            }
-
-            lTimer = lTimer->mNextTimer;
+            mEarliestTimer = remove->mNextTimer;
         }
-    }
+        else
+        {
+            TimerList::Node * lTimer = mEarliestTimer;
 
-    remove->mNextTimer = nullptr;
+            while (lTimer->mNextTimer)
+            {
+                if (remove == lTimer->mNextTimer)
+                {
+                    lTimer->mNextTimer = remove->mNextTimer;
+                    break;
+                }
+
+                lTimer = lTimer->mNextTimer;
+            }
+        }
+
+        remove->mNextTimer = nullptr;
+    }
     return mEarliestTimer;
 }
 


### PR DESCRIPTION
#### Problem

Only the higher-level `System::Layer` timer operations had tests;
the utility classes in `system/SystemTimer.h` had no unit tests,
and a recent refactor (#12628) introduced a bug that a proper unit
test would have caught.

Fixes #12729 Add unit tests for SystemTimer.h

#### Change overview

What's in this PR

- Add tests covering `TimerData`, `TimeList`, and `TimerPool`.
- Changed these helpers to take a `Timestamp` rather than a `Timeout`.
- Fixed `TimerList::Remove(Node*)` to allow an empty list or null
  argument (matching its description).

#### Testing

Quis custodiet ipsos custodes?
