### PR TITLE
Need init and cleanup mSelfProcessedEvents and mLastScheduledEventNumber,

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -671,7 +671,6 @@ CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aD
 {
     EventLoadOutContext * const loadOutContext = static_cast<EventLoadOutContext *>(apContext);
     CHIP_ERROR err                             = EventIterator(aReader, aDepth, loadOutContext);
-    loadOutContext->mCurrentEventNumber++;
     if (err == CHIP_EVENT_ID_FOUND)
     {
         // checkpoint the writer
@@ -693,7 +692,7 @@ CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aD
         loadOutContext->mFirst               = false;
         loadOutContext->mEventCount++;
     }
-
+    loadOutContext->mCurrentEventNumber++;
     return err;
 }
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -47,7 +47,12 @@ CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, Interac
     mpAttributeClusterInfoList = nullptr;
     mpEventClusterInfoList     = nullptr;
     mCurrentPriority           = PriorityLevel::Invalid;
-    mIsPrimingReports          = true;
+    for (size_t index = 0; index < kNumPriorityLevel; index++)
+    {
+        mSelfProcessedEvents[index]      = 0;
+        mLastScheduledEventNumber[index] = 0;
+    }
+    mIsPrimingReports = true;
     MoveToState(HandlerState::Initialized);
     mpDelegate          = apDelegate;
     mSubscriptionId     = 0;
@@ -103,14 +108,19 @@ void ReadHandler::Shutdown(ShutdownOptions aOptions)
     mpAttributeClusterInfoList = nullptr;
     mpEventClusterInfoList     = nullptr;
     mCurrentPriority           = PriorityLevel::Invalid;
-    mIsPrimingReports          = false;
-    mpDelegate                 = nullptr;
-    mHoldReport                = false;
-    mDirty                     = false;
-    mActiveSubscription        = false;
-    mIsChunkedReport           = false;
-    mInitiatorNodeId           = kUndefinedNodeId;
-    mHoldSync                  = false;
+    for (size_t index = 0; index < kNumPriorityLevel; index++)
+    {
+        mSelfProcessedEvents[index]      = 0;
+        mLastScheduledEventNumber[index] = 0;
+    }
+    mIsPrimingReports   = false;
+    mpDelegate          = nullptr;
+    mHoldReport         = false;
+    mDirty              = false;
+    mActiveSubscription = false;
+    mIsChunkedReport    = false;
+    mInitiatorNodeId    = kUndefinedNodeId;
+    mHoldSync           = false;
 }
 
 CHIP_ERROR ReadHandler::OnReadInitialRequest(System::PacketBufferHandle && aPayload)

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -199,12 +199,12 @@ private:
     PriorityLevel mCurrentPriority = PriorityLevel::Invalid;
 
     // The event number of the last processed event for each priority level
-    EventNumber mSelfProcessedEvents[kNumPriorityLevel];
+    EventNumber mSelfProcessedEvents[kNumPriorityLevel] = { 0 };
 
     // The last schedule event number snapshoted in the beginning when preparing to fill new events to reports
-    EventNumber mLastScheduledEventNumber[kNumPriorityLevel];
-    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-    InteractionModelDelegate * mpDelegate      = nullptr;
+    EventNumber mLastScheduledEventNumber[kNumPriorityLevel] = { 0 };
+    Messaging::ExchangeManager * mpExchangeMgr               = nullptr;
+    InteractionModelDelegate * mpDelegate                    = nullptr;
 
     // Tracks whether we're in the initial phase of receiving priming
     // reports, which is always true for reads and true for subscriptions


### PR DESCRIPTION
#### Problem
Need init and cleanup mSelfProcessedEvents and mLastScheduledEventNumber, so that read/subscribe would start to read event from 0 in priming stage.

#### Change overview
See above

#### Testing
Update unit test to test this behavior and update the cirque mobile test