### PR TITLE
Add path expanded flag

### DIFF
--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -117,6 +117,8 @@ bool AttributePathExpandIterator::Next()
 {
     for (; mpClusterInfo != nullptr; (mpClusterInfo = mpClusterInfo->mpNext, mEndpointIndex = UINT16_MAX))
     {
+        mOutputPath.mExpanded = mpClusterInfo->HasAttributeWildcard();
+
         if (mEndpointIndex == UINT16_MAX)
         {
             // Special case: If this is a concrete path, we just return its value as-is.

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -26,6 +26,9 @@ namespace app {
 
 /**
  * A representation of a concrete attribute path. This does not convey any list index specifiers.
+ *
+ * The expanded flag can be set to indicate that a concrete path was expanded from a wildcard
+ * or group path.
  */
 struct ConcreteAttributePath
 {
@@ -41,6 +44,7 @@ struct ConcreteAttributePath
     }
 
     EndpointId mEndpointId   = 0;
+    bool mExpanded           = false;
     ClusterId mClusterId     = 0;
     AttributeId mAttributeId = 0;
 };

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -40,8 +40,7 @@ struct ConcreteAttributePath
 
     bool operator==(const ConcreteAttributePath & other) const
     {
-        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId &&
-            mExpanded == other.mExpanded;
+        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId;
     }
 
     EndpointId mEndpointId   = 0;

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -40,11 +40,12 @@ struct ConcreteAttributePath
 
     bool operator==(const ConcreteAttributePath & other) const
     {
-        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId;
+        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId &&
+            mExpanded == other.mExpanded;
     }
 
     EndpointId mEndpointId   = 0;
-    bool mExpanded           = false;
+    bool mExpanded           = false; // NOTE: in between larger members
     ClusterId mClusterId     = 0;
     AttributeId mAttributeId = 0;
 };
@@ -58,9 +59,7 @@ struct ConcreteReadAttributePath : public ConcreteAttributePath
 {
     ConcreteReadAttributePath() {}
 
-    ConcreteReadAttributePath(const ConcreteAttributePath & path) :
-        ConcreteReadAttributePath(path.mEndpointId, path.mClusterId, path.mAttributeId)
-    {}
+    ConcreteReadAttributePath(const ConcreteAttributePath & path) : ConcreteAttributePath(path) {}
 
     ConcreteReadAttributePath(EndpointId aEndpointId, ClusterId aClusterId, AttributeId aAttributeId) :
         ConcreteAttributePath(aEndpointId, aClusterId, aAttributeId)
@@ -93,6 +92,8 @@ struct ConcreteDataAttributePath : public ConcreteAttributePath
     };
 
     ConcreteDataAttributePath() {}
+
+    ConcreteDataAttributePath(const ConcreteAttributePath & path) : ConcreteAttributePath(path) {}
 
     ConcreteDataAttributePath(EndpointId aEndpointId, ClusterId aClusterId, AttributeId aAttributeId) :
         ConcreteAttributePath(aEndpointId, aClusterId, aAttributeId)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -359,8 +359,9 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, c
                                  AttributeValueEncoder::AttributeEncodeState * apEncoderState)
 {
     ChipLogDetail(DataManagement,
-                  "Reading attribute: Cluster=" ChipLogFormatMEI " Endpoint=%" PRIx16 " AttributeId=" ChipLogFormatMEI,
-                  ChipLogValueMEI(aPath.mClusterId), aPath.mEndpointId, ChipLogValueMEI(aPath.mAttributeId));
+                  "Reading attribute: Cluster=" ChipLogFormatMEI " Endpoint=%" PRIx16 " AttributeId=" ChipLogFormatMEI
+                  " (expanded=%d)",
+                  ChipLogValueMEI(aPath.mClusterId), aPath.mEndpointId, ChipLogValueMEI(aPath.mAttributeId), aPath.mExpanded);
 
     if (aPath.mAttributeId == Clusters::Globals::Attributes::AttributeList::Id)
     {


### PR DESCRIPTION
#### Problem
When processing concrete attribute paths, it's not known if they were originally
concrete, or if they were expanded (from a wildcard or group path). This is necessary
because handling may need to differ based on whether the concrete path was
expanded or not (e.g. if access is denied).

#### Change overview
Add an expanded flag to ConcreteAttributePath. It can be a boolean fit in between
other larger member variables, so alignment means it shouldn't typically use more
space.

The expanded flag defaults to false. It's effectively "optional". (Only some code will
care what it's set to.)

It's set to true by the AttributeExpandPathIterator based on the ClusterInfo it's currently
iterating.

It's logged in the log statement in ReadSingleClusterData.

#### Testing
How was this tested? (at least one bullet point required)
- Build and run chip-all-clusters-app using chip-repl
- Test reading specific endpoint specific cluster logs expanded=0
- Test reading any endpoint specific cluster logs expanded=1
- Test reading specific endpoint any cluster logs expanded=1