### PR TITLE
Fix gn_build error on ToT

### DIFF
--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -87,6 +87,14 @@ private:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetReachable(bool & reachable) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if !defined(NDEBUG)
     CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif


### PR DESCRIPTION
#### Problem
gn_build break on ToT with following error:

```

../../src/platform/fake/ConfigurationManagerImpl.cpp: In static member function ‘static chip::DeviceLayer::ConfigurationManagerImpl& chip::DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance()’:
../../src/platform/fake/ConfigurationManagerImpl.cpp:18:37: error: cannot declare variable ‘sInstance’ to be of abstract type ‘chip::DeviceLayer::ConfigurationManagerImpl’
   18 |     static ConfigurationManagerImpl sInstance;
      |                                     ^~~~~~~~~
In file included from ../../src/include/platform/ConfigurationManager.h:214,
                 from ../../src/platform/fake/ConfigurationManagerImpl.cpp:11:
../../src/platform/fake/ConfigurationManagerImpl.h:28:7: note:   because the following virtual functions are pure within ‘chip::DeviceLayer::ConfigurationManagerImpl’:
   28 | class ConfigurationManagerImpl : public ConfigurationManager
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../../src/platform/fake/ConfigurationManagerImpl.cpp:11:
../../src/include/platform/ConfigurationManager.h:119:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetNodeLabel(char*, size_t)’
  119 |     virtual CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize)                        = 0;
      |                        ^~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:120:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::StoreNodeLabel(const char*, size_t)’
  120 |     virtual CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize)                = 0;
      |                        ^~~~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:121:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetPartNumber(char*, size_t)’
  121 |     virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize)                       = 0;
      |                        ^~~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:122:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetProductURL(char*, size_t)’
  122 |     virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                       = 0;
      |                        ^~~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:123:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetProductLabel(char*, size_t)’
  123 |     virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                     = 0;
      |                        ^~~~~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:124:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetLocalConfigDisabled(bool&)’
  124 |     virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                         = 0;
      |                        ^~~~~~~~~~~~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:125:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetReachable(bool&)’
  125 |     virtual CHIP_ERROR GetReachable(bool & reachable)                                  = 0;
      |                        ^~~~~~~~~~~~
../../src/include/platform/ConfigurationManager.h:126:24: note:   ‘virtual CHIP_ERROR chip::DeviceLayer::ConfigurationManager::GetUniqueId(char*, size_t)’
  126 |     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
      |                        ^~~~~~~~~~~
At global scope:
cc1plus: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
cc1plus: all warnings being treated as errors
[773/7375] c++ fake_x64_gcc/obj/src/platform/libDeviceLayer.Globals.cpp.o
ninja: build stopped: subcommand failed.

```

#### Change overview
Fix gn_build error on ToT

#### Testing
How was this tested? (at least one bullet point required)
* Confirm gn_build pass with this fix
