### PR TITLE
Add CI tests for fake platform

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"
     build_linux:
-        name: Build on Linux (gcc_release, clang, mbedtls, simulated)
+        name: Build on Linux (fake, gcc_release, clang, mbedtls, simulated)
         timeout-minutes: 90
 
         runs-on: ubuntu-latest
@@ -146,8 +146,9 @@ jobs:
             - name: Setup Build, Run Build and Run Tests
               timeout-minutes: 50
               run: |
-                  for BUILD_TYPE  in gcc_release clang mbedtls; do
+                  for BUILD_TYPE  in fake gcc_release clang mbedtls; do
                       case $BUILD_TYPE in
+                          "fake") GN_ARGS='chip_device_platform="fake"';;
                           "gcc_release") GN_ARGS='is_debug=false';;
                           "clang") GN_ARGS='is_clang=true';;
                           "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;


### PR DESCRIPTION
#### Problem
Fake platform is not verified by GitHub CI.

#### Change overview
Run CI tests for fake platform on GitHub Action

#### Testing
Verified using unit-tests