### PR TITLE
Fix flashbundle error in infineon. Ensure CI will catch this in the future

### DIFF
--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -61,7 +61,12 @@ jobs:
               timeout-minutes: 10
               run: |
                 scripts/run_in_build_env.sh \
-                  "scripts/build/build_examples.py --no-log-timestamps --target 'infineon-p6-lock' build"
+                  "scripts/build/build_examples.py \
+                      --enable-flashbundle --no-log-timestamps \
+                      --target infineon-p6-lock \
+                      build \
+                      --copy-artifacts-to out/artifacts \
+                  "
                 .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     p6 default lock-app \
                     out/infineon-p6-lock/chip-p6-lock-example.out
@@ -69,7 +74,12 @@ jobs:
               timeout-minutes: 10
               run: |
                 scripts/run_in_build_env.sh \
-                  "scripts/build/build_examples.py --no-log-timestamps --target 'infineon-p6-all-clusters' build"
+                  "scripts/build/build_examples.py \
+                      --enable-flashbundle --no-log-timestamps \
+                      --target infineon-p6-all-clusters \
+                      build \
+                      --copy-artifacts-to out/artifacts \
+                  "
                 .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     p6 default all-clusters-app \
                     out/infineon-p6-all-clusters/chip-p6-clusters-example.out
@@ -77,7 +87,12 @@ jobs:
               timeout-minutes: 10
               run: |
                 scripts/run_in_build_env.sh \
-                  "scripts/build/build_examples.py --no-log-timestamps --target 'infineon-p6-light' build"
+                  "scripts/build/build_examples.py \
+                      --enable-flashbundle --no-log-timestamps \
+                      --target infineon-p6-light \
+                      build \
+                      --copy-artifacts-to out/artifacts \
+                  "
                 .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     p6 default light-app \
                     out/infineon-p6-light/chip-p6-lighting-example.out

--- a/scripts/build/builders/infineon.py
+++ b/scripts/build/builders/infineon.py
@@ -49,7 +49,7 @@ class InfineonApp(Enum):
         elif self == InfineonApp.ALL_CLUSTERS:
             return 'clusters_app.flashbundle.txt'
         elif self == InfineonApp.LIGHT:
-            return 'light_app.flashbundle.txt'
+            return 'lighting_app.flashbundle.txt'
         else:
             raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
#### Problem
The flashbundle name in #12189 has a typo in it, resulting in errors:

```
...
Step #1 - "CompileAll":   File "/workspace/scripts/build/build/__init__.py", line 75, in CreateArtifactArchives
Step #1 - "CompileAll":     builder.CompressArtifacts(os.path.join(
Step #1 - "CompileAll":   File "/workspace/scripts/build/builders/builder.py", line 98, in CompressArtifacts
Step #1 - "CompileAll":     for target_name, source_name in self.outputs().items():
Step #1 - "CompileAll":   File "/workspace/scripts/build/builders/builder.py", line 85, in outputs
Step #1 - "CompileAll":     artifacts.update(self.flashbundle())
Step #1 - "CompileAll":   File "/workspace/scripts/build/builders/infineon.py", line 95, in flashbundle
Step #1 - "CompileAll":     with open(os.path.join(self.output_dir, self.app.FlashBundleName()), 'r') as fp:
Step #1 - "CompileAll": FileNotFoundError: [Errno 2] No such file or directory: '/workspace/out/infineon-p6-light/light_app.flashbundle.txt'
```


#### Change overview
Fix the name, ensure CI runs the full 'copy artifacts with flashbundle' build step to catch this in the future.

#### Testing
CI will validate this. Manually using build_examples.py compilation in my vscode instance.