### PR TITLE
Update the esp-idf commit ID

### DIFF
--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
 
 RUN set -x \
     && git clone --depth 1 --recursive -b release/v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
-    && git -C /tmp/esp-idf checkout ddc44956bf718540d5451e17e1becf6c7dffe5b8 \
+    && git -C /tmp/esp-idf checkout e104dd7f27d2e73ab0e9b614dd7b9295099069bf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.35 Add K32W SDKs into chip-build-vscode
+0.5.36 Version bump reason: ESP32 update to newest 4.4 commit: e104dd7f27d2e73ab0e9b614dd7b9295099069bf


### PR DESCRIPTION
#### Problem
Apparently the ddc44956bf718540d5451e17e1becf6c7dffe5b8 commit ID is not valid anymore, resulting in an [error](https://github.com/project-chip/connectedhomeip/runs/4472852425?check_suite_focus=true) during the execution

```
Submodule path 'components/esp_wifi/lib': checked out '657dd399cff195341fd536d503ce99f0d46876a6'
+ git -C /tmp/esp-idf checkout ddc44956bf718540d5451e17e1becf6c7dffe5b8
fatal: reference is not a tree: ddc44956bf718540d5451e17e1becf6c7dffe5b8
```

#### Change overview
This change bumps the commit ID to the latest available

#### Testing
It was tested manually using `act` tool