### PR TITLE
Implement IM event buffer-pressure-based flushing

### DIFF
--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -355,9 +355,9 @@ public:
     bool IsValid(void) { return EventManagementStates::Shutdown != mState; };
 
     /**
-     *  Logger would save last logged event number for each logger buffer into schedule event number array
+     *  Logger would save last logged event number and initial written event bytes number into schedule event number array
      */
-    void SetScheduledEventNumber(EventNumber & aEventNumber);
+    void SetScheduledEventInfo(EventNumber & aEventNumber, uint32_t & aInitialWrittenEventBytes);
 
 private:
     void VendEventNumber();

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -51,16 +51,17 @@ CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, Interac
     mLastScheduledEventNumber  = 0;
     mIsPrimingReports          = true;
     MoveToState(HandlerState::Initialized);
-    mpDelegate          = apDelegate;
-    mSubscriptionId     = 0;
-    mHoldReport         = false;
-    mDirty              = false;
-    mActiveSubscription = false;
-    mIsChunkedReport    = false;
-    mInteractionType    = aInteractionType;
-    mInitiatorNodeId    = apExchangeContext->GetSessionHandle().GetPeerNodeId();
-    mSubjectDescriptor  = apExchangeContext->GetSessionHandle().GetSubjectDescriptor();
-    mHoldSync           = false;
+    mpDelegate              = apDelegate;
+    mSubscriptionId         = 0;
+    mHoldReport             = false;
+    mDirty                  = false;
+    mActiveSubscription     = false;
+    mIsChunkedReport        = false;
+    mInteractionType        = aInteractionType;
+    mInitiatorNodeId        = apExchangeContext->GetSessionHandle().GetPeerNodeId();
+    mSubjectDescriptor      = apExchangeContext->GetSessionHandle().GetSubjectDescriptor();
+    mHoldSync               = false;
+    mLastWrittenEventsBytes = 0;
     if (apExchangeContext != nullptr)
     {
         apExchangeContext->SetDelegate(this);
@@ -115,6 +116,7 @@ void ReadHandler::Shutdown(ShutdownOptions aOptions)
     mIsChunkedReport           = false;
     mInitiatorNodeId           = kUndefinedNodeId;
     mHoldSync                  = false;
+    mLastWrittenEventsBytes    = 0;
 }
 
 CHIP_ERROR ReadHandler::OnReadInitialRequest(System::PacketBufferHandle && aPayload)
@@ -530,7 +532,7 @@ bool ReadHandler::CheckEventClean(EventManagement & aEventManager)
         if ((lastEventNumber != 0) && (mEventMin <= lastEventNumber))
         {
             // We have more events. snapshot last event number
-            aEventManager.SetScheduledEventNumber(mLastScheduledEventNumber);
+            aEventManager.SetScheduledEventInfo(mLastScheduledEventNumber, mLastWrittenEventsBytes);
             return false;
         }
     }

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -157,6 +157,7 @@ public:
 
     const AttributeValueEncoder::AttributeEncodeState & GetAttributeEncodeState() const { return mAttributeEncoderState; }
     void SetAttributeEncodeState(const AttributeValueEncoder::AttributeEncodeState & aState) { mAttributeEncoderState = aState; }
+    uint32_t GetLastWrittenEventsBytes() { return mLastWrittenEventsBytes; }
 
 private:
     friend class TestReadInteraction;
@@ -226,6 +227,7 @@ private:
     AttributePathExpandIterator mAttributePathExpandIterator = AttributePathExpandIterator(nullptr);
     bool mIsFabricFiltered                                   = false;
     bool mHoldSync                                           = false;
+    uint32_t mLastWrittenEventsBytes                         = 0;
     SubjectDescriptor mSubjectDescriptor;
     // The detailed encoding state for a single attribute, used by list chunking feature.
     AttributeValueEncoder::AttributeEncodeState mAttributeEncoderState;

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -91,10 +91,10 @@ public:
 
     /**
      * @brief
-     *  Schedule the urgent event delivery
+     *  Schedule the event delivery
      *
      */
-    CHIP_ERROR ScheduleUrgentEventDelivery(ConcreteEventPath & aPath);
+    CHIP_ERROR ScheduleEventDelivery(ConcreteEventPath & aPath, EventOptions::Type aUrgent, uint32_t aBytesWritten);
 
 private:
     friend class TestReportingEngine;
@@ -130,6 +130,10 @@ private:
      *
      */
     static void Run(System::Layer * aSystemLayer, void * apAppState);
+
+    CHIP_ERROR ScheduleUrgentEventDelivery(ConcreteEventPath & aPath);
+    CHIP_ERROR ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten);
+    void GetMinEventLogPosition(uint32_t & aMinLogPosition);
 
     /**
      * Boolean to indicate if ScheduleRun is pending. This flag is used to prevent calling ScheduleRun multiple times

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2760,6 +2760,26 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_EVENT_LOGGING_BYTE_THRESHOLD
+ *
+ * @brief The number of bytes written to the event logging system that
+ *   will trigger Report Delivery.
+ *
+ * The configuration captures the number of bytes written to the event
+ * logging subsystem needed to trigger a report. For example, if an application wants to offload all DEBUG events
+ * reliably, the threshold should be set to less than the size of the
+ * DEBUG buffer (plus a slop factor to account for events generated
+ * during the scheduling and event offload).  Similarly, if the
+ * application does not want to drop INFO events, the threshold should
+ * be set to the sum of DEBUG and INFO buffers (with the same
+ * correction).
+ *
+ */
+#ifndef CHIP_CONFIG_EVENT_LOGGING_BYTE_THRESHOLD
+#define CHIP_CONFIG_EVENT_LOGGING_BYTE_THRESHOLD 512
+#endif /* CHIP_CONFIG_EVENT_LOGGING_BYTE_THRESHOLD */
+
+/**
  * @def CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
  *
  * @brief Enable Interaction model Event support in server


### PR DESCRIPTION
#### Problem
When the IM event buffers bytes number exceed the specified water mark, it would schedule event delivery.

#### Change overview
See above

#### Testing
Manually validated

