### PR TITLE
Make CASESessionManager the resolver delegate if ResolverProxy is not passed in

### DIFF
--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -25,6 +25,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/dnssd/DnssdCache.h>
 #include <lib/support/Pool.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <transport/SessionDelegate.h>
 
 #include <lib/dnssd/ResolverProxy.h>
@@ -58,11 +59,15 @@ public:
 
         mConfig = params;
 
-        // TODO: Revisit who should be set as the resolver delegate
-        Dnssd::Resolver::Instance().SetResolverDelegate(this);
+        if (mConfig.dnsResolver == nullptr)
+        {
+            VerifyOrDie(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()) == CHIP_NO_ERROR);
+            mDNSResolver.SetResolverDelegate(this);
+            mConfig.dnsResolver = &mDNSResolver;
+        }
     }
 
-    virtual ~CASESessionManager() {}
+    virtual ~CASESessionManager() { mDNSResolver.Shutdown(); }
 
     /**
      * Find an existing session for the given node ID, or trigger a new session request.
@@ -109,6 +114,7 @@ private:
     void ReleaseSession(OperationalDeviceProxy * device);
 
     CASESessionManagerConfig mConfig;
+    Dnssd::ResolverProxy mDNSResolver;
 };
 
 } // namespace chip

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -17,6 +17,7 @@
 
 #include "Resolver.h"
 
+#include <lib/dnssd/ResolverProxy.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -47,5 +48,21 @@ Resolver & chip::Dnssd::Resolver::Instance()
 {
     return gResolver;
 }
+
+CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip


### PR DESCRIPTION
#### Problem
After https://github.com/project-chip/connectedhomeip/pull/12481 merged, CASESessionManager now takes a ResolverProxy for the config param in order to keep track of which controller is issuing a DNS request. For OTARequestor class, nullptr was being passed in for the ResolverProxy which causes DNS lookup to fail for the OTA case.

Fixes: https://github.com/project-chip/connectedhomeip/issues/12773

#### Change overview
Make CASESessionManager the resolver delegate if a ResolverProxy is not passed in. This helps with any users of CASESessionManager where it just needs the Node ID resolved but does not need to take additional action.

#### Testing
Manually tested on Linux:
```
./out/debug/chip-ota-provider-app -f test.bin
./out/chip-tool pairing onnetwork 1 20202021
./out/debug/chip-ota-requestor-app -d 30 -u 5550
./out/chip-tool pairing onnetwork-long 2 20202021 30
./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 2 0
```