### PR TITLE
[app] make CASESessionManager fabric independent

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -20,12 +20,13 @@
 
 namespace chip {
 
-CHIP_ERROR CASESessionManager::FindOrEstablishSession(NodeId nodeId, Callback::Callback<OnDeviceConnected> * onConnection,
+CHIP_ERROR CASESessionManager::FindOrEstablishSession(FabricInfo * fabric, NodeId nodeId,
+                                                      Callback::Callback<OnDeviceConnected> * onConnection,
                                                       Callback::Callback<OnDeviceConnectionFailure> * onFailure)
 {
     Dnssd::ResolvedNodeData resolutionData;
 
-    PeerId peerId = GetFabricInfo()->GetPeerIdForNode(nodeId);
+    PeerId peerId = fabric->GetPeerIdForNode(nodeId);
 
     bool nodeIDWasResolved = (mConfig.dnsCache != nullptr && mConfig.dnsCache->Lookup(peerId, resolutionData) == CHIP_NO_ERROR);
 
@@ -67,9 +68,9 @@ void CASESessionManager::ReleaseSession(NodeId nodeId)
     ReleaseSession(FindExistingSession(nodeId));
 }
 
-CHIP_ERROR CASESessionManager::ResolveDeviceAddress(NodeId nodeId)
+CHIP_ERROR CASESessionManager::ResolveDeviceAddress(FabricInfo * fabric, NodeId nodeId)
 {
-    return mConfig.dnsResolver->ResolveNodeId(GetFabricInfo()->GetPeerIdForNode(nodeId), Inet::IPAddressType::kAny,
+    return mConfig.dnsResolver->ResolveNodeId(fabric->GetPeerIdForNode(nodeId), Inet::IPAddressType::kAny,
                                               Dnssd::Resolver::CacheBypass::On);
 }
 
@@ -94,12 +95,12 @@ void CASESessionManager::OnNodeIdResolutionFailed(const PeerId & peer, CHIP_ERRO
     ChipLogError(Controller, "Error resolving node id: %s", ErrorStr(error));
 }
 
-CHIP_ERROR CASESessionManager::GetPeerAddress(NodeId nodeId, Transport::PeerAddress & addr)
+CHIP_ERROR CASESessionManager::GetPeerAddress(FabricInfo * fabric, NodeId nodeId, Transport::PeerAddress & addr)
 {
     if (mConfig.dnsCache != nullptr)
     {
         Dnssd::ResolvedNodeData resolutionData;
-        ReturnErrorOnFailure(mConfig.dnsCache->Lookup(GetFabricInfo()->GetPeerIdForNode(nodeId), resolutionData));
+        ReturnErrorOnFailure(mConfig.dnsCache->Lookup(fabric->GetPeerIdForNode(nodeId), resolutionData));
         addr = OperationalDeviceProxy::ToPeerAddress(resolutionData);
         return CHIP_NO_ERROR;
     }

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -70,14 +70,12 @@ public:
      * these will be used to inform the caller about successful or failed connection establishment.
      * If the connection is already established, the `onConnection` callback will be immediately called.
      */
-    CHIP_ERROR FindOrEstablishSession(NodeId nodeId, Callback::Callback<OnDeviceConnected> * onConnection,
+    CHIP_ERROR FindOrEstablishSession(FabricInfo * fabric, NodeId nodeId, Callback::Callback<OnDeviceConnected> * onConnection,
                                       Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
     OperationalDeviceProxy * FindExistingSession(NodeId nodeId);
 
     void ReleaseSession(NodeId nodeId);
-
-    FabricInfo * GetFabricInfo() { return mConfig.sessionInitParams.fabricInfo; }
 
     /**
      * This API triggers the DNS-SD resolution for the given node ID. The node ID will be looked up
@@ -86,7 +84,7 @@ public:
      * The results of the DNS-SD resolution request is provided to the class via `ResolverDelegate`
      * implementation of CASESessionManager.
      */
-    CHIP_ERROR ResolveDeviceAddress(NodeId nodeId);
+    CHIP_ERROR ResolveDeviceAddress(FabricInfo * fabric, NodeId nodeId);
 
     /**
      * This API returns the address for the given node ID.
@@ -96,7 +94,7 @@ public:
      * an ongoing session with the peer node. If the session doesn't exist, the API will return
      * `CHIP_ERROR_NOT_CONNECTED` error.
      */
-    CHIP_ERROR GetPeerAddress(NodeId nodeId, Transport::PeerAddress & addr);
+    CHIP_ERROR GetPeerAddress(FabricInfo * fabric, NodeId nodeId, Transport::PeerAddress & addr);
 
     //////////// SessionReleaseDelegate Implementation ///////////////
     void OnSessionReleased(SessionHandle session) override;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -151,9 +151,8 @@ bool OperationalDeviceProxy::GetAddress(Inet::IPAddress & addr, uint16_t & port)
 
 CHIP_ERROR OperationalDeviceProxy::EstablishConnection()
 {
-    mCASEClient = mInitParams.clientPool->Allocate(CASEClientInitParams{ mInitParams.sessionManager, mInitParams.exchangeMgr,
-                                                                         mInitParams.idAllocator, mInitParams.fabricInfo,
-                                                                         mInitParams.mrpLocalConfig });
+    mCASEClient = mInitParams.clientPool->Allocate(CASEClientInitParams{
+        mInitParams.sessionManager, mInitParams.exchangeMgr, mInitParams.idAllocator, mFabricInfo, mInitParams.mrpLocalConfig });
     ReturnErrorCodeIf(mCASEClient == nullptr, CHIP_ERROR_NO_MEMORY);
     CHIP_ERROR err =
         mCASEClient->EstablishSession(mPeerId, mDeviceAddress, mMRPConfig, HandleCASEConnected, HandleCASEConnectionFailure, this);
@@ -301,8 +300,7 @@ void OperationalDeviceProxy::OnSessionReleased(SessionHandle session)
 
 CHIP_ERROR OperationalDeviceProxy::ShutdownSubscriptions()
 {
-    return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mInitParams.fabricInfo->GetFabricIndex(),
-                                                                             GetDeviceId());
+    return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricInfo->GetFabricIndex(), GetDeviceId());
 }
 
 OperationalDeviceProxy::~OperationalDeviceProxy() {}

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -52,7 +52,7 @@ struct DeviceProxyInitParams
     SessionManager * sessionManager          = nullptr;
     Messaging::ExchangeManager * exchangeMgr = nullptr;
     SessionIDAllocator * idAllocator         = nullptr;
-    FabricInfo * fabricInfo                  = nullptr;
+    FabricTable * fabricTable                = nullptr;
     CASEClientPoolDelegate * clientPool      = nullptr;
 
     Controller::DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
@@ -64,7 +64,7 @@ struct DeviceProxyInitParams
         ReturnErrorCodeIf(sessionManager == nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorCodeIf(exchangeMgr == nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorCodeIf(idAllocator == nullptr, CHIP_ERROR_INCORRECT_STATE);
-        ReturnErrorCodeIf(fabricInfo == nullptr, CHIP_ERROR_INCORRECT_STATE);
+        ReturnErrorCodeIf(fabricTable == nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorCodeIf(clientPool == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
         return CHIP_NO_ERROR;
@@ -87,6 +87,7 @@ public:
         mSystemLayer = params.exchangeMgr->GetSessionManager()->SystemLayer();
         mInitParams  = params;
         mPeerId      = peerId;
+        mFabricInfo  = params.fabricTable->FindFabricWithCompressedId(peerId.GetCompressedFabricId());
 
         mState = State::NeedsAddress;
     }
@@ -198,6 +199,7 @@ private:
     };
 
     DeviceProxyInitParams mInitParams;
+    FabricInfo * mFabricInfo;
     System::Layer * mSystemLayer;
 
     CASEClient * mCASEClient = nullptr;

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -193,39 +193,22 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-CHIP_ERROR OTARequestor::SetupCASESessionManager(FabricIndex fabricIndex)
+CHIP_ERROR OTARequestor::SetupCASESessionManager()
 {
     // A previous CASE session had been established
     if (mCASESessionManager != nullptr)
     {
-        if (mCASESessionManager->GetFabricInfo()->GetFabricIndex() != fabricIndex)
-        {
-            // CSM is per fabric so if fabric index does not match the previous session, CSM needs to be set up again
-            Platform::Delete(mCASESessionManager);
-            mCASESessionManager = nullptr;
-        }
-        else
-        {
-            // Fabric index matches so use previous instance
-            return CHIP_NO_ERROR;
-        }
+        return CHIP_NO_ERROR;
     }
 
     // CSM has not been setup so create a new instance of it
     if (mCASESessionManager == nullptr)
     {
-        FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(fabricIndex);
-        if (fabricInfo == nullptr)
-        {
-            ChipLogError(SoftwareUpdate, "Did not find fabric for index %d", fabricIndex);
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-
         DeviceProxyInitParams initParams = {
             .sessionManager = &(mServer->GetSecureSessionManager()),
             .exchangeMgr    = &(mServer->GetExchangeManager()),
             .idAllocator    = &(mServer->GetSessionIDAllocator()),
-            .fabricInfo     = fabricInfo,
+            .fabricTable    = &(mServer->GetFabricTable()),
             .clientPool     = mServer->GetCASEClientPool(),
             // TODO: Determine where this should be instantiated
             .imDelegate = Platform::New<Controller::DeviceControllerInteractionModelDelegate>(),
@@ -252,16 +235,19 @@ CHIP_ERROR OTARequestor::SetupCASESessionManager(FabricIndex fabricIndex)
 
 void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 {
-    CHIP_ERROR err = SetupCASESessionManager(mProviderFabricIndex);
+    CHIP_ERROR err          = SetupCASESessionManager();
+    FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderFabricIndex);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    ChipLogError(SoftwareUpdate, "Cannot setup CASESessionManager: %" CHIP_ERROR_FORMAT, err.Format()));
+    VerifyOrReturn(fabricInfo != nullptr, ChipLogError(SoftwareUpdate, "Cannot find fabric"));
 
     // Set the action to take once connection is successfully established
     mOnConnectedAction = onConnectedAction;
 
     ChipLogDetail(SoftwareUpdate, "Establishing session to provider node ID 0x" ChipLogFormatX64 " on fabric index %d",
                   ChipLogValueX64(mProviderNodeId), mProviderFabricIndex);
-    err = mCASESessionManager->FindOrEstablishSession(mProviderNodeId, &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    err = mCASESessionManager->FindOrEstablishSession(fabricInfo, mProviderNodeId, &mOnConnectedCallback,
+                                                      &mOnConnectionFailureCallback);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    ChipLogError(SoftwareUpdate, "Cannot establish connection to provider: %" CHIP_ERROR_FORMAT, err.Format()));
 }

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -170,7 +170,7 @@ private:
     /**
      * Setup CASESessionManager used to establish a session with the provider
      */
-    CHIP_ERROR SetupCASESessionManager(chip::FabricIndex fabricIndex);
+    CHIP_ERROR SetupCASESessionManager();
 
     /**
      * Create a QueryImage request using values from the Basic cluster attributes

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -239,7 +239,7 @@ public:
                                           Callback::Callback<OnDeviceConnectionFailure> * onFailure)
     {
         VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
-        return mCASESessionManager->FindOrEstablishSession(deviceId, onConnection, onFailure);
+        return mCASESessionManager->FindOrEstablishSession(mFabricInfo, deviceId, onConnection, onFailure);
     }
 
     /**
@@ -253,7 +253,7 @@ public:
     CHIP_ERROR UpdateDevice(NodeId deviceId)
     {
         VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
-        return mCASESessionManager->ResolveDeviceAddress(deviceId);
+        return mCASESessionManager->ResolveDeviceAddress(mFabricInfo, deviceId);
     }
 
     /**
@@ -363,6 +363,7 @@ protected:
 
     PeerId mLocalId    = PeerId();
     FabricId mFabricId = kUndefinedFabricId;
+    FabricInfo * mFabricInfo;
 
     PersistentStorageDelegate * mStorageDelegate = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -313,7 +313,7 @@ CHIP_ERROR ConnectProvider(FabricIndex fabricIndex, NodeId nodeId, const Transpo
     DeviceProxyInitParams initParams = { .sessionManager = &Server::GetInstance().GetSecureSessionManager(),
                                          .exchangeMgr    = &Server::GetInstance().GetExchangeManager(),
                                          .idAllocator    = &Server::GetInstance().GetSessionIDAllocator(),
-                                         .fabricInfo     = fabric,
+                                         .fabricTable    = &Server::GetInstance().GetFabricTable(),
                                          .imDelegate     = &sIMDelegate };
 
     auto deviceProxy = Platform::New<OperationalDeviceProxy>(initParams, fabric->GetPeerIdForNode(nodeId));


### PR DESCRIPTION
#### Problem

The `CASESessionManager` class is currently bound to a fabric. This enforces the `CASESessionManager` to be re-allocated for each fabric as in https://github.com/project-chip/connectedhomeip/pull/12636.


#### Change overview

Make `CASESessionManager` fabric independent.

#### Testing

* Local all-cluster-app pairing 
* OTA tested with
```
./out/debug/chip-ota-provider-app -f test.bin
./out/chip-tool pairing onnetwork 1 20202021
./out/debug/chip-ota-requestor-app -d 30 -u 5550
./out/chip-tool pairing onnetwork-long 2 20202021 30
./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 2 0
```
 * CI tests.
