### PR TITLE
Add an API to subscribe to a single event.

### DIFF
--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -127,9 +127,12 @@ public:
     using OnErrorCallbackType   = std::function<void(const app::EventHeader * apEventHeader,
                                                    Protocols::InteractionModel::Status aIMStatus, CHIP_ERROR aError)>;
     using OnDoneCallbackType    = std::function<void(app::ReadClient * client, TypedReadEventCallback * callback)>;
+    using OnSubscriptionEstablishedCallbackType = std::function<void()>;
 
-    TypedReadEventCallback(OnSuccessCallbackType aOnSuccess, OnErrorCallbackType aOnError, OnDoneCallbackType aOnDone) :
-        mOnSuccess(aOnSuccess), mOnError(aOnError), mOnDone(aOnDone)
+    TypedReadEventCallback(OnSuccessCallbackType aOnSuccess, OnErrorCallbackType aOnError, OnDoneCallbackType aOnDone,
+                           OnSubscriptionEstablishedCallbackType aOnSubscriptionEstablished = nullptr) :
+        mOnSuccess(aOnSuccess),
+        mOnError(aOnError), mOnDone(aOnDone), mOnSubscriptionEstablished(aOnSubscriptionEstablished)
     {}
 
 private:
@@ -162,9 +165,18 @@ private:
 
     void OnDone(app::ReadClient * apReadClient) override { mOnDone(apReadClient, this); }
 
+    void OnSubscriptionEstablished(const app::ReadClient * apReadClient) override
+    {
+        if (mOnSubscriptionEstablished)
+        {
+            mOnSubscriptionEstablished();
+        }
+    }
+
     OnSuccessCallbackType mOnSuccess;
     OnErrorCallbackType mOnError;
     OnDoneCallbackType mOnDone;
+    OnSubscriptionEstablishedCallbackType mOnSubscriptionEstablished;
 };
 
 } // namespace Controller


### PR DESCRIPTION
Might be useful in YAML tests.

#### Problem
No convenient API for tests to use to subscribe to a single event.

#### Change overview
Add one, similar to the one we have for attributes.

#### Testing
No idea how to test this (past it compiling), so far.  Once we have more event code in, we can add yaml tests.