### PR TITLE
Add support for matter cli in EFR32 example apps

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -93,7 +93,6 @@ efr32_executable("lighting_app") {
 
   deps = [
     ":sdk",
-    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
@@ -102,6 +101,7 @@ efr32_executable("lighting_app") {
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
     "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+    "${examples_plat_dir}:efr-matter-shell",
   ]
 
   include_dirs = [ "include" ]

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -18,7 +18,6 @@ import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/defaults.gni")
-import("${chip_root}/src/lib/lib.gni")
 import("${efr32_sdk_build_root}/efr32_executable.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
 
@@ -70,14 +69,6 @@ efr32_sdk("sdk") {
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setupDiscriminator}",
   ]
 
-  if (chip_build_libshell)
-  {
-    defines += [
-      "ENABLE_CHIP_SHELL",
-      "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
-    ]
-  }
-
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -102,11 +93,11 @@ efr32_executable("lighting_app") {
 
   deps = [
     ":sdk",
+    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
-    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -18,6 +18,7 @@ import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/defaults.gni")
+import("${chip_root}/src/lib/lib.gni")
 import("${efr32_sdk_build_root}/efr32_executable.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
 
@@ -69,6 +70,14 @@ efr32_sdk("sdk") {
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setupDiscriminator}",
   ]
 
+  if (chip_build_libshell)
+  {
+    defines += [
+      "ENABLE_CHIP_SHELL",
+      "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
+    ]
+  }
+
   if (chip_enable_pw_rpc) {
     defines += [
       "HAL_VCOM_ENABLE=1",
@@ -84,7 +93,7 @@ efr32_executable("lighting_app") {
     "${examples_plat_dir}/LEDWidget.cpp",
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/uart.cpp",
     "src/AppTask.cpp",
     "src/LightingManager.cpp",
     "src/ZclCallbacks.cpp",
@@ -97,6 +106,7 @@ efr32_executable("lighting_app") {
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
+    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -66,9 +66,9 @@
 #include "Rpc.h"
 #endif
 
-//#if defined(ENABLE_CHIP_SHELL)
+#ifdef ENABLE_CHIP_SHELL
 #include "matter_shell.h"
-//#endif
+#endif
 
 using namespace ::chip;
 using namespace ::chip::Inet;
@@ -181,9 +181,9 @@ int main(void)
         appError(ret);
     }
 
-//#if defined(ENABLE_CHIP_SHELL)
+#ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
-//#endif
+#endif
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -66,6 +66,10 @@
 #include "Rpc.h"
 #endif
 
+//#if defined(ENABLE_CHIP_SHELL)
+#include "matter_shell.h"
+//#endif
+
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
@@ -176,6 +180,10 @@ int main(void)
         EFR32_LOG("GetAppTask().Init() failed");
         appError(ret);
     }
+
+//#if defined(ENABLE_CHIP_SHELL)
+    chip::startShellTask();
+//#endif
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -90,7 +90,6 @@ efr32_executable("lock_app") {
 
   deps = [
     ":sdk",
-    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lock-app/lock-common",
     "${chip_root}/src/lib",
@@ -99,6 +98,7 @@ efr32_executable("lock_app") {
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
     "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+    "${examples_plat_dir}:efr-matter-shell",
   ]
 
   include_dirs = [ "include" ]

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -81,7 +81,7 @@ efr32_executable("lock_app") {
     "${examples_plat_dir}/LEDWidget.cpp",
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/uart.cpp",
     "src/AppTask.cpp",
     "src/BoltLockManager.cpp",
     "src/ZclCallbacks.cpp",

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -90,6 +90,7 @@ efr32_executable("lock_app") {
 
   deps = [
     ":sdk",
+    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lock-app/lock-common",
     "${chip_root}/src/lib",

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -52,6 +52,10 @@
 #include "Rpc.h"
 #endif
 
+#ifdef ENABLE_CHIP_SHELL
+#include "matter_shell.h"
+#endif
+
 #if CHIP_ENABLE_OPENTHREAD
 #include <mbedtls/platform.h>
 #include <openthread/cli.h>
@@ -173,6 +177,10 @@ int main(void)
         EFR32_LOG("GetAppTask().Init() failed");
         appError(ret);
     }
+
+#ifdef ENABLE_CHIP_SHELL
+    chip::startShellTask();
+#endif
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -57,7 +57,7 @@ efr32_executable("pigweed_app") {
     "${examples_plat_dir}/PigweedLogger.cpp",
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.cpp,
+    "${examples_plat_dir}/uart.cpp",
     "src/main.cpp",
   ]
 

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -57,7 +57,7 @@ efr32_executable("pigweed_app") {
     "${examples_plat_dir}/PigweedLogger.cpp",
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/uart.cpp,
     "src/main.cpp",
   ]
 

--- a/examples/platform/efr32/BUILD.gn
+++ b/examples/platform/efr32/BUILD.gn
@@ -14,8 +14,8 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
-
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
+import("${chip_root}/src/lib/lib.gni")
 
 config("chip_examples_project_config") {
   include_dirs = [ "project_include" ]
@@ -48,4 +48,20 @@ source_set("openthread_core_config_efr32_chip_examples") {
   ]
 
   public_configs = [ ":chip_examples_project_config" ]
+}
+
+source_set("efr-matter-shell") {
+  if (chip_build_libshell)
+  {
+    defines = ["ENABLE_CHIP_SHELL"]
+
+    sources = ["matter_shell.cpp"]
+    include_dirs = [ "${chip_root}/examples/platform/efr32" ]
+
+    public_deps = [
+      "${chip_root}/src/lib/shell:shell",
+      "${chip_root}/src/lib/shell:shell_core",
+      #"${chip_root}/examples/shell/shell_common:shell_common",
+    ]
+  }
 }

--- a/examples/platform/efr32/BUILD.gn
+++ b/examples/platform/efr32/BUILD.gn
@@ -14,8 +14,8 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
-import("${efr32_sdk_build_root}/efr32_sdk.gni")
 import("${chip_root}/src/lib/lib.gni")
+import("${efr32_sdk_build_root}/efr32_sdk.gni")
 
 config("chip_examples_project_config") {
   include_dirs = [ "project_include" ]
@@ -51,17 +51,16 @@ source_set("openthread_core_config_efr32_chip_examples") {
 }
 
 source_set("efr-matter-shell") {
-  if (chip_build_libshell)
-  {
-    defines = ["ENABLE_CHIP_SHELL"]
+  if (chip_build_libshell) {
+    defines = [ "ENABLE_CHIP_SHELL" ]
 
-    sources = ["matter_shell.cpp"]
+    sources = [ "matter_shell.cpp" ]
     include_dirs = [ "." ]
 
     public_deps = [
+      "${chip_root}/examples/shell/shell_common:shell_common",
       "${chip_root}/src/lib/shell:shell",
       "${chip_root}/src/lib/shell:shell_core",
-      "${chip_root}/examples/shell/shell_common:shell_common",
     ]
   }
 }

--- a/examples/platform/efr32/BUILD.gn
+++ b/examples/platform/efr32/BUILD.gn
@@ -56,7 +56,7 @@ source_set("efr-matter-shell") {
     defines = ["ENABLE_CHIP_SHELL"]
 
     sources = ["matter_shell.cpp"]
-    include_dirs = [ "${chip_root}/examples/platform/efr32" ]
+    include_dirs = [ "." ]
 
     public_deps = [
       "${chip_root}/src/lib/shell:shell",

--- a/examples/platform/efr32/BUILD.gn
+++ b/examples/platform/efr32/BUILD.gn
@@ -61,7 +61,7 @@ source_set("efr-matter-shell") {
     public_deps = [
       "${chip_root}/src/lib/shell:shell",
       "${chip_root}/src/lib/shell:shell_core",
-      #"${chip_root}/examples/shell/shell_common:shell_common",
+      "${chip_root}/examples/shell/shell_common:shell_common",
     ]
   }
 }

--- a/examples/platform/efr32/matter_shell.cpp
+++ b/examples/platform/efr32/matter_shell.cpp
@@ -16,11 +16,11 @@
  */
 
 #include "matter_shell.h"
-#include <FreeRTOS.h>
-#include <task.h>
 #include <ChipShellCollection.h>
-#include <lib/shell/Engine.h>
+#include <FreeRTOS.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/shell/Engine.h>
+#include <task.h>
 
 using namespace ::chip;
 using chip::Shell::Engine;
@@ -81,7 +81,8 @@ void startShellTask()
     cmd_ping_init();
     cmd_send_init();
 
-    shellTaskHandle = xTaskCreateStatic(MatterShellTask, "matter_cli", ArraySize(shellStack), NULL, SHELL_TASK_PRIORITY, shellStack, &shellTaskStruct);
+    shellTaskHandle = xTaskCreateStatic(MatterShellTask, "matter_cli", ArraySize(shellStack), NULL, SHELL_TASK_PRIORITY, shellStack,
+                                        &shellTaskStruct);
 }
 
 } // namespace chip

--- a/examples/platform/efr32/matter_shell.cpp
+++ b/examples/platform/efr32/matter_shell.cpp
@@ -18,7 +18,7 @@
 #include "matter_shell.h"
 #include <FreeRTOS.h>
 #include <task.h>
-//#include <ChipShellCollection.h>
+#include <ChipShellCollection.h>
 #include <lib/shell/Engine.h>
 #include <lib/core/CHIPCore.h>
 
@@ -74,12 +74,12 @@ void startShellTask()
     int status = chip::Shell::streamer_init(chip::Shell::streamer_get());
     assert(status == 0);
 
-#ifdef SHELL_APP
+    // For now also register commands from shell_common (shell app).
+    // TODO move at least OTCLI to default commands in lib/shell/commands
     cmd_misc_init();
     cmd_otcli_init();
     cmd_ping_init();
     cmd_send_init();
-#endif
 
     shellTaskHandle = xTaskCreateStatic(MatterShellTask, "matter_cli", ArraySize(shellStack), NULL, SHELL_TASK_PRIORITY, shellStack, &shellTaskStruct);
 }

--- a/examples/platform/efr32/matter_shell.cpp
+++ b/examples/platform/efr32/matter_shell.cpp
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "matter_shell.h"
+#include <FreeRTOS.h>
+#include <task.h>
+//#include <ChipShellCollection.h>
+#include <lib/shell/Engine.h>
+#include <lib/core/CHIPCore.h>
+
+using namespace ::chip;
+using chip::Shell::Engine;
+
+namespace {
+
+#define SHELL_TASK_STACK_SIZE 2048
+#define SHELL_TASK_PRIORITY 5
+TaskHandle_t shellTaskHandle;
+StackType_t shellStack[SHELL_TASK_STACK_SIZE / sizeof(StackType_t)];
+StaticTask_t shellTaskStruct;
+
+void MatterShellTask(void * args)
+{
+    chip::Shell::Engine::Root().RunMainLoop();
+}
+
+} // namespace
+
+extern "C" unsigned int sleep(unsigned int seconds)
+{
+    const TickType_t xDelay = 1000 * seconds / portTICK_PERIOD_MS;
+    vTaskDelay(xDelay);
+    return 0;
+}
+
+namespace chip {
+
+void NotifyShellProcess()
+{
+    xTaskNotifyGive(shellTaskHandle);
+}
+
+void NotifyShellProcessFromISR()
+{
+    BaseType_t yieldRequired = pdFALSE;
+    if (shellTaskHandle != NULL)
+    {
+        vTaskNotifyGiveFromISR(shellTaskHandle, &yieldRequired);
+    }
+    portYIELD_FROM_ISR(yieldRequired);
+}
+
+void WaitForShellActivity()
+{
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+}
+
+void startShellTask()
+{
+    int status = chip::Shell::streamer_init(chip::Shell::streamer_get());
+    assert(status == 0);
+
+#ifdef SHELL_APP
+    cmd_misc_init();
+    cmd_otcli_init();
+    cmd_ping_init();
+    cmd_send_init();
+#endif
+
+    shellTaskHandle = xTaskCreateStatic(MatterShellTask, "matter_cli", ArraySize(shellStack), NULL, SHELL_TASK_PRIORITY, shellStack, &shellTaskStruct);
+    // if (!shellTaskHandle)
+    // {
+    //     EFR32_LOG("Shell task creation error");
+    // }
+}
+
+} // namespace chip

--- a/examples/platform/efr32/matter_shell.cpp
+++ b/examples/platform/efr32/matter_shell.cpp
@@ -82,10 +82,6 @@ void startShellTask()
 #endif
 
     shellTaskHandle = xTaskCreateStatic(MatterShellTask, "matter_cli", ArraySize(shellStack), NULL, SHELL_TASK_PRIORITY, shellStack, &shellTaskStruct);
-    // if (!shellTaskHandle)
-    // {
-    //     EFR32_LOG("Shell task creation error");
-    // }
 }
 
 } // namespace chip

--- a/examples/platform/efr32/matter_shell.h
+++ b/examples/platform/efr32/matter_shell.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-//#define CHIP_SHELL_PROMPT "matter >"
-
 namespace chip {
 
 void NotifyShellProcess();

--- a/examples/platform/efr32/matter_shell.h
+++ b/examples/platform/efr32/matter_shell.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+//#define CHIP_SHELL_PROMPT "matter >"
+
+namespace chip {
+
+void NotifyShellProcess();
+void NotifyShellProcessFromISR();
+void WaitForShellActivity();
+void startShellTask();
+
+} // namespace chip

--- a/examples/platform/efr32/uart.cpp
+++ b/examples/platform/efr32/uart.cpp
@@ -21,13 +21,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "uart.h"
 #include "assert.h"
 #include "em_core.h"
 #include "em_usart.h"
 #include "sl_board_control.h"
 #include "sl_uartdrv_instances.h"
 #include "sl_uartdrv_usart_vcom_config.h"
+#include "uart.h"
 #include "uartdrv.h"
 #include <stddef.h>
 #include <string.h>

--- a/examples/platform/efr32/uart.cpp
+++ b/examples/platform/efr32/uart.cpp
@@ -15,8 +15,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "uart.h"
 #include "AppConfig.h"
+#include "matter_shell.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "uart.h"
 #include "assert.h"
 #include "em_core.h"
 #include "em_usart.h"
@@ -26,8 +31,6 @@
 #include "uartdrv.h"
 #include <stddef.h>
 #include <string.h>
-
-#include "matter_shell.h"
 
 #if !defined(MIN)
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
@@ -178,7 +181,7 @@ static uint8_t RetrieveFromFifo(Fifo_t * fifo, uint8_t * pData, uint16_t SizeToR
  */
 void uartConsoleInit(void)
 {
-    //sl_board_enable_vcom();
+    sl_board_enable_vcom();
     // Init a fifo for the data received on the uart
     InitFifo(&sReceiveFifo, sRxFifoBuffer, MAX_BUFFER_SIZE);
 
@@ -276,3 +279,7 @@ int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
 
     return (int16_t) RetrieveFromFifo(&sReceiveFifo, (uint8_t *) Buf, NbBytesToRead);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/platform/efr32/uart.cpp
+++ b/examples/platform/efr32/uart.cpp
@@ -27,6 +27,8 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "matter_shell.h"
+
 #if !defined(MIN)
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
 #endif
@@ -176,7 +178,7 @@ static uint8_t RetrieveFromFifo(Fifo_t * fifo, uint8_t * pData, uint16_t SizeToR
  */
 void uartConsoleInit(void)
 {
-    sl_board_enable_vcom();
+    //sl_board_enable_vcom();
     // Init a fifo for the data received on the uart
     InitFifo(&sReceiveFifo, sRxFifoBuffer, MAX_BUFFER_SIZE);
 
@@ -192,6 +194,9 @@ void uartConsoleInit(void)
 
 void USART_IRQHandler(void)
 {
+#ifdef ENABLE_CHIP_SHELL
+    chip::NotifyShellProcessFromISR();
+#endif
 #ifndef PW_RPC_ENABLED
     otSysEventSignalPending();
 #endif
@@ -212,6 +217,10 @@ static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, ui
     }
 
     UARTDRV_Receive(sl_uartdrv_usart_vcom_handle, data, transferCount, UART_rx_callback);
+
+#ifdef ENABLE_CHIP_SHELL
+    chip::NotifyShellProcessFromISR();
+#endif
 #ifndef PW_RPC_ENABLED
     otSysEventSignalPending();
 #endif

--- a/examples/shell/efr32/BUILD.gn
+++ b/examples/shell/efr32/BUILD.gn
@@ -65,6 +65,7 @@ efr32_executable("shell_app") {
 
   deps = [
     ":sdk",
+    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/shell/shell_common:shell_common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",

--- a/examples/shell/efr32/BUILD.gn
+++ b/examples/shell/efr32/BUILD.gn
@@ -64,13 +64,13 @@ efr32_executable("shell_app") {
 
   deps = [
     ":sdk",
-    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/shell/shell_common:shell_common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+    "${examples_plat_dir}:efr-matter-shell",
   ]
 
   include_dirs = [ "include" ]

--- a/examples/shell/efr32/BUILD.gn
+++ b/examples/shell/efr32/BUILD.gn
@@ -49,6 +49,7 @@ efr32_sdk("sdk") {
     "BOARD_ID=${efr32_board}",
     "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
     "ENABLE_CHIP_SHELL",
+    "SHELL_APP",
   ]
 }
 
@@ -58,7 +59,7 @@ efr32_executable("shell_app") {
   sources = [
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/uart.cpp",
     "src/main.cpp",
   ]
 

--- a/examples/shell/efr32/BUILD.gn
+++ b/examples/shell/efr32/BUILD.gn
@@ -49,7 +49,6 @@ efr32_sdk("sdk") {
     "BOARD_ID=${efr32_board}",
     "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
     "ENABLE_CHIP_SHELL",
-    "SHELL_APP",
   ]
 }
 

--- a/examples/shell/efr32/src/main.cpp
+++ b/examples/shell/efr32/src/main.cpp
@@ -63,13 +63,6 @@ using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 using chip::Shell::Engine;
 
-#define SHELL_TASK_STACK_SIZE 8192
-#define SHELL_TASK_PRIORITY 3
-static TaskHandle_t sShellTaskHandle;
-#define APP_TASK_STACK_SIZE (1536)
-static StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
-static StaticTask_t appTaskStruct;
-
 // ================================================================================
 // Supporting functions
 // ================================================================================
@@ -87,24 +80,12 @@ void appError(CHIP_ERROR error)
     appError(static_cast<int>(error.AsInteger()));
 }
 
-extern "C" unsigned int sleep(unsigned int seconds)
-{
-    const TickType_t xDelay = 1000 * seconds / portTICK_PERIOD_MS;
-    vTaskDelay(xDelay);
-    return 0;
-}
-
 extern "C" void vApplicationIdleHook(void)
 {
     // FreeRTOS Idle callback
 
     // Check CHIP Config nvm3 and repack flash if necessary.
     Internal::EFR32Config::RepackNvm3Flash();
-}
-
-static void shell_task(void * args)
-{
-    Engine::Root().RunMainLoop();
 }
 
 // ================================================================================
@@ -174,19 +155,6 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
-    int status = chip::Shell::streamer_init(chip::Shell::streamer_get());
-    assert(status == 0);
-
-    cmd_misc_init();
-    cmd_otcli_init();
-    cmd_ping_init();
-    cmd_send_init();
-
-    sShellTaskHandle = xTaskCreateStatic(shell_task, APP_TASK_NAME, ArraySize(appStack), NULL, 1, appStack, &appTaskStruct);
-    if (!sShellTaskHandle)
-    {
-        EFR32_LOG("MEMORY ERROR!!!");
-    }
-
+    chip::startShellTask();
     sl_system_kernel_start();
 }

--- a/examples/shell/efr32/src/main.cpp
+++ b/examples/shell/efr32/src/main.cpp
@@ -40,6 +40,7 @@
 #include <app/server/Server.h>
 #include <init_efrPlatform.h>
 #include <sl_system_kernel.h>
+#include "matter_shell.h"
 
 #ifdef HEAP_MONITORING
 #include "MemMonitoring.h"

--- a/examples/shell/efr32/src/main.cpp
+++ b/examples/shell/efr32/src/main.cpp
@@ -36,11 +36,11 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
 
+#include "matter_shell.h"
 #include <AppConfig.h>
 #include <app/server/Server.h>
 #include <init_efrPlatform.h>
 #include <sl_system_kernel.h>
-#include "matter_shell.h"
 
 #ifdef HEAP_MONITORING
 #include "MemMonitoring.h"

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -80,7 +80,6 @@ efr32_executable("window_app") {
 
   deps = [
     ":sdk",
-    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/window-app/common:window-common",
     "${chip_root}/src/lib",
@@ -89,6 +88,7 @@ efr32_executable("window_app") {
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
     "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+    "${examples_plat_dir}:efr-matter-shell",
   ]
 
   include_dirs = [

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -71,7 +71,7 @@ efr32_executable("window_app") {
     "${examples_plat_dir}/LEDWidget.cpp",
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/uart.cpp",
     "${project_dir}/common/src/WindowApp.cpp",
     "${project_dir}/common/src/ZclCallbacks.cpp",
     "src/WindowAppImpl.cpp",

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -80,6 +80,7 @@ efr32_executable("window_app") {
 
   deps = [
     ":sdk",
+    "${examples_plat_dir}:efr-matter-shell",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/window-app/common:window-common",
     "${chip_root}/src/lib",

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -46,6 +46,10 @@
 #include <Rpc.h>
 #endif
 
+#ifdef ENABLE_CHIP_SHELL
+#include "matter_shell.h"
+#endif
+
 using namespace ::chip::DeviceLayer;
 
 // ================================================================================
@@ -139,6 +143,10 @@ int main(void)
         appError(err);
     }
 #endif // CHIP_ENABLE_OPENTHREAD
+
+#ifdef ENABLE_CHIP_SHELL
+    chip::startShellTask();
+#endif
 
     WindowApp & app = WindowApp::Instance();
 

--- a/src/lib/lib.gni
+++ b/src/lib/lib.gni
@@ -14,5 +14,5 @@
 
 declare_args() {
   # Enable libshell support.
-  chip_build_libshell = true
+  chip_build_libshell = false
 }

--- a/src/lib/lib.gni
+++ b/src/lib/lib.gni
@@ -14,5 +14,5 @@
 
 declare_args() {
   # Enable libshell support.
-  chip_build_libshell = false
+  chip_build_libshell = true
 }

--- a/src/lib/shell/BUILD.gn
+++ b/src/lib/shell/BUILD.gn
@@ -50,7 +50,7 @@ static_library("shell") {
     ]
   } else if (chip_device_platform == "efr32") {
     sources += [
-      "MainLoopDefault.cpp",
+      "MainLoopEFR32.cpp",
       "streamer_efr32.cpp",
     ]
   } else if (chip_device_platform == "k32w0") {

--- a/src/lib/shell/MainLoopEFR32.cpp
+++ b/src/lib/shell/MainLoopEFR32.cpp
@@ -1,0 +1,204 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "streamer.h"
+#include <lib/shell/Engine.h>
+#include <lib/support/CHIPMem.h>
+#include <platform/CHIPDeviceLayer.h>
+#include "matter_shell.h"
+
+#include <ctype.h>
+#include <string.h>
+
+using chip::FormatCHIPError;
+using chip::Platform::MemoryAlloc;
+using chip::Platform::MemoryFree;
+using chip::Shell::Engine;
+using chip::Shell::streamer_get;
+
+namespace {
+
+constexpr const char kShellPrompt[] = "matterCli >";
+
+void ReadLine(char * buffer, size_t max)
+{
+    ssize_t read = 0;
+    bool done    = false;
+    char * inptr = buffer;
+
+    // Read in characters until we get a new line or we hit our max size.
+    while (((inptr - buffer) < static_cast<int>(max)) && !done)
+    {
+        chip::WaitForShellActivity();
+        if (read == 0)
+        {
+            read = streamer_read(streamer_get(), inptr, 1);
+        }
+
+        // Process any characters we just read in.
+        while (read > 0)
+        {
+            switch (*inptr)
+            {
+            case '\r':
+            case '\n':
+                streamer_printf(streamer_get(), "\r\n");
+                *inptr = 0; // null terminate
+                done   = true;
+                break;
+            case 0x7F:
+                // delete backspace character + 1 more
+                inptr -= 2;
+                if (inptr >= buffer - 1)
+                {
+                    streamer_printf(streamer_get(), "\b \b");
+                }
+                else
+                {
+                    inptr = buffer - 1;
+                }
+                break;
+            default:
+                if (isprint(static_cast<int>(*inptr)) || *inptr == '\t')
+                {
+                    streamer_printf(streamer_get(), "%c", *inptr);
+                }
+                else
+                {
+                    inptr--;
+                }
+                break;
+            }
+
+            inptr++;
+            read--;
+        }
+    }
+}
+
+bool IsSeparator(char ch)
+{
+    return (ch == ' ') || (ch == '\t') || (ch == '\r') || (ch == '\n');
+}
+
+bool IsEscape(char ch)
+{
+    return (ch == '\\');
+}
+
+bool IsEscapable(char ch)
+{
+    return IsSeparator(ch) || IsEscape(ch);
+}
+
+int TokenizeLine(char * buffer, char ** tokens, int max_tokens)
+{
+    size_t len = strlen(buffer);
+    int cursor = 0;
+    size_t i   = 0;
+
+    // Strip leading spaces
+    while (buffer[i] && buffer[i] == ' ')
+    {
+        i++;
+    }
+
+    if (len <= i)
+    {
+        return 0;
+    }
+
+    // The first token starts at the beginning.
+    tokens[cursor++] = &buffer[i];
+
+    for (; i < len && cursor < max_tokens; i++)
+    {
+        if (IsEscape(buffer[i]) && IsEscapable(buffer[i + 1]))
+        {
+            // include the null terminator: strlen(cmd) = strlen(cmd + 1) + 1
+            memmove(&buffer[i], &buffer[i + 1], strlen(&buffer[i]));
+        }
+        else if (IsSeparator(buffer[i]))
+        {
+            buffer[i] = 0;
+            if (!IsSeparator(buffer[i + 1]))
+            {
+                tokens[cursor++] = &buffer[i + 1];
+            }
+        }
+    }
+
+    tokens[cursor] = nullptr;
+
+    return cursor;
+}
+
+void ProcessShellLine(intptr_t args)
+{
+    int argc;
+    char * argv[CHIP_SHELL_MAX_TOKENS];
+
+    char * line = reinterpret_cast<char *>(args);
+    argc        = TokenizeLine(line, argv, CHIP_SHELL_MAX_TOKENS);
+
+    if (argc > 0)
+    {
+        CHIP_ERROR retval = Engine::Root().ExecCommand(argc, argv);
+
+        if (retval != CHIP_NO_ERROR)
+        {
+            char errorStr[160];
+            bool errorStrFound = FormatCHIPError(errorStr, sizeof(errorStr), retval);
+            if (!errorStrFound)
+            {
+                errorStr[0] = 0;
+            }
+            streamer_printf(streamer_get(), "Error %s: %s\r\n", argv[0], errorStr);
+        }
+        else
+        {
+            streamer_printf(streamer_get(), "Done\r\n", argv[0]);
+        }
+    }
+    MemoryFree(line);
+    streamer_printf(streamer_get(), kShellPrompt);
+}
+
+} // namespace
+
+namespace chip {
+namespace Shell {
+
+void Engine::RunMainLoop()
+{
+    Engine::Root().RegisterDefaultCommands();
+    streamer_printf(streamer_get(), kShellPrompt);
+
+    while (true)
+    {
+        char * line = static_cast<char *>(Platform::MemoryAlloc(CHIP_SHELL_MAX_LINE_SIZE));
+        ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE);
+#if CONFIG_DEVICE_LAYER
+        DeviceLayer::PlatformMgr().ScheduleWork(ProcessShellLine, reinterpret_cast<intptr_t>(line));
+#else
+        ProcessShellLine(reinterpret_cast<intptr_t>(line));
+#endif
+    }
+}
+
+} // namespace Shell
+} // namespace chip

--- a/src/lib/shell/MainLoopEFR32.cpp
+++ b/src/lib/shell/MainLoopEFR32.cpp
@@ -32,7 +32,7 @@ using chip::Shell::streamer_get;
 
 namespace {
 
-constexpr const char kShellPrompt[] = "matterCli >";
+constexpr const char kShellPrompt[] = "matterCli > ";
 
 void ReadLine(char * buffer, size_t max)
 {

--- a/src/lib/shell/MainLoopEFR32.cpp
+++ b/src/lib/shell/MainLoopEFR32.cpp
@@ -15,11 +15,11 @@
  *    limitations under the License.
  */
 
+#include "matter_shell.h"
 #include "streamer.h"
 #include <lib/shell/Engine.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/CHIPDeviceLayer.h>
-#include "matter_shell.h"
 
 #include <ctype.h>
 #include <string.h>

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -69,7 +69,7 @@ efr32_executable("efr32_device_tests") {
     "${examples_plat_dir}/PigweedLogger.cpp",
     "${examples_plat_dir}/heap_4_silabs.c",
     "${examples_plat_dir}/init_efrPlatform.cpp",
-    "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/uart.cpp",
     "src/main.cpp",
   ]
 

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -18,6 +18,7 @@ import("//build_overrides/jlink.gni")
 import("//build_overrides/mbedtls.gni")
 
 import("efr32_board.gni")
+import("${chip_root}/src/lib/lib.gni")
 
 declare_args() {
   # Location of the efr32 SDK.
@@ -144,6 +145,14 @@ template("efr32_sdk") {
     ]
 
     defines += board_defines
+
+    if (chip_build_libshell)
+    { 
+      defines += [
+       "ENABLE_CHIP_SHELL",
+       "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
+      ]
+    }
 
     if (efr32_family == "efr32mg12") {
       _include_dirs += [

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -17,8 +17,8 @@ import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/jlink.gni")
 import("//build_overrides/mbedtls.gni")
 
-import("efr32_board.gni")
 import("${chip_root}/src/lib/lib.gni")
+import("efr32_board.gni")
 
 declare_args() {
   # Location of the efr32 SDK.
@@ -146,11 +146,10 @@ template("efr32_sdk") {
 
     defines += board_defines
 
-    if (chip_build_libshell)
-    { 
+    if (chip_build_libshell) {
       defines += [
-       "ENABLE_CHIP_SHELL",
-       "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
+        "ENABLE_CHIP_SHELL",
+        "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
       ]
     }
 


### PR DESCRIPTION
#### Problem
Matter cli only runs on the shell example app for EFR32 platform 

#### Change overview
Create a platform source_set for shell support on efr32.
Pull the shell task to platform wide file. 
Shell main loob is notified on uart rx activity instead of the busy wait to read a line used in the shell example app.

#### Testing
build examples with `chip_build_libshell` argument to true
e.g:`gn gen out/debug --args='efr32_board="BRD4186A" chip_build_libshell=true'`
Test that matter cli is available on the serial port
