### PR TITLE
Truncate string test value to maxLength in Darwin tests

### DIFF
--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -56,9 +56,9 @@ function asExpectedEndpointForCluster(clusterName)
 function asTestValue()
 {
   if (StringHelper.isOctetString(this.type)) {
-    return '[@"Test" dataUsingEncoding:NSUTF8StringEncoding]';
+    return `[@"${"Test".substring(0, this.maxLength)}" dataUsingEncoding:NSUTF8StringEncoding]`;
   } else if (StringHelper.isCharString(this.type)) {
-    return '@"Test"';
+    return `@"${"Test".substring(0, this.maxLength)}"`;
   } else if (this.isArray) {
     return '[NSArray array]';
   } else {


### PR DESCRIPTION
#### Problem
Fix Darwin test case failure in #12639 due to out-of-bounds test value.

#### Change overview
Now `helper.js` truncates strings for `OCTET_STRING` and `CHAR_STRING` types to their maximum length for Darwin tests.  

#### Testing
How was this tested? (at least one bullet point required)
* Regenerated all the auto-generated code both for `master` and #12639 to make sure there were no unexpected changes.
* Ran Darwin tests with changes from #12639.
* Wrote `Tes` into `Language` attribute in Door Lock Cluster (in #12639).
