### PR TITLE
EFR32: Add hex binary to build output

### DIFF
--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -96,6 +96,13 @@ template("flashable_executable") {
     # The executable is the final target.
     final_target = executable_target
   }
+
+  if (defined(invoker.flashbundle_name)) {
+    flashbundle_name = invoker.flashbundle_name
+  } else {
+    flashbundle_name = "${target_name}.flashbundle.txt"
+  }
+
   group(target_name) {
     data_deps = [ ":$final_target" ]
 
@@ -103,7 +110,7 @@ template("flashable_executable") {
       data_deps += invoker.data_deps
     }
 
-    write_runtime_deps = "${root_out_dir}/${target_name}.flashbundle.txt"
+    write_runtime_deps = "${root_out_dir}/${flashbundle_name}"
   }
 
   if (defined(invoker.objcopy_image_name)) {

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -118,14 +118,10 @@ class Efr32Builder(GnBuilder):
         return args
 
     def build_outputs(self):
-        items = {
-            '%s.out' % self.app.AppNamePrefix():
-                os.path.join(self.output_dir, '%s.out' %
-                             self.app.AppNamePrefix()),
-            '%s.out.map' % self.app.AppNamePrefix():
-                os.path.join(self.output_dir,
-                             '%s.out.map' % self.app.AppNamePrefix()),
-        }
+        items = {}
+        for extension in ["out", "out.map", "hex"]:
+            name = '%s.%s' % (self.app.AppNamePrefix(), extension)
+            items[name] = os.path.join(self.output_dir, name)
 
         if self.app == Efr32App.UNIT_TEST:
             # Include test runner python wheels
@@ -133,6 +129,7 @@ class Efr32Builder(GnBuilder):
                 for file in files:
                     items["chip_nl_test_runner_wheels/" +
                           file] = os.path.join(root, file)
+
         # Figure out flash bundle files and build accordingly
         with open(os.path.join(self.output_dir, self.app.FlashBundleName())) as f:
             for line in f.readlines():

--- a/third_party/efr32_sdk/efr32_executable.gni
+++ b/third_party/efr32_sdk/efr32_executable.gni
@@ -44,8 +44,28 @@ template("efr32_executable") {
   flashing_script_name = output_base_name + ".flash.py"
   flashing_options = [ "efr32" ]
 
-  flashable_executable(target_name) {
+  flash_target_name = target_name + ".flash_executable"
+  flashbundle_name = "${target_name}.flashbundle.txt"
+  flashable_executable(flash_target_name) {
     forward_variables_from(invoker, "*")
     data_deps = [ ":${flashing_runtime_target}" ]
+  }
+
+  # Add a target which generates the hex file in addition to s37.
+  executable_target = "$flash_target_name.executable"
+  hex_image_name = output_base_name + ".hex"
+  hex_target_name = target_name + ".hex"
+  objcopy_convert(hex_target_name) {
+    conversion_input = "${root_out_dir}/${invoker.output_name}"
+    conversion_output = "${root_out_dir}/${hex_image_name}"
+    conversion_target_format = "ihex"
+    deps = [ ":$executable_target" ]
+  }
+
+  group(target_name) {
+    deps = [
+      ":$flash_target_name",
+      ":$hex_target_name",
+    ]
   }
 }


### PR DESCRIPTION

#### Problem
Currently efr32 builds only output s37 binaries which require commander tool to flash.

#### Change overview
Add a gn action which provides a hex binary in addition to the s37.
The hex binary can be flashed with jlink, and is therefore an easier format for use in test automation.


#### Testing
Built efr32 lighting and locking examples and verified hex file was generated. 
