### PR TITLE
Disable cirque

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -15,8 +15,8 @@
 name: Cirque
 
 on:
-  push:
-  pull_request:
+#  push:
+#  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
#### Problem
Cirque uses an old python API to run tests  which is difficult to maintain, causing CI issues.

Disable until we can use chip-repl and test things like events (or just use python directly without using cirque as we do not benefit from testing complex topologies currently).