### PR TITLE
[Darwin] expose the "getDeviceBeingCommissioned" API to ObjC

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -56,6 +56,7 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
 - (void)updateDevice:(uint64_t)deviceID fabricId:(uint64_t)fabricId;
 
 - (BOOL)isDevicePaired:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
+- (nullable CHIPDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error;
 - (BOOL)getConnectedDevice:(uint64_t)deviceID
                      queue:(dispatch_queue_t)queue
          completionHandler:(CHIPDeviceConnectionCallback)completionHandler;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -405,6 +405,25 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     return paired;
 }
 
+- (CHIPDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error
+{
+    CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
+    if (![self isRunning]) {
+        [self checkForError:errorCode logMsg:kErrorNotRunning error:error];
+        return nil;
+    }
+
+    chip::CommissioneeDeviceProxy * deviceProxy;
+    errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(deviceId, &deviceProxy);
+    if (errorCode != CHIP_NO_ERROR) {
+        if (error) {
+            *error = [CHIPError errorForCHIPErrorCode:errorCode];
+        }
+        return nil;
+    }
+    return [[CHIPDevice alloc] initWithDevice:deviceProxy];
+}
+
 - (BOOL)getConnectedDevice:(uint64_t)deviceID
                      queue:(dispatch_queue_t)queue
          completionHandler:(CHIPDeviceConnectionCallback)completionHandler


### PR DESCRIPTION
#### Problem
The Darwin SDK doesn't have access to the `getDeviceBeingCommissioned` API. 
Without this it's not possible to provision an accessory with network credentials and enable them. 

#### Change overview
Just exposing this API

#### Testing
* If no testing is required, why not?
Just directly exposing this API in the SDK. 
