### PR TITLE
extend cirque test timeout

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -15,8 +15,8 @@
 name: Cirque
 
 on:
-#  push:
-#  pull_request:
+  push:
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -91,7 +91,7 @@ class TestPythonController(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 75 -a {}".format(
+        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {}".format(
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/mobile-device-test.py"),
             ethernet_ip)


### PR DESCRIPTION
#### Problem
Cirque is failing because it recently add severals new tests, we need to extend timeout.

#### Change overview
Re-enable cirque and try the fix

#### Testing
See above
