### PR TITLE
Group Data Provider updated to newest Group Key Management spec.

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -68,40 +68,23 @@ using namespace app::Clusters;
 using namespace app::Clusters::Groups;
 using namespace chip::Credentials;
 
-static FabricIndex GetFabricIndex(app::CommandHandler * commandObj)
-{
-    VerifyOrReturnError(nullptr != commandObj, 0);
-    VerifyOrReturnError(nullptr != commandObj->GetExchangeContext(), 0);
-    return commandObj->GetExchangeContext()->GetSessionHandle().GetFabricIndex();
-}
-
 static bool GroupExists(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, false);
 
-    GroupDataProvider::GroupMapping mapping(endpointId, groupId);
-
-    return provider->GroupMappingExists(fabricIndex, mapping);
+    return provider->HasEndpoint(fabricIndex, groupId, endpointId);
 }
 
 static EmberAfStatus GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId, const CharSpan & groupName)
 {
     VerifyOrReturnError(IsFabricGroupId(groupId), EMBER_ZCL_STATUS_INVALID_VALUE);
 
-    // Check for duplicates.
-    if (GroupExists(fabricIndex, endpointId, groupId))
-    {
-        // Even if the group already exists, tell the application about the name,
-        // so it can cope with renames.
-        return EMBER_ZCL_STATUS_DUPLICATE_EXISTS;
-    }
-
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, EMBER_ZCL_STATUS_NOT_FOUND);
-    GroupDataProvider::GroupMapping mapping(endpointId, groupId, groupName);
 
-    CHIP_ERROR err = provider->AddGroupMapping(fabricIndex, mapping);
+    provider->SetGroupInfo(fabricIndex, GroupDataProvider::GroupInfo(groupId, groupName));
+    CHIP_ERROR err = provider->AddEndpoint(fabricIndex, groupId, endpointId);
     if (CHIP_NO_ERROR == err)
     {
         return EMBER_ZCL_STATUS_SUCCESS;
@@ -121,9 +104,8 @@ static EmberAfStatus GroupRemove(FabricIndex fabricIndex, EndpointId endpointId,
 
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, EMBER_ZCL_STATUS_NOT_FOUND);
-    GroupDataProvider::GroupMapping mapping(endpointId, groupId);
 
-    CHIP_ERROR err = provider->RemoveGroupMapping(fabricIndex, mapping);
+    CHIP_ERROR err = provider->RemoveEndpoint(fabricIndex, groupId, endpointId);
     if (CHIP_NO_ERROR == err)
     {
         return EMBER_ZCL_STATUS_SUCCESS;
@@ -138,10 +120,9 @@ static EmberAfStatus GroupRemove(FabricIndex fabricIndex, EndpointId endpointId,
 
 void emberAfGroupsClusterServerInitCallback(EndpointId endpointId)
 {
-    GroupDataProvider * provider = GetGroupDataProvider();
-    uint8_t nameSupport          = (provider && provider->HasGroupNamesSupport()) ? 0x80 : 0x00;
-
-    EmberAfStatus status = Attributes::NameSupport::Set(endpointId, nameSupport);
+    // The most significant bit of the NameSupport attribute indicates whether or not group names are supported
+    static constexpr uint8_t nameSupport = 0x80;
+    EmberAfStatus status                 = Attributes::NameSupport::Set(endpointId, nameSupport);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogDetail(Zcl, "ERR: writing name support %x", status);
@@ -151,17 +132,9 @@ void emberAfGroupsClusterServerInitCallback(EndpointId endpointId)
 bool emberAfGroupsClusterAddGroupCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                           const Commands::AddGroup::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
-    auto groupId     = commandData.groupId;
-    auto groupName   = commandData.groupName;
-    auto endpointId  = commandPath.mEndpointId;
-
-    EmberAfStatus status;
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
+    Groups::Commands::AddGroupResponse::Type response;
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    ChipLogDetail(Zcl, "RX: AddGroup 0x%2x, \"%.*s\"", groupId, static_cast<int>(groupName.size()), groupName.data());
-
-    status = GroupAdd(fabricIndex, endpointId, groupId, groupName);
 
     // For all networks, Add Group commands are only responded to when
     // they are addressed to a single device.
@@ -170,19 +143,13 @@ bool emberAfGroupsClusterAddGroupCallback(app::CommandHandler * commandObj, cons
         return true;
     }
 
+    response.groupId = commandData.groupId;
+    response.status  = GroupAdd(fabricIndex, commandPath.mEndpointId, commandData.groupId, commandData.groupName);
+    err              = commandObj->AddResponseData(commandPath, response);
+    if (CHIP_NO_ERROR != err)
     {
-        app::ConcreteCommandPath path = { emberAfCurrentEndpoint(), Groups::Id, Commands::AddGroupResponse::Id };
-        TLV::TLVWriter * writer       = nullptr;
-        SuccessOrExit(err = commandObj->PrepareCommand(path));
-        VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(0), status));
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
-        SuccessOrExit(err = commandObj->FinishCommand());
-    }
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Zcl, "Failed to encode response command.");
+        ChipLogDetail(Zcl, "GroupsCluster: AddGroup failed: %s", err.AsString());
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }
     return true;
 }
@@ -190,58 +157,36 @@ exit:
 bool emberAfGroupsClusterViewGroupCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                            const Commands::ViewGroup::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
-    auto groupId     = commandData.groupId;
-    auto endpointId  = commandPath.mEndpointId;
-
-    GroupDataProvider::GroupMapping mapping;
-    EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
+    auto fabricIndex             = commandObj->GetAccessingFabricIndex();
+    auto groupId                 = commandData.groupId;
+    GroupDataProvider * provider = GetGroupDataProvider();
+    GroupDataProvider::GroupInfo info;
+    Groups::Commands::ViewGroupResponse::Type response;
     CHIP_ERROR err       = CHIP_NO_ERROR;
-    size_t nameSize      = 0;
+    EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
 
     if (emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST && emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST_REPLY)
     {
         return true;
     }
 
-    if (IsFabricGroupId(groupId))
-    {
-        GroupDataProvider * provider = GetGroupDataProvider();
-        VerifyOrReturnError(nullptr != provider, false);
+    VerifyOrExit(IsFabricGroupId(groupId), status = EMBER_ZCL_STATUS_INVALID_VALUE);
+    VerifyOrExit(nullptr != provider, status = EMBER_ZCL_STATUS_FAILURE);
+    VerifyOrExit(provider->HasEndpoint(fabricIndex, groupId, commandPath.mEndpointId), status = EMBER_ZCL_STATUS_NOT_FOUND);
 
-        auto * groupIt = provider->IterateGroupMappings(fabricIndex, endpointId);
-        VerifyOrReturnError(nullptr != groupIt, false);
+    err = provider->GetGroupInfo(fabricIndex, groupId, info);
+    VerifyOrExit(CHIP_NO_ERROR == err, status = EMBER_ZCL_STATUS_NOT_FOUND);
 
-        while (groupIt->Next(mapping))
-        {
-            if (mapping.group == groupId)
-            {
-                nameSize = strnlen(mapping.name, GroupDataProvider::GroupMapping::kGroupNameMax);
-                status   = EMBER_ZCL_STATUS_SUCCESS;
-                break;
-            }
-        }
-        groupIt->Release();
-    }
-    else
-    {
-        status = EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-
-    {
-        app::ConcreteCommandPath path = { endpointId, Groups::Id, Commands::ViewGroupResponse::Id };
-        TLV::TLVWriter * writer       = nullptr;
-        SuccessOrExit(err = commandObj->PrepareCommand(path));
-        VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(0), status));
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
-        SuccessOrExit(err = writer->PutString(TLV::ContextTag(2), mapping.name, static_cast<uint32_t>(nameSize)));
-        SuccessOrExit(err = commandObj->FinishCommand());
-    }
+    response.groupName = CharSpan(info.name, strnlen(info.name, GroupDataProvider::GroupInfo::kGroupNameMax));
+    status             = EMBER_ZCL_STATUS_SUCCESS;
 exit:
-    if (err != CHIP_NO_ERROR)
+    response.groupId = groupId;
+    response.status  = status;
+    err              = commandObj->AddResponseData(commandPath, response);
+    if (CHIP_NO_ERROR != err)
     {
-        ChipLogError(Zcl, "Failed to encode response command.");
+        ChipLogDetail(Zcl, "GroupsCluster: ViewGroup failed: %s", err.AsString());
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }
     return true;
 }
@@ -255,14 +200,15 @@ struct GroupMembershipResponse
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
-    GroupMembershipResponse(const Commands::GetGroupMembership::DecodableType & data,
-                            GroupDataProvider::GroupMappingIterator * iter) :
+    GroupMembershipResponse(const Commands::GetGroupMembership::DecodableType & data, chip::EndpointId endpoint,
+                            GroupDataProvider::EndpointIterator * iter) :
         mCommandData(data),
-        mIterator(iter)
+        mEndpoint(endpoint), mIterator(iter)
     {}
 
     const Commands::GetGroupMembership::DecodableType & mCommandData;
-    GroupDataProvider::GroupMappingIterator * mIterator = nullptr;
+    chip::EndpointId mEndpoint                      = kInvalidEndpointId;
+    GroupDataProvider::EndpointIterator * mIterator = nullptr;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     {
@@ -278,35 +224,37 @@ struct GroupMembershipResponse
                 writer.StartContainer(TLV::ContextTag(to_underlying(Commands::GetGroupMembershipResponse::Fields::kGroupList)),
                                       TLV::kTLVType_Array, type));
             {
-                GroupDataProvider::GroupMapping mapping;
+                GroupDataProvider::GroupEndpoint mapping;
                 size_t requestedCount = 0;
                 size_t matchCount     = 0;
                 ReturnErrorOnFailure(mCommandData.groupList.ComputeSize(&requestedCount));
 
-                ChipLogDetail(Zcl, "RX: GetGroupMembership [");
                 if (0 == requestedCount)
                 {
                     // 1.3.6.3.1. If the GroupList field is empty, the entity SHALL respond with all group identifiers of which the
                     // entity is a member.
-                    while (mIterator->Next(mapping))
+                    while (mIterator && mIterator->Next(mapping))
                     {
-                        ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, mapping.group));
-                        matchCount++;
-                        ChipLogDetail(Zcl, " 0x%02" PRIx16, mapping.group);
+                        if (mapping.endpoint_id == mEndpoint)
+                        {
+                            ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, mapping.group_id));
+                            matchCount++;
+                            ChipLogDetail(Zcl, " 0x%02" PRIx16, mapping.group_id);
+                        }
                     }
                 }
                 else
                 {
-                    while (mIterator->Next(mapping))
+                    while (mIterator && mIterator->Next(mapping))
                     {
                         auto iter = mCommandData.groupList.begin();
                         while (iter.Next())
                         {
-                            if (mapping.group == iter.GetValue())
+                            if (mapping.endpoint_id == mEndpoint && mapping.group_id == iter.GetValue())
                             {
-                                ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, mapping.group));
+                                ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, mapping.group_id));
                                 matchCount++;
-                                ChipLogDetail(Zcl, " 0x%02" PRIx16, mapping.group);
+                                ChipLogDetail(Zcl, " 0x%02" PRIx16, mapping.group_id);
                                 break;
                             }
                         }
@@ -325,31 +273,29 @@ struct GroupMembershipResponse
 bool emberAfGroupsClusterGetGroupMembershipCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                     const Commands::GetGroupMembership::DecodableType & commandData)
 {
-    auto fabricIndex   = GetFabricIndex(commandObj);
-    auto * provider    = GetGroupDataProvider();
-    EmberStatus status = EMBER_ZCL_STATUS_FAILURE;
-    CHIP_ERROR err     = CHIP_NO_ERROR;
+    auto fabricIndex     = commandObj->GetAccessingFabricIndex();
+    auto * provider      = GetGroupDataProvider();
+    EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
 
-    if (nullptr == provider)
-    {
-        status = emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-    }
-    else
-    {
-        auto iter = provider->IterateGroupMappings(fabricIndex, commandPath.mEndpointId);
-        VerifyOrExit(nullptr != iter, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(nullptr != provider, status = EMBER_ZCL_STATUS_FAILURE);
 
-        err = commandObj->AddResponseData(commandPath, GroupMembershipResponse(commandData, iter));
+    {
+        GroupDataProvider::EndpointIterator * iter = nullptr;
+        CHIP_ERROR err                             = CHIP_NO_ERROR;
+
+        iter = provider->IterateEndpoints(fabricIndex);
+        VerifyOrExit(nullptr != iter, status = EMBER_ZCL_STATUS_FAILURE);
+
+        err = commandObj->AddResponseData(commandPath, GroupMembershipResponse(commandData, commandPath.mEndpointId, iter));
         iter->Release();
-        if (CHIP_NO_ERROR == err)
-        {
-            status = EMBER_SUCCESS;
-        }
+        status = (CHIP_NO_ERROR == err) ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
     }
+
 exit:
-    if (EMBER_SUCCESS != status)
+    if (EMBER_ZCL_STATUS_SUCCESS != status)
     {
-        ChipLogDetail(Zcl, "Groups: failed to send get_group_membership response: 0x%x", status);
+        ChipLogDetail(Zcl, "GroupsCluster: GetGroupMembership failed: failed: 0x%x", status);
+        emberAfSendImmediateDefaultResponse(status);
     }
     return true;
 }
@@ -357,15 +303,9 @@ exit:
 bool emberAfGroupsClusterRemoveGroupCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                              const Commands::RemoveGroup::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
-    auto groupId     = commandData.groupId;
-    auto endpointId  = commandPath.mEndpointId;
-    EmberAfStatus status;
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
+    Groups::Commands::RemoveGroupResponse::Type response;
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    ChipLogDetail(Zcl, "RX: RemoveGroup 0x%2x", groupId);
-
-    status = GroupRemove(fabricIndex, endpointId, groupId);
 
     // For all networks, Remove Group commands are only responded to when
     // they are addressed to a single device.
@@ -373,23 +313,19 @@ bool emberAfGroupsClusterRemoveGroupCallback(app::CommandHandler * commandObj, c
     {
         return true;
     }
+
 #ifdef EMBER_AF_PLUGIN_SCENES
     // If a group is, removed the scenes associated with that group SHOULD be removed.
-    emberAfScenesClusterRemoveScenesInGroupCallback(endpointId, groupId);
+    emberAfScenesClusterRemoveScenesInGroupCallback(commandPath.mEndpointId, commandData.groupId);
 #endif
+    response.groupId = commandData.groupId;
+    response.status  = GroupRemove(fabricIndex, commandPath.mEndpointId, commandData.groupId);
+
+    err = commandObj->AddResponseData(commandPath, response);
+    if (CHIP_NO_ERROR != err)
     {
-        app::ConcreteCommandPath path = { endpointId, Groups::Id, Commands::RemoveGroupResponse::Id };
-        TLV::TLVWriter * writer       = nullptr;
-        SuccessOrExit(err = commandObj->PrepareCommand(path));
-        VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(0), status));
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
-        SuccessOrExit(err = commandObj->FinishCommand());
-    }
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Zcl, "Failed to encode response command.");
+        ChipLogDetail(Zcl, "GroupsCluster: RemoveGroup failed: %s", err.AsString());
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }
     return true;
 }
@@ -397,34 +333,39 @@ exit:
 bool emberAfGroupsClusterRemoveAllGroupsCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::RemoveAllGroups::DecodableType & commandData)
 {
-    FabricIndex fabricIndex      = GetFabricIndex(commandObj);
-    GroupDataProvider * provider = GetGroupDataProvider();
-    EndpointId endpointId        = commandPath.mEndpointId;
-    EmberStatus sendStatus       = EMBER_SUCCESS;
-    CHIP_ERROR err               = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    auto fabricIndex     = commandObj->GetAccessingFabricIndex();
+    auto * provider      = GetGroupDataProvider();
+    EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
 
-    ChipLogDetail(Zcl, "RX: RemoveAllGroups");
-    VerifyOrReturnError(nullptr != provider, true);
+    VerifyOrExit(nullptr != provider, status = EMBER_ZCL_STATUS_FAILURE);
 
 #ifdef EMBER_AF_PLUGIN_SCENES
-    auto groupIter = provider->IterateGroupMappings(fabricIndex, endpointId);
-    VerifyOrReturnError(nullptr != groupIter, true);
-
-    GroupDataProvider::GroupMapping mapping;
-    while (groupIter->Next(mapping))
     {
-        emberAfScenesClusterRemoveScenesInGroupCallback(endpointId, mapping.group);
+        GroupDataProvider::EndpointIterator * iter = provider->IterateEndpoints(fabricIndex);
+        ;
+        GroupDataProvider::GroupEndpoint mapping;
+
+        VerifyOrExit(nullptr != iter, status = EMBER_ZCL_STATUS_FAILURE);
+        while (iter->Next(mapping))
+        {
+            if (commandPath.mEndpointId == mapping.endpoint_id)
+            {
+                emberAfScenesClusterRemoveScenesInGroupCallback(mapping.endpoint_id, mapping.group_id);
+            }
+        }
+        iter->Release();
+        emberAfScenesClusterRemoveScenesInGroupCallback(commandPath.mEndpointId, ZCL_SCENES_GLOBAL_SCENE_GROUP_ID);
     }
-    groupIter->Release();
-
-    emberAfScenesClusterRemoveScenesInGroupCallback(endpointId, ZCL_SCENES_GLOBAL_SCENE_GROUP_ID);
 #endif
-    err = provider->RemoveAllGroupMappings(fabricIndex, endpointId);
 
-    sendStatus = emberAfSendImmediateDefaultResponse(CHIP_NO_ERROR == err ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
-    if (EMBER_SUCCESS != sendStatus)
+    provider->RemoveEndpoint(fabricIndex, commandPath.mEndpointId);
+    status = EMBER_ZCL_STATUS_SUCCESS;
+
+exit:
+    emberAfSendImmediateDefaultResponse(status);
+    if (EMBER_ZCL_STATUS_SUCCESS != status)
     {
-        ChipLogDetail(Zcl, "Groups: failed to send %s: 0x%x", "default_response", sendStatus);
+        ChipLogDetail(Zcl, "GroupsCluster: RemoveAllGroups failed: 0x%x", status);
     }
     return true;
 }
@@ -433,15 +374,13 @@ bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(app::CommandHandler * com
                                                        const app::ConcreteCommandPath & commandPath,
                                                        const Commands::AddGroupIfIdentifying::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
     auto groupId     = commandData.groupId;
     auto groupName   = commandData.groupName;
     auto endpointId  = commandPath.mEndpointId;
 
     EmberAfStatus status;
     EmberStatus sendStatus = EMBER_SUCCESS;
-
-    ChipLogDetail(Zcl, "RX: AddGroupIfIdentifying 0x%2x, \"%.*s\"", groupId, static_cast<int>(groupName.size()), groupName.data());
 
     if (!emberAfIsDeviceIdentifying(endpointId))
     {

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -30,34 +30,24 @@ namespace Credentials {
 class GroupDataProvider
 {
 public:
-    // An EpochKey is a single key usable to determine an operational group key
-    struct EpochKey
-    {
-        static constexpr size_t kLengthBytes = Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES;
-        // Validity start time in microseconds since 2000-01-01T00:00:00 UTC ("the Epoch")
-        uint64_t start_time;
-        // Actual key bits. Depending on context, it may be a raw epoch key (as seen within `SetKeySet` calls)
-        // or it may be the derived operational group key (as seen in any other usage).
-        uint8_t key[kLengthBytes];
-    };
+    static constexpr uint16_t kMaxGroupsPerFabric    = CHIP_CONFIG_MAX_GROUPS_PER_FABRIC;
+    static constexpr uint16_t kMaxGroupKeysPerFabric = CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC;
 
-    // A GroupMapping maps a controlling GroupId to a given EndpointId. There may be
-    // multiple GroupMapping having the same `group` value, but each with different
-    // `endpoint` value.
-    struct GroupMapping
+    struct GroupInfo
     {
         static constexpr size_t kGroupNameMax = CHIP_CONFIG_MAX_GROUP_NAME_LENGTH;
 
-        // The endpoint to which a GroupId is mapped.
-        EndpointId endpoint = kInvalidEndpointId;
-        // The GroupId, which, when received in a message will map to the `endpoint`.
-        GroupId group = kUndefinedGroupId;
-        // Group name
+        // Identifies group within the scope of the given Fabric
+        chip::GroupId group_id = kUndefinedGroupId;
+        // Lastest group name written for a given GroupId on any Endpoint via the Groups cluster
         char name[kGroupNameMax + 1] = { 0 };
 
-        GroupMapping() = default;
-        GroupMapping(EndpointId eid, GroupId gid) : GroupMapping(eid, gid, nullptr) {}
-        GroupMapping(EndpointId eid, GroupId gid, const char * groupName) : endpoint(eid), group(gid)
+        GroupInfo() { SetName(nullptr); }
+        GroupInfo(const char * groupName) { SetName(groupName); }
+        GroupInfo(const CharSpan & groupName) { SetName(groupName); }
+        GroupInfo(chip::GroupId id, const char * groupName) : group_id(id) { SetName(groupName); }
+        GroupInfo(chip::GroupId id, const CharSpan & groupName) : group_id(id) { SetName(groupName); }
+        void SetName(const char * groupName)
         {
             if (nullptr == groupName)
             {
@@ -70,7 +60,7 @@ public:
                 name[size] = 0;
             }
         }
-        GroupMapping(EndpointId eid, GroupId gid, const CharSpan & groupName) : endpoint(eid), group(gid)
+        void SetName(const CharSpan & groupName)
         {
             if (nullptr == groupName.data())
             {
@@ -83,30 +73,47 @@ public:
                 name[size] = 0;
             }
         }
-        bool operator==(const GroupMapping & other)
+        bool operator==(const GroupInfo & other)
         {
-            return (this->endpoint == other.endpoint) && (this->group == other.group) &&
-                strncmp(this->name, other.name, kGroupNameMax);
+            return (this->group_id == other.group_id) && !strncmp(this->name, other.name, kGroupNameMax);
         }
     };
 
-    // A group state maps the group key set to use for encryption/decryption for a given group ID.
-    struct GroupState
+    struct GroupKey
     {
-        GroupState() = default;
-        GroupState(chip::FabricIndex fabric, chip::GroupId group_id, uint16_t key_set) :
-            fabric_index(fabric), group(group_id), keyset_id(key_set)
-        {}
-        // Fabric Index associated with the group state entry's fabric scoping
-        chip::FabricIndex fabric_index = kUndefinedFabricIndex;
-        // Identifies the group within the scope of the given fabric
-        chip::GroupId group = kUndefinedGroupId;
-        // References the set of group keys that generate operationa group keys for use with the given group
-        uint16_t keyset_id = 0;
-        bool operator==(const GroupState & other)
+        GroupKey() = default;
+        GroupKey(chip::GroupId group, chip::KeysetId keyset) : group_id(group), keyset_id(keyset) {}
+        // Identifies group within the scope of the given Fabric
+        chip::GroupId group_id = kUndefinedGroupId;
+        // Set of group keys that generate operational group keys for use with this group
+        chip::KeysetId keyset_id = 0;
+        bool operator==(const GroupKey & other) { return this->group_id == other.group_id && this->keyset_id == other.keyset_id; }
+    };
+
+    struct GroupEndpoint
+    {
+        GroupEndpoint() = default;
+        GroupEndpoint(chip::GroupId group, chip::EndpointId endpoint) : group_id(group), endpoint_id(endpoint) {}
+        // Identifies group within the scope of the given Fabric
+        chip::GroupId group_id = kUndefinedGroupId;
+        // Endpoint on the Node to which messages to this group may be forwarded
+        chip::EndpointId endpoint_id = kInvalidEndpointId;
+
+        bool operator==(const GroupEndpoint & other)
         {
-            return this->fabric_index == other.fabric_index && this->group == other.group && this->keyset_id == other.keyset_id;
+            return this->group_id == other.group_id && this->endpoint_id == other.endpoint_id;
         }
+    };
+
+    // An EpochKey is a single key usable to determine an operational group key
+    struct EpochKey
+    {
+        static constexpr size_t kLengthBytes = Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES;
+        // Validity start time in microseconds since 2000-01-01T00:00:00 UTC ("the Epoch")
+        uint64_t start_time;
+        // Actual key bits. Depending on context, it may be a raw epoch key (as seen within `SetKeySet` calls)
+        // or it may be the derived operational group key (as seen in any other usage).
+        uint8_t key[kLengthBytes];
     };
 
     // A operational group key set, usable by many GroupState mappings
@@ -115,10 +122,8 @@ public:
         using SecurityPolicy = chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy;
 
         KeySet() = default;
-        KeySet(uint16_t id) : keyset_id(id) {}
         KeySet(uint16_t id, SecurityPolicy policy_id, uint8_t num_keys) : keyset_id(id), policy(policy_id), num_keys_used(num_keys)
         {}
-        KeySet(SecurityPolicy policy_id, uint8_t num_keys) : keyset_id(0), policy(policy_id), num_keys_used(num_keys) {}
 
         // The actual keys for the group key set
         EpochKey epoch_keys[3];
@@ -131,11 +136,8 @@ public:
 
         bool operator==(const KeySet & other)
         {
-            if (this->policy == other.policy && this->num_keys_used == other.num_keys_used)
-            {
-                return !memcmp(this->epoch_keys, other.epoch_keys, this->num_keys_used * sizeof(EpochKey));
-            }
-            return false;
+            VerifyOrReturnError(this->policy == other.policy && this->num_keys_used == other.num_keys_used, false);
+            return !memcmp(this->epoch_keys, other.epoch_keys, this->num_keys_used * sizeof(EpochKey));
         }
     };
 
@@ -167,33 +169,10 @@ public:
         Iterator() = default;
     };
 
-    using GroupMappingIterator = Iterator<GroupMapping>;
-    using GroupStateIterator   = Iterator<GroupState>;
-    using KeySetIterator       = Iterator<KeySet>;
-
-    /**
-     *  Interface for a listener of changes in any Group configuration. Necessary
-     *  to implement attribute subscription for Group Key Management cluster, and
-     *  to react to configuration changes that may impact in-progress functional work.
-     */
-    class GroupListener
-    {
-    public:
-        virtual ~GroupListener() = default;
-        /**
-         *  Listener callback invoked when a GroupState entry is mutated or added.
-         *
-         *  @param[in] old_state  GroupState reflecting the previous entry. Set to nullptr on appends.
-         *  @param[in] new_state  GroupState reflecting the updated/new entry.
-         */
-        virtual void OnGroupStateChanged(const GroupState * old_state, const GroupState * new_state) = 0;
-        /**
-         *  Listener callback invoked when a GroupState entry is removed from the Groups list.
-         *
-         *  @param[in] removed_state  Copy of GroupState that was just removed. Index included is no longer accessible.
-         */
-        virtual void OnGroupStateRemoved(const GroupState * removed_state) = 0;
-    };
+    using GroupInfoIterator = Iterator<GroupInfo>;
+    using GroupKeyIterator  = Iterator<GroupKey>;
+    using EndpointIterator  = Iterator<GroupEndpoint>;
+    using KeySetIterator    = Iterator<KeySet>;
 
     GroupDataProvider()          = default;
     virtual ~GroupDataProvider() = default;
@@ -207,68 +186,68 @@ public:
      *  initialization. Must be called once before any other API succeeds.
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE if called when already initialized.
-     *  @retval #CHIP_NO_ERROR on success.
+     *  @retval #CHIP_NO_ERROR on success
      */
     virtual CHIP_ERROR Init() = 0;
     virtual void Finish()     = 0;
 
     //
-    // Group Mappings
+    // Group Table
     //
 
-    virtual bool HasGroupNamesSupport()                                                                 = 0;
-    virtual bool GroupMappingExists(chip::FabricIndex fabric_index, const GroupMapping & mapping)       = 0;
-    virtual CHIP_ERROR AddGroupMapping(chip::FabricIndex fabric_index, const GroupMapping & mapping)    = 0;
-    virtual CHIP_ERROR RemoveGroupMapping(chip::FabricIndex fabric_index, const GroupMapping & mapping) = 0;
-    virtual CHIP_ERROR RemoveAllGroupMappings(chip::FabricIndex fabric_index, EndpointId endpoint)      = 0;
+    // By id
+    virtual CHIP_ERROR SetGroupInfo(chip::FabricIndex fabric_index, const GroupInfo & info)                   = 0;
+    virtual CHIP_ERROR GetGroupInfo(chip::FabricIndex fabric_index, chip::GroupId group_id, GroupInfo & info) = 0;
+    // By index
+    virtual CHIP_ERROR SetGroupInfoAt(chip::FabricIndex fabric_index, size_t index, const GroupInfo & info) = 0;
+    virtual CHIP_ERROR GetGroupInfoAt(chip::FabricIndex fabric_index, size_t index, GroupInfo & info)       = 0;
+    virtual CHIP_ERROR RemoveGroupInfoAt(chip::FabricIndex fabric_index, size_t index)                      = 0;
+    // Endpoints
+    virtual bool HasEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id)          = 0;
+    virtual CHIP_ERROR AddEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id)    = 0;
+    virtual CHIP_ERROR RemoveEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id) = 0;
+    virtual CHIP_ERROR RemoveEndpoint(chip::FabricIndex fabric_index, chip::EndpointId endpoint_id)                         = 0;
+    // Iterators
     /**
-     *  Creates an iterator that may be used to obtain the groups associated with the given fabric.
+     *  Creates an iterator that may be used to obtain the list of groups associated with the given fabric.
      *  The number of concurrent instances of this iterator is limited. In order to release the allocated memory,
      *  the iterator's Release() method must be called after the iteration is finished.
-     *  @retval An instance of GroupMappingIterator on success
+     *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
-    virtual GroupMappingIterator * IterateGroupMappings(chip::FabricIndex fabric_index) = 0;
+    virtual GroupInfoIterator * IterateGroupInfo(chip::FabricIndex fabric_index) = 0;
     /**
-     *  Creates an iterator that may be used to obtain the groups associated with the given fabric and endpoint.
+     *  Creates an iterator that may be used to obtain the list of (group, endpoint) pairs associated with the given fabric.
      *  The number of concurrent instances of this iterator is limited. In order to release the allocated memory,
      *  the iterator's Release() method must be called after the iteration is finished.
-     *  @retval An instance of GroupMappingIterator on success
+     *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
-    virtual GroupMappingIterator * IterateGroupMappings(chip::FabricIndex fabric_index, EndpointId endpoint) = 0;
+    virtual EndpointIterator * IterateEndpoints(chip::FabricIndex fabric_index) = 0;
 
     //
-    // Group States
+    // Group-Key map
     //
 
-    virtual CHIP_ERROR SetGroupState(size_t state_index, const GroupState & state) = 0;
-    virtual CHIP_ERROR GetGroupState(size_t state_index, GroupState & state)       = 0;
-    virtual CHIP_ERROR RemoveGroupState(size_t state_index)                        = 0;
+    virtual CHIP_ERROR SetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, const GroupKey & info) = 0;
+    virtual CHIP_ERROR GetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, GroupKey & info)       = 0;
+    virtual CHIP_ERROR RemoveGroupKeyAt(chip::FabricIndex fabric_index, size_t index)                     = 0;
     /**
-     *  Creates an iterator that may be used to obtain the list of group states.
+     *  Creates an iterator that may be used to obtain the list of (group, keyset) pairs associated with the given fabric.
      *  The number of concurrent instances of this iterator is limited. In order to release the allocated memory,
      *  the iterator's Release() method must be called after the iteration is finished.
-     *  @retval An instance of GroupStateIterator on success
+     *  @retval An instance of GroupKeyIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
-    virtual GroupStateIterator * IterateGroupStates() = 0;
-    /**
-     *  Creates an iterator that may be used to obtain the list of group states associated with the given fabric.
-     *  The number of concurrent instances of this iterator is limited. In order to release the allocated memory,
-     *  the iterator's Release() method must be called after the iteration is finished.
-     *  @retval An instance of GroupStateIterator on success
-     *  @retval nullptr if no iterator instances are available.
-     */
-    virtual GroupStateIterator * IterateGroupStates(chip::FabricIndex fabric_index) = 0;
+    virtual GroupKeyIterator * IterateGroupKey(chip::FabricIndex fabric_index) = 0;
 
     //
     // Key Sets
     //
 
-    virtual CHIP_ERROR SetKeySet(chip::FabricIndex fabric_index, uint16_t keyset_id, const KeySet & keys) = 0;
-    virtual CHIP_ERROR GetKeySet(chip::FabricIndex fabric_index, uint16_t keyset_id, KeySet & keys)       = 0;
-    virtual CHIP_ERROR RemoveKeySet(chip::FabricIndex fabric_index, uint16_t keyset_id)                   = 0;
+    virtual CHIP_ERROR SetKeySet(chip::FabricIndex fabric_index, const KeySet & keys)                     = 0;
+    virtual CHIP_ERROR GetKeySet(chip::FabricIndex fabric_index, chip::KeysetId keyset_id, KeySet & keys) = 0;
+    virtual CHIP_ERROR RemoveKeySet(chip::FabricIndex fabric_index, chip::KeysetId keyset_id)             = 0;
     /**
      *  Creates an iterator that may be used to obtain the list of key sets associated with the given fabric.
      *  The number of concurrent instances of this iterator is limited. In order to release the allocated memory,
@@ -283,13 +262,6 @@ public:
 
     // General
     virtual CHIP_ERROR Decrypt(PacketHeader packetHeader, PayloadHeader & payloadHeader, System::PacketBufferHandle & msg) = 0;
-
-    // Listener
-    void SetListener(GroupListener * listener) { mListener = listener; };
-    void RemoveListener() { mListener = nullptr; };
-
-protected:
-    GroupListener * mListener = nullptr;
 };
 
 /**

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -30,7 +30,6 @@ static constexpr size_t kPersistentBufferMax = 128;
 template <size_t kMaxSerializedSize>
 struct PersistentData
 {
-public:
     virtual ~PersistentData() = default;
 
     virtual void UpdateKey(DefaultStorageKeyAllocator & key)    = 0;
@@ -51,12 +50,7 @@ public:
         ReturnErrorOnFailure(Serialize(writer));
 
         // Save serialized data
-        ReturnErrorOnFailure(storage.SyncSetKeyValue(key.KeyName(), buffer, static_cast<uint16_t>(writer.GetLengthWritten())));
-
-        // WARNING: This read-back is a walkaround for a bug in the Darwing implementation of KeyValueStoreMgr
-        //          See https://github.com/project-chip/connectedhomeip/issues/12174.
-        uint16_t size = static_cast<uint16_t>(sizeof(buffer));
-        return storage.SyncGetKeyValue(key.KeyName(), buffer, size);
+        return storage.SyncSetKeyValue(key.KeyName(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
     }
 
     CHIP_ERROR Load(chip::PersistentStorageDelegate & storage)
@@ -77,14 +71,12 @@ public:
         // Decode serialized data
         TLV::TLVReader reader;
         reader.Init(buffer, size);
-
         return Deserialize(reader);
     }
 
     CHIP_ERROR Delete(chip::PersistentStorageDelegate & storage)
     {
         DefaultStorageKeyAllocator key;
-
         // Update storage key
         UpdateKey(key);
         // Delete stored data
@@ -92,92 +84,48 @@ public:
     }
 };
 
-struct FabricData : public PersistentData<kPersistentBufferMax>
+struct LinkedData : public PersistentData<kPersistentBufferMax>
 {
-    static const TLV::Tag kTagFirstEndpoint = TLV::ContextTag(1);
-    static const TLV::Tag kTagEndpointCount = TLV::ContextTag(2);
-    static const TLV::Tag kTagFirstKeySet   = TLV::ContextTag(3);
-    static const TLV::Tag kTagKeySetCount   = TLV::ContextTag(4);
+    static constexpr uint16_t kMinLinkId = 1;
 
-    chip::FabricIndex fabric        = kUndefinedFabricIndex;
-    chip::EndpointId first_endpoint = kInvalidEndpointId;
-    uint16_t endpoint_count         = 0;
-    uint16_t first_keyset           = 0;
-    uint16_t keyset_count           = 0;
-
-    FabricData(chip::FabricIndex fabric_index) : fabric(fabric_index) {}
-
-    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricGroups(this->fabric); }
-
-    void Clear() override
-    {
-        first_endpoint = kInvalidEndpointId;
-        endpoint_count = 0;
-        first_keyset   = 0;
-        keyset_count   = 0;
-    }
-
-    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
-    {
-        TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
-
-        ReturnErrorOnFailure(writer.Put(kTagFirstEndpoint, static_cast<uint16_t>(first_endpoint)));
-        ReturnErrorOnFailure(writer.Put(kTagEndpointCount, static_cast<uint16_t>(endpoint_count)));
-        ReturnErrorOnFailure(writer.Put(kTagFirstKeySet, static_cast<uint16_t>(first_keyset)));
-        ReturnErrorOnFailure(writer.Put(kTagKeySetCount, static_cast<uint16_t>(keyset_count)));
-
-        return writer.EndContainer(container);
-    }
-    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
-    {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
-        VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
-
-        TLV::TLVType container;
-        ReturnErrorOnFailure(reader.EnterContainer(container));
-
-        // first_endpoint
-        ReturnErrorOnFailure(reader.Next(kTagFirstEndpoint));
-        ReturnErrorOnFailure(reader.Get(first_endpoint));
-        // endpoint_count
-        ReturnErrorOnFailure(reader.Next(kTagEndpointCount));
-        ReturnErrorOnFailure(reader.Get(endpoint_count));
-        // first_keyset
-        ReturnErrorOnFailure(reader.Next(kTagFirstKeySet));
-        ReturnErrorOnFailure(reader.Get(first_keyset));
-        // keyset_count
-        ReturnErrorOnFailure(reader.Next(kTagKeySetCount));
-        ReturnErrorOnFailure(reader.Get(keyset_count));
-
-        return reader.ExitContainer(container);
-    }
+    LinkedData() = default;
+    LinkedData(uint16_t linked_id) : id(linked_id) {}
+    uint16_t id     = kMinLinkId;
+    uint16_t index  = 0;
+    uint16_t next   = 0;
+    uint16_t prev   = 0;
+    uint16_t max_id = 0;
+    bool first      = true;
 };
 
-struct EndpointData : public PersistentData<kPersistentBufferMax>
+struct FabricData : public PersistentData<kPersistentBufferMax>
 {
-    static const TLV::Tag kTagFirstGroup   = TLV::ContextTag(1);
-    static const TLV::Tag kTagNextEndpoint = TLV::ContextTag(2);
+    static const TLV::Tag kTagFirstGroup  = TLV::ContextTag(1);
+    static const TLV::Tag kTagGroupCount  = TLV::ContextTag(2);
+    static const TLV::Tag kTagFirstMap    = TLV::ContextTag(3);
+    static const TLV::Tag kTagMapCount    = TLV::ContextTag(4);
+    static const TLV::Tag kTagFirstKeyset = TLV::ContextTag(5);
+    static const TLV::Tag kTagKeysetCount = TLV::ContextTag(6);
 
-    chip::FabricIndex fabric     = kUndefinedFabricIndex;
-    chip::EndpointId endpoint_id = 0;
-    chip::GroupId first_group    = kUndefinedGroupId;
-    chip::EndpointId next        = kInvalidEndpointId;
+    chip::FabricIndex fabric_index = kUndefinedFabricIndex;
+    chip::GroupId first_group      = kUndefinedGroupId;
+    uint16_t group_count           = 0;
+    uint16_t first_map             = 0;
+    uint16_t map_count             = 0;
+    chip::KeysetId first_keyset    = 0xffff;
+    uint16_t keyset_count          = 0;
 
-    EndpointData() = default;
+    FabricData() = default;
+    FabricData(chip::FabricIndex fabric) : fabric_index(fabric) {}
 
-    EndpointData(chip::FabricIndex fabric_index, chip::EndpointId endpoint = kInvalidEndpointId,
-                 chip::GroupId first = kUndefinedGroupId, chip::EndpointId next_endpoint = kInvalidEndpointId) :
-        fabric(fabric_index),
-        endpoint_id(endpoint), first_group(first), next(next_endpoint)
-    {}
-
-    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricEndpoint(this->fabric, this->endpoint_id); }
+    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricGroups(fabric_index); }
 
     void Clear() override
     {
-        first_group = kUndefinedGroupId;
-        next        = kInvalidEndpointId;
+        first_group  = kUndefinedGroupId;
+        group_count  = 0;
+        first_keyset = 0xffff;
+        keyset_count = 0;
     }
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
@@ -186,11 +134,14 @@ struct EndpointData : public PersistentData<kPersistentBufferMax>
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
         ReturnErrorOnFailure(writer.Put(kTagFirstGroup, static_cast<uint16_t>(first_group)));
-        ReturnErrorOnFailure(writer.Put(kTagNextEndpoint, static_cast<uint16_t>(next)));
+        ReturnErrorOnFailure(writer.Put(kTagGroupCount, static_cast<uint16_t>(group_count)));
+        ReturnErrorOnFailure(writer.Put(kTagFirstMap, static_cast<uint16_t>(first_map)));
+        ReturnErrorOnFailure(writer.Put(kTagMapCount, static_cast<uint16_t>(map_count)));
+        ReturnErrorOnFailure(writer.Put(kTagFirstKeyset, static_cast<uint16_t>(first_keyset)));
+        ReturnErrorOnFailure(writer.Put(kTagKeysetCount, static_cast<uint16_t>(keyset_count)));
 
         return writer.EndContainer(container);
     }
-
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
         ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
@@ -202,56 +153,186 @@ struct EndpointData : public PersistentData<kPersistentBufferMax>
         // first_group
         ReturnErrorOnFailure(reader.Next(kTagFirstGroup));
         ReturnErrorOnFailure(reader.Get(first_group));
+        // group_count
+        ReturnErrorOnFailure(reader.Next(kTagGroupCount));
+        ReturnErrorOnFailure(reader.Get(group_count));
+        // first_map
+        ReturnErrorOnFailure(reader.Next(kTagFirstMap));
+        ReturnErrorOnFailure(reader.Get(first_map));
+        // map_count
+        ReturnErrorOnFailure(reader.Next(kTagMapCount));
+        ReturnErrorOnFailure(reader.Get(map_count));
+        // first_keyset
+        ReturnErrorOnFailure(reader.Next(kTagFirstKeyset));
+        ReturnErrorOnFailure(reader.Get(first_keyset));
+        // keyset_count
+        ReturnErrorOnFailure(reader.Next(kTagKeysetCount));
+        ReturnErrorOnFailure(reader.Get(keyset_count));
+
+        return reader.ExitContainer(container);
+    }
+};
+
+struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
+{
+    static const TLV::Tag kTagGroupId       = TLV::ContextTag(1);
+    static const TLV::Tag kTagName          = TLV::ContextTag(2);
+    static const TLV::Tag kTagFirstEndpoint = TLV::ContextTag(3);
+    static const TLV::Tag kTagEndpointCount = TLV::ContextTag(4);
+    static const TLV::Tag kTagNext          = TLV::ContextTag(5);
+
+    chip::FabricIndex fabric_index  = kUndefinedFabricIndex;
+    chip::EndpointId first_endpoint = kInvalidEndpointId;
+    uint16_t endpoint_count         = 0;
+
+    GroupData() : GroupInfo(nullptr){};
+    GroupData(chip::FabricIndex fabric) : GroupInfo(), LinkedData(), fabric_index(fabric) {}
+    GroupData(chip::FabricIndex fabric, uint16_t link_id) : GroupInfo(), LinkedData(link_id), fabric_index(fabric) {}
+
+    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricGroup(fabric_index, id); }
+
+    void Clear() override
+    {
+        group_id = kUndefinedGroupId;
+        SetName(CharSpan());
+        first_endpoint = kInvalidEndpointId;
+        endpoint_count = 0;
+        next           = 0;
+    }
+
+    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
+    {
+        TLV::TLVType container;
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
+
+        size_t name_size = strnlen(name, GroupDataProvider::GroupInfo::kGroupNameMax);
+        ReturnErrorOnFailure(writer.Put(kTagGroupId, static_cast<uint16_t>(group_id)));
+        ReturnErrorOnFailure(writer.PutString(kTagName, name, static_cast<uint32_t>(name_size)));
+        ReturnErrorOnFailure(writer.Put(kTagFirstEndpoint, static_cast<uint16_t>(first_endpoint)));
+        ReturnErrorOnFailure(writer.Put(kTagEndpointCount, static_cast<uint16_t>(endpoint_count)));
+        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
+        return writer.EndContainer(container);
+    }
+    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
+    {
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+        VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
+
+        TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // group_id
+        ReturnErrorOnFailure(reader.Next(kTagGroupId));
+        ReturnErrorOnFailure(reader.Get(group_id));
+        // name
+        ReturnErrorOnFailure(reader.Next(kTagName));
+        ReturnErrorOnFailure(reader.GetString(name, sizeof(name)));
+        size_t size = strnlen(name, kGroupNameMax);
+        name[size]  = 0;
+        // first_endpoint
+        ReturnErrorOnFailure(reader.Next(kTagFirstEndpoint));
+        ReturnErrorOnFailure(reader.Get(first_endpoint));
+        // endpoint_count
+        ReturnErrorOnFailure(reader.Next(kTagEndpointCount));
+        ReturnErrorOnFailure(reader.Get(endpoint_count));
         // next
-        ReturnErrorOnFailure(reader.Next(kTagNextEndpoint));
+        ReturnErrorOnFailure(reader.Next(kTagNext));
         ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);
     }
+
+    bool Get(chip::PersistentStorageDelegate & storage, const FabricData & fabric, size_t target_index)
+    {
+        fabric_index = fabric.fabric_index;
+        id           = fabric.first_group;
+        max_id       = kMinLinkId;
+        index        = 0;
+        first        = true;
+
+        while (index < fabric.group_count)
+        {
+            if (CHIP_NO_ERROR != Load(storage))
+            {
+                break;
+            }
+            if (index == target_index)
+            {
+                // Target index found
+                return true;
+            }
+
+            max_id = std::max(id, max_id);
+            first  = false;
+            prev   = id;
+            id     = next;
+            index++;
+        }
+
+        id = static_cast<uint16_t>(max_id + 1);
+        return false;
+    }
+
+    bool Find(chip::PersistentStorageDelegate & storage, const FabricData & fabric, chip::GroupId target_group)
+    {
+        fabric_index = fabric.fabric_index;
+        id           = fabric.first_group;
+        max_id       = 0;
+        index        = 0;
+        first        = true;
+
+        while (index < fabric.group_count)
+        {
+            if (CHIP_NO_ERROR != Load(storage))
+            {
+                break;
+            }
+            if (group_id == target_group)
+            {
+                // Target index found
+                return true;
+            }
+            max_id = std::max(id, max_id);
+            first  = false;
+            prev   = id;
+            id     = next;
+            index++;
+        }
+        id = static_cast<uint16_t>(max_id + 1);
+        return false;
+    }
 };
 
-struct GroupData : public GroupDataProvider::GroupMapping, PersistentData<kPersistentBufferMax>
+struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
 {
-    static const TLV::Tag kTagName = TLV::ContextTag(1);
-    static const TLV::Tag kTagNext = TLV::ContextTag(2);
+    static const TLV::Tag kTagGroupId  = TLV::ContextTag(1);
+    static const TLV::Tag kTagKeysetId = TLV::ContextTag(2);
+    static const TLV::Tag kTagNext     = TLV::ContextTag(3);
 
-    chip::FabricIndex fabric = kUndefinedFabricIndex;
-    chip::GroupId next       = 0;
+    chip::FabricIndex fabric_index = kUndefinedFabricIndex;
+    chip::GroupId group_id         = kUndefinedGroupId;
+    chip::KeysetId keyset_id       = 0;
 
-    GroupData(chip::FabricIndex fabric_index, chip::EndpointId endpoint_id, chip::GroupId group_id,
-              chip::GroupId next_group = kUndefinedGroupId) :
-        GroupDataProvider::GroupMapping(endpoint_id, group_id),
-        fabric(fabric_index), next(next_group)
+    KeyMapData() : GroupKey(){};
+    KeyMapData(chip::FabricIndex fabric, uint16_t link_id = 0, chip::GroupId group = kUndefinedGroupId, chip::KeysetId keyset = 0) :
+        GroupKey(group, keyset), LinkedData(link_id), fabric_index(fabric)
     {}
 
-    GroupData(chip::FabricIndex fabric_index, chip::EndpointId endpoint_id, chip::GroupId group_id, const char * group_name,
-              chip::GroupId next_group = kUndefinedGroupId) :
-        GroupDataProvider::GroupMapping(endpoint_id, group_id, group_name),
-        fabric(fabric_index), next(next_group)
-    {}
+    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricGroupKey(fabric_index, id); }
 
-    void UpdateKey(DefaultStorageKeyAllocator & key) override
-    {
-        key.FabricEndpointGroup(this->fabric, this->endpoint, this->group);
-    }
-
-    void Clear() override
-    {
-        name[0] = 0;
-        next    = kUndefinedGroupId;
-    }
+    void Clear() override {}
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
-        size_t name_size = strnlen(this->name, GroupDataProvider::GroupMapping::kGroupNameMax);
-        ReturnErrorOnFailure(writer.PutString(kTagName, this->name, static_cast<uint32_t>(name_size)));
-        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(this->next)));
-
+        ReturnErrorOnFailure(writer.Put(kTagGroupId, static_cast<uint16_t>(group_id)));
+        ReturnErrorOnFailure(writer.Put(kTagKeysetId, static_cast<uint16_t>(keyset_id)));
+        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
         return writer.EndContainer(container);
     }
+
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
         ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
@@ -260,101 +341,105 @@ struct GroupData : public GroupDataProvider::GroupMapping, PersistentData<kPersi
         TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
-        // name
-        ReturnErrorOnFailure(reader.Next(kTagName));
-        ReturnErrorOnFailure(reader.GetString(this->name, sizeof(this->name)));
-        size_t size      = strnlen(this->name, kGroupNameMax);
-        this->name[size] = 0;
+        // first_endpoint
+        ReturnErrorOnFailure(reader.Next(kTagGroupId));
+        ReturnErrorOnFailure(reader.Get(group_id));
+        // endpoint_count
+        ReturnErrorOnFailure(reader.Next(kTagKeysetId));
+        ReturnErrorOnFailure(reader.Get(keyset_id));
         // next
         ReturnErrorOnFailure(reader.Next(kTagNext));
-        ReturnErrorOnFailure(reader.Get(this->next));
+        ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);
     }
+
+    bool Get(chip::PersistentStorageDelegate & storage, const FabricData & fabric, size_t target_index)
+    {
+        fabric_index = fabric.fabric_index;
+        id           = fabric.first_map;
+        max_id       = 0;
+        index        = 0;
+        first        = true;
+
+        while (index < fabric.map_count)
+        {
+            if (CHIP_NO_ERROR != Load(storage))
+            {
+                break;
+            }
+            if (index == target_index)
+            {
+                // Target index found
+                return true;
+            }
+            max_id = std::max(id, max_id);
+            first  = false;
+            prev   = id;
+            id     = next;
+            index++;
+        }
+
+        id = static_cast<uint16_t>(max_id + 1);
+        return false;
+    }
+
+    bool Find(chip::PersistentStorageDelegate & storage, const FabricData & fabric, const GroupKey & map)
+    {
+        fabric_index = fabric.fabric_index;
+        id           = fabric.first_map;
+        max_id       = 0;
+        index        = 0;
+        first        = true;
+
+        while (index < fabric.map_count)
+        {
+            if (CHIP_NO_ERROR != Load(storage))
+            {
+                break;
+            }
+            if ((group_id == map.group_id) && (keyset_id == map.keyset_id))
+            {
+                // Match found
+                return true;
+            }
+            max_id = std::max(id, max_id);
+            first  = false;
+            prev   = id;
+            id     = next;
+            index++;
+        }
+
+        id = static_cast<uint16_t>(max_id + 1);
+        return false;
+    }
 };
 
-struct StateListData : public PersistentData<kPersistentBufferMax>
+struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
 {
-    static const TLV::Tag kTagFirst = TLV::ContextTag(1);
-    static const TLV::Tag kTagCount = TLV::ContextTag(2);
+    static const TLV::Tag kTagEndpoint = TLV::ContextTag(1);
+    static const TLV::Tag kTagNext     = TLV::ContextTag(2);
 
-    uint16_t first = 0;
-    uint16_t count = 0;
+    chip::FabricIndex fabric_index = kUndefinedFabricIndex;
+    uint16_t group_link_id         = 0;
 
-    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.GroupStates(); }
-
-    void Clear() override
-    {
-        first = 0;
-        count = 0;
-    }
-
-    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
-    {
-        TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
-
-        ReturnErrorOnFailure(writer.Put(kTagFirst, static_cast<uint16_t>(first)));
-        ReturnErrorOnFailure(writer.Put(kTagCount, static_cast<uint16_t>(count)));
-
-        return writer.EndContainer(container);
-    }
-    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
-    {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
-        VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
-
-        TLV::TLVType container;
-        ReturnErrorOnFailure(reader.EnterContainer(container));
-
-        // first
-        ReturnErrorOnFailure(reader.Next(kTagFirst));
-        ReturnErrorOnFailure(reader.Get(first));
-        // count
-        ReturnErrorOnFailure(reader.Next(kTagCount));
-        ReturnErrorOnFailure(reader.Get(count));
-
-        return reader.ExitContainer(container);
-    }
-};
-
-struct StateData : public GroupDataProvider::GroupState, PersistentData<kPersistentBufferMax>
-{
-    static const TLV::Tag kTagFabric = TLV::ContextTag(1);
-    static const TLV::Tag kTagGroup  = TLV::ContextTag(2);
-    static const TLV::Tag kTagKeySet = TLV::ContextTag(3);
-    static const TLV::Tag kTagNext   = TLV::ContextTag(4);
-
-    // Linked-list entry id. May be different to state_index
-    uint16_t id = 0;
-    // Index of the next element of the linked-list
-    uint16_t next = 0;
-
-    StateData() = default;
-    StateData(uint16_t state_id, chip::FabricIndex fabric = kUndefinedFabricIndex, chip::GroupId group_id = kUndefinedGroupId,
-              uint16_t key_set = 0) :
-        GroupState(fabric, group_id, key_set),
-        id(state_id)
+    EndpointData() = default;
+    EndpointData(chip::FabricIndex fabric, uint16_t group_linked_id, uint16_t link_id = kMinLinkId,
+                 chip::GroupId group = kUndefinedGroupId, chip::EndpointId endpoint = kInvalidEndpointId) :
+        GroupEndpoint(group, endpoint),
+        LinkedData(link_id), fabric_index(fabric), group_link_id(group_linked_id)
     {}
 
-    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.GroupState(this->id); }
+    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricGroupEndpoint(fabric_index, group_link_id, id); }
 
-    void Clear() override
-    {
-        fabric_index = 0;
-        group        = kUndefinedGroupId;
-        keyset_id    = 0;
-        next         = 0;
-    }
+    void Clear() override { next = kInvalidEndpointId; }
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagFabric, static_cast<uint8_t>(fabric_index)));
-        ReturnErrorOnFailure(writer.Put(kTagGroup, static_cast<uint16_t>(group)));
-        ReturnErrorOnFailure(writer.Put(kTagKeySet, static_cast<uint16_t>(keyset_id)));
+        ReturnErrorOnFailure(writer.Put(kTagEndpoint, static_cast<uint16_t>(endpoint_id)));
         ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
 
         return writer.EndContainer(container);
@@ -367,20 +452,48 @@ struct StateData : public GroupDataProvider::GroupState, PersistentData<kPersist
         TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
-        // fabric_index
-        ReturnErrorOnFailure(reader.Next(kTagFabric));
-        ReturnErrorOnFailure(reader.Get(fabric_index));
-        // group
-        ReturnErrorOnFailure(reader.Next(kTagGroup));
-        ReturnErrorOnFailure(reader.Get(group));
-        // keyset_id
-        ReturnErrorOnFailure(reader.Next(kTagKeySet));
-        ReturnErrorOnFailure(reader.Get(keyset_id));
+        // endpoint_id
+        ReturnErrorOnFailure(reader.Next(kTagEndpoint));
+        ReturnErrorOnFailure(reader.Get(endpoint_id));
         // next
         ReturnErrorOnFailure(reader.Next(kTagNext));
         ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);
+    }
+
+    bool Find(chip::PersistentStorageDelegate & storage, const FabricData & fabric, const GroupData & group,
+              chip::EndpointId target_id)
+    {
+        fabric_index  = fabric.fabric_index;
+        group_link_id = group.id;
+        group_id      = group.group_id;
+        id            = group.first_endpoint;
+        max_id        = 0;
+        index         = 0;
+        first         = true;
+
+        while (index < group.endpoint_count)
+        {
+            if (CHIP_NO_ERROR != Load(storage))
+            {
+                break;
+            }
+            if (this->endpoint_id == target_id)
+            {
+                // Match found
+                return true;
+            }
+
+            max_id = std::max(id, max_id);
+            first  = false;
+            prev   = id;
+            id     = next;
+            index++;
+        }
+
+        id = static_cast<uint16_t>(max_id + 1);
+        return false;
     }
 };
 
@@ -394,23 +507,25 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
     static const TLV::Tag kTagKey       = TLV::ContextTag(6);
     static const TLV::Tag kTagNext      = TLV::ContextTag(7);
 
-    chip::FabricIndex fabric = kUndefinedFabricIndex;
-    uint16_t next            = 0;
+    chip::FabricIndex fabric_index = kUndefinedFabricIndex;
+    chip::KeysetId next            = 0xffff;
+    chip::KeysetId prev            = 0xffff;
+    bool first                     = true;
 
     KeySetData() = default;
-    KeySetData(chip::FabricIndex fabric_index, uint16_t id) : KeySet(id), fabric(fabric_index) {}
-    KeySetData(chip::FabricIndex fabric_index, uint16_t id, SecurityPolicy policy_id, uint8_t num_keys) :
-        KeySet(id, policy_id, num_keys), fabric(fabric_index)
+    KeySetData(chip::FabricIndex fabric, chip::KeysetId id) : fabric_index(fabric) { keyset_id = id; }
+    KeySetData(chip::FabricIndex fabric, chip::KeysetId id, SecurityPolicy policy_id, uint8_t num_keys) :
+        KeySet(id, policy_id, num_keys), fabric_index(fabric)
     {}
 
-    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricKeySet(this->fabric, this->keyset_id); }
+    void UpdateKey(DefaultStorageKeyAllocator & key) override { key.FabricKeyset(fabric_index, keyset_id); }
 
     void Clear() override
     {
         policy        = KeySet::SecurityPolicy::kStandard;
         num_keys_used = 0;
-        next          = 0;
         memset(epoch_keys, 0x00, sizeof(epoch_keys));
+        next = 0xffff;
     }
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
@@ -428,7 +543,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
         {
             TLV::TLVType array, item;
             ReturnErrorOnFailure(writer.StartContainer(kTagEpochKeys, TLV::kTLVType_Array, array));
-            for (auto & epoch : this->epoch_keys)
+            for (auto & epoch : epoch_keys)
             {
                 ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, item));
                 ReturnErrorOnFailure(writer.Put(kTagStartTime, static_cast<uint64_t>(epoch.start_time)));
@@ -467,7 +582,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
 
             TLV::TLVType array, item;
             ReturnErrorOnFailure(reader.EnterContainer(array));
-            for (auto & epoch : this->epoch_keys)
+            for (auto & epoch : epoch_keys)
             {
                 ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
                 VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
@@ -492,11 +607,44 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
 
         return reader.ExitContainer(container);
     }
+
+    bool Find(chip::PersistentStorageDelegate & storage, const FabricData & fabric, size_t target_id)
+    {
+        uint16_t count = 0;
+
+        fabric_index = fabric.fabric_index;
+        keyset_id    = fabric.first_keyset;
+        first        = true;
+
+        while (count++ < fabric.keyset_count)
+        {
+            if (CHIP_NO_ERROR != Load(storage))
+            {
+                break;
+            }
+            if (keyset_id == target_id)
+            {
+                // Target id found
+                return true;
+            }
+
+            first     = false;
+            prev      = keyset_id;
+            keyset_id = next;
+        }
+
+        return false;
+    }
 };
 
 //
 // General
 //
+
+constexpr uint16_t GroupDataProvider::kMaxGroupsPerFabric;
+constexpr uint16_t GroupDataProvider::kMaxGroupKeysPerFabric;
+constexpr size_t GroupDataProvider::GroupInfo::kGroupNameMax;
+constexpr size_t GroupDataProviderImpl::kIteratorsMax;
 
 CHIP_ERROR GroupDataProviderImpl::Init()
 {
@@ -510,748 +658,592 @@ void GroupDataProviderImpl::Finish()
 }
 
 //
-// Group Mappings
+// Group Info
 //
 
-constexpr size_t GroupDataProvider::GroupMapping::kGroupNameMax;
-
-bool GroupDataProviderImpl::HasGroupNamesSupport()
+CHIP_ERROR GroupDataProviderImpl::SetGroupInfo(chip::FabricIndex fabric_index, const GroupInfo & info)
 {
-    return true;
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    GroupData group;
+
+    // Load fabric data (defaults to zero)
+    fabric.Load(mStorage);
+    if (group.Find(mStorage, fabric, info.group_id))
+    {
+        // Existing group_id
+        group.SetName(info.name);
+        return group.Save(mStorage);
+    }
+    else
+    {
+        // New group_id
+        group.group_id = info.group_id;
+        group.SetName(info.name);
+        return SetGroupInfoAt(fabric_index, fabric.group_count, group);
+    }
 }
 
-bool GroupDataProviderImpl::GroupMappingExists(chip::FabricIndex fabric_index, const GroupMapping & mapping)
+CHIP_ERROR GroupDataProviderImpl::GetGroupInfo(chip::FabricIndex fabric_index, chip::GroupId group_id, GroupInfo & info)
+{
+    FabricData fabric(fabric_index);
+    GroupData group;
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(group.Find(mStorage, fabric, group_id), CHIP_ERROR_KEY_NOT_FOUND);
+
+    info.group_id = group_id;
+    info.SetName(group.name);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupDataProviderImpl::SetGroupInfoAt(chip::FabricIndex fabric_index, size_t index, const GroupInfo & info)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    GroupData group;
+
+    // Load fabric, defaults to zero
+    fabric.Load(mStorage);
+
+    // If the group exists, the index must match
+    bool found = group.Find(mStorage, fabric, info.group_id);
+    VerifyOrReturnError(!found || (group.index == index), CHIP_ERROR_DUPLICATE_KEY_ID);
+
+    found          = group.Get(mStorage, fabric, index);
+    group.group_id = info.group_id;
+    group.SetName(info.name);
+
+    if (found)
+    {
+        // Update existing group
+        return group.Save(mStorage);
+    }
+
+    // Insert last
+    VerifyOrReturnError(fabric.group_count == index, CHIP_ERROR_INVALID_ARGUMENT);
+
+    group.next = 0;
+    ReturnErrorOnFailure(group.Save(mStorage));
+
+    if (group.first)
+    {
+        // First group, update fabric
+        fabric.first_group = group.id;
+    }
+    else
+    {
+        // Last group, update previous
+        GroupData prev(fabric_index, group.prev);
+        ReturnErrorOnFailure(prev.Load(mStorage));
+        prev.next = group.id;
+        ReturnErrorOnFailure(prev.Save(mStorage));
+    }
+    // Update fabric
+    fabric.group_count++;
+    return fabric.Save(mStorage);
+}
+
+CHIP_ERROR GroupDataProviderImpl::GetGroupInfoAt(chip::FabricIndex fabric_index, size_t index, GroupInfo & info)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    GroupData group;
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(group.Get(mStorage, fabric, index), CHIP_ERROR_KEY_NOT_FOUND);
+
+    // Target group found
+    info.group_id = group.group_id;
+    info.SetName(group.name);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupDataProviderImpl::RemoveGroupInfoAt(chip::FabricIndex fabric_index, size_t index)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    GroupData group;
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(group.Get(mStorage, fabric, index), CHIP_ERROR_KEY_NOT_FOUND);
+
+    // Remove endpoints
+    EndpointData endpoint(fabric_index, group.id, group.first_endpoint);
+    size_t count = 0;
+    while (count++ < group.endpoint_count)
+    {
+        if (CHIP_NO_ERROR != endpoint.Load(mStorage))
+        {
+            break;
+        }
+        endpoint.Delete(mStorage);
+        endpoint.id = endpoint.next;
+    }
+
+    ReturnErrorOnFailure(group.Delete(mStorage));
+    if (group.first)
+    {
+        // Remove first group
+        fabric.first_group = group.next;
+    }
+    else
+    {
+        // Remove intermediate group, update previous
+        GroupData prev_data(fabric_index, group.prev);
+        ReturnErrorOnFailure(prev_data.Load(mStorage));
+        prev_data.next = group.next;
+        ReturnErrorOnFailure(prev_data.Save(mStorage));
+    }
+    if (fabric.group_count > 0)
+    {
+        fabric.group_count--;
+    }
+    // Update fabric info
+    return fabric.Save(mStorage);
+}
+
+bool GroupDataProviderImpl::HasEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id)
 {
     VerifyOrReturnError(mInitialized, false);
 
     FabricData fabric(fabric_index);
+    GroupData group;
+    EndpointData endpoint;
 
     VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), false);
-    VerifyOrReturnError(kInvalidEndpointId != fabric.first_endpoint, false);
-
-    // Existing fabric
-
-    EndpointData endpoint(fabric_index, fabric.first_endpoint);
-    size_t endpoint_count = 0;
-
-    // Loop through the fabric's endpoints
-    do
-    {
-        VerifyOrReturnError(CHIP_NO_ERROR == endpoint.Load(mStorage), false);
-        if (endpoint.endpoint_id == mapping.endpoint)
-        {
-            // Target endpoint found
-            break;
-        }
-        endpoint.endpoint_id = endpoint.next;
-    } while ((++endpoint_count < fabric.endpoint_count) && (kInvalidEndpointId != endpoint.endpoint_id));
-    VerifyOrReturnError(endpoint.endpoint_id == mapping.endpoint, false);
-
-    // Target endpoint found
-
-    GroupData group(fabric_index, mapping.endpoint, endpoint.first_group);
-
-    // Loop through the endpoint's groups
-    do
-    {
-        // Load next group
-        VerifyOrReturnError(CHIP_NO_ERROR == group.Load(mStorage), false);
-        if (group.group == mapping.group)
-        {
-            // Target group found
-            return true;
-        }
-        group.group = group.next;
-    } while (kUndefinedGroupId != group.group);
-
-    // Not found
-    return false;
+    VerifyOrReturnError(group.Find(mStorage, fabric, group_id), false);
+    return endpoint.Find(mStorage, fabric, group, endpoint_id);
 }
 
-CHIP_ERROR GroupDataProviderImpl::AddGroupMapping(chip::FabricIndex fabric_index, const GroupMapping & mapping)
+CHIP_ERROR GroupDataProviderImpl::AddEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id)
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(kInvalidEndpointId != mapping.endpoint, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(IsFabricGroupId(mapping.group), CHIP_ERROR_INVALID_ARGUMENT);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
     FabricData fabric(fabric_index);
+    GroupData group;
 
-    if (CHIP_NO_ERROR != fabric.Load(mStorage) || kInvalidEndpointId == fabric.first_endpoint)
+    // Load fabric data (defaults to zero)
+    fabric.Load(mStorage);
+
+    if (!group.Find(mStorage, fabric, group_id))
     {
-        // New fabric, or new endpoint
-        GroupData group(fabric_index, mapping.endpoint, mapping.group, mapping.name);
+        // New group
+        EndpointData endpoint(fabric_index, group.id);
+        endpoint.endpoint_id = endpoint_id;
+        ReturnErrorOnFailure(endpoint.Save(mStorage));
+        // Save the new group into the fabric
+        group.group_id       = group_id;
+        group.first_endpoint = endpoint.id;
+        group.endpoint_count = 1;
+        group.next           = fabric.first_group;
+        group.prev           = kUndefinedGroupId;
         ReturnErrorOnFailure(group.Save(mStorage));
-
-        EndpointData endpoint(fabric_index, mapping.endpoint, mapping.group);
-        err = endpoint.Save(mStorage);
-        if (CHIP_NO_ERROR != err)
-        {
-            // Clean-up the orphan group
-            group.Delete(mStorage);
-            return err;
-        }
-
-        fabric.first_endpoint = mapping.endpoint;
-        fabric.endpoint_count = 1;
-        err                   = fabric.Save(mStorage);
-        if (CHIP_NO_ERROR != err)
-        {
-            // Clean-up the orphan entries
-            group.Delete(mStorage);
-            endpoint.Delete(mStorage);
-        }
-        return err;
-    }
-
-    // Existing fabric
-
-    EndpointData endpoint(fabric_index, fabric.first_endpoint);
-    size_t endpoint_count = 0;
-
-    // Loop through the fabric's endpoints
-    do
-    {
-        if (CHIP_NO_ERROR != endpoint.Load(mStorage))
-        {
-            // Endpoint info not found
-            break;
-        }
-        if (endpoint.endpoint_id == mapping.endpoint)
-        {
-            // Target endpoint info found
-            break;
-        }
-        endpoint.endpoint_id = endpoint.next;
-    } while ((++endpoint_count < fabric.endpoint_count) && (kInvalidEndpointId != endpoint.endpoint_id));
-
-    if (endpoint.endpoint_id != mapping.endpoint)
-    {
-        // Endpoint not found, create new, and insert first
-        GroupData group(fabric_index, mapping.endpoint, mapping.group, mapping.name);
-        ReturnErrorOnFailure(group.Save(mStorage));
-
-        endpoint.endpoint_id = mapping.endpoint;
-        endpoint.first_group = mapping.group;
-        endpoint.next        = fabric.first_endpoint;
-        err                  = endpoint.Save(mStorage);
-        if (CHIP_NO_ERROR != err)
-        {
-            // Clean-up the orphan group
-            group.Delete(mStorage);
-            return err;
-        }
-
-        fabric.first_endpoint = mapping.endpoint;
-        fabric.endpoint_count++;
+        // Update fabric
+        fabric.first_group = group.id;
+        fabric.group_count++;
         return fabric.Save(mStorage);
     }
 
-    // Endpoint info found, loop endpoints
+    // Existing group
+    EndpointData endpoint;
+    VerifyOrReturnError(!endpoint.Find(mStorage, fabric, group, endpoint_id), CHIP_NO_ERROR);
 
-    GroupData group(fabric_index, endpoint.endpoint_id, endpoint.first_group);
+    // New endpoint, insert last
+    endpoint.endpoint_id = endpoint_id;
+    ReturnErrorOnFailure(endpoint.Save(mStorage));
+    if (endpoint.first)
+    {
+        // First endpoint of group
+        group.first_endpoint = endpoint.id;
+    }
+    else
+    {
+        // Previous endpoint(s)
+        ReturnErrorOnFailure(endpoint.Save(mStorage));
+        EndpointData prev(fabric_index, group.id, endpoint.prev);
+        ReturnErrorOnFailure(prev.Load(mStorage));
+        prev.next = endpoint.id;
+        ReturnErrorOnFailure(prev.Save(mStorage));
+    }
+    group.endpoint_count++;
+    return group.Save(mStorage);
+}
 
-    do
+CHIP_ERROR GroupDataProviderImpl::RemoveEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id,
+                                                 chip::EndpointId endpoint_id)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    GroupData group;
+    EndpointData endpoint;
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(group.Find(mStorage, fabric, group_id), CHIP_ERROR_KEY_NOT_FOUND);
+    VerifyOrReturnError(endpoint.Find(mStorage, fabric, group, endpoint_id), CHIP_ERROR_KEY_NOT_FOUND);
+
+    // Existing endpoint
+    endpoint.Delete(mStorage);
+
+    if (endpoint.first)
+    {
+        // Remove first
+        group.first_endpoint = endpoint.next;
+    }
+    else
+    {
+        // Remove middle
+        EndpointData prev(fabric_index, group.id, endpoint.prev);
+        ReturnErrorOnFailure(prev.Load(mStorage));
+        prev.next = endpoint.next;
+        ReturnErrorOnFailure(prev.Save(mStorage));
+    }
+    if (group.endpoint_count > 0)
+    {
+        group.endpoint_count--;
+    }
+    return group.Save(mStorage);
+}
+
+CHIP_ERROR GroupDataProviderImpl::RemoveEndpoint(chip::FabricIndex fabric_index, chip::EndpointId endpoint_id)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+
+    GroupData group(fabric_index, fabric.first_group);
+    size_t group_index = 0;
+
+    // Loop through all the groups
+    while (group_index < fabric.group_count)
     {
         if (CHIP_NO_ERROR != group.Load(mStorage))
         {
             break;
         }
-        if (group.group == mapping.group)
+        EndpointData endpoint(fabric_index, group.id, group.first_endpoint);
+        EndpointData prev_endpoint;
+        size_t endpoint_index = 0;
+        while (endpoint_index < group.endpoint_count)
         {
-            // Duplicated group
-            return CHIP_NO_ERROR;
+            if (CHIP_NO_ERROR != endpoint.Load(mStorage))
+            {
+                break;
+            }
+            if (endpoint.endpoint_id == endpoint_id)
+            {
+                // Remove endpoint from curent group
+                if (0 == endpoint_index)
+                {
+                    // Remove first
+                    group.first_endpoint = endpoint.next;
+                }
+                else
+                {
+                    prev_endpoint.next = endpoint.next;
+                    ReturnErrorOnFailure(prev_endpoint.Save(mStorage));
+                }
+                endpoint.Delete(mStorage);
+                if (group.endpoint_count > 0)
+                {
+                    group.endpoint_count--;
+                }
+                ReturnErrorOnFailure(group.Save(mStorage));
+            }
+            prev_endpoint = endpoint;
+            endpoint.id   = endpoint.next;
+            endpoint_index++;
         }
-        group.group = group.next;
-    } while (kUndefinedGroupId != group.group);
-
-    // Insert group first, update endpoint
-    ReturnErrorOnFailure(
-        GroupData(fabric_index, mapping.endpoint, mapping.group, mapping.name, endpoint.first_group).Save(mStorage));
-    endpoint.first_group = mapping.group;
-    return endpoint.Save(mStorage);
-}
-
-CHIP_ERROR GroupDataProviderImpl::RemoveGroupMapping(chip::FabricIndex fabric_index, const GroupMapping & mapping)
-{
-    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(kInvalidEndpointId != mapping.endpoint, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(IsFabricGroupId(mapping.group), CHIP_ERROR_INVALID_ARGUMENT);
-
-    FabricData fabric(fabric_index);
-
-    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
-    VerifyOrReturnError(kInvalidEndpointId != fabric.first_endpoint, CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Existing fabric
-
-    EndpointData endpoint(fabric_index, fabric.first_endpoint);
-    size_t endpoint_count = 0;
-
-    // Loop through the fabric's endpoints
-    do
-    {
-        VerifyOrReturnError(CHIP_NO_ERROR == endpoint.Load(mStorage), CHIP_ERROR_KEY_NOT_FOUND);
-        if (endpoint.endpoint_id == mapping.endpoint)
-        {
-            // Target endpoint info found
-            break;
-        }
-        endpoint.endpoint_id = endpoint.next;
-    } while ((++endpoint_count < fabric.endpoint_count) && (kInvalidEndpointId != endpoint.endpoint_id));
-    VerifyOrReturnError(endpoint.endpoint_id == mapping.endpoint, CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Target endpoint found
-
-    GroupData group(fabric_index, endpoint.endpoint_id, endpoint.first_group);
-    chip::GroupId prev_gid = kUndefinedGroupId;
-
-    do
-    {
-        VerifyOrReturnError(CHIP_NO_ERROR == group.Load(mStorage), CHIP_ERROR_KEY_NOT_FOUND);
-        if (group.group == mapping.group)
-        {
-            // Target group found
-            break;
-        }
-        prev_gid    = group.group;
-        group.group = group.next;
-    } while (kUndefinedGroupId != group.group);
-
-    VerifyOrReturnError(group.group == mapping.group, CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Target group found, remove
-    ReturnErrorOnFailure(group.Delete(mStorage));
-
-    if (prev_gid == kUndefinedGroupId)
-    {
-        // Removing first group, update endpoint
-        endpoint.first_group = group.next;
-        return endpoint.Save(mStorage);
+        group.id = group.next;
+        group_index++;
     }
 
-    // Removing intermediate group, update previous
-
-    GroupData prev_group(fabric_index, endpoint.endpoint_id, prev_gid);
-    ReturnErrorOnFailure(prev_group.Load(mStorage));
-
-    prev_group.next = group.next;
-    return prev_group.Save(mStorage);
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GroupDataProviderImpl::RemoveAllGroupMappings(chip::FabricIndex fabric_index, EndpointId endpoint_id)
-{
-    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(kInvalidEndpointId != endpoint_id, CHIP_ERROR_INVALID_ARGUMENT);
-
-    FabricData fabric(fabric_index);
-
-    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
-    VerifyOrReturnError(kInvalidEndpointId != fabric.first_endpoint, CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Existing fabric
-
-    EndpointData endpoint(fabric_index, fabric.first_endpoint);
-    chip::EndpointId prev_eid = kInvalidEndpointId;
-    size_t endpoint_count     = 0;
-
-    // Loop through the fabric's endpoints
-    do
-    {
-        VerifyOrReturnError(CHIP_NO_ERROR == endpoint.Load(mStorage), CHIP_ERROR_KEY_NOT_FOUND);
-        if (endpoint.endpoint_id == endpoint_id)
-        {
-            // Target endpoint info found
-            break;
-        }
-        prev_eid             = endpoint.endpoint_id;
-        endpoint.endpoint_id = endpoint.next;
-    } while ((++endpoint_count < fabric.endpoint_count) && (kInvalidEndpointId != endpoint.endpoint_id));
-    VerifyOrReturnError(endpoint.endpoint_id == endpoint_id, CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Target endpoint found
-    GroupData group(fabric_index, endpoint.endpoint_id, endpoint.first_group);
-
-    // Remove endpoint's groups
-    do
-    {
-        ReturnErrorOnFailure(group.Load(mStorage));
-        group.Delete(mStorage);
-        group.group = group.next;
-    } while (kUndefinedGroupId != group.group);
-
-    // Remove endpoint
-    ReturnErrorOnFailure(endpoint.Delete(mStorage));
-
-    if (kInvalidEndpointId == prev_eid)
-    {
-        // First endpoint, update fabric info
-        fabric.first_endpoint = endpoint.next;
-        return fabric.Save(mStorage);
-    }
-    else
-    {
-        // Mid endpoint, update previous endpoint's info
-        EndpointData prev_endpoint(fabric_index, prev_eid);
-        ReturnErrorOnFailure(prev_endpoint.Load(mStorage));
-        prev_endpoint.next = endpoint.next;
-        return prev_endpoint.Save(mStorage);
-    }
-}
-
-GroupDataProvider::GroupMappingIterator * GroupDataProviderImpl::IterateGroupMappings(chip::FabricIndex fabric_index)
+GroupDataProvider::GroupInfoIterator * GroupDataProviderImpl::IterateGroupInfo(chip::FabricIndex fabric_index)
 {
     VerifyOrReturnError(mInitialized, nullptr);
-    return mAllGroupsIterators.CreateObject(*this, fabric_index);
+    return mGroupInfoIterators.CreateObject(*this, fabric_index);
 }
 
-GroupDataProviderImpl::AllGroupMappingsIteratorImpl::AllGroupMappingsIteratorImpl(GroupDataProviderImpl & provider,
-                                                                                  chip::FabricIndex fabric_index) :
+GroupDataProviderImpl::GroupInfoIteratorImpl::GroupInfoIteratorImpl(GroupDataProviderImpl & provider,
+                                                                    chip::FabricIndex fabric_index) :
     mProvider(provider),
     mFabric(fabric_index)
 {
     FabricData fabric(fabric_index);
-    ReturnOnFailure(fabric.Load(provider.mStorage));
-
-    // Existing fabric
-    mFirstEndpoint = fabric.first_endpoint;
-    mFirstGroup    = true;
-    mEndpointCount = fabric.endpoint_count;
-    mEndpoint      = fabric.first_endpoint;
-    mEndpointIndex = 0;
-}
-
-size_t GroupDataProviderImpl::AllGroupMappingsIteratorImpl::Count()
-{
-    size_t count          = 0;
-    size_t endpoint_index = 0;
-    EndpointData endpoint_data(mFabric, mFirstEndpoint);
-
-    // Loop through the fabric's endpoints
-    while ((endpoint_index < mEndpointCount) && (CHIP_NO_ERROR == endpoint_data.Load(mProvider.mStorage)))
+    if (CHIP_NO_ERROR == fabric.Load(provider.mStorage))
     {
-        GroupData group_data(mFabric, endpoint_data.endpoint_id, endpoint_data.first_group);
-        // Loop through the endpoint's groups
-        while ((kUndefinedGroupId != group_data.group) && (CHIP_NO_ERROR == group_data.Load(mProvider.mStorage)))
-        {
-            group_data.group = group_data.next;
-            count++;
-        }
-        endpoint_data.endpoint_id = endpoint_data.next;
-        endpoint_index++;
+        mNextId = fabric.first_group;
+        mTotal  = fabric.group_count;
+        mCount  = 0;
     }
-
-    return count;
 }
 
-bool GroupDataProviderImpl::AllGroupMappingsIteratorImpl::Next(GroupMapping & item)
+size_t GroupDataProviderImpl::GroupInfoIteratorImpl::Count()
 {
-    while (mEndpointIndex < mEndpointCount)
-    {
-        EndpointData endpoint_data(mFabric, mEndpoint);
-        if (CHIP_NO_ERROR != endpoint_data.Load(mProvider.mStorage))
-        {
-            mEndpointIndex = mEndpointCount;
-            return false;
-        }
-
-        if (mFirstGroup)
-        {
-            mGroup      = endpoint_data.first_group;
-            mFirstGroup = false;
-        }
-
-        GroupData group_data(mFabric, mEndpoint, mGroup);
-        if ((kUndefinedGroupId != mGroup) && CHIP_NO_ERROR == group_data.Load(mProvider.mStorage))
-        {
-            item.endpoint = mEndpoint;
-            item.group    = mGroup;
-            size_t size   = strnlen(group_data.name, GroupData::kGroupNameMax);
-            strncpy(item.name, group_data.name, size);
-            item.name[size] = 0;
-            mGroup          = group_data.next;
-            return true;
-        }
-
-        mEndpoint = endpoint_data.next;
-        mEndpointIndex++;
-        mFirstGroup = true;
-    }
-    return false;
+    return mTotal;
 }
 
-void GroupDataProviderImpl::AllGroupMappingsIteratorImpl::Release()
+bool GroupDataProviderImpl::GroupInfoIteratorImpl::Next(GroupInfo & output)
 {
-    mProvider.mAllGroupsIterators.ReleaseObject(this);
+    VerifyOrReturnError(mCount < mTotal, false);
+
+    GroupData group(mFabric, mNextId);
+    VerifyOrReturnError(CHIP_NO_ERROR == group.Load(mProvider.mStorage), false);
+
+    mCount++;
+    mNextId         = group.next;
+    output.group_id = group.group_id;
+    output.SetName(group.name);
+    return true;
 }
 
-GroupDataProvider::GroupMappingIterator * GroupDataProviderImpl::IterateGroupMappings(chip::FabricIndex fabric_index,
-                                                                                      EndpointId endpoint_id)
+void GroupDataProviderImpl::GroupInfoIteratorImpl::Release()
+{
+    mProvider.mGroupInfoIterators.ReleaseObject(this);
+}
+
+GroupDataProvider::EndpointIterator * GroupDataProviderImpl::IterateEndpoints(chip::FabricIndex fabric_index)
 {
     VerifyOrReturnError(mInitialized, nullptr);
-    return mEndpointGroupsIterators.CreateObject(*this, fabric_index, endpoint_id);
+    return mEndpointIterators.CreateObject(*this, fabric_index);
 }
 
-GroupDataProviderImpl::GroupMappingIteratorImpl::GroupMappingIteratorImpl(GroupDataProviderImpl & provider,
-                                                                          chip::FabricIndex fabric_index,
-                                                                          chip::EndpointId endpoint_id) :
+GroupDataProviderImpl::EndpointIteratorImpl::EndpointIteratorImpl(GroupDataProviderImpl & provider,
+                                                                  chip::FabricIndex fabric_index) :
     mProvider(provider),
-    mFabric(fabric_index), mEndpoint(endpoint_id)
+    mFabric(fabric_index)
 {
     FabricData fabric(fabric_index);
-    ReturnOnFailure(fabric.Load(provider.mStorage));
+    VerifyOrReturn(CHIP_NO_ERROR == fabric.Load(provider.mStorage));
 
-    // Existing fabric
+    GroupData group(fabric_index, fabric.first_group);
+    VerifyOrReturn(CHIP_NO_ERROR == group.Load(provider.mStorage));
 
-    EndpointData endpoint(fabric_index, fabric.first_endpoint);
-    uint16_t count = 0;
-
-    // Loop through the fabric's endpoints
-    do
-    {
-        ReturnOnFailure(endpoint.Load(provider.mStorage));
-        if (endpoint.endpoint_id == endpoint_id)
-        {
-            // Target endpoint found
-            mFirstGroup = endpoint.first_group;
-            break;
-        }
-        endpoint.endpoint_id = endpoint.next;
-    } while (++count < fabric.endpoint_count);
-
-    mGroup = mFirstGroup;
+    mGroup         = fabric.first_group;
+    mFirstGroup    = fabric.first_group;
+    mGroupCount    = fabric.group_count;
+    mEndpoint      = group.first_endpoint;
+    mEndpointCount = group.endpoint_count;
 }
 
-size_t GroupDataProviderImpl::GroupMappingIteratorImpl::Count()
+size_t GroupDataProviderImpl::EndpointIteratorImpl::Count()
 {
-    size_t count = 0;
+    GroupData group(mFabric, mFirstGroup);
+    size_t group_index    = 0;
+    size_t endpoint_index = 0;
+    size_t count          = 0;
 
-    GroupData group(mFabric, mEndpoint, mFirstGroup);
-    chip::GroupId prev_gid = kUndefinedGroupId;
-
-    while ((kUndefinedGroupId != group.group) && (prev_gid != group.group))
+    while (group_index++ < mGroupCount)
     {
         if (CHIP_NO_ERROR != group.Load(mProvider.mStorage))
         {
             break;
         }
-        prev_gid    = group.group;
-        group.group = group.next;
-        count++;
-    }
-    return count;
-}
-
-bool GroupDataProviderImpl::GroupMappingIteratorImpl::Next(GroupMapping & item)
-{
-    GroupData group(mFabric, mEndpoint, mGroup);
-    CHIP_ERROR err = group.Load(mProvider.mStorage);
-    if ((kUndefinedGroupId == mGroup) || (CHIP_NO_ERROR != err))
-    {
-        return false;
-    }
-    item.endpoint = mEndpoint;
-    item.group    = mGroup;
-    size_t size   = strnlen(group.name, GroupData::kGroupNameMax);
-    strncpy(item.name, group.name, size);
-    item.name[size] = 0;
-    mGroup          = group.next;
-    return true;
-}
-
-void GroupDataProviderImpl::GroupMappingIteratorImpl::Release()
-{
-    mProvider.mEndpointGroupsIterators.ReleaseObject(this);
-}
-
-//
-// Group States
-//
-
-CHIP_ERROR GroupDataProviderImpl::SetGroupState(size_t state_index, const GroupState & in_state)
-{
-    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(IsFabricGroupId(in_state.group), CHIP_ERROR_INVALID_ARGUMENT);
-
-    StateListData states;
-
-    if (CHIP_NO_ERROR != states.Load(mStorage))
-    {
-        // First state
-        VerifyOrReturnError(0 == state_index, CHIP_ERROR_INVALID_ARGUMENT);
-        states.first = 0;
-        states.count = 1;
-        ReturnLogErrorOnFailure(StateData(states.first, in_state.fabric_index, in_state.group, in_state.keyset_id).Save(mStorage));
-        return states.Save(mStorage);
-    }
-
-    StateData state(states.first);
-    StateData prev_state;
-    uint16_t index  = 0;
-    uint16_t new_id = 0;
-    bool found      = false;
-    bool previous   = false;
-
-    // Loop until the desired index
-    do
-    {
-        if (CHIP_NO_ERROR != state.Load(mStorage))
+        EndpointData endpoint_data(mFabric, group.id, group.first_endpoint);
+        while (endpoint_index++ < group.endpoint_count)
         {
-            break;
-        }
-        if (new_id == state.id)
-        {
-            // Used index, keep looking
-            new_id++;
-        }
-        if (index == state_index)
-        {
-            // Target index found
-            found = true;
-            break;
-        }
-        previous   = true;
-        prev_state = state;
-        state.id   = state.next;
-    } while (++index < states.count);
-
-    VerifyOrReturnError(state_index <= index, CHIP_ERROR_INVALID_ARGUMENT);
-
-    if (found)
-    {
-        // Update existing state, must be in the same fabric
-        VerifyOrReturnError(state.fabric_index == in_state.fabric_index, CHIP_ERROR_ACCESS_DENIED);
-        GroupState old_state = state;
-        state.group          = in_state.group;
-        state.keyset_id      = in_state.keyset_id;
-        ReturnErrorOnFailure(state.Save(mStorage));
-        if (nullptr != mListener)
-        {
-            mListener->OnGroupStateChanged(&old_state, &state);
-        }
-        return CHIP_NO_ERROR;
-    }
-
-    // New state
-    ReturnErrorOnFailure(StateData(new_id, in_state.fabric_index, in_state.group, in_state.keyset_id).Save(mStorage));
-
-    if (previous)
-    {
-        // New middle state, update previous
-        prev_state.next = new_id;
-        ReturnErrorOnFailure(prev_state.Save(mStorage));
-    }
-    else
-    {
-        // New first state
-        states.first = new_id;
-    }
-    // Update main list
-    states.count = static_cast<uint16_t>(index + 1);
-    return states.Save(mStorage);
-}
-
-CHIP_ERROR GroupDataProviderImpl::GetGroupState(size_t state_index, GroupState & out_state)
-{
-    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
-
-    StateListData states;
-    VerifyOrReturnError(CHIP_NO_ERROR == states.Load(mStorage), CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Fabric info found
-
-    StateData state(states.first);
-    size_t index = 0;
-
-    // Loop until the desired index
-    while (index < states.count)
-    {
-        if (CHIP_NO_ERROR != state.Load(mStorage))
-        {
-            break;
-        }
-        if (index == state_index)
-        {
-            // Target index found
-            out_state.fabric_index = state.fabric_index;
-            out_state.group        = state.group;
-            out_state.keyset_id    = state.keyset_id;
-            return CHIP_NO_ERROR;
-        }
-        state.id = state.next;
-        index++;
-    }
-    return CHIP_ERROR_KEY_NOT_FOUND;
-}
-
-CHIP_ERROR GroupDataProviderImpl::RemoveGroupState(size_t state_index)
-{
-    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
-
-    StateListData states;
-
-    VerifyOrReturnError(CHIP_NO_ERROR == states.Load(mStorage), CHIP_ERROR_KEY_NOT_FOUND);
-
-    StateData state(states.first);
-    StateData prev_state;
-    size_t index  = 0;
-    bool found    = false;
-    bool previous = false;
-
-    // Loop until the desired index
-    while (index < states.count)
-    {
-        if (CHIP_NO_ERROR != state.Load(mStorage))
-        {
-            break;
-        }
-        if (index == state_index)
-        {
-            // Target index found
-            found = true;
-            break;
-        }
-        previous   = true;
-        prev_state = state;
-        state.id   = state.next;
-        index++;
-    }
-
-    VerifyOrReturnError(found, CHIP_ERROR_KEY_NOT_FOUND);
-
-    if (states.count > 0)
-    {
-        states.count--;
-    }
-
-    ReturnErrorOnFailure(state.Delete(mStorage));
-    if (previous)
-    {
-        // Remove intermediate state
-        prev_state.next = state.next;
-        ReturnErrorOnFailure(prev_state.Save(mStorage));
-    }
-    else
-    {
-        // Remove first state
-        states.first = state.next;
-    }
-    ReturnErrorOnFailure(states.Save(mStorage));
-    if (nullptr != mListener)
-    {
-        mListener->OnGroupStateRemoved(&state);
-    }
-    return CHIP_NO_ERROR;
-}
-
-GroupDataProvider::GroupStateIterator * GroupDataProviderImpl::IterateGroupStates()
-{
-    VerifyOrReturnError(mInitialized, nullptr);
-    return mAllStatesIterators.CreateObject(*this);
-}
-
-GroupDataProvider::GroupStateIterator * GroupDataProviderImpl::IterateGroupStates(chip::FabricIndex fabric_index)
-{
-    VerifyOrReturnError(mInitialized, nullptr);
-    return mFabricStatesIterators.CreateObject(*this, fabric_index);
-}
-
-GroupDataProviderImpl::AllStatesIterator::AllStatesIterator(GroupDataProviderImpl & provider) : mProvider(provider)
-{
-    StateListData states;
-    if (CHIP_NO_ERROR == states.Load(provider.mStorage))
-    {
-        mIndex      = states.first;
-        mTotalCount = states.count;
-    }
-}
-
-size_t GroupDataProviderImpl::AllStatesIterator::Count()
-{
-    return mTotalCount;
-}
-
-bool GroupDataProviderImpl::AllStatesIterator::Next(GroupState & item)
-{
-    VerifyOrReturnError(mCount < mTotalCount, false);
-
-    StateData state(mIndex);
-    VerifyOrReturnError(CHIP_NO_ERROR == state.Load(mProvider.mStorage), false);
-
-    mCount++;
-    mIndex            = state.next;
-    item.fabric_index = state.fabric_index;
-    item.group        = state.group;
-    item.keyset_id    = state.keyset_id;
-    return true;
-}
-
-void GroupDataProviderImpl::AllStatesIterator::Release()
-{
-    mProvider.mAllStatesIterators.ReleaseObject(this);
-}
-
-GroupDataProviderImpl::FabricStatesIterator::FabricStatesIterator(GroupDataProviderImpl & provider,
-                                                                  chip::FabricIndex fabric_index) :
-    mProvider(provider),
-    mFabric(fabric_index)
-{
-    StateListData states;
-    if (CHIP_NO_ERROR == states.Load(provider.mStorage))
-    {
-        mIndex      = states.first;
-        mTotalCount = states.count;
-    }
-}
-
-size_t GroupDataProviderImpl::FabricStatesIterator::Count()
-{
-    size_t count = 0;
-    size_t index = 0;
-    StateData state(mIndex);
-
-    while (index++ < mTotalCount)
-    {
-        if (CHIP_NO_ERROR != state.Load(mProvider.mStorage))
-        {
-            break;
-        }
-        if (state.fabric_index == mFabric)
-        {
+            if (CHIP_NO_ERROR != endpoint_data.Load(mProvider.mStorage))
+            {
+                break;
+            }
+            endpoint_data.id = endpoint_data.next;
             count++;
         }
-        state.id = state.next;
+        group.id       = group.next;
+        endpoint_index = 0;
     }
     return count;
 }
 
-bool GroupDataProviderImpl::FabricStatesIterator::Next(GroupState & item)
+bool GroupDataProviderImpl::EndpointIteratorImpl::Next(GroupEndpoint & output)
 {
-    StateData state(mIndex);
-
-    while (mCount++ < mTotalCount)
+    while (mGroupIndex < mGroupCount)
     {
-        if (CHIP_NO_ERROR != state.Load(mProvider.mStorage))
+        GroupData group(mFabric, mGroup);
+        if (CHIP_NO_ERROR != group.Load(mProvider.mStorage))
         {
-            mCount = mTotalCount;
-            break;
+            mGroupIndex = mGroupCount;
+            return false;
         }
-        state.id = state.next;
-        if (state.fabric_index == mFabric)
+        if (mEndpointIndex < mEndpointCount)
         {
-            item.fabric_index = state.fabric_index;
-            item.group        = state.group;
-            item.keyset_id    = state.keyset_id;
-            mIndex            = state.id;
-            return true;
+            EndpointData endpoint_data(mFabric, mGroup, mEndpoint);
+            if (CHIP_NO_ERROR == endpoint_data.Load(mProvider.mStorage))
+            {
+                output.group_id    = group.group_id;
+                output.endpoint_id = endpoint_data.endpoint_id;
+                mEndpoint          = endpoint_data.next;
+                mEndpointIndex++;
+                return true;
+            }
         }
+
+        mGroup = group.next;
+        mGroupIndex++;
+        mEndpoint      = group.first_endpoint;
+        mEndpointIndex = 0;
+        mEndpointCount = group.endpoint_count;
     }
     return false;
 }
 
-void GroupDataProviderImpl::FabricStatesIterator::Release()
+void GroupDataProviderImpl::EndpointIteratorImpl::Release()
 {
-    mProvider.mFabricStatesIterators.ReleaseObject(this);
+    mProvider.mEndpointIterators.ReleaseObject(this);
+}
+
+//
+// Group-Key map
+//
+
+CHIP_ERROR GroupDataProviderImpl::SetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, const GroupKey & in_map)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    KeyMapData map(fabric_index);
+
+    // Load fabric, defaults to zero
+    fabric.Load(mStorage);
+
+    // If the group exists, the index must match
+    bool found = map.Find(mStorage, fabric, in_map);
+    VerifyOrReturnError(!found || (map.index == index), CHIP_ERROR_DUPLICATE_KEY_ID);
+
+    found         = map.Get(mStorage, fabric, index);
+    map.group_id  = in_map.group_id;
+    map.keyset_id = in_map.keyset_id;
+
+    if (found)
+    {
+        // Update existing map
+        return map.Save(mStorage);
+    }
+
+    // Insert last
+    VerifyOrReturnError(fabric.map_count == index, CHIP_ERROR_INVALID_ARGUMENT);
+
+    map.next = 0;
+    ReturnErrorOnFailure(map.Save(mStorage));
+
+    if (map.first)
+    {
+        // First map, update fabric
+        fabric.first_map = map.id;
+    }
+    else
+    {
+        // Last map, update previous
+        KeyMapData prev(fabric_index, map.prev);
+        ReturnErrorOnFailure(prev.Load(mStorage));
+        prev.next = map.id;
+        ReturnErrorOnFailure(prev.Save(mStorage));
+    }
+    // Update fabric
+    fabric.map_count++;
+    return fabric.Save(mStorage);
+}
+
+CHIP_ERROR GroupDataProviderImpl::GetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, GroupKey & out_map)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    KeyMapData map;
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(map.Get(mStorage, fabric, index), CHIP_ERROR_KEY_NOT_FOUND);
+
+    // Target map found
+    out_map.group_id  = map.group_id;
+    out_map.keyset_id = map.keyset_id;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GroupDataProviderImpl::RemoveGroupKeyAt(chip::FabricIndex fabric_index, size_t index)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
+
+    FabricData fabric(fabric_index);
+    KeyMapData map;
+
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(map.Get(mStorage, fabric, index), CHIP_ERROR_KEY_NOT_FOUND);
+
+    ReturnErrorOnFailure(map.Delete(mStorage));
+    if (map.first)
+    {
+        // Remove first map
+        fabric.first_map = map.next;
+    }
+    else
+    {
+        // Remove intermediate map, update previous
+        KeyMapData prev_data(fabric_index, map.prev);
+        ReturnErrorOnFailure(prev_data.Load(mStorage));
+        prev_data.next = map.next;
+        ReturnErrorOnFailure(prev_data.Save(mStorage));
+    }
+    if (fabric.map_count > 0)
+    {
+        fabric.map_count--;
+    }
+    // Update fabric
+    return fabric.Save(mStorage);
+}
+
+GroupDataProvider::GroupKeyIterator * GroupDataProviderImpl::IterateGroupKey(chip::FabricIndex fabric_index)
+{
+    VerifyOrReturnError(mInitialized, nullptr);
+    return mGroupKeyIterators.CreateObject(*this, fabric_index);
+}
+
+GroupDataProviderImpl::GroupKeyIteratorImpl::GroupKeyIteratorImpl(GroupDataProviderImpl & provider,
+                                                                  chip::FabricIndex fabric_index) :
+    mProvider(provider),
+    mFabric(fabric_index)
+{
+    FabricData fabric(fabric_index);
+    if (CHIP_NO_ERROR == fabric.Load(provider.mStorage))
+    {
+        mNextId = fabric.first_map;
+        mTotal  = fabric.map_count;
+        mCount  = 0;
+    }
+}
+
+size_t GroupDataProviderImpl::GroupKeyIteratorImpl::Count()
+{
+    return mTotal;
+}
+
+bool GroupDataProviderImpl::GroupKeyIteratorImpl::Next(GroupKey & output)
+{
+    VerifyOrReturnError(mCount < mTotal, false);
+
+    KeyMapData map(mFabric, mNextId);
+    VerifyOrReturnError(CHIP_NO_ERROR == map.Load(mProvider.mStorage), false);
+
+    mCount++;
+    mNextId          = map.next;
+    output.group_id  = map.group_id;
+    output.keyset_id = map.keyset_id;
+    return true;
+}
+
+void GroupDataProviderImpl::GroupKeyIteratorImpl::Release()
+{
+    mProvider.mGroupKeyIterators.ReleaseObject(this);
 }
 
 //
@@ -1260,61 +1252,39 @@ void GroupDataProviderImpl::FabricStatesIterator::Release()
 
 constexpr size_t GroupDataProvider::EpochKey::kLengthBytes;
 
-CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, uint16_t target_id, const KeySet & in_keyset)
+CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, const KeySet & in_keyset)
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
 
     FabricData fabric(fabric_index);
-    if (CHIP_NO_ERROR != fabric.Load(mStorage))
-    {
-        // First in_keyset
-        fabric.keyset_count = 1;
-        fabric.first_keyset = target_id;
-        KeySetData keyset(fabric_index, target_id, in_keyset.policy, in_keyset.num_keys_used);
-        memcpy(keyset.epoch_keys, in_keyset.epoch_keys, sizeof(in_keyset.epoch_keys));
-        ReturnLogErrorOnFailure(keyset.Save(mStorage));
-        return fabric.Save(mStorage);
-    }
+    KeySetData keyset;
 
-    KeySetData keyset(fabric_index, fabric.first_keyset);
-    size_t keyset_count = 0;
-    bool found          = false;
+    // Load fabric, defaults to zero
+    fabric.Load(mStorage);
 
-    // Seach for the target in_keyset id
-    while (keyset_count < fabric.keyset_count)
-    {
-        if (CHIP_NO_ERROR != keyset.Load(mStorage))
-        {
-            break;
-        }
-        if (keyset.keyset_id == target_id)
-        {
-            // Target id found
-            found = true;
-            break;
-        }
-        keyset.keyset_id = keyset.next;
-        keyset_count++;
-    }
+    // Search existing keyset
+    bool found = keyset.Find(mStorage, fabric, in_keyset.keyset_id);
 
-    keyset.keyset_id     = target_id;
+    keyset.keyset_id     = in_keyset.keyset_id;
     keyset.policy        = in_keyset.policy;
     keyset.num_keys_used = in_keyset.num_keys_used;
     memcpy(keyset.epoch_keys, in_keyset.epoch_keys, sizeof(in_keyset.epoch_keys));
 
     if (found)
     {
-        // Update existing in_keyset info, keep next
+        // Update existing keyset info, keep next
         return keyset.Save(mStorage);
     }
-
-    // New in_keyset, insert first
-    keyset.next = fabric.first_keyset;
-    ReturnErrorOnFailure(keyset.Save(mStorage));
-    // Update fabric info
-    fabric.keyset_count++;
-    fabric.first_keyset = target_id;
-    return fabric.Save(mStorage);
+    else
+    {
+        // New keyset, insert first
+        keyset.next = fabric.first_keyset;
+        ReturnErrorOnFailure(keyset.Save(mStorage));
+        // Update fabric
+        fabric.keyset_count++;
+        fabric.first_keyset = in_keyset.keyset_id;
+        return fabric.Save(mStorage);
+    }
 }
 
 CHIP_ERROR GroupDataProviderImpl::GetKeySet(chip::FabricIndex fabric_index, uint16_t target_id, KeySet & out_keyset)
@@ -1322,32 +1292,18 @@ CHIP_ERROR GroupDataProviderImpl::GetKeySet(chip::FabricIndex fabric_index, uint
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
 
     FabricData fabric(fabric_index);
+    KeySetData keyset;
+
     VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(keyset.Find(mStorage, fabric, target_id), CHIP_ERROR_KEY_NOT_FOUND);
 
-    KeySetData keyset(fabric_index, fabric.first_keyset);
-    size_t keyset_count = 0;
+    VerifyOrReturnError(keyset.Find(mStorage, fabric, target_id), CHIP_ERROR_KEY_NOT_FOUND);
 
-    // Loop until the desired index
-    while (keyset_count < fabric.keyset_count)
-    {
-        if (CHIP_NO_ERROR != keyset.Load(mStorage))
-        {
-            break;
-        }
-        if (keyset.keyset_id == target_id)
-        {
-            // Target index found
-            out_keyset.keyset_id     = keyset.keyset_id;
-            out_keyset.policy        = keyset.policy;
-            out_keyset.num_keys_used = keyset.num_keys_used;
-            memcpy(out_keyset.epoch_keys, keyset.epoch_keys, sizeof(out_keyset.epoch_keys));
-            return CHIP_NO_ERROR;
-        }
-        keyset.keyset_id = keyset.next;
-        keyset_count++;
-    }
-
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    // Target keyset found
+    out_keyset.policy        = keyset.policy;
+    out_keyset.num_keys_used = keyset.num_keys_used;
+    memcpy(out_keyset.epoch_keys, keyset.epoch_keys, sizeof(out_keyset.epoch_keys));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GroupDataProviderImpl::RemoveKeySet(chip::FabricIndex fabric_index, uint16_t target_id)
@@ -1355,44 +1311,24 @@ CHIP_ERROR GroupDataProviderImpl::RemoveKeySet(chip::FabricIndex fabric_index, u
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INTERNAL);
 
     FabricData fabric(fabric_index);
-    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_KEY_NOT_FOUND);
+    KeySetData keyset;
 
-    KeySetData keyset(fabric_index, fabric.first_keyset);
-    uint16_t prev_id    = 0;
-    size_t keyset_count = 0;
-
-    // Loop until the desired index
-    while (keyset_count < fabric.keyset_count)
-    {
-        if (CHIP_NO_ERROR != keyset.Load(mStorage))
-        {
-            break;
-        }
-        if (keyset.keyset_id == target_id)
-        {
-            // Target index found
-            break;
-        }
-        prev_id          = keyset.keyset_id;
-        keyset.keyset_id = keyset.next;
-        keyset_count++;
-    }
-
-    VerifyOrReturnError(keyset.keyset_id == target_id, CHIP_ERROR_KEY_NOT_FOUND);
-
+    VerifyOrReturnError(CHIP_NO_ERROR == fabric.Load(mStorage), CHIP_ERROR_INVALID_FABRIC_ID);
+    VerifyOrReturnError(keyset.Find(mStorage, fabric, target_id), CHIP_ERROR_KEY_NOT_FOUND);
     ReturnErrorOnFailure(keyset.Delete(mStorage));
-    if (keyset_count > 0)
-    {
-        // Remove intermediate keyset, update previous
-        KeySetData prev_data(fabric_index, prev_id);
-        ReturnErrorOnFailure(prev_data.Load(mStorage));
-        prev_data.next = keyset.next;
-        ReturnErrorOnFailure(prev_data.Save(mStorage));
-    }
-    else
+
+    if (keyset.first)
     {
         // Remove first keyset
         fabric.first_keyset = keyset.next;
+    }
+    else
+    {
+        // Remove intermediate keyset, update previous
+        KeySetData prev_data(fabric_index, keyset.prev);
+        ReturnErrorOnFailure(prev_data.Load(mStorage));
+        prev_data.next = keyset.next;
+        ReturnErrorOnFailure(prev_data.Save(mStorage));
     }
     if (fabric.keyset_count > 0)
     {
@@ -1415,29 +1351,29 @@ GroupDataProviderImpl::KeySetIteratorImpl::KeySetIteratorImpl(GroupDataProviderI
     if (CHIP_NO_ERROR == fabric.Load(provider.mStorage))
     {
         mNextId = fabric.first_keyset;
-        mCount  = fabric.keyset_count;
-        mIndex  = 0;
+        mTotal  = fabric.keyset_count;
+        mCount  = 0;
     }
 }
 
 size_t GroupDataProviderImpl::KeySetIteratorImpl::Count()
 {
-    return mCount;
+    return mTotal;
 }
 
-bool GroupDataProviderImpl::KeySetIteratorImpl::Next(KeySet & item)
+bool GroupDataProviderImpl::KeySetIteratorImpl::Next(KeySet & output)
 {
-    VerifyOrReturnError(mIndex < mCount, false);
+    VerifyOrReturnError(mCount < mTotal, false);
 
     KeySetData keyset(mFabric, mNextId);
     VerifyOrReturnError(CHIP_NO_ERROR == keyset.Load(mProvider.mStorage), false);
 
-    mIndex++;
-    mNextId            = keyset.next;
-    item.keyset_id     = keyset.keyset_id;
-    item.policy        = keyset.policy;
-    item.num_keys_used = keyset.num_keys_used;
-    memcpy(item.epoch_keys, keyset.epoch_keys, sizeof(item.epoch_keys));
+    mCount++;
+    mNextId              = keyset.next;
+    output.keyset_id     = keyset.keyset_id;
+    output.policy        = keyset.policy;
+    output.num_keys_used = keyset.num_keys_used;
+    memcpy(output.epoch_keys, keyset.epoch_keys, sizeof(output.epoch_keys));
     return true;
 }
 
@@ -1458,48 +1394,18 @@ CHIP_ERROR GroupDataProviderImpl::RemoveFabric(chip::FabricIndex fabric_index)
     // However, states has a separate list, and needs to be removed regardless
     fabric.Load(mStorage);
 
-    // Remove Group Mappings
+    // Remove Group mappings
 
-    EndpointData endpoint(fabric_index, fabric.first_endpoint);
-    size_t endpoint_count = 0;
-
-    do
+    for (size_t i = 0; i < fabric.map_count; i++)
     {
-        if (CHIP_NO_ERROR != endpoint.Load(mStorage))
-        {
-            break;
-        }
-        RemoveAllGroupMappings(fabric_index, endpoint.endpoint_id);
-        endpoint.endpoint_id = endpoint.next;
-    } while ((++endpoint_count < fabric.endpoint_count) && (kInvalidEndpointId != endpoint.endpoint_id));
+        RemoveGroupKeyAt(fabric_index, fabric.map_count - i - 1);
+    }
 
-    // Remove States
+    // Remove group info
 
-    StateListData states;
-
-    // Load state list info. No error check needed: If the list is not found,
-    // the number of states defaults to zero, so the following loop is skipped.
-    states.Load(mStorage);
-
-    StateData state(states.first);
-    size_t index = 0;
-
-    while (index < states.count)
+    for (size_t i = 0; i < fabric.group_count; i++)
     {
-        if (CHIP_NO_ERROR != state.Load(mStorage))
-        {
-            break;
-        }
-        if (state.fabric_index == fabric_index)
-        {
-            // Remove the N state from the array. State N+1 becomes N
-            RemoveGroupState(index);
-        }
-        else
-        {
-            index++;
-        }
-        state.id = state.next;
+        RemoveGroupInfoAt(fabric_index, fabric.group_count - i - 1);
     }
 
     // Remove Keysets

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -655,6 +655,10 @@ CHIP_ERROR GroupDataProviderImpl::Init()
 void GroupDataProviderImpl::Finish()
 {
     mInitialized = false;
+    mGroupInfoIterators.ReleaseAll();
+    mGroupKeyIterators.ReleaseAll();
+    mEndpointIterators.ReleaseAll();
+    mKeySetIterators.ReleaseAll();
 }
 
 //

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -149,13 +149,10 @@ private:
 
     chip::PersistentStorageDelegate & mStorage;
     bool mInitialized = false;
-    BitMapObjectPool<GroupInfoIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
-        mGroupInfoIterators;
-    BitMapObjectPool<GroupKeyIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
-        mGroupKeyIterators;
-    BitMapObjectPool<EndpointIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
-        mEndpointIterators;
-    BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode> mKeySetIterators;
+    BitMapObjectPool<GroupInfoIteratorImpl, kIteratorsMax> mGroupInfoIterators;
+    BitMapObjectPool<GroupKeyIteratorImpl, kIteratorsMax> mGroupKeyIterators;
+    BitMapObjectPool<EndpointIteratorImpl, kIteratorsMax> mEndpointIterators;
+    BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax> mKeySetIterators;
 };
 
 } // namespace Credentials

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -23,11 +23,11 @@
 namespace chip {
 namespace Credentials {
 
-static constexpr size_t kIteratorsMax = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
-
 class GroupDataProviderImpl : public GroupDataProvider
 {
 public:
+    static constexpr size_t kIteratorsMax = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
+
     GroupDataProviderImpl(chip::PersistentStorageDelegate & storage_delegate) : mStorage(storage_delegate) {}
     virtual ~GroupDataProviderImpl() {}
 
@@ -35,34 +35,41 @@ public:
     void Finish() override;
 
     //
-    // Group Mappings
+    // Group Info
     //
 
-    bool HasGroupNamesSupport() override;
-    bool GroupMappingExists(chip::FabricIndex fabric_index, const GroupMapping & mapping) override;
-    CHIP_ERROR AddGroupMapping(chip::FabricIndex fabric_index, const GroupMapping & mapping) override;
-    CHIP_ERROR RemoveGroupMapping(chip::FabricIndex fabric_index, const GroupMapping & mapping) override;
-    CHIP_ERROR RemoveAllGroupMappings(chip::FabricIndex fabric_index, EndpointId endpoint) override;
-    GroupMappingIterator * IterateGroupMappings(chip::FabricIndex fabric_index) override;
-    GroupMappingIterator * IterateGroupMappings(chip::FabricIndex fabric_index, EndpointId endpoint) override;
+    // By id
+    CHIP_ERROR SetGroupInfo(chip::FabricIndex fabric_index, const GroupInfo & info) override;
+    CHIP_ERROR GetGroupInfo(chip::FabricIndex fabric_index, chip::GroupId group_id, GroupInfo & info) override;
+    // By index
+    CHIP_ERROR SetGroupInfoAt(chip::FabricIndex fabric_index, size_t index, const GroupInfo & info) override;
+    CHIP_ERROR GetGroupInfoAt(chip::FabricIndex fabric_index, size_t index, GroupInfo & info) override;
+    CHIP_ERROR RemoveGroupInfoAt(chip::FabricIndex fabric_index, size_t index) override;
+    // Endpoints
+    bool HasEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id) override;
+    CHIP_ERROR AddEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id) override;
+    CHIP_ERROR RemoveEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id, chip::EndpointId endpoint_id) override;
+    CHIP_ERROR RemoveEndpoint(chip::FabricIndex fabric_index, chip::EndpointId endpoint_id) override;
+    // Iterators
+    GroupInfoIterator * IterateGroupInfo(chip::FabricIndex fabric_index) override;
+    EndpointIterator * IterateEndpoints(chip::FabricIndex fabric_index) override;
 
     //
-    // Group States
+    // Group-Key map
     //
 
-    CHIP_ERROR SetGroupState(size_t state_index, const GroupState & state) override;
-    CHIP_ERROR GetGroupState(size_t state_index, GroupState & state) override;
-    CHIP_ERROR RemoveGroupState(size_t state_index) override;
-    GroupStateIterator * IterateGroupStates() override;
-    GroupStateIterator * IterateGroupStates(chip::FabricIndex fabric_index) override;
+    CHIP_ERROR SetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, const GroupKey & info) override;
+    CHIP_ERROR GetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, GroupKey & info) override;
+    CHIP_ERROR RemoveGroupKeyAt(chip::FabricIndex fabric_index, size_t index) override;
+    GroupKeyIterator * IterateGroupKey(chip::FabricIndex fabric_index) override;
 
     //
     // Key Sets
     //
 
-    CHIP_ERROR SetKeySet(chip::FabricIndex fabric_index, uint16_t keyset_id, const KeySet & keys) override;
-    CHIP_ERROR GetKeySet(chip::FabricIndex fabric_index, uint16_t keyset_id, KeySet & keys) override;
-    CHIP_ERROR RemoveKeySet(chip::FabricIndex fabric_index, uint16_t keyset_id) override;
+    CHIP_ERROR SetKeySet(chip::FabricIndex fabric_index, const KeySet & keys) override;
+    CHIP_ERROR GetKeySet(chip::FabricIndex fabric_index, chip::KeysetId keyset_id, KeySet & keys) override;
+    CHIP_ERROR RemoveKeySet(chip::FabricIndex fabric_index, chip::KeysetId keyset_id) override;
     KeySetIterator * IterateKeySets(chip::FabricIndex fabric_index) override;
 
     // Fabrics
@@ -72,78 +79,12 @@ public:
     CHIP_ERROR Decrypt(PacketHeader packetHeader, PayloadHeader & payloadHeader, System::PacketBufferHandle & msg) override;
 
 private:
-    class AllGroupMappingsIteratorImpl : public GroupMappingIterator
+    class GroupInfoIteratorImpl : public GroupInfoIterator
     {
     public:
-        AllGroupMappingsIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric);
+        GroupInfoIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index);
         size_t Count() override;
-        bool Next(GroupMapping & item) override;
-        void Release() override;
-
-    private:
-        GroupDataProviderImpl & mProvider;
-        chip::FabricIndex mFabric       = kUndefinedFabricIndex;
-        chip::EndpointId mEndpoint      = kInvalidEndpointId;
-        size_t mEndpointIndex           = 0;
-        size_t mEndpointCount           = 0;
-        chip::GroupId mGroup            = kUndefinedGroupId;
-        chip::EndpointId mFirstEndpoint = kInvalidEndpointId;
-        bool mFirstGroup                = true;
-    };
-
-    class GroupMappingIteratorImpl : public GroupMappingIterator
-    {
-    public:
-        GroupMappingIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric, chip::EndpointId endpoint);
-        size_t Count() override;
-        bool Next(GroupMapping & item) override;
-        void Release() override;
-
-    private:
-        GroupDataProviderImpl & mProvider;
-        chip::FabricIndex mFabric  = kUndefinedFabricIndex;
-        chip::EndpointId mEndpoint = kInvalidEndpointId;
-        chip::GroupId mFirstGroup  = kUndefinedGroupId;
-        chip::GroupId mGroup       = kUndefinedGroupId;
-    };
-
-    class AllStatesIterator : public GroupStateIterator
-    {
-    public:
-        AllStatesIterator(GroupDataProviderImpl & provider);
-        size_t Count() override;
-        bool Next(GroupState & item) override;
-        void Release() override;
-
-    private:
-        GroupDataProviderImpl & mProvider;
-        uint16_t mIndex    = 0;
-        size_t mCount      = 0;
-        size_t mTotalCount = 0;
-    };
-
-    class FabricStatesIterator : public GroupStateIterator
-    {
-    public:
-        FabricStatesIterator(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index);
-        size_t Count() override;
-        bool Next(GroupState & item) override;
-        void Release() override;
-
-    private:
-        GroupDataProviderImpl & mProvider;
-        chip::FabricIndex mFabric = kUndefinedFabricIndex;
-        uint16_t mIndex           = 0;
-        size_t mCount             = 0;
-        size_t mTotalCount        = 0;
-    };
-
-    class KeySetIteratorImpl : public KeySetIterator
-    {
-    public:
-        KeySetIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index);
-        size_t Count() override;
-        bool Next(KeySet & item) override;
+        bool Next(GroupInfo & output) override;
         void Release() override;
 
     private:
@@ -151,16 +92,70 @@ private:
         chip::FabricIndex mFabric = kUndefinedFabricIndex;
         uint16_t mNextId          = 0;
         size_t mCount             = 0;
-        size_t mIndex             = 0;
+        size_t mTotal             = 0;
+    };
+
+    class GroupKeyIteratorImpl : public GroupKeyIterator
+    {
+    public:
+        GroupKeyIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index);
+        size_t Count() override;
+        bool Next(GroupKey & output) override;
+        void Release() override;
+
+    private:
+        GroupDataProviderImpl & mProvider;
+        chip::FabricIndex mFabric = kUndefinedFabricIndex;
+        uint16_t mNextId          = 0;
+        size_t mCount             = 0;
+        size_t mTotal             = 0;
+    };
+
+    class EndpointIteratorImpl : public EndpointIterator
+    {
+    public:
+        EndpointIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index);
+        size_t Count() override;
+        bool Next(GroupEndpoint & output) override;
+        void Release() override;
+
+    private:
+        GroupDataProviderImpl & mProvider;
+        chip::FabricIndex mFabric = kUndefinedFabricIndex;
+        chip::GroupId mFirstGroup = kUndefinedGroupId;
+        uint16_t mGroup           = 0;
+        size_t mGroupIndex        = 0;
+        size_t mGroupCount        = 0;
+        uint16_t mEndpoint        = 0;
+        size_t mEndpointIndex     = 0;
+        size_t mEndpointCount     = 0;
+    };
+
+    class KeySetIteratorImpl : public KeySetIterator
+    {
+    public:
+        KeySetIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index);
+        size_t Count() override;
+        bool Next(KeySet & output) override;
+        void Release() override;
+
+    private:
+        GroupDataProviderImpl & mProvider;
+        chip::FabricIndex mFabric = kUndefinedFabricIndex;
+        uint16_t mNextId          = 0;
+        size_t mCount             = 0;
+        size_t mTotal             = 0;
     };
 
     chip::PersistentStorageDelegate & mStorage;
     bool mInitialized = false;
-    BitMapObjectPool<AllGroupMappingsIteratorImpl, kIteratorsMax> mAllGroupsIterators;
-    BitMapObjectPool<GroupMappingIteratorImpl, kIteratorsMax> mEndpointGroupsIterators;
-    BitMapObjectPool<AllStatesIterator, kIteratorsMax> mAllStatesIterators;
-    BitMapObjectPool<FabricStatesIterator, kIteratorsMax> mFabricStatesIterators;
-    BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax> mKeySetIterators;
+    BitMapObjectPool<GroupInfoIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
+        mGroupInfoIterators;
+    BitMapObjectPool<GroupKeyIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
+        mGroupKeyIterators;
+    BitMapObjectPool<EndpointIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
+        mEndpointIterators;
+    BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax, OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode> mKeySetIterators;
 };
 
 } // namespace Credentials

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -25,12 +25,15 @@
 #include <platform/KeyValueStoreManager.h>
 #include <set>
 #include <string.h>
+#include <tuple>
+#include <utility>
 
 using namespace chip::Credentials;
-using GroupMapping = GroupDataProvider::GroupMapping;
-using KeySet       = GroupDataProvider::KeySet;
-using GroupState   = GroupDataProvider::GroupState;
-using EpochKey     = GroupDataProvider::EpochKey;
+using GroupInfo     = GroupDataProvider::GroupInfo;
+using GroupKey      = GroupDataProvider::GroupKey;
+using GroupEndpoint = GroupDataProvider::GroupEndpoint;
+using EpochKey      = GroupDataProvider::EpochKey;
+using KeySet        = GroupDataProvider::KeySet;
 
 namespace chip {
 namespace app {
@@ -41,6 +44,56 @@ static const char * kValue1 = "abc/def";
 static const char * kValue2 = "abc/ghi/xyz";
 static const size_t kSize1  = strlen(kValue1) + 1;
 static const size_t kSize2  = strlen(kValue2) + 1;
+
+constexpr chip::FabricIndex kFabric1 = 1;
+constexpr chip::FabricIndex kFabric2 = 7;
+
+constexpr chip::GroupId kGroup1 = kMinFabricGroupId;
+constexpr chip::GroupId kGroup2 = 0x2222;
+constexpr chip::GroupId kGroup3 = kMaxFabricGroupId;
+constexpr chip::GroupId kGroup4 = 0x4444;
+constexpr chip::GroupId kGroup5 = 0x5555;
+
+constexpr chip::EndpointId kEndpointId0 = 0xee00;
+constexpr chip::EndpointId kEndpointId1 = 0xee01;
+constexpr chip::EndpointId kEndpointId2 = 0xee02;
+constexpr chip::EndpointId kEndpointId3 = 0xee03;
+constexpr chip::EndpointId kEndpointId4 = 0xee04;
+
+constexpr uint16_t kKeysetId0 = 0x0;
+constexpr uint16_t kKeysetId1 = 0x1111;
+constexpr uint16_t kKeysetId2 = 0x2222;
+constexpr uint16_t kKeysetId3 = 0x3333;
+
+static const GroupInfo kGroupInfo1_1(kGroup1, "Group-1.1");
+static const GroupInfo kGroupInfo1_2(kGroup2, "Group-1.2");
+static const GroupInfo kGroupInfo1_3(kGroup3, "Group-1.3");
+static const GroupInfo kGroupInfo2_1(kGroup1, "Group-2.1");
+static const GroupInfo kGroupInfo2_2(kGroup2, "Group-2.2");
+static const GroupInfo kGroupInfo2_3(kGroup3, "Group-2.3");
+static const GroupInfo kGroupInfo3_1(kGroup1, "Group-3.1");
+static const GroupInfo kGroupInfo3_2(kGroup2, "Group-3.2");
+static const GroupInfo kGroupInfo3_3(kGroup3, "Group-3.3");
+static const GroupInfo kGroupInfo3_4(kGroup4, "Group-3.4");
+static const GroupInfo kGroupInfo3_5(kGroup4, "Group-3.5");
+
+static const GroupKey kGroup1Keyset0(kGroup1, kKeysetId0);
+static const GroupKey kGroup1Keyset1(kGroup1, kKeysetId1);
+static const GroupKey kGroup1Keyset2(kGroup1, kKeysetId2);
+static const GroupKey kGroup1Keyset3(kGroup1, kKeysetId3);
+static const GroupKey kGroup2Keyset0(kGroup2, kKeysetId0);
+static const GroupKey kGroup2Keyset1(kGroup2, kKeysetId1);
+static const GroupKey kGroup2Keyset2(kGroup2, kKeysetId2);
+static const GroupKey kGroup2Keyset3(kGroup2, kKeysetId3);
+static const GroupKey kGroup3Keyset0(kGroup3, kKeysetId0);
+static const GroupKey kGroup3Keyset1(kGroup3, kKeysetId1);
+static const GroupKey kGroup3Keyset2(kGroup3, kKeysetId2);
+static const GroupKey kGroup3Keyset3(kGroup3, kKeysetId3);
+
+static KeySet kKeySet0(kKeysetId0, KeySet::SecurityPolicy::kStandard, 3);
+static KeySet kKeySet1(kKeysetId1, KeySet::SecurityPolicy::kLowLatency, 1);
+static KeySet kKeySet2(kKeysetId2, KeySet::SecurityPolicy::kLowLatency, 2);
+static KeySet kKeySet3(kKeysetId3, KeySet::SecurityPolicy::kStandard, 3);
 
 void TestStorageDelegate(nlTestSuite * apSuite, void * apContext)
 {
@@ -73,1497 +126,800 @@ void TestStorageDelegate(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND == delegate.SyncGetKeyValue(kKey1, out, size));
 }
 
-constexpr chip::FabricIndex kFabric1  = 1;
-constexpr chip::FabricIndex kFabric2  = 7;
-constexpr chip::EndpointId kEndpoint1 = 1;
-constexpr chip::EndpointId kEndpoint2 = 0xabcd;
-constexpr chip::EndpointId kEndpoint3 = 0xfffe;
-constexpr chip::GroupId kGroup1       = kMinFabricGroupId;
-constexpr chip::GroupId kGroup2       = 0x2222;
-constexpr chip::GroupId kGroup3       = kMaxFabricGroupId;
-
-static const GroupMapping endpoint1group1(kEndpoint1, kGroup1, "Group 1.1");
-static const GroupMapping endpoint1group2(kEndpoint1, kGroup2, "Group 1.2");
-static const GroupMapping endpoint1group3(kEndpoint1, kGroup3, "Group 1.3");
-
-static const GroupMapping endpoint2group1(kEndpoint2, kGroup1, "Group 2.1");
-static const GroupMapping endpoint2group2(kEndpoint2, kGroup2, "Group 2.2");
-static const GroupMapping endpoint2group3(kEndpoint2, kGroup3, "Group 2.3");
-
-static const GroupMapping endpoint3group1(kEndpoint3, kGroup1, "Group 3.1");
-static const GroupMapping endpoint3group2(kEndpoint3, kGroup2, "Group 3.2");
-static const GroupMapping endpoint3group3(kEndpoint3, kGroup3, "Group 3.3");
-
-void TestGroupMappings(nlTestSuite * apSuite, void * apContext)
+void TestGroupInfo(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    // Test initial conditions
+    GroupInfo group;
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group3));
+    // Set Group Info
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint2group3));
+    // Out-of-order
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_3));
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group3));
+    // Duplicated
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric1, 3, kGroupInfo1_1));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric2, 3, kGroupInfo2_3));
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group3));
+    // Get Group Info
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group3));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetGroupInfoAt(kUndefinedFabricIndex, 0, group));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupInfoAt(kFabric2, 999, group));
 
-    // Add Group (new)
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 2, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 2, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_3);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint1group1));
-    // Keep these out to check for unexisting groups:
-    // NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint1group2));
-    // NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint3group3));
+    // Remove Groups
 
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupInfoAt(kFabric1, 2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupInfoAt(kFabric2, 0));
 
-    // Add Group (duplicated)
+    // Remaining entries shift up
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint1group2));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupInfoAt(kFabric2, 2, group));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_1);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupInfoAt(kFabric1, 3, group));
 
-    // Remove Group (invalid)
+    // Overwrite with new group
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR != groups->RemoveGroupMapping(kFabric1, GroupMapping(kInvalidEndpointId, 1, nullptr)));
-    NL_TEST_ASSERT(apSuite,
-                   CHIP_NO_ERROR != groups->RemoveGroupMapping(kFabric1, GroupMapping(kEndpoint1, kUndefinedGroupId, nullptr)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo3_4));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo3_4));
 
-    // Remove Group (existing)
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 2, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo3_4);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveGroupMapping(kFabric1, endpoint1group1)); // First
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveGroupMapping(kFabric2, endpoint2group1)); // Last
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveGroupMapping(kFabric2, endpoint2group2)); // Middle
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo3_4);
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group3));
+    // Overwrite existing group, index must match
 
-    // Remove Group (already removed)
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo2_2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveGroupMapping(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveGroupMapping(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveGroupMapping(kFabric2, endpoint2group2));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo3_4));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo1_3));
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
 
-    // Remove All
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_3);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveAllGroupMappings(kFabric2, kEndpoint1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveAllGroupMappings(kFabric1, kEndpoint3));
+    // By group_id
 
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric1, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, groups->GroupMappingExists(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group3));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveAllGroupMappings(kFabric1, kEndpoint1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveAllGroupMappings(kFabric2, kEndpoint2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveAllGroupMappings(kFabric2, kEndpoint3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveAllGroupMappings(kFabric1, kEndpoint2));
-
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric1, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, !groups->GroupMappingExists(kFabric2, endpoint3group3));
-}
-
-void TestGroupMappingIterator(nlTestSuite * apSuite, void * apContext)
-{
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
-
-    // Add Groups
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint1group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint1group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint2group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric1, endpoint3group3));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint1group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint2group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint2group1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint3group3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint3group2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->AddGroupMapping(kFabric2, endpoint3group1));
-
-    GroupMapping mapping;
-
-    // Fabric1, all endpoints
-
-    std::set<std::pair<EndpointId, GroupId>> expected_f1_all = {
-        { kEndpoint1, kGroup1 }, { kEndpoint1, kGroup2 }, { kEndpoint1, kGroup3 }, { kEndpoint2, kGroup1 }, { kEndpoint2, kGroup2 },
-        { kEndpoint2, kGroup3 }, { kEndpoint3, kGroup1 }, { kEndpoint3, kGroup2 }, { kEndpoint3, kGroup3 },
-    };
-
-    auto it = groups->IterateGroupMappings(kFabric1);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t count = 0;
-        NL_TEST_ASSERT(apSuite, it->Count() == expected_f1_all.size());
-        while (it->Next(mapping))
-        {
-            std::pair<EndpointId, GroupId> pair(mapping.endpoint, mapping.group);
-            NL_TEST_ASSERT(apSuite, expected_f1_all.count(pair) > 0);
-            count++;
-        }
-
-        NL_TEST_ASSERT(apSuite, count == expected_f1_all.size());
-        NL_TEST_ASSERT(apSuite, it->Count() == expected_f1_all.size());
-        it->Release();
-    }
-
-    // Fabric 1, by endpoint
-
-    constexpr size_t endpoints_count                = 3;
-    constexpr EndpointId endpoints[endpoints_count] = { kEndpoint1, kEndpoint2, kEndpoint3 };
-
-    std::set<GroupId> expected_f1{ kGroup1, kGroup2, kGroup3 };
-    std::map<GroupId, int> group_map = { { kGroup1, 1 }, { kGroup2, 2 }, { kGroup3, 3 } };
-    std::map<GroupId, int> end_map   = { { kEndpoint1, 1 }, { kEndpoint2, 2 }, { kEndpoint3, 3 } };
-    char expected_name[64];
-    size_t j = 0;
-
-    for (size_t i = 0; i < endpoints_count; i++)
-    {
-        it = groups->IterateGroupMappings(kFabric1, endpoints[i]);
-        NL_TEST_ASSERT(apSuite, it);
-        if (it)
-        {
-            size_t count = it->Count();
-            NL_TEST_ASSERT(apSuite, expected_f1.size() == count);
-            j = 0;
-            while (it->Next(mapping) && j < expected_f1.size())
-            {
-                sprintf(expected_name, "Group %d.%d", end_map[mapping.endpoint], group_map[mapping.group]);
-                NL_TEST_ASSERT(apSuite, expected_f1.count(mapping.group) > 0);
-                NL_TEST_ASSERT(apSuite, !strcmp(expected_name, mapping.name));
-                j++;
-            }
-            NL_TEST_ASSERT(apSuite, j == expected_f1.size());
-            it->Release();
-        }
-    }
-
-    // Fabric2, all endpoints
-
-    std::set<std::pair<EndpointId, GroupId>> expected_f2_all = { { kEndpoint1, kGroup1 }, { kEndpoint2, kGroup2 },
-                                                                 { kEndpoint2, kGroup1 }, { kEndpoint3, kGroup3 },
-                                                                 { kEndpoint3, kGroup2 }, { kEndpoint3, kGroup1 } };
-
-    it = groups->IterateGroupMappings(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t count = 0;
-        NL_TEST_ASSERT(apSuite, it->Count() == expected_f2_all.size());
-
-        while (it->Next(mapping))
-        {
-            std::pair<EndpointId, GroupId> pair(mapping.endpoint, mapping.group);
-            NL_TEST_ASSERT(apSuite, expected_f2_all.count(pair) > 0);
-            count++;
-        }
-
-        NL_TEST_ASSERT(apSuite, count == expected_f2_all.size());
-        NL_TEST_ASSERT(apSuite, it->Count() == expected_f2_all.size());
-        it->Release();
-        it = nullptr;
-    }
-
-    // Fabric 2, by endpoint
-
-    std::set<GroupId> expected_f2[3]                     = { { kGroup1, kUndefinedGroupId, kUndefinedGroupId },
-                                         { kGroup2, kGroup1, kUndefinedGroupId },
-                                         { kGroup3, kGroup2, kGroup1 } };
-    constexpr size_t expected_f2_counts[endpoints_count] = { 1, 2, 3 };
-
-    for (size_t i = 0; i < endpoints_count; i++)
-    {
-        it = groups->IterateGroupMappings(kFabric2, endpoints[i]);
-        NL_TEST_ASSERT(apSuite, it);
-        if (it)
-        {
-            size_t expected_count = expected_f2_counts[i];
-            size_t count          = it->Count();
-
-            NL_TEST_ASSERT(apSuite, expected_count == count);
-            j = 0;
-            while (it->Next(mapping) && j < expected_count)
-            {
-                sprintf(expected_name, "Group %d.%d", end_map[mapping.endpoint], group_map[mapping.group]);
-                NL_TEST_ASSERT(apSuite, mapping.endpoint == endpoints[i]);
-                NL_TEST_ASSERT(apSuite, expected_f2[i].count(mapping.group) > 0);
-                NL_TEST_ASSERT(apSuite, !strcmp(expected_name, mapping.name));
-                j++;
-            }
-            NL_TEST_ASSERT(apSuite, j == expected_count);
-            it->Release();
-            it = nullptr;
-        }
-    }
-}
-
-constexpr uint16_t kKeySet1 = 101;
-constexpr uint16_t kKeySet2 = 102;
-constexpr uint16_t kKeySet3 = 103;
-
-static const GroupState fabric0group0set0(0, 0, 0);
-
-static const GroupState fabric1group1set1(kFabric1, kGroup1, kKeySet1);
-static const GroupState fabric1group1set2(kFabric1, kGroup1, kKeySet2);
-static const GroupState fabric1group1set3(kFabric1, kGroup1, kKeySet3);
-static const GroupState fabric1group2set1(kFabric1, kGroup2, kKeySet1);
-static const GroupState fabric1group2set2(kFabric1, kGroup2, kKeySet2);
-static const GroupState fabric1group2set3(kFabric1, kGroup2, kKeySet3);
-
-static const GroupState fabric2group1set1(kFabric2, kGroup1, kKeySet1);
-static const GroupState fabric2group1set2(kFabric2, kGroup1, kKeySet2);
-static const GroupState fabric2group1set3(kFabric2, kGroup1, kKeySet3);
-static const GroupState fabric2group2set1(kFabric2, kGroup2, kKeySet1);
-static const GroupState fabric2group2set2(kFabric2, kGroup2, kKeySet2);
-static const GroupState fabric2group2set3(kFabric2, kGroup2, kKeySet3);
-
-void TestGroupStates(nlTestSuite * apSuite, void * apContext)
-{
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
-
-    // Add States
-
-    GroupState state(0, 0, 0);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(0, fabric1group1set1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(1, fabric1group1set2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(2, fabric1group1set3));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(0, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group1set1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(1, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group1set2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(2, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group1set3);
-
+    // New
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfo(kFabric1, kGroupInfo3_5));
     // Override
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(2, fabric1group2set1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(1, fabric1group2set2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(0, fabric1group2set3));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(0, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group2set3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(1, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group2set2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(2, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group2set1);
-    // Invalid
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT == groups->SetGroupState(4, fabric1group1set1));
-
-    // Remove States
-
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveGroupState(3));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveGroupState(0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(0, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group2set2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(1, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group2set1);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveGroupState(1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(0, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group2set2);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT != groups->GetGroupState(1, state));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveGroupState(0));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT != groups->GetGroupState(0, state));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT != groups->GetGroupState(1, state));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT != groups->GetGroupState(3, state));
-
-    // Multiple fabrics
-
-    // Invalid index
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR != groups->SetGroupState(1, fabric2group1set1));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(0, fabric1group1set3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(1, fabric2group1set1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(2, fabric1group1set1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(3, fabric2group1set2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(4, fabric2group1set3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(5, fabric1group1set2));
-    // Incorrect fabric
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_ACCESS_DENIED == groups->SetGroupState(1, fabric1group1set1));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(2, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group1set1);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(5, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group1set2);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(0, state));
-    NL_TEST_ASSERT(apSuite, state == fabric1group1set3);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(4, state));
-    NL_TEST_ASSERT(apSuite, state == fabric2group1set3);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(1, state));
-    NL_TEST_ASSERT(apSuite, state == fabric2group1set1);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetGroupState(3, state));
-    NL_TEST_ASSERT(apSuite, state == fabric2group1set2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfo(kFabric2, kGroupInfo3_2));
+    // Not found
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupInfo(kFabric2, kGroup5, group));
+    // Existing
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfo(kFabric2, kGroup2, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo3_2);
 }
 
-void TestGroupStateIterator(nlTestSuite * apSuite, void * apContext)
+void TestGroupInfoIterator(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    // Add data to iterate
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(0, fabric1group1set3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(1, fabric2group1set1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(2, fabric1group1set1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(3, fabric2group1set2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(4, fabric2group1set3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetGroupState(5, fabric1group1set2));
+    GroupInfo group;
 
-    // Iterate All Fabrics
+    // Set Group Info
 
-    constexpr size_t expected_count           = 6;
-    const GroupState expected[expected_count] = { fabric1group1set3, fabric2group1set1, fabric1group1set1,
-                                                  fabric2group1set2, fabric2group1set3, fabric1group1set2 };
-    GroupState state(0, 0, 0);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2));
 
-    auto it = groups->IterateGroupStates();
+    // Iterate fabric 1
+
+    GroupInfo expected_f1[]  = { kGroupInfo1_3, kGroupInfo1_2, kGroupInfo1_1 };
+    size_t expected_f1_count = sizeof(expected_f1) / sizeof(GroupInfo);
+
+    auto it  = provider->IterateGroupInfo(kFabric1);
+    size_t i = 0;
     NL_TEST_ASSERT(apSuite, it);
     if (it)
     {
-        size_t i = 0;
-        NL_TEST_ASSERT(apSuite, expected_count == it->Count());
-
-        while (it->Next(state) && i < expected_count)
+        NL_TEST_ASSERT(apSuite, expected_f1_count == it->Count());
+        while (it->Next(group) && i < expected_f1_count)
         {
-            NL_TEST_ASSERT(apSuite, state == expected[i]);
-            i++;
+            NL_TEST_ASSERT(apSuite, expected_f1[i++] == group);
         }
-        NL_TEST_ASSERT(apSuite, i == expected_count);
+        NL_TEST_ASSERT(apSuite, i == it->Count());
         it->Release();
-        it = nullptr;
     }
 
-    // Iterate Fabric 1 only
+    // Iterate fabric 2
 
-    constexpr size_t expected_count_f1              = 3;
-    const GroupState expected_f1[expected_count_f1] = { fabric1group1set3, fabric1group1set1, fabric1group1set2 };
+    GroupInfo expected_f2[]  = { kGroupInfo2_1, kGroupInfo2_3, kGroupInfo2_2 };
+    size_t expected_f2_count = sizeof(expected_f2) / sizeof(GroupInfo);
 
-    it = groups->IterateGroupStates(kFabric1);
+    it = provider->IterateGroupInfo(kFabric2);
     NL_TEST_ASSERT(apSuite, it);
     if (it)
     {
-        size_t i = 0;
-        NL_TEST_ASSERT(apSuite, expected_count_f1 == it->Count());
-
-        while (it->Next(state) && i < expected_count_f1)
+        i = 0;
+        NL_TEST_ASSERT(apSuite, expected_f2_count == it->Count());
+        while (it->Next(group) && i < expected_f2_count)
         {
-            NL_TEST_ASSERT(apSuite, state == expected_f1[i]);
-            i++;
+            NL_TEST_ASSERT(apSuite, expected_f2[i++] == group);
         }
-        NL_TEST_ASSERT(apSuite, i == expected_count_f1);
+        NL_TEST_ASSERT(apSuite, i == it->Count());
         it->Release();
-        it = nullptr;
-    }
-
-    // Iterate Fabric 2 only
-
-    constexpr size_t expected_count_f2              = 3;
-    const GroupState expected_f2[expected_count_f2] = { fabric2group1set1, fabric2group1set2, fabric2group1set3 };
-
-    it = groups->IterateGroupStates(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t i = 0;
-        NL_TEST_ASSERT(apSuite, expected_count_f2 == it->Count());
-
-        while (it->Next(state) && i < expected_count_f2)
-        {
-            NL_TEST_ASSERT(apSuite, state == expected_f2[i]);
-            i++;
-        }
-        NL_TEST_ASSERT(apSuite, i == expected_count_f2);
-        it->Release();
-        it = nullptr;
-    }
-}
-
-static EpochKey epoch_keys0[3] = {
-    { 0x1111111111111111, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
-    { 0x2222222222222222, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
-    { 0x3333333333333333, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } }
-};
-static EpochKey epoch_keys1[3] = {
-    { 0xaaaaaaaaaaaaaaaa, { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f } },
-    { 0xbbbbbbbbbbbbbbbb, { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f } },
-    { 0xcccccccccccccccc, { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f } },
-};
-static EpochKey epoch_keys2[2] = {
-    { 0xeeeeeeeeeeeeeeee, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
-    { 0xffffffffffffffff, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
-};
-
-constexpr uint16_t kKeySetId0 = 0x0;
-constexpr uint16_t kKeySetId1 = 0x1111;
-constexpr uint16_t kKeySetId2 = 0x2222;
-constexpr uint16_t kKeySetId3 = 0x3333;
-
-void TestKeySets(nlTestSuite * apSuite, void * apContext)
-{
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
-
-    KeySet keyset0(KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keyset1(KeySet::SecurityPolicy::kStandard, 1);
-    KeySet keyset2(KeySet::SecurityPolicy::kLowLatency, 2);
-    KeySet keyset3(KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keysets;
-
-    memcpy(keyset0.epoch_keys, epoch_keys0, sizeof(epoch_keys1));
-    memcpy(keyset1.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keyset2.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
-    memcpy(keyset3.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-
-    // Add KeySets
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId1, keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId0, keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId2, keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId3, keyset3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId1, keyset3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId0, keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId2, keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId3, keyset2));
-
-    // Get KeySets
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric1, kKeySetId3, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric1, kKeySetId1, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric1, kKeySetId0, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric1, kKeySetId2, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset2);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId3, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId2, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId1, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId0, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset0);
-
-    // Remove Keysets
-
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveKeySet(kFabric1, 0xffff));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric1, kKeySetId1)); // First
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric1, kKeySetId3)); // Last
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric2, kKeySetId2)); // Middle
-
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric1, kKeySetId3, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric1, kKeySetId1, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric1, kKeySetId0, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric1, kKeySetId2, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset2);
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId3, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset2);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric2, kKeySetId2, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId1, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->GetKeySet(kFabric2, kKeySetId0, keysets));
-    NL_TEST_ASSERT(apSuite, keysets == keyset0);
-
-    // Remove all
-
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveKeySet(kFabric1, kKeySetId3));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveKeySet(kFabric1, kKeySetId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric1, kKeySetId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric1, kKeySetId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric2, kKeySetId3));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->RemoveKeySet(kFabric2, kKeySetId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric2, kKeySetId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->RemoveKeySet(kFabric2, kKeySetId0));
-
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric1, kKeySetId3, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric1, kKeySetId1, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric1, kKeySetId0, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric1, kKeySetId2, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric2, kKeySetId3, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric2, kKeySetId2, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric2, kKeySetId1, keysets));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == groups->GetKeySet(kFabric2, kKeySetId0, keysets));
-}
-
-void TestKeySetIterator(nlTestSuite * apSuite, void * apContext)
-{
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    KeySet keyset0(KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keyset1(KeySet::SecurityPolicy::kStandard, 1);
-    KeySet keyset2(KeySet::SecurityPolicy::kLowLatency, 2);
-    KeySet keyset3(KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keysets;
-
-    memcpy(keyset0.epoch_keys, epoch_keys0, sizeof(epoch_keys1));
-    memcpy(keyset1.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keyset2.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
-    memcpy(keyset3.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-
-    // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
-
-    // Add data to iterate
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId1, keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId0, keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId2, keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric1, kKeySetId3, keyset3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId1, keyset3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId2, keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == groups->SetKeySet(kFabric2, kKeySetId3, keyset2));
-
-    // Iterate Fabric 1
-
-    std::map<uint16_t, const KeySet> expected_f1{
-        { kKeySetId1, keyset1 }, { kKeySetId0, keyset0 }, { kKeySetId2, keyset2 }, { kKeySetId3, keyset3 }
-    };
-
-    auto it = groups->IterateKeySets(kFabric1);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t i = 0;
-        NL_TEST_ASSERT(apSuite, expected_f1.size() == it->Count());
-
-        while (it->Next(keysets) && i < expected_f1.size())
-        {
-            NL_TEST_ASSERT(apSuite, expected_f1.count(keysets.keyset_id) > 0);
-            NL_TEST_ASSERT(apSuite, keysets == expected_f1[keysets.keyset_id]);
-            i++;
-        }
-        NL_TEST_ASSERT(apSuite, i == expected_f1.size());
-        it->Release();
-        it = nullptr;
-    }
-
-    // Iterate Fabric 2
-
-    std::map<uint16_t, const KeySet> expected_f2{ { kKeySetId3, keyset2 }, { kKeySetId1, keyset3 }, { kKeySetId2, keyset1 } };
-
-    it = groups->IterateKeySets(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t i = 0;
-        NL_TEST_ASSERT(apSuite, expected_f2.size() == it->Count());
-
-        while (it->Next(keysets) && i < expected_f2.size())
-        {
-            NL_TEST_ASSERT(apSuite, expected_f2.count(keysets.keyset_id) > 0);
-            NL_TEST_ASSERT(apSuite, keysets == expected_f2[keysets.keyset_id]);
-            i++;
-        }
-        NL_TEST_ASSERT(apSuite, i == expected_f2.size());
-        it->Release();
-        it = nullptr;
     }
 }
 
 void TestEndpoints(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    bool exists    = false;
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupInfo group;
 
-    exists = groups->GroupMappingExists(0xff, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
+    // Existing groups
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_3));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
+    // New groups
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
 
-    err = groups->RemoveGroupMapping(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup4, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
+    // Remove
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->RemoveEndpoint(kFabric1, kGroup1, kEndpointId4));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->RemoveEndpoint(kFabric2, kGroup5, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric2, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric2, kGroup3, kEndpointId2));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Check removed
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, exists);
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
+    // Remove All
 
-    err = groups->RemoveAllGroupMappings(kFabric1, 1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup4, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup4, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric1, kEndpointId3));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    // Test multiple fabrics
-
-    NL_TEST_ASSERT(apSuite, groups);
-
-    exists = groups->GroupMappingExists(0xff, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    err = groups->AddGroupMapping(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->AddGroupMapping(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->AddGroupMapping(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->AddGroupMapping(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    err = groups->RemoveGroupMapping(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    err = groups->AddGroupMapping(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->AddGroupMapping(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    err = groups->RemoveAllGroupMappings(kFabric2, 1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, !exists);
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup4, kEndpointId3));
 }
 
 void TestEndpointIterator(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    GroupInfo group;
 
-    err = groups->AddGroupMapping(kFabric1, endpoint3group2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Set Endpoints
 
-    err = groups->AddGroupMapping(kFabric1, endpoint2group2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId4));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint3group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Iterate fabric 1
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    std::set<std::pair<GroupId, EndpointId>> expected_f1 = {
+        { kGroup1, kEndpointId0 }, { kGroup1, kEndpointId2 }, { kGroup1, kEndpointId4 },
+        { kGroup2, kEndpointId1 }, { kGroup2, kEndpointId2 }, { kGroup2, kEndpointId3 },
+    };
 
-    err = groups->AddGroupMapping(kFabric1, endpoint3group3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    // Endpoint 1
-
-    GroupDataProvider::GroupMapping mapping;
-    auto * it = groups->IterateGroupMappings(kFabric1, kEndpoint1);
+    auto it      = provider->IterateEndpoints(kFabric1);
+    size_t count = 0;
     NL_TEST_ASSERT(apSuite, it);
     if (it)
     {
-        size_t count1 = it->Count();
-        size_t count2 = 0;
-        NL_TEST_ASSERT(apSuite, 2 == count1);
-        while (it->Next(mapping))
+        GroupEndpoint output;
+        NL_TEST_ASSERT(apSuite, expected_f1.size() == it->Count());
+        while (it->Next(output) && count < expected_f1.size())
         {
-            count2++;
-            NL_TEST_ASSERT(apSuite, kGroup1 == mapping.group || kGroup2 == mapping.group);
+            std::pair<chip::GroupId, chip::EndpointId> mapping(output.group_id, output.endpoint_id);
+            NL_TEST_ASSERT(apSuite, expected_f1.count(mapping) > 0);
+            count++;
         }
-        NL_TEST_ASSERT(apSuite, count2 == count1);
+        NL_TEST_ASSERT(apSuite, count == it->Count());
         it->Release();
     }
 
-    // Endpoint 3
+    // Iterate fabric 2
 
-    it = groups->IterateGroupMappings(kFabric1, kEndpoint3);
+    std::set<std::pair<GroupId, EndpointId>> expected_f2 = {
+        { kGroup3, kEndpointId0 }, { kGroup3, kEndpointId1 }, { kGroup3, kEndpointId2 },
+        { kGroup3, kEndpointId3 }, { kGroup3, kEndpointId4 },
+    };
+
+    it = provider->IterateEndpoints(kFabric2);
     NL_TEST_ASSERT(apSuite, it);
     if (it)
     {
-        size_t count1 = it->Count();
-        size_t count2 = 0;
-        NL_TEST_ASSERT(apSuite, 3 == count1);
-        while (it->Next(mapping))
+        count = 0;
+        GroupEndpoint output;
+        NL_TEST_ASSERT(apSuite, expected_f2.size() == it->Count());
+        while (it->Next(output) && count < expected_f2.size())
         {
-            count2++;
-            NL_TEST_ASSERT(apSuite, kGroup1 == mapping.group || kGroup2 == mapping.group || kGroup3 == mapping.group);
+            std::pair<chip::GroupId, chip::EndpointId> mapping(output.group_id, output.endpoint_id);
+            NL_TEST_ASSERT(apSuite, expected_f2.count(mapping) > 0);
+            count++;
         }
-        NL_TEST_ASSERT(apSuite, count2 == count1);
+        NL_TEST_ASSERT(apSuite, count == it->Count());
         it->Release();
-        it = nullptr;
     }
 }
 
-void TestStates(nlTestSuite * apSuite, void * apContext)
+void TestGroupKey(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    GroupDataProvider::GroupState state0a(1, 1, 1);
-    GroupDataProvider::GroupState state0b(0, 10, 11);
-    GroupDataProvider::GroupState state1a(1, 1, 2);
-    GroupDataProvider::GroupState state1b(0, 10, 12);
-    GroupDataProvider::GroupState state3b(0, 10, 13);
-    GroupDataProvider::GroupState state4a(1, 5, 3);
-    GroupDataProvider::GroupState state4b(0, 10, 14);
+    GroupKey pair;
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    // Set Group Info
 
-    // First append
-    err = groups->SetGroupState(0, state0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Out-of-order
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT == provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
 
-    // Second append
-    err = groups->SetGroupState(1, state1a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup1Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup1Keyset1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup1Keyset3));
+    // Duplicated
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset2));
 
-    // Attempt to set past the append slot
-    err = groups->SetGroupState(3, state0a);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3));
+    // Duplicated
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric2, 4, kGroup2Keyset0));
 
-    auto * it = groups->IterateGroupStates(kFabric1);
-    if (it)
-    {
-        NL_TEST_ASSERT(apSuite, it != nullptr);
-        NL_TEST_ASSERT(apSuite, 2 == it->Count());
-        it->Release();
-        it = nullptr;
-    }
+    // Get Group Info
 
-    err = groups->GetGroupState(0, state0b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state0a.group == state0b.group);
-    NL_TEST_ASSERT(apSuite, state0a.keyset_id == state0b.keyset_id);
-    NL_TEST_ASSERT(apSuite, kFabric1 == state0b.fabric_index);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetGroupKeyAt(kUndefinedFabricIndex, 0, pair));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupKeyAt(kFabric2, 999, pair));
 
-    err = groups->GetGroupState(1, state1b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state1a.group == state1b.group);
-    NL_TEST_ASSERT(apSuite, state1a.keyset_id == state1b.keyset_id);
-    NL_TEST_ASSERT(apSuite, kFabric1 == state1b.fabric_index);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 3, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 2, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 1, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 0, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset0);
 
-    err = groups->GetGroupState(2, state3b);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 3, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 2, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 1, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset0);
 
-    err = groups->RemoveGroupState(0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Remove Groups (remaining entries shift up)
 
-    // Entry 1 should remain, now at slot 0
-    state1b.group        = 10;
-    state1b.keyset_id    = 12;
-    state1b.fabric_index = 14;
-    err                  = groups->GetGroupState(0, state1b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state1a.group == state1b.group);
-    NL_TEST_ASSERT(apSuite, state1a.keyset_id == state1b.keyset_id);
-    NL_TEST_ASSERT(apSuite, kFabric1 == state1b.fabric_index);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupKeyAt(kFabric1, 2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupKeyAt(kFabric2, 0));
 
-    state1b.group        = 10;
-    state1b.keyset_id    = 12;
-    state1b.fabric_index = 14;
-    err                  = groups->GetGroupState(1, state1b);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupKeyAt(kFabric1, 3, pair));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 2, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 1, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 0, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset0);
 
-    err = groups->RemoveGroupState(0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetGroupKeyAt(kFabric2, 3, pair));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 2, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 1, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset1);
 
-    err = groups->GetGroupState(0, state1b);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+    // Overwrite, (group_id, keyset_id) must be unique
 
-    // Test Override
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup3Keyset1));
 
-    err = groups->SetGroupState(0, state0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 2, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup3Keyset0);
 
-    err = groups->SetGroupState(0, state4a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->GetGroupState(0, state4b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state4a.group == state4b.group);
-    NL_TEST_ASSERT(apSuite, state4a.keyset_id == state4b.keyset_id);
-    NL_TEST_ASSERT(apSuite, state4a.fabric_index == state4b.fabric_index);
-
-    // Incorrect fabric
-
-    state4a.fabric_index = 3;
-    err                  = groups->SetGroupState(0, state4a);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_ACCESS_DENIED == err);
-
-    err = groups->RemoveGroupState(0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
+    NL_TEST_ASSERT(apSuite, pair == kGroup3Keyset1);
 }
 
-void TestStateIterator(nlTestSuite * apSuite, void * apContext)
+void TestGroupKeyIterator(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    GroupDataProvider::GroupState state0(kFabric1, 1, 1);
-    GroupDataProvider::GroupState state1(kFabric1, 2, 1);
-    GroupDataProvider::GroupState state2(kFabric2, 2, 2);
-    GroupDataProvider::GroupState state3(kFabric1, 3, 1);
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    NL_TEST_ASSERT(apSuite, groups);
-
-    err = groups->SetGroupState(0, state0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetGroupState(1, state1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetGroupState(2, state2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetGroupState(3, state3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    {
-        // Fabric Index 1 has 3 entries
-        auto * it = groups->IterateGroupStates(kFabric1);
-        NL_TEST_ASSERT(apSuite, it != nullptr);
-
-        size_t count1 = it->Count();
-        size_t count2 = 0;
-        NL_TEST_ASSERT(apSuite, 3 == count1);
-        GroupDataProvider::GroupState state;
-        while (it->Next(state))
-        {
-            NL_TEST_ASSERT(apSuite, (state.group > 0 && state.group < 4) && (state.keyset_id == 1));
-            NL_TEST_ASSERT(apSuite, (state.fabric_index == kFabric1));
-            count2++;
-        }
-        NL_TEST_ASSERT(apSuite, count2 == count1);
-        it->Release();
-        it = nullptr;
-    }
-
-    // Fabric Index 2 has 1 entry
-    auto * it = groups->IterateGroupStates(kFabric2);
-    NL_TEST_ASSERT(apSuite, it != nullptr);
-    if (it)
-    {
-        size_t count1 = it->Count();
-        NL_TEST_ASSERT(apSuite, 1 == count1);
-        GroupDataProvider::GroupState state;
-        NL_TEST_ASSERT(apSuite, it->Next(state));
-
-        NL_TEST_ASSERT(apSuite, (state.group > 0 && state.group < 4) && (state.keyset_id == 2));
-        NL_TEST_ASSERT(apSuite, (state.fabric_index == kFabric2));
-
-        NL_TEST_ASSERT(apSuite, !it->Next(state));
-
-        it->Release();
-        it = nullptr;
-    }
-
-    // Fabric Index 1 has 3 entries + Fabric Index 2 has 1 entry
-    it = groups->IterateGroupStates();
-    NL_TEST_ASSERT(apSuite, it != nullptr);
-    if (it)
-    {
-        size_t count1 = it->Count();
-        size_t count2 = 0;
-        NL_TEST_ASSERT(apSuite, 4 == count1);
-        GroupDataProvider::GroupState state;
-        while (it->Next(state))
-        {
-            NL_TEST_ASSERT(apSuite, (state.fabric_index == kFabric1 || state.fabric_index == kFabric2));
-            NL_TEST_ASSERT(apSuite, (state.group > 0 && state.group < 4) && (state.keyset_id == 1 || state.keyset_id == 2));
-            count2++;
-        }
-        NL_TEST_ASSERT(apSuite, count2 == count1);
-        it->Release();
-        it = nullptr;
-    }
-}
-
-void TestKeys(nlTestSuite * apSuite, void * apContext)
-{
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    // Pairs keys0[a|b], keys1[a|b] have different values. [b] is used as Get target, so it
-    // should get overwritten with the values from [a].
-    KeySet keys0a(0, KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keys0b(0, KeySet::SecurityPolicy::kStandard, 2);
-    KeySet keys1a(0, KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keys1b(0, KeySet::SecurityPolicy::kStandard, 2);
-    KeySet keys3(0, KeySet::SecurityPolicy::kStandard, 2);
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    GroupKey pair;
 
-    NL_TEST_ASSERT(apSuite, groups);
+    // Set Group Info
 
-    memcpy(keys0a.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keys0b.epoch_keys, epoch_keys0, sizeof(epoch_keys0));
-    memcpy(keys1a.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keys1b.epoch_keys, epoch_keys0, sizeof(epoch_keys0));
-    memcpy(keys3.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup3Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup3Keyset1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 5, kGroup1Keyset1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 6, kGroup1Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 7, kGroup1Keyset3));
 
-    err = groups->SetKeySet(kFabric1, kKeySetId0, keys0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3));
 
-    err = groups->SetKeySet(kFabric1, kKeySetId1, keys1a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Iterate fabric 1
 
-    auto * it = groups->IterateKeySets(kFabric1);
-    NL_TEST_ASSERT(apSuite, it != nullptr);
-    if (it)
-    {
-        NL_TEST_ASSERT(apSuite, it->Count() == 2);
-        it->Release();
-        it = nullptr;
-    }
+    GroupKey expected_f1[]   = { kGroup3Keyset0, kGroup3Keyset1, kGroup3Keyset2, kGroup3Keyset3,
+                               kGroup1Keyset0, kGroup1Keyset1, kGroup1Keyset2, kGroup1Keyset3 };
+    size_t expected_f1_count = sizeof(expected_f1) / sizeof(GroupKey);
 
-    err = groups->GetKeySet(kFabric1, kKeySetId0, keys0b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys0b.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys0b.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(keys0a.epoch_keys, keys0b.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
-
-    err = groups->GetKeySet(kFabric1, kKeySetId1, keys1b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys1a.policy == keys1b.policy);
-    NL_TEST_ASSERT(apSuite, keys1a.num_keys_used == keys1b.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(keys1a.epoch_keys, keys1b.epoch_keys, sizeof(keys1a.epoch_keys[0]) * keys1a.num_keys_used));
-
-    err = groups->GetKeySet(kFabric1, kKeySetId3, keys3);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
-
-    err = groups->RemoveKeySet(kFabric1, kKeySetId0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->GetKeySet(kFabric1, kKeySetId1, keys1b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->GetKeySet(kFabric1, kKeySetId0, keys0b);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
-}
-
-void TestKeysIterator(nlTestSuite * apSuite, void * apContext)
-{
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
-
-    // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
-
-    KeySet keys0(0, KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keys1(0, KeySet::SecurityPolicy::kStandard, 2);
-    KeySet keys2(0, KeySet::SecurityPolicy::kStandard, 3);
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    NL_TEST_ASSERT(apSuite, groups);
-
-    memcpy(keys0.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keys1.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
-    memcpy(keys2.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-
-    NL_TEST_ASSERT(apSuite, groups);
-
-    err = groups->SetKeySet(kFabric1, kKeySetId2, keys2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric1, kKeySetId0, keys0);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric1, kKeySetId1, keys1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    auto * it = groups->IterateKeySets(kFabric1);
+    auto it      = provider->IterateGroupKey(kFabric1);
+    size_t count = 0;
     NL_TEST_ASSERT(apSuite, it);
     if (it)
     {
-        size_t count1 = it->Count();
-        size_t count2 = 0;
-        NL_TEST_ASSERT(apSuite, 3 == count1);
-        GroupDataProvider::KeySet keys;
-
-        uint16_t last_keyset_id = UINT16_MAX;
-
-        while (it->Next(keys))
+        NL_TEST_ASSERT(apSuite, expected_f1_count == it->Count());
+        while (it->Next(pair) && count < expected_f1_count)
         {
-            NL_TEST_ASSERT(apSuite, keys.keyset_id == kKeySetId0 || keys.keyset_id == kKeySetId1 || keys.keyset_id == kKeySetId2);
-            NL_TEST_ASSERT(apSuite, keys.keyset_id != last_keyset_id);
-            last_keyset_id = keys.keyset_id;
-            count2++;
+            NL_TEST_ASSERT(apSuite, expected_f1[count++] == pair);
         }
-        NL_TEST_ASSERT(apSuite, count2 == count1);
+        NL_TEST_ASSERT(apSuite, count == it->Count());
         it->Release();
-        it = nullptr;
+    }
+
+    // Iterate fabric 2
+
+    GroupKey expected_f2[]   = { kGroup2Keyset0, kGroup2Keyset1, kGroup2Keyset2, kGroup2Keyset3 };
+    size_t expected_f2_count = sizeof(expected_f2) / sizeof(GroupKey);
+
+    it = provider->IterateGroupKey(kFabric2);
+    NL_TEST_ASSERT(apSuite, it);
+    if (it)
+    {
+        count = 0;
+        NL_TEST_ASSERT(apSuite, expected_f2_count == it->Count());
+        while (it->Next(pair) && count < expected_f2_count)
+        {
+            NL_TEST_ASSERT(apSuite, expected_f2[count++] == pair);
+        }
+        NL_TEST_ASSERT(apSuite, count == it->Count());
+        it->Release();
+    }
+}
+
+void TestKeySets(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
+
+    // Reset test
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
+
+    KeySet keyset;
+
+    // Add KeySets
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet1));
+
+    // Get KeySets
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet0);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet2);
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet0);
+
+    // Remove Keysets
+
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->RemoveKeySet(kFabric1, 0xffff));
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId1)); // First
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId3)); // Last
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId2)); // Middle
+
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet0);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet2);
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet3);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, keyset == kKeySet0);
+
+    // Remove all
+
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->RemoveKeySet(kFabric1, kKeysetId3));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->RemoveKeySet(kFabric1, kKeysetId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId3));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->RemoveKeySet(kFabric2, kKeysetId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId0));
+
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+}
+
+void TestKeySetIterator(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
+
+    // Reset test
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
+
+    // Add data to iterate
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet1));
+
+    // Iterate Fabric 1
+
+    KeySet keyset;
+
+    std::map<uint16_t, const KeySet> expected_f1{
+        { kKeysetId0, kKeySet0 }, { kKeysetId1, kKeySet1 }, { kKeysetId2, kKeySet2 }, { kKeysetId3, kKeySet3 }
+    };
+
+    auto it = provider->IterateKeySets(kFabric1);
+    NL_TEST_ASSERT(apSuite, it);
+    if (it)
+    {
+        size_t count = 0;
+        NL_TEST_ASSERT(apSuite, expected_f1.size() == it->Count());
+
+        while (it->Next(keyset) && count < expected_f1.size())
+        {
+            NL_TEST_ASSERT(apSuite, expected_f1.count(keyset.keyset_id) > 0);
+            NL_TEST_ASSERT(apSuite, keyset == expected_f1[keyset.keyset_id]);
+            count++;
+        }
+        NL_TEST_ASSERT(apSuite, count == expected_f1.size());
+        it->Release();
+    }
+
+    // Iterate Fabric 2
+
+    std::map<uint16_t, const KeySet> expected_f2{ { kKeysetId1, kKeySet1 }, { kKeysetId2, kKeySet2 }, { kKeysetId3, kKeySet3 } };
+
+    it = provider->IterateKeySets(kFabric2);
+    NL_TEST_ASSERT(apSuite, it);
+    if (it)
+    {
+        size_t count = 0;
+        NL_TEST_ASSERT(apSuite, expected_f2.size() == it->Count());
+
+        while (it->Next(keyset) && count < expected_f2.size())
+        {
+            NL_TEST_ASSERT(apSuite, expected_f2.count(keyset.keyset_id) > 0);
+            NL_TEST_ASSERT(apSuite, keyset == expected_f2[keyset.keyset_id]);
+            count++;
+        }
+        NL_TEST_ASSERT(apSuite, count == expected_f2.size());
+        it->Release();
     }
 }
 
 void TestPerFabricData(nlTestSuite * apSuite, void * apContext)
 {
-    GroupDataProvider * groups = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, groups);
+    GroupDataProvider * provider = GetGroupDataProvider();
+    NL_TEST_ASSERT(apSuite, provider);
 
     // Reset test
-    groups->RemoveFabric(kFabric1);
-    groups->RemoveFabric(kFabric2);
+    provider->RemoveFabric(kFabric1);
+    provider->RemoveFabric(kFabric2);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    bool exists    = false;
+    // Group Info
+    GroupInfo group;
 
-    // Mappings
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2));
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 2, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 2, group));
+    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    // Endpoints
 
-    err = groups->AddGroupMapping(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4));
 
-    err = groups->AddGroupMapping(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->AddGroupMapping(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    // States
-
-    const GroupDataProvider::GroupState state0a(kFabric1, kGroup1, 101);
-    GroupDataProvider::GroupState state0b(0, 0, 0);
-
-    const GroupDataProvider::GroupState state1a(kFabric2, kGroup1, 102);
-    GroupDataProvider::GroupState state1b(0, 0, 0);
-
-    const GroupDataProvider::GroupState state2a(kFabric2, kGroup2, 101);
-    GroupDataProvider::GroupState state2b(0, 0, 0);
-
-    const GroupDataProvider::GroupState state3a(kFabric1, kGroup2, 102);
-    GroupDataProvider::GroupState state4b(0, 0, 0);
-
-    err = groups->SetGroupState(0, state0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetGroupState(1, state1a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetGroupState(2, state2a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetGroupState(3, state3a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->GetGroupState(0, state0b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state0a.fabric_index == state0b.fabric_index);
-    NL_TEST_ASSERT(apSuite, state0a.group == state0b.group);
-    NL_TEST_ASSERT(apSuite, state0a.keyset_id == state0b.keyset_id);
-
-    err = groups->GetGroupState(1, state1b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state1a.fabric_index == state1b.fabric_index);
-    NL_TEST_ASSERT(apSuite, state1a.group == state1b.group);
-    NL_TEST_ASSERT(apSuite, state1a.keyset_id == state1b.keyset_id);
-
-    err = groups->GetGroupState(2, state2b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state2a.fabric_index == state2b.fabric_index);
-    NL_TEST_ASSERT(apSuite, state2a.group == state2b.group);
-    NL_TEST_ASSERT(apSuite, state2a.keyset_id == state2b.keyset_id);
-
-    err = groups->GetGroupState(4, state4b);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId4));
 
     // Keys
 
-    KeySet keys0a(0, KeySet::SecurityPolicy::kStandard, 3);
-    KeySet keys1a(0, KeySet::SecurityPolicy::kLowLatency, 3);
-    KeySet keys_out(0, KeySet::SecurityPolicy::kStandard, 0);
+    KeySet keys;
 
-    NL_TEST_ASSERT(apSuite, groups);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet0));
 
-    memcpy(keys0a.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keys1a.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
-    memcpy(keys_out.epoch_keys, epoch_keys0, sizeof(epoch_keys0));
-
-    err = groups->SetKeySet(kFabric2, kKeySetId0, keys0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric1, kKeySetId0, keys0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric2, kKeySetId1, keys1a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric1, kKeySetId1, keys1a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric2, kKeySetId2, keys0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->SetKeySet(kFabric1, kKeySetId2, keys0a);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-
-    err = groups->GetKeySet(kFabric2, kKeySetId0, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys0a.epoch_keys, keys_out.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
+                   0 == memcmp(kKeySet0.epoch_keys, keys.epoch_keys, sizeof(kKeySet0.epoch_keys[0]) * kKeySet0.num_keys_used));
 
-    err = groups->GetKeySet(kFabric2, kKeySetId1, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys1a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys1a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys1a.epoch_keys, keys_out.epoch_keys, sizeof(keys1a.epoch_keys[0]) * keys1a.num_keys_used));
+                   0 == memcmp(kKeySet1.epoch_keys, keys.epoch_keys, sizeof(kKeySet1.epoch_keys[0]) * kKeySet1.num_keys_used));
 
-    err = groups->GetKeySet(kFabric2, kKeySetId2, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys0a.epoch_keys, keys_out.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
+                   0 == memcmp(kKeySet2.epoch_keys, keys.epoch_keys, sizeof(kKeySet2.epoch_keys[0]) * kKeySet2.num_keys_used));
 
-    err = groups->GetKeySet(kFabric1, kKeySetId2, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys0a.epoch_keys, keys_out.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
+                   0 == memcmp(kKeySet2.epoch_keys, keys.epoch_keys, sizeof(kKeySet2.epoch_keys[0]) * kKeySet2.num_keys_used));
 
-    err = groups->GetKeySet(kFabric1, kKeySetId1, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys1a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys1a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys1a.epoch_keys, keys_out.epoch_keys, sizeof(keys1a.epoch_keys[0]) * keys1a.num_keys_used));
+                   0 == memcmp(kKeySet1.epoch_keys, keys.epoch_keys, sizeof(kKeySet1.epoch_keys[0]) * kKeySet1.num_keys_used));
 
-    err = groups->GetKeySet(kFabric1, kKeySetId0, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys0a.epoch_keys, keys_out.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
+                   0 == memcmp(kKeySet0.epoch_keys, keys.epoch_keys, sizeof(kKeySet0.epoch_keys[0]) * kKeySet0.num_keys_used));
 
     //
     // Remove Fabric
     //
 
-    err = groups->RemoveFabric(kFabric1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveFabric(kFabric1));
 
-    // Mappings
+    // Endpoints
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, !exists);
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId0));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId1));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId3));
+    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId4));
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
+    // Group Info
 
-    exists = groups->GroupMappingExists(kFabric1, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group1);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group2);
-    NL_TEST_ASSERT(apSuite, !exists);
-
-    exists = groups->GroupMappingExists(kFabric2, endpoint1group3);
-    NL_TEST_ASSERT(apSuite, exists);
-
-    // States: Removing the fabric shift the remaining groups states to a lower index
-
-    err = groups->GetGroupState(0, state0b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state1a.fabric_index == state0b.fabric_index);
-    NL_TEST_ASSERT(apSuite, state1a.group == state0b.group);
-    NL_TEST_ASSERT(apSuite, state1a.keyset_id == state0b.keyset_id);
-
-    err = groups->GetGroupState(1, state1b);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, state2a.fabric_index == state1b.fabric_index);
-    NL_TEST_ASSERT(apSuite, state2a.group == state1b.group);
-    NL_TEST_ASSERT(apSuite, state2a.keyset_id == state1b.keyset_id);
-
-    err = groups->GetGroupState(2, state2b);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetGroupInfoAt(kFabric1, 0, group));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetGroupInfoAt(kFabric1, 1, group));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetGroupInfoAt(kFabric1, 2, group));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 2, group));
 
     // Keys
 
-    err = groups->GetKeySet(kFabric2, kKeySetId0, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys0a.epoch_keys, keys_out.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
+                   0 == memcmp(kKeySet0.epoch_keys, keys.epoch_keys, sizeof(kKeySet0.epoch_keys[0]) * kKeySet0.num_keys_used));
 
-    err = groups->GetKeySet(kFabric2, kKeySetId1, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys1a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys1a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys1a.epoch_keys, keys_out.epoch_keys, sizeof(keys1a.epoch_keys[0]) * keys1a.num_keys_used));
+                   0 == memcmp(kKeySet1.epoch_keys, keys.epoch_keys, sizeof(kKeySet1.epoch_keys[0]) * kKeySet1.num_keys_used));
 
-    err = groups->GetKeySet(kFabric2, kKeySetId0, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
-    NL_TEST_ASSERT(apSuite, keys0a.policy == keys_out.policy);
-    NL_TEST_ASSERT(apSuite, keys0a.num_keys_used == keys_out.num_keys_used);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keys));
+    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
+    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
     NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(keys0a.epoch_keys, keys_out.epoch_keys, sizeof(keys0a.epoch_keys[0]) * keys0a.num_keys_used));
+                   0 == memcmp(kKeySet0.epoch_keys, keys.epoch_keys, sizeof(kKeySet0.epoch_keys[0]) * kKeySet0.num_keys_used));
 
-    err = groups->GetKeySet(kFabric1, 202, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == err);
-
-    err = groups->GetKeySet(kFabric1, 404, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == err);
-
-    err = groups->GetKeySet(kFabric1, 606, keys_out);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == err);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetKeySet(kFabric1, 202, keys));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetKeySet(kFabric1, 404, keys));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_ID == provider->GetKeySet(kFabric1, 606, keys));
 }
 
 } // namespace TestGroups
@@ -1575,6 +931,22 @@ namespace {
 static chip::TestPersistentStorageDelegate sDelegate;
 static GroupDataProviderImpl sProvider(sDelegate);
 
+static EpochKey kEpochKeys0[] = {
+    { 0x1111111111111111, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+    { 0x2222222222222222, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+    { 0x3333333333333333, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } }
+};
+static EpochKey kEpochKeys1[] = {
+    { 0xaaaaaaaaaaaaaaaa, { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f } },
+    { 0xbbbbbbbbbbbbbbbb, { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f } },
+    { 0xcccccccccccccccc, { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f } },
+};
+static EpochKey kEpochKeys2[] = {
+    { 0xeeeeeeeeeeeeeeee, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
+    { 0xffffffffffffffff, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
+    { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } }
+};
+
 /**
  *  Set up the test suite.
  */
@@ -1583,6 +955,11 @@ int Test_Setup(void * inContext)
     SetGroupDataProvider(&sProvider);
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
     VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(), FAILURE);
+
+    memcpy(chip::app::TestGroups::kKeySet0.epoch_keys, kEpochKeys0, sizeof(kEpochKeys0));
+    memcpy(chip::app::TestGroups::kKeySet1.epoch_keys, kEpochKeys1, sizeof(kEpochKeys1));
+    memcpy(chip::app::TestGroups::kKeySet2.epoch_keys, kEpochKeys2, sizeof(kEpochKeys2));
+    memcpy(chip::app::TestGroups::kKeySet3.epoch_keys, kEpochKeys1, sizeof(kEpochKeys1));
     return SUCCESS;
 }
 
@@ -1592,29 +969,25 @@ int Test_Setup(void * inContext)
 int Test_Teardown(void * inContext)
 {
     chip::Platform::MemoryShutdown();
-    GroupDataProvider * groups = GetGroupDataProvider();
-    if (nullptr != groups)
+    GroupDataProvider * provider = GetGroupDataProvider();
+    if (nullptr != provider)
     {
-        groups->Finish();
+        provider->Finish();
     }
     return SUCCESS;
 }
 
 const nlTest sTests[] = { NL_TEST_DEF("TestStorageDelegate", chip::app::TestGroups::TestStorageDelegate),
-                          NL_TEST_DEF("TestGroupMappings", chip::app::TestGroups::TestGroupMappings),
-                          NL_TEST_DEF("TestGroupMappingIterator", chip::app::TestGroups::TestGroupMappingIterator),
-                          NL_TEST_DEF("TestGroupStates", chip::app::TestGroups::TestGroupStates),
-                          NL_TEST_DEF("TestGroupStateIterator", chip::app::TestGroups::TestGroupStateIterator),
-                          NL_TEST_DEF("TestKeySets", chip::app::TestGroups::TestKeySets),
-                          NL_TEST_DEF("TestKeySetIterator", chip::app::TestGroups::TestKeySetIterator),
-                          // Old Tests
+                          NL_TEST_DEF("TestGroupInfo", chip::app::TestGroups::TestGroupInfo),
+                          NL_TEST_DEF("TestGroupInfoIterator", chip::app::TestGroups::TestGroupInfoIterator),
                           NL_TEST_DEF("TestEndpoints", chip::app::TestGroups::TestEndpoints),
                           NL_TEST_DEF("TestEndpointIterator", chip::app::TestGroups::TestEndpointIterator),
-                          NL_TEST_DEF("TestStates", chip::app::TestGroups::TestStates),
-                          NL_TEST_DEF("TestStateIterator", chip::app::TestGroups::TestStateIterator),
-                          NL_TEST_DEF("TestKeys", chip::app::TestGroups::TestKeys),
-                          NL_TEST_DEF("TestKeysIterator", chip::app::TestGroups::TestKeysIterator),
-                          NL_TEST_DEF("TestPerFabricData", chip::app::TestGroups::TestPerFabricData), NL_TEST_SENTINEL() };
+                          NL_TEST_DEF("TestGroupKey", chip::app::TestGroups::TestGroupKey),
+                          NL_TEST_DEF("TestGroupKeyIterator", chip::app::TestGroups::TestGroupKeyIterator),
+                          NL_TEST_DEF("TestKeySets", chip::app::TestGroups::TestKeySets),
+                          NL_TEST_DEF("TestKeySetIterator", chip::app::TestGroups::TestKeySetIterator),
+                          NL_TEST_DEF("TestPerFabricData", chip::app::TestGroups::TestPerFabricData),
+                          NL_TEST_SENTINEL() };
 } // namespace
 
 int TestGroups()

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2581,7 +2581,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #define CHIP_CONFIG_MAX_GROUPS_PER_FABRIC 1
 #endif
 
-// TODO: Need to cap number of KeySets
+/**
+ * @def CHIP_CONFIG_MAX_GROUPS_PER_FABRIC
+ *
+ * @brief Defines the number of groups supported per fabric, see Group Key Management Cluster in specification.
+ *
+ * Binds to number of GroupState entries to support per fabric
+ */
+#ifndef CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC
+#define CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC 1
+#endif
 
 /**
  * @def CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC

--- a/src/lib/core/DataModelTypes.h
+++ b/src/lib/core/DataModelTypes.h
@@ -42,6 +42,7 @@ typedef uint8_t FabricIndex;
 typedef uint32_t FieldId;
 typedef uint16_t ListIndex;
 typedef uint32_t TransactionId;
+typedef uint16_t KeysetId;
 
 constexpr FabricIndex kUndefinedFabricIndex = 0;
 constexpr EndpointId kInvalidEndpointId     = 0xFFFF;

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -28,6 +28,7 @@ class DefaultStorageKeyAllocator
 {
 public:
     DefaultStorageKeyAllocator() = default;
+    const char * KeyName() { return mKeyName; }
 
     // Fabric Table
 
@@ -36,18 +37,13 @@ public:
     // Group Data Provider
 
     const char * FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }
-    const char * FabricEndpoint(chip::FabricIndex fabric, chip::EndpointId endpoint)
+    const char * FabricGroup(chip::FabricIndex fabric, chip::GroupId group) { return Format("f/%x/g/%x", fabric, group); }
+    const char * FabricGroupKey(chip::FabricIndex fabric, uint16_t index) { return Format("f/%x/gk/%x", fabric, index); }
+    const char * FabricGroupEndpoint(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId endpoint)
     {
-        return Format("f/%x/e/%x", fabric, endpoint);
+        return Format("f/%x/g/%x/e/%x", fabric, group, endpoint);
     }
-    const char * FabricEndpointGroup(chip::FabricIndex fabric, chip::EndpointId endpoint, chip::GroupId group)
-    {
-        return Format("f/%x/e/%x/g/%x", fabric, endpoint, group);
-    }
-    const char * GroupStates() { return Format("g/s"); }
-    const char * GroupState(uint16_t state_id) { return Format("g/s/%x", state_id); }
-    const char * FabricKeySet(chip::FabricIndex fabric, uint16_t keyset_id) { return Format("f/%x/k/%x", fabric, keyset_id); }
-    const char * KeyName() { return mKeyName; }
+    const char * FabricKeyset(chip::FabricIndex fabric, uint16_t keyset) { return Format("f/%x/k/%x", fabric, keyset); }
 
 private:
     static const size_t kKeyLengthMax = 32;


### PR DESCRIPTION
#### Problem
The Group Data Provider lacks support for the new Group Key Management attributes.

#### Change overview
* Group Key Management interface updated:
   * GroupMapping functions replaced. The data provider should support two types of mappings, groups to endpoint, and groups to keysets.
   * Three new sections replace GroupMappings: GroupInfo, Endpoints, and GroupKeys.
   * Unit tests updated to support the new functions.
   * Groups cluster server updated to use the new interface.

#### Testing
* Unit tests run successfully (existing KeySet tests, plus new tests).
* Existing YAML group cluster tests executed successfully. 