### PR TITLE
Turn off progress logging on K32W for now.

### DIFF
--- a/src/platform/nxp/k32w/k32w0/args.gni
+++ b/src/platform/nxp/k32w/k32w0/args.gni
@@ -28,7 +28,9 @@ chip_build_tests = false
 
 chip_mdns = "platform"
 
+# Trying to fit into the available flash by disabling optional logging for now
 chip_detail_logging = false
+chip_progress_logging = false
 
 mbedtls_target = "${chip_root}/third_party/nxp/k32w0_sdk:mbedtls"
 openthread_external_mbedtls = mbedtls_target


### PR DESCRIPTION
We are running out of flash again.

#### Problem
ToT does not fit in flash on K32W

#### Change overview
Disable progress logging.

