### PR TITLE
Remove unnecessary static cast

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -863,7 +863,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
             }
         }
 
-        err = encoder.Encode(static_cast<uint8_t>(routingRole));
+        err = encoder.Encode(routingRole);
     }
     break;
 


### PR DESCRIPTION
#### Problem
Remnant from a previous implementation.
```
otDeviceRole role = otThreadGetDeviceRole(mOTInst);
err               = encoder.Encode(static_cast<uint8_t>(role));
```
Where otDeviceRole had to cast to a uint8_t . Now that is correctly mapped to ThreadNetworkDiagnostics::RoutingRole, it doesn’t have to be casted

#### Change overview
Remove unnecessary cast as it could cause problems as code and spec evolves

#### Testing
Minimal change, just validated that it builds.
