### PR TITLE
Define XX as the default value for the Country Code Location attribute

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -100,7 +100,19 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     size_t codeLen = 0;
     if (ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR)
     {
-        status = Attributes::Location::Set(endpoint, chip::CharSpan(location, strlen(location)));
+        if (codeLen == 0)
+        {
+            status = Attributes::Location::Set(endpoint, chip::CharSpan("XX", strlen("XX")));
+        }
+        else
+        {
+            status = Attributes::Location::Set(endpoint, chip::CharSpan(location, strlen(location)));
+        }
+        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
+    }
+    else
+    {
+        status = Attributes::Location::Set(endpoint, chip::CharSpan("XX", strlen("XX")));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
     }
 

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -27,7 +27,7 @@ tests:
       command: "readAttribute"
       attribute: "location"
       response:
-          value: ""
+          value: "XX"
 
     - label: "Write location"
       command: "writeAttribute"

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -251,7 +251,7 @@ class BaseTestHelper:
             "ProductName": "TEST_PRODUCT",
             "ProductID": 65279,
             "NodeLabel": "Test",
-            "Location": "",
+            "Location": "XX",
             "HardwareVersion": 0,
             "HardwareVersionString": "TEST_VERSION",
             "SoftwareVersion": 0,

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -29950,7 +29950,7 @@ uint16_t readAttributeVendorIdDefaultValue;
 
         {
             id actualValue = value;
-            XCTAssertTrue([actualValue isEqualToString:@""]);
+            XCTAssertTrue([actualValue isEqualToString:@"XX"]);
         }
 
         [expectation fulfill];

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -49137,7 +49137,7 @@ private:
 
     void OnSuccessResponse_1(chip::CharSpan location)
     {
-        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("", 0)));
+        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("XX", 2)));
 
         NextTest();
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/4758 which Define XX as the special value and default for region agnostic use in Location attribute in the Country Code Location attribute.

#### Change overview
Change the default for the Location attribute from an empty string to XX. This attribute will always follow its fixed length.

#### Testing
How was this tested? (at least one bullet point required)
* Confirm 'XX' is returned from the debug log if no country code is set
