### PR TITLE
[app] Move CASESessionManager to server internal storage

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -16,8 +16,6 @@
  *    limitations under the License.
  */
 
-#include <app/CASEClientPool.h>
-#include <app/OperationalDeviceProxyPool.h>
 #include <app/server/Server.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -31,7 +29,6 @@
 
 using chip::BDXDownloader;
 using chip::ByteSpan;
-using chip::CASEClientPool;
 using chip::CharSpan;
 using chip::EndpointId;
 using chip::FabricIndex;
@@ -40,7 +37,6 @@ using chip::LinuxOTAImageProcessor;
 using chip::NodeId;
 using chip::OnDeviceConnected;
 using chip::OnDeviceConnectionFailure;
-using chip::OperationalDeviceProxyPool;
 using chip::OTADownloader;
 using chip::OTAImageProcessorParams;
 using chip::OTARequestor;

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -190,6 +190,7 @@ int main(int argc, char * argv[])
 
     // Init Data Model and CHIP App Server with user specified UDP port
     Server::GetInstance().Init(nullptr, requestorSecurePort);
+    chip::Dnssd::Resolver::Instance().Init(chip::DeviceLayer::UDPEndPointManager());
     ChipLogProgress(SoftwareUpdate, "Initializing the Application Server. Listening on UDP port %d", requestorSecurePort);
 
     // Initialize device attestation config

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -55,15 +55,10 @@ using namespace chip::ArgParser;
 using namespace chip::Messaging;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
-constexpr size_t kMaxActiveCaseClients = 2;
-constexpr size_t kMaxActiveDevices     = 8;
-
 OTARequestor gRequestorCore;
 LinuxOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 LinuxOTAImageProcessor gImageProcessor;
-CASEClientPool<kMaxActiveCaseClients> gCASEClientPool;
-OperationalDeviceProxyPool<kMaxActiveDevices> gDevicePool;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
 void OnStartDelayTimerHandler(Layer * systemLayer, void * appState);
@@ -205,8 +200,6 @@ int main(int argc, char * argv[])
 
     // Set server instance used for session establishment
     chip::Server * server = &(chip::Server::GetInstance());
-    server->SetCASEClientPool(&gCASEClientPool);
-    server->SetDevicePool(&gDevicePool);
     gRequestorCore.SetServerInstance(server);
 
     // Connect the Requestor and Requestor Driver objects

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/CASESessionManager.h>
+#include <platform/CHIPDeviceLayer.h>
 
 namespace chip {
 

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -53,18 +53,22 @@ class CASESessionManager : public SessionReleaseDelegate, public Dnssd::Resolver
 public:
     CASESessionManager() = delete;
 
-    CASESessionManager(CASESessionManagerConfig & params)
+    CASESessionManager(const CASESessionManagerConfig & params)
     {
         VerifyOrDie(params.sessionInitParams.Validate() == CHIP_NO_ERROR);
 
         mConfig = params;
+    }
 
+    CHIP_ERROR Init()
+    {
         if (mConfig.dnsResolver == nullptr)
         {
-            VerifyOrDie(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()) == CHIP_NO_ERROR);
+            ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
             mDNSResolver.SetResolverDelegate(this);
             mConfig.dnsResolver = &mDNSResolver;
         }
+        return CHIP_NO_ERROR;
     }
 
     virtual ~CASESessionManager() { mDNSResolver.Shutdown(); }

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -59,7 +59,7 @@ struct DeviceProxyInitParams
 
     Optional<ReliableMessageProtocolConfig> mrpLocalConfig = Optional<ReliableMessageProtocolConfig>::Missing();
 
-    CHIP_ERROR Validate()
+    CHIP_ERROR Validate() const
     {
         ReturnErrorCodeIf(sessionManager == nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorCodeIf(exchangeMgr == nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -226,52 +226,9 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-CHIP_ERROR OTARequestor::SetupCASESessionManager()
-{
-    // A previous CASE session had been established
-    if (mCASESessionManager != nullptr)
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    // CSM has not been setup so create a new instance of it
-    if (mCASESessionManager == nullptr)
-    {
-        DeviceProxyInitParams initParams = {
-            .sessionManager = &(mServer->GetSecureSessionManager()),
-            .exchangeMgr    = &(mServer->GetExchangeManager()),
-            .idAllocator    = &(mServer->GetSessionIDAllocator()),
-            .fabricTable    = &(mServer->GetFabricTable()),
-            .clientPool     = mServer->GetCASEClientPool(),
-            // TODO: Determine where this should be instantiated
-            .imDelegate = Platform::New<Controller::DeviceControllerInteractionModelDelegate>(),
-        };
-
-        CASESessionManagerConfig sessionManagerConfig = {
-            .sessionInitParams = initParams,
-            .dnsCache          = nullptr,
-            .devicePool        = mServer->GetDevicePool(),
-            .dnsResolver       = nullptr,
-        };
-
-        mCASESessionManager = Platform::New<CASESessionManager>(sessionManagerConfig);
-    }
-
-    if (mCASESessionManager == nullptr)
-    {
-        ChipLogError(SoftwareUpdate, "Failed in creating an instance of CASESessionManager");
-        return CHIP_ERROR_NO_MEMORY;
-    }
-
-    return CHIP_NO_ERROR;
-}
-
 void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 {
-    CHIP_ERROR err          = SetupCASESessionManager();
     FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderFabricIndex);
-    VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(SoftwareUpdate, "Cannot setup CASESessionManager: %" CHIP_ERROR_FORMAT, err.Format()));
     VerifyOrReturn(fabricInfo != nullptr, ChipLogError(SoftwareUpdate, "Cannot find fabric"));
 
     // Set the action to take once connection is successfully established
@@ -279,8 +236,8 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 
     ChipLogDetail(SoftwareUpdate, "Establishing session to provider node ID 0x" ChipLogFormatX64 " on fabric index %d",
                   ChipLogValueX64(mProviderNodeId), mProviderFabricIndex);
-    err = mCASESessionManager->FindOrEstablishSession(fabricInfo, mProviderNodeId, &mOnConnectedCallback,
-                                                      &mOnConnectionFailureCallback);
+    CHIP_ERROR err = mCASESessionManager->FindOrEstablishSession(fabricInfo, mProviderNodeId, &mOnConnectedCallback,
+                                                                 &mOnConnectionFailureCallback);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    ChipLogError(SoftwareUpdate, "Cannot establish connection to provider: %" CHIP_ERROR_FORMAT, err.Format()));
 }

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -102,7 +102,11 @@ public:
      * Called to set the server instance which used to get access to the system resources necessary to open CASE sessions and drive
      * BDX transfers
      */
-    void SetServerInstance(Server * server) { mServer = server; }
+    void SetServerInstance(Server * server)
+    {
+        mServer             = server;
+        mCASESessionManager = server->GetCASESessionManager();
+    }
 
     /**
      * Called to establish a session to mProviderNodeId on mProviderFabricIndex. This must be called from the same externally
@@ -196,11 +200,6 @@ private:
         chip::Messaging::ExchangeContext * mExchangeCtx;
         chip::BDXDownloader * mDownloader;
     };
-
-    /**
-     * Setup CASESessionManager used to establish a session with the provider
-     */
-    CHIP_ERROR SetupCASESessionManager();
 
     /**
      * Create a QueryImage request using values from the Basic cluster attributes

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -233,7 +233,6 @@ exit:
 
 CHIP_ERROR Server::InitCASESessionManager()
 {
-    ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
     DeviceProxyInitParams initParams = {
         .sessionManager = &mSessions,
         .exchangeMgr    = &mExchangeMgr,
@@ -246,7 +245,7 @@ CHIP_ERROR Server::InitCASESessionManager()
         .sessionInitParams = initParams,
         .dnsCache          = nullptr,
         .devicePool        = &mDevicePool,
-        .dnsResolver       = &mDNSResolver,
+        .dnsResolver       = nullptr,
     };
     mCASESessionManager = new (&mCASESessionManagerStorage) CASESessionManager(sessionManagerConfig);
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -147,7 +147,6 @@ private:
     CASESessionManager * mCASESessionManager;
     CASEClientPool<kCASEClientPoolSize> mCASEClientPool;
     OperationalDeviceProxyPool<kOperationalDevicePoolSize> mDevicePool;
-    Dnssd::ResolverProxy mDNSResolver;
 
     Messaging::ExchangeManager mExchangeMgr;
     FabricTable mFabrics;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -67,13 +67,9 @@ public:
 
     FabricTable & GetFabricTable() { return mFabrics; }
 
-    CASEClientPoolDelegate * GetCASEClientPool() { return mCASEClientPool; }
+    CASEClientPoolDelegate * GetCASEClientPool() { return &mCASEClientPool; }
 
-    void SetCASEClientPool(CASEClientPoolDelegate * clientPool) { mCASEClientPool = clientPool; }
-
-    OperationalDeviceProxyPoolDelegate * GetDevicePool() { return mDevicePool; }
-
-    void SetDevicePool(OperationalDeviceProxyPoolDelegate * devicePool) { mDevicePool = devicePool; }
+    OperationalDeviceProxyPoolDelegate * GetDevicePool() { return &mDevicePool; }
 
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeMgr; }
 
@@ -141,8 +137,13 @@ private:
     ServerTransportMgr mTransports;
     SessionManager mSessions;
     CASEServer mCASEServer;
-    CASEClientPoolDelegate * mCASEClientPool         = nullptr;
-    OperationalDeviceProxyPoolDelegate * mDevicePool = nullptr;
+
+    static constexpr size_t kCASEClientPoolSize        = 2;
+    static constexpr size_t kOperationalDevicePoolSize = 4;
+
+    CASEClientPool<kCASEClientPoolSize> mCASEClientPool;
+    OperationalDeviceProxyPool<kOperationalDevicePoolSize> mDevicePool;
+
     Messaging::ExchangeManager mExchangeMgr;
     FabricTable mFabrics;
     SessionIDAllocator mSessionIDAllocator;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -69,7 +69,7 @@ public:
 
     FabricTable & GetFabricTable() { return mFabrics; }
 
-    CASESessionManager * GetCASESessionManager() { return mCASESessionManager; }
+    CASESessionManager * GetCASESessionManager() { return &mCASESessionManager; }
 
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeMgr; }
 
@@ -90,7 +90,7 @@ public:
     static Server & GetInstance() { return sServer; }
 
 private:
-    Server() : mCommissioningWindowManager(this), mGroupsProvider(mGroupsStorage) {}
+    Server();
 
     static Server sServer;
 
@@ -130,8 +130,6 @@ private:
         CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
     };
 
-    CHIP_ERROR InitCASESessionManager();
-
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
 #endif
@@ -140,13 +138,9 @@ private:
     SessionManager mSessions;
     CASEServer mCASEServer;
 
-    static constexpr size_t kCASEClientPoolSize        = CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS;
-    static constexpr size_t kOperationalDevicePoolSize = CHIP_CONFIG_DEVICE_MAX_ACTIVE_DEVICES;
-
-    std::aligned_storage_t<sizeof(CASESessionManager), sizeof(void *)> mCASESessionManagerStorage;
-    CASESessionManager * mCASESessionManager;
-    CASEClientPool<kCASEClientPoolSize> mCASEClientPool;
-    OperationalDeviceProxyPool<kOperationalDevicePoolSize> mDevicePool;
+    CASESessionManager mCASESessionManager;
+    CASEClientPool<CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS> mCASEClientPool;
+    OperationalDeviceProxyPool<CHIP_CONFIG_DEVICE_MAX_ACTIVE_DEVICES> mDevicePool;
 
     Messaging::ExchangeManager mExchangeMgr;
     FabricTable mFabrics;

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2571,6 +2571,24 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS
+ *
+ * @brief Number of outgoing CASE sessions can be simutaneously negotiated on an end device.
+ */
+#ifndef CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS
+#define CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS 2
+#endif
+
+/**
+ * @def CHIP_CONFIG_DEVICE_MAX_ACTIVE_DEVICES
+ *
+ * @brief Number of devices an end device can be simultaneously connected to
+ */
+#ifndef CHIP_CONFIG_DEVICE_MAX_ACTIVE_DEVICES
+#define CHIP_CONFIG_DEVICE_MAX_ACTIVE_DEVICES 4
+#endif
+
+/**
  * @def CHIP_CONFIG_MAX_GROUPS_PER_FABRIC
  *
  * @brief Defines the number of groups supported per fabric, see Group Key Management Cluster in specification.


### PR DESCRIPTION
#### Problem

CASESessionManager is now only availabe on linux devices.
For OTA and binding cluster to work, we need to share the `CASESessionManager` with the OTA requestor on all platforms.

#### Changes

Move `CASESessionManager` to the Server class.

#### Test

Tested with OTA requestor & provider.