### PR TITLE
Fix missing __APPLE_USE_RFC_3542

### DIFF
--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -21,6 +21,7 @@
  * This file implements Inet::UDPEndPoint using sockets.
  */
 
+#define __APPLE_USE_RFC_3542
 #include <inet/UDPEndPointImplSockets.h>
 
 #include <lib/support/CodeUtils.h>

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -21,6 +21,8 @@
  * This file implements Inet::UDPEndPoint using sockets.
  */
 
+// Required to properly support underlying RFC3542-related fields to IPV6_PKTINFO 
+// on Darwin.
 #define __APPLE_USE_RFC_3542
 #include <inet/UDPEndPointImplSockets.h>
 

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -21,7 +21,7 @@
  * This file implements Inet::UDPEndPoint using sockets.
  */
 
-// Required to properly support underlying RFC3542-related fields to IPV6_PKTINFO 
+// Required to properly support underlying RFC3542-related fields to IPV6_PKTINFO
 // on Darwin.
 #define __APPLE_USE_RFC_3542
 #include <inet/UDPEndPointImplSockets.h>


### PR DESCRIPTION
#### Problem

In splitting `UDPEndPoint.cpp` by implementation (#12688), the definition of `__APPLE_USE_RFC_3542` was lost, which caused `IPV6_PKTINFO` to not be defined and corresponding parts of `UDPEndPoint` not to be built.

#### Change overview

Add `#define __APPLE_USE_RFC_3542` to the top of `UDPEndPointImplSockets.cpp`, as it had been in `UDPEndPoint.cpp`.

#### Testing

CI
