### PR TITLE
Thermostat Cluster Init Function Enabled

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -67,10 +67,9 @@ constexpr int8_t kDefaultDeadBand                    = 25; // 2.5C is the defaul
 #define FEATURE_MAP_SB 0x10
 #define FEATURE_MAP_AUTO 0x20
 
-// Uncomment out FEATURE_MAP_OVERIDE and set appropriately for testing to overide ZAP
-//#define FEATURE_MAP_OVERIDE FEATURE_MAP_HEAT | FEATURE_MAP_COOL | FEATURE_MAP_AUTO
+#define FEATURE_MAP_DEFAULT FEATURE_MAP_HEAT | FEATURE_MAP_COOL | FEATURE_MAP_AUTO
 
-void emberAfThermostatClusterServerInitCallback()
+void emberAfThermostatClusterServerInitCallback(chip::EndpointId endpoint)
 {
     // TODO
     // Get from the "real thermostat"
@@ -105,43 +104,40 @@ MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttr
     int16_t AbsMaxCoolSetpointLimit;
     int16_t MinCoolSetpointLimit;
     int16_t MaxCoolSetpointLimit;
-    int8_t DeadBand         = 0;
-    int16_t DeadBandTemp    = 0;
-    uint32_t FeatureMap     = 0;
-    bool AutoSupported      = false;
-    bool HeatSupported      = false;
-    bool CoolSupported      = false;
-    bool OccupancySupported = false;
+    int8_t DeadBand      = 0;
+    int16_t DeadBandTemp = 0;
     int16_t OccupiedCoolingSetpoint;
     int16_t OccupiedHeatingSetpoint;
     int16_t UnoccupiedCoolingSetpoint;
     int16_t UnoccupiedHeatingSetpoint;
+    uint32_t OurFeatureMap;
+    bool AutoSupported      = false;
+    bool HeatSupported      = false;
+    bool CoolSupported      = false;
+    bool OccupancySupported = false;
 
-#ifndef FEATURE_MAP_OVERIDE
-    emberAfReadServerAttribute(endpoint, chip::app::Clusters::Thermostat::Id,
-                               chip::app::Clusters::Thermostat::Attributes::FeatureMap::Id,
-                               reinterpret_cast<uint8_t *>(&FeatureMap), sizeof(FeatureMap));
-#else
-    FeatureMap = FEATURE_MAP_OVERIDE;
-#endif
+    if (FeatureMap::Get(endpoint, &OurFeatureMap) != EMBER_ZCL_STATUS_SUCCESS)
+        OurFeatureMap = FEATURE_MAP_DEFAULT;
 
-    if (FeatureMap & 1 << 5) // Bit 5 is Auto Mode supported
-    {
+    if (OurFeatureMap & 1 << 5) // Bit 5 is Auto Mode supported
         AutoSupported = true;
-        if (MinSetpointDeadBand::Get(endpoint, &DeadBand) != EMBER_ZCL_STATUS_SUCCESS)
-        {
-            DeadBand = kDefaultDeadBand;
-        }
-        DeadBandTemp = static_cast<int16_t>(DeadBand * 10);
-    }
-    if (FeatureMap & 1 << 0)
+
+    if (OurFeatureMap & 1 << 0)
         HeatSupported = true;
 
-    if (FeatureMap & 1 << 1)
+    if (OurFeatureMap & 1 << 1)
         CoolSupported = true;
 
-    if (FeatureMap & 1 << 2)
-        OccupancySupported = true;
+    if (OurFeatureMap & 1 << 2)
+
+        if (AutoSupported)
+        {
+            if (MinSetpointDeadBand::Get(endpoint, &DeadBand) != EMBER_ZCL_STATUS_SUCCESS)
+            {
+                DeadBand = kDefaultDeadBand;
+            }
+            DeadBandTemp = static_cast<int16_t>(DeadBand * 10);
+        }
 
     if (AbsMinCoolSetpointLimit::Get(endpoint, &AbsMinCoolSetpointLimit) != EMBER_ZCL_STATUS_SUCCESS)
         AbsMinCoolSetpointLimit = kDefaultAbsMinCoolSetpointLimit;
@@ -551,33 +547,31 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(app::CommandHandler * co
     EmberAfStatus status                     = EMBER_ZCL_STATUS_FAILURE;
     EmberAfStatus WriteCoolingSetpointStatus = EMBER_ZCL_STATUS_FAILURE;
     EmberAfStatus WriteHeatingSetpointStatus = EMBER_ZCL_STATUS_FAILURE;
-    bool AutoSupported                       = false;
-    bool HeatSupported                       = false;
-    bool CoolSupported                       = false;
     int16_t DeadBandTemp                     = 0;
     int8_t DeadBand                          = 0;
-    uint32_t FeatureMap                      = 0;
+    uint32_t OurFeatureMap;
+    bool AutoSupported = false;
+    bool HeatSupported = false;
+    bool CoolSupported = false;
 
-#ifndef FEATURE_MAP_OVERIDE
-    emberAfReadServerAttribute(aEndpointId, chip::app::Clusters::Thermostat::Id,
-                               chip::app::Clusters::Thermostat::Attributes::FeatureMap::Id,
-                               reinterpret_cast<uint8_t *>(&FeatureMap), sizeof(FeatureMap));
-#else
-    FeatureMap = FEATURE_MAP_OVERIDE;
-#endif
+    if (FeatureMap::Get(aEndpointId, &OurFeatureMap) != EMBER_ZCL_STATUS_SUCCESS)
+        OurFeatureMap = FEATURE_MAP_DEFAULT;
 
-    if (FeatureMap & 1 << 5) // Bit 5 is Auto Mode supported
-    {
+    if (OurFeatureMap & 1 << 5) // Bit 5 is Auto Mode supported
         AutoSupported = true;
+
+    if (OurFeatureMap & 1 << 0)
+        HeatSupported = true;
+
+    if (OurFeatureMap & 1 << 1)
+        CoolSupported = true;
+
+    if (AutoSupported)
+    {
         if (MinSetpointDeadBand::Get(aEndpointId, &DeadBand) != EMBER_ZCL_STATUS_SUCCESS)
             DeadBand = kDefaultDeadBand;
         DeadBandTemp = static_cast<int16_t>(DeadBand * 10);
     }
-    if (FeatureMap & 1 << 0)
-        HeatSupported = true;
-
-    if (FeatureMap & 1 << 1)
-        CoolSupported = true;
 
     switch (mode)
     {

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -97,15 +97,16 @@ function asReadType(type)
 // List of all cluster with generated functions
 var endpointClusterWithInit = [
   'Basic',
-  'Identify',
+  'Color Control',
   'Groups',
-  'Scenes',
+  'IAS Zone',
+  'Identify',
+  'Level Control',
   'Occupancy Sensing',
   'On/Off',
-  'Level Control',
-  'Color Control',
-  'IAS Zone',
   'Pump Configuration and Control',
+  'Scenes',
+  'Thermostat',
 ];
 var endpointClusterWithAttributeChanged = [ 'Identify', 'Door Lock', 'Pump Configuration and Control' ];
 var endpointClusterWithPreAttribute     = [ 'IAS Zone', 'Thermostat User Interface Configuration' ];

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -2301,6 +2301,9 @@
         (EmberAfGenericClusterFunction) emberAfPumpConfigurationAndControlClusterServerInitCallback,                               \
         (EmberAfGenericClusterFunction) MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback,                    \
     };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayThermostatServer[] = {                                                        \
+        (EmberAfGenericClusterFunction) emberAfThermostatClusterServerInitCallback,                                                \
+    };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayThermostatUserInterfaceConfigurationServer[] = {                              \
         (EmberAfGenericClusterFunction) MatterThermostatUserInterfaceConfigurationClusterServerPreAttributeChangedCallback,        \
     };                                                                                                                             \
@@ -2478,9 +2481,12 @@
                 ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(ATTRIBUTE_CHANGED_FUNCTION),         \
                 chipFuncArrayPumpConfigurationAndControlServer                                                                     \
             }, /* Endpoint: 1, Cluster: Pump Configuration and Control (server) */                                                 \
-            {                                                                                                                      \
-                0x0201, ZAP_ATTRIBUTE_INDEX(320), 19, 34, ZAP_CLUSTER_MASK(SERVER), NULL                                           \
-            }, /* Endpoint: 1, Cluster: Thermostat (server) */                                                                     \
+            { 0x0201,                                                                                                              \
+              ZAP_ATTRIBUTE_INDEX(320),                                                                                            \
+              19,                                                                                                                  \
+              34,                                                                                                                  \
+              ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION),                                                          \
+              chipFuncArrayThermostatServer }, /* Endpoint: 1, Cluster: Thermostat (server) */                                     \
             {                                                                                                                      \
                 0x0204,                                                                                                            \
                 ZAP_ATTRIBUTE_INDEX(339),                                                                                          \

--- a/zzz_generated/thermostat/zap-generated/endpoint_config.h
+++ b/zzz_generated/thermostat/zap-generated/endpoint_config.h
@@ -942,6 +942,9 @@
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayScenesServer[] = {                                                            \
         (EmberAfGenericClusterFunction) emberAfScenesClusterServerInitCallback,                                                    \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayThermostatServer[] = {                                                        \
+        (EmberAfGenericClusterFunction) emberAfThermostatClusterServerInitCallback,                                                \
     };
 
 #define ZAP_CLUSTER_MASK(mask) CLUSTER_MASK_##mask
@@ -1030,9 +1033,12 @@
               246,                                                                                                                 \
               ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION),                                                          \
               chipFuncArrayBasicServer }, /* Endpoint: 1, Cluster: Basic (server) */                                               \
-            {                                                                                                                      \
-                0x0201, ZAP_ATTRIBUTE_INDEX(182), 19, 34, ZAP_CLUSTER_MASK(SERVER), NULL                                           \
-            }, /* Endpoint: 1, Cluster: Thermostat (server) */                                                                     \
+            { 0x0201,                                                                                                              \
+              ZAP_ATTRIBUTE_INDEX(182),                                                                                            \
+              19,                                                                                                                  \
+              34,                                                                                                                  \
+              ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION),                                                          \
+              chipFuncArrayThermostatServer }, /* Endpoint: 1, Cluster: Thermostat (server) */                                     \
     }
 
 #define ZAP_CLUSTER_INDEX(index) ((EmberAfCluster *) (&generatedClusters[index]))

--- a/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
@@ -1661,6 +1661,9 @@
     const EmberAfGenericClusterFunction chipFuncArrayDoorLockServer[] = {                                                          \
         (EmberAfGenericClusterFunction) MatterDoorLockClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayThermostatServer[] = {                                                        \
+        (EmberAfGenericClusterFunction) emberAfThermostatClusterServerInitCallback,                                                \
+    };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayColorControlServer[] = {                                                      \
         (EmberAfGenericClusterFunction) emberAfColorControlClusterServerInitCallback,                                              \
     };                                                                                                                             \
@@ -1787,9 +1790,12 @@
             {                                                                                                                      \
                 0x0103, ZAP_ATTRIBUTE_INDEX(260), 5, 7, ZAP_CLUSTER_MASK(SERVER), NULL                                             \
             }, /* Endpoint: 1, Cluster: Barrier Control (server) */                                                                \
-            {                                                                                                                      \
-                0x0201, ZAP_ATTRIBUTE_INDEX(265), 10, 17, ZAP_CLUSTER_MASK(SERVER), NULL                                           \
-            }, /* Endpoint: 1, Cluster: Thermostat (server) */                                                                     \
+            { 0x0201,                                                                                                              \
+              ZAP_ATTRIBUTE_INDEX(265),                                                                                            \
+              10,                                                                                                                  \
+              17,                                                                                                                  \
+              ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION),                                                          \
+              chipFuncArrayThermostatServer }, /* Endpoint: 1, Cluster: Thermostat (server) */                                     \
             { 0x0300,                                                                                                              \
               ZAP_ATTRIBUTE_INDEX(275),                                                                                            \
               51,                                                                                                                  \


### PR DESCRIPTION
Problem:
emberAfThermostatClusterServerInitCallback was not enabled in the helper.js file for code gen. 
FeatureMap usage involves Conditional compiles and repeated code

Changes:
Enabled Init for thermostat
Eliminated #ifndefs
Used Feature Map accessor function now available in SDK, in place of deprecated read.

Tested:
Manual testing with thermostat-app (Linux) and chip-tool
