### PR TITLE
Using SessionHolder to store a session

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -249,8 +249,8 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, const Transport::PeerAddr
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, CryptoContext::SessionRole::kInitiator,
-                                     gFabricIndex);
+    err = gSessionManager.NewPairing(gSession, peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
+                                     CryptoContext::SessionRole::kInitiator, gFabricIndex);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -329,7 +329,7 @@ void StartPinging(streamer_t * stream, char * destination)
     err = EstablishSecureSession(stream, GetEchoPeerAddress());
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, SessionHandle(kTestDeviceNodeId, 1, 1, gFabricIndex));
+    err = gEchoClient.Init(&gExchangeManager, gSession.Get());
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -128,7 +128,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     uint32_t payloadSize = gSendArguments.GetPayloadSize();
 
     // Create a new exchange context.
-    auto * ec = gExchangeManager.NewContext(SessionHandle(kTestDeviceNodeId, 1, 1, gFabricIndex), &gMockAppDelegate);
+    auto * ec = gExchangeManager.NewContext(gSession.Get(), &gMockAppDelegate);
     VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     payloadBuf = MessagePacketBuffer::New(payloadSize);
@@ -181,8 +181,8 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & 
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, CryptoContext::SessionRole::kInitiator,
-                                     gFabricIndex);
+    err = gSessionManager.NewPairing(gSession, peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
+                                     CryptoContext::SessionRole::kInitiator, gFabricIndex);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/examples/shell/shell_common/globals.cpp
+++ b/examples/shell/shell_common/globals.cpp
@@ -21,6 +21,7 @@ chip::secure_channel::MessageCounterManager gMessageCounterManager;
 chip::Messaging::ExchangeManager gExchangeManager;
 chip::SessionManager gSessionManager;
 chip::Inet::IPAddress gDestAddr;
+chip::SessionHolder gSession;
 
 chip::FabricIndex gFabricIndex = 0;
 

--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -20,6 +20,7 @@
 #include <lib/core/CHIPCore.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/SessionHolder.h>
 #include <transport/SessionManager.h>
 #include <transport/raw/TCP.h>
 #include <transport/raw/UDP.h>
@@ -34,6 +35,7 @@ extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
 extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::SessionManager gSessionManager;
 extern chip::Inet::IPAddress gDestAddr;
+extern chip::SessionHolder gSession;
 
 extern chip::FabricIndex gFabricIndex;
 

--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -73,18 +73,16 @@ void CASEClient::OnSessionEstablished()
     }
 }
 
-CHIP_ERROR CASEClient::DeriveSecureSessionHandle(Optional<SessionHandle> & handle)
+CHIP_ERROR CASEClient::DeriveSecureSessionHandle(SessionHolder & handle)
 {
     CHIP_ERROR err = mInitParams.sessionManager->NewPairing(
-        Optional<Transport::PeerAddress>::Value(mPeerAddress), mPeerId.GetNodeId(), &mCASESession,
+        handle, Optional<Transport::PeerAddress>::Value(mPeerAddress), mPeerId.GetNodeId(), &mCASESession,
         CryptoContext::SessionRole::kInitiator, mInitParams.fabricInfo->GetFabricIndex());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up CASE secure channel: err %s", ErrorStr(err));
         return err;
     }
-    handle.SetValue(SessionHandle(mPeerId.GetNodeId(), mCASESession.GetLocalSessionId(), mCASESession.GetPeerSessionId(),
-                                  mInitParams.fabricInfo->GetFabricIndex()));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -55,7 +55,7 @@ public:
 
     void OnSessionEstablished() override;
 
-    CHIP_ERROR DeriveSecureSessionHandle(Optional<SessionHandle> & handle);
+    CHIP_ERROR DeriveSecureSessionHandle(SessionHolder & handle);
 
 private:
     CASEClientInitParams mInitParams;

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -155,7 +155,7 @@ public:
 
     PeerId GetPeerId() const { return mPeerId; }
 
-    bool MatchesSession(SessionHandle session) const { return mSecureSession.HasValue() && mSecureSession.Value() == session; }
+    bool MatchesSession(SessionHandle session) const { return mSecureSession.Contains(session); }
 
     uint8_t GetNextSequenceNumber() override { return mSequenceNumber++; };
 
@@ -165,7 +165,7 @@ public:
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mInitParams.exchangeMgr; }
 
-    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession; }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
 
     bool GetAddress(Inet::IPAddress & addr, uint16_t & port) const override;
 
@@ -210,7 +210,7 @@ private:
 
     State mState = State::Uninitialized;
 
-    Optional<SessionHandle> mSecureSession = Optional<SessionHandle>::Missing();
+    SessionHolder mSecureSession;
 
     uint8_t mSequenceNumber = 0;
 

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -132,8 +132,9 @@ void CommissioningWindowManager::OnSessionEstablishmentStarted()
 void CommissioningWindowManager::OnSessionEstablished()
 {
     DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
+    SessionHolder sessionHolder;
     CHIP_ERROR err = mServer->GetSecureSessionManager().NewPairing(
-        Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()), mPairingSession.GetPeerNodeId(),
+        sessionHolder, Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()), mPairingSession.GetPeerNodeId(),
         &mPairingSession, CryptoContext::SessionRole::kResponder, 0);
     if (err != CHIP_NO_ERROR)
     {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -281,13 +281,15 @@ CHIP_ERROR Server::AddTestCommissioning()
     CHIP_ERROR err            = CHIP_NO_ERROR;
     PASESession * testSession = nullptr;
     PASESessionSerializable serializedTestSession;
+    SessionHolder session;
 
     mTestPairing.ToSerializable(serializedTestSession);
 
     testSession = chip::Platform::New<PASESession>();
     testSession->FromSerializable(serializedTestSession);
-    SuccessOrExit(err = mSessions.NewPairing(Optional<PeerAddress>{ PeerAddress::Uninitialized() }, chip::kTestControllerNodeId,
-                                             testSession, CryptoContext::SessionRole::kResponder, kMinValidFabricIndex));
+    SuccessOrExit(err = mSessions.NewPairing(session, Optional<PeerAddress>{ PeerAddress::Uninitialized() },
+                                             chip::kTestControllerNodeId, testSession, CryptoContext::SessionRole::kResponder,
+                                             kMinValidFabricIndex));
 
 exit:
     if (testSession)

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -247,7 +247,7 @@ CHIP_ERROR SendCommandRequest(std::unique_ptr<chip::app::CommandSender> && comma
     err = commandSender->FinishCommand();
     SuccessOrExit(err);
 
-    err = commandSender->SendCommandRequest(gSessionManager.FindSecureSessionForNode(chip::kTestDeviceNodeId), gMessageTimeout);
+    err = commandSender->SendCommandRequest(gSession.Get(), gMessageTimeout);
     SuccessOrExit(err);
 
     gCommandCount++;
@@ -283,7 +283,7 @@ CHIP_ERROR SendBadCommandRequest(std::unique_ptr<chip::app::CommandSender> && co
     err = commandSender->FinishCommand();
     SuccessOrExit(err);
 
-    err = commandSender->SendCommandRequest(gSessionManager.FindSecureSessionForNode(chip::kTestDeviceNodeId), gMessageTimeout);
+    err = commandSender->SendCommandRequest(gSession.Get(), gMessageTimeout);
     SuccessOrExit(err);
     gCommandCount++;
     commandSender.release();
@@ -311,7 +311,7 @@ CHIP_ERROR SendReadRequest()
 
     printf("\nSend read request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
+    chip::app::ReadPrepareParams readPrepareParams(gSession.Get());
     readPrepareParams.mTimeout                     = gMessageTimeout;
     readPrepareParams.mpAttributePathParamsList    = &attributePathParams;
     readPrepareParams.mAttributePathParamsListSize = 1;
@@ -352,8 +352,7 @@ CHIP_ERROR SendWriteRequest(chip::app::WriteClientHandle & apWriteClient)
     SuccessOrExit(err =
                       writer->PutBoolean(chip::TLV::ContextTag(chip::to_underlying(chip::app::AttributeDataIB::Tag::kData)), true));
     SuccessOrExit(err = apWriteClient->FinishAttribute());
-    SuccessOrExit(
-        err = apWriteClient.SendWriteRequest(gSessionManager.FindSecureSessionForNode(chip::kTestDeviceNodeId), gMessageTimeout));
+    SuccessOrExit(err = apWriteClient.SendWriteRequest(gSession.Get(), gMessageTimeout));
 
     gWriteCount++;
 
@@ -370,7 +369,7 @@ CHIP_ERROR SendSubscribeRequest()
     CHIP_ERROR err   = CHIP_NO_ERROR;
     gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
-    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
+    chip::app::ReadPrepareParams readPrepareParams(gSession.Get());
     chip::app::EventPathParams eventPathParams[2];
     chip::app::AttributePathParams attributePathParams[1];
     readPrepareParams.mpEventPathParamsList                = eventPathParams;
@@ -416,7 +415,8 @@ CHIP_ERROR EstablishSecureSession()
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
+    err = gSessionManager.NewPairing(gSession,
+                                     chip::Optional<chip::Transport::PeerAddress>::Value(
                                          chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null())),
                                      chip::kTestDeviceNodeId, testSecurePairingSecret, chip::CryptoContext::SessionRole::kInitiator,
                                      gFabricIndex);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -213,8 +213,8 @@ int main(int argc, char * argv[])
 
     InitializeEventLogging(&gExchangeManager);
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::CryptoContext::SessionRole::kResponder,
-                                     gFabricIndex);
+    err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &gTestPairing,
+                                     chip::CryptoContext::SessionRole::kResponder, gFabricIndex);
     SuccessOrExit(err);
 
     printf("Listening for IM requests...\n");

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -33,6 +33,7 @@
 chip::Messaging::ExchangeManager gExchangeManager;
 chip::SessionManager gSessionManager;
 chip::secure_channel::MessageCounterManager gMessageCounterManager;
+chip::SessionHolder gSession;
 
 void InitializeChip(void)
 {

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -27,6 +27,7 @@
 #include <app/util/basic-types.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/SessionHolder.h>
 
 #define MAX_MESSAGE_SOURCE_STR_LENGTH (100)
 #define NETWORK_SLEEP_TIME_MSECS (100 * 1000)
@@ -34,6 +35,7 @@
 extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::SessionManager gSessionManager;
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
+extern chip::SessionHolder gSession;
 
 constexpr chip::NodeId kTestNodeId         = 0x1ULL;
 constexpr chip::NodeId kTestNodeId1        = 0x2ULL;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -441,7 +441,6 @@ private:
  *   will be stored.
  */
 class DLL_EXPORT DeviceCommissioner : public DeviceController,
-                                      public SessionCreationDelegate,
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
                                       public Protocols::UserDirectedCommissioning::InstanceNameResolver,
                                       public Protocols::UserDirectedCommissioning::UserConfirmationProvider,
@@ -698,8 +697,6 @@ private:
 
     void OnSessionEstablishmentTimeout();
 
-    //////////// SessionCreationDelegate Implementation ///////////////
-    void OnNewSession(SessionHandle session) override;
     //////////// SessionReleaseDelegate Implementation ///////////////
     void OnSessionReleased(SessionHandle session) override;
 

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -56,9 +56,9 @@ CHIP_ERROR CommissioneeDeviceProxy::LoadSecureSessionParametersIfNeeded(bool & d
     }
     else
     {
-        if (mSecureSession.HasValue())
+        if (mSecureSession)
         {
-            Transport::SecureSession * secureSession = mSessionManager->GetSecureSession(mSecureSession.Value());
+            Transport::SecureSession * secureSession = mSessionManager->GetSecureSession(mSecureSession.Get());
             // Check if the connection state has the correct transport information
             if (secureSession->GetPeerAddress().GetTransportType() == Transport::Type::kUndefined)
             {
@@ -83,29 +83,23 @@ CHIP_ERROR CommissioneeDeviceProxy::SendCommands(app::CommandSender * commandObj
     bool loadedSecureSession = false;
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
     VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return commandObj->SendCommandRequest(mSecureSession.Value());
-}
-
-void CommissioneeDeviceProxy::OnNewConnection(SessionHandle session)
-{
-    mState = ConnectionState::SecureConnected;
-    mSecureSession.SetValue(session);
+    return commandObj->SendCommandRequest(mSecureSession.Get());
 }
 
 void CommissioneeDeviceProxy::OnSessionReleased(SessionHandle session)
 {
-    VerifyOrReturn(mSecureSession.HasValue() && mSecureSession.Value() == session,
+    VerifyOrReturn(mSecureSession.Contains(session),
                    ChipLogDetail(Controller, "Connection expired, but it doesn't match the current session"));
     mState = ConnectionState::NotConnected;
-    mSecureSession.ClearValue();
+    mSecureSession.Release();
 }
 
 CHIP_ERROR CommissioneeDeviceProxy::CloseSession()
 {
     ReturnErrorCodeIf(mState != ConnectionState::SecureConnected, CHIP_ERROR_INCORRECT_STATE);
-    if (mSecureSession.HasValue())
+    if (mSecureSession)
     {
-        mSessionManager->ExpirePairing(mSecureSession.Value());
+        mSessionManager->ExpirePairing(mSecureSession.Get());
     }
     mState = ConnectionState::NotConnected;
     mPairing.Clear();
@@ -127,7 +121,7 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(didLoad));
 
-    if (!mSecureSession.HasValue())
+    if (!mSecureSession)
     {
         // Nothing needs to be done here.  It's not an error to not have a
         // secureSession.  For one thing, we could have gotten an different
@@ -136,7 +130,7 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
         return CHIP_NO_ERROR;
     }
 
-    Transport::SecureSession * secureSession = mSessionManager->GetSecureSession(mSecureSession.Value());
+    Transport::SecureSession * secureSession = mSessionManager->GetSecureSession(mSecureSession.Get());
     secureSession->SetPeerAddress(addr);
 
     return CHIP_NO_ERROR;
@@ -172,9 +166,9 @@ CHIP_ERROR CommissioneeDeviceProxy::LoadSecureSessionParameters()
         ExitNow(err = CHIP_NO_ERROR);
     }
 
-    err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &mPairing,
-                                      CryptoContext::SessionRole::kInitiator, mFabricIndex);
-    SuccessOrExit(err);
+    SuccessOrExit(mSessionManager->NewPairing(mSecureSession, Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId,
+                                              &mPairing, CryptoContext::SessionRole::kInitiator, mFabricIndex));
+    mState = ConnectionState::SecureConnected;
 
 exit:
 

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -41,6 +41,7 @@
 #include <messaging/Flags.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <protocols/secure_channel/SessionIDAllocator.h>
+#include <transport/SessionHolder.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/MessageHeader.h>
@@ -157,14 +158,6 @@ public:
 
     /**
      * @brief
-     *   Called when a new pairing is being established
-     *
-     * @param session A handle to the secure session
-     */
-    void OnNewConnection(SessionHandle session);
-
-    /**
-     * @brief
      *   Called when the associated session is released
      *
      *   The receiver should release all resources associated with the connection.
@@ -211,9 +204,10 @@ public:
 
     NodeId GetDeviceId() const override { return mDeviceId; }
 
-    bool MatchesSession(SessionHandle session) const { return mSecureSession.HasValue() && mSecureSession.Value() == session; }
+    bool MatchesSession(SessionHandle session) const { return mSecureSession.Contains(session); }
 
-    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession; }
+    SessionHolder & GetSecureSessionHolder() { return mSecureSession; }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }
 
@@ -304,7 +298,7 @@ private:
 
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
 
-    Optional<SessionHandle> mSecureSession = Optional<SessionHandle>::Missing();
+    SessionHolder mSecureSession;
 
     Controller::DeviceControllerInteractionModelDelegate * mpIMDelegate = nullptr;
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
     }
 
     VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(mSession.HasValue(), CHIP_ERROR_CONNECTION_ABORTED);
+    VerifyOrReturnError(mSession, CHIP_ERROR_CONNECTION_ABORTED);
 
     // Don't let method get called on a freed object.
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() > 0);
@@ -161,7 +161,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
         }
 
         // Create a new scope for `err`, to avoid shadowing warning previous `err`.
-        CHIP_ERROR err = mDispatch->SendMessage(mSession.Value(), mExchangeId, IsInitiator(), GetReliableMessageContext(),
+        CHIP_ERROR err = mDispatch->SendMessage(mSession.Get(), mExchangeId, IsInitiator(), GetReliableMessageContext(),
                                                 reliableTransmissionRequested, protocolId, msgType, std::move(msgBuf));
         if (err != CHIP_NO_ERROR && IsResponseExpected())
         {
@@ -255,7 +255,7 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, Sess
 
     mExchangeMgr = em;
     mExchangeId  = ExchangeId;
-    mSession.SetValue(session);
+    mSession.Grab(session);
     mFlags.Set(Flags::kFlagInitiator, Initiator);
     mDelegate = delegate;
 
@@ -320,8 +320,8 @@ bool ExchangeContext::MatchExchange(SessionHandle session, const PacketHeader & 
         // The exchange identifier of the message matches the exchange identifier of the context.
         (mExchangeId == payloadHeader.GetExchangeID())
 
-        // AND The Session ID associated with the incoming message matches the Session ID associated with the exchange.
-        && (mSession.HasValue() && mSession.Value().MatchIncomingSession(session))
+        // AND The Session associated with the incoming message matches the Session associated with the exchange.
+        && (mSession.Contains(session))
 
         // TODO: This check should be already implied by the equality of session check,
         // It should be removed after we have implemented the temporary node id for PASE and CASE sessions
@@ -340,7 +340,7 @@ void ExchangeContext::OnConnectionExpired()
     // connection state) value, because it's still referencing the now-expired
     // connection.  This will mean that no more messages can be sent via this
     // exchange, which seems fine given the semantics of connection expiration.
-    mSession.ClearValue();
+    mSession.Release();
 
     if (!IsResponseExpected())
     {

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -76,7 +76,7 @@ public:
 
     bool IsEncryptionRequired() const { return mDispatch->IsEncryptionRequired(); }
 
-    bool IsGroupExchangeContext() const { return (mSession.HasValue() && mSession.Value().IsGroupSession()); }
+    bool IsGroupExchangeContext() const { return (mSession && mSession.Get().IsGroupSession()); }
 
     /**
      *  Send a CHIP message on this exchange.
@@ -151,8 +151,8 @@ public:
 
     ExchangeMessageDispatch * GetMessageDispatch() { return mDispatch; }
 
-    SessionHandle GetSessionHandle() const { return mSession.Value(); }
-    bool HasSessionHandle() const { return mSession.HasValue(); }
+    SessionHandle GetSessionHandle() const { return mSession.Get(); }
+    bool HasSessionHandle() const { return mSession; }
 
     uint16_t GetExchangeId() const { return mExchangeId; }
 
@@ -185,8 +185,8 @@ private:
 
     ExchangeMessageDispatch * mDispatch = nullptr;
 
-    Optional<SessionHandle> mSession; // The connection state
-    uint16_t mExchangeId;             // Assigned exchange ID.
+    SessionHolder mSession; // The connection state
+    uint16_t mExchangeId;   // Assigned exchange ID.
 
     /**
      *  Determine whether a response is currently expected for a message that was sent over

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -322,7 +322,7 @@ void ExchangeManager::OnSessionReleased(SessionHandle session)
 void ExchangeManager::ExpireExchangesForSession(SessionHandle session)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {
-        if (ec->mSession.HasValue() && ec->mSession.Value() == session)
+        if (ec->mSession.Contains(session))
         {
             ec->OnConnectionExpired();
             // Continue to iterate because there can be multiple exchanges

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -108,6 +108,9 @@ private:
     Transport::PeerAddress mBobAddress;
     SecurePairingUsingTestSecret mPairingAliceToBob;
     SecurePairingUsingTestSecret mPairingBobToAlice;
+    SessionHolder mSessionAliceToBob;
+    SessionHolder mSessionBobToAlice;
+    SessionHolder mSessionBobToFriends;
     FabricIndex mSrcFabricIndex  = 0;
     FabricIndex mDestFabricIndex = 0;
 };

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -60,6 +60,7 @@ chip::Protocols::Echo::EchoClient gEchoClient;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
 chip::Inet::IPAddress gDestAddr;
+chip::SessionHolder gSession;
 
 // The last time a CHIP Echo was attempted to be sent.
 chip::System::Clock::Timestamp gLastEchoTime = chip::System::Clock::kZero;
@@ -166,7 +167,7 @@ CHIP_ERROR EstablishSecureSession()
     }
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
+    err = gSessionManager.NewPairing(gSession, peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
                                      chip::CryptoContext::SessionRole::kInitiator, gFabricIndex);
 
 exit:
@@ -257,7 +258,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
+    err = gEchoClient.Init(&gExchangeManager, gSession.Get());
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -45,6 +45,7 @@ chip::Protocols::Echo::EchoServer gEchoServer;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
+chip::SessionHolder gSession;
 
 // Callback handler when a CHIP EchoRequest is received.
 void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle && payload)
@@ -117,8 +118,8 @@ int main(int argc, char * argv[])
         SuccessOrExit(err);
     }
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::CryptoContext::SessionRole::kResponder,
-                                     gFabricIndex);
+    err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &gTestPairing,
+                                     chip::CryptoContext::SessionRole::kResponder, gFabricIndex);
     SuccessOrExit(err);
 
     if (!disableEcho)

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -128,9 +128,10 @@ void CASEServer::OnSessionEstablished()
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
     mSessionManager->ExpireAllPairings(GetSession().GetPeerNodeId(), GetSession().GetFabricIndex());
 
-    CHIP_ERROR err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(GetSession().GetPeerAddress()),
-                                                 GetSession().GetPeerNodeId(), &GetSession(),
-                                                 CryptoContext::SessionRole::kResponder, GetSession().GetFabricIndex());
+    SessionHolder sessionHolder;
+    CHIP_ERROR err = mSessionManager->NewPairing(
+        sessionHolder, Optional<Transport::PeerAddress>::Value(GetSession().GetPeerAddress()), GetSession().GetPeerNodeId(),
+        &GetSession(), CryptoContext::SessionRole::kResponder, GetSession().GetFabricIndex());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -20,20 +20,6 @@
 
 namespace chip {
 
-class DLL_EXPORT SessionCreationDelegate
-{
-public:
-    virtual ~SessionCreationDelegate() {}
-
-    /**
-     * @brief
-     *   Called when a new session is being established
-     *
-     * @param session   The handle to the secure session
-     */
-    virtual void OnNewSession(SessionHandle session) = 0;
-};
-
 class DLL_EXPORT SessionReleaseDelegate
 {
 public:

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -62,12 +62,6 @@ public:
 
     bool operator==(const SessionHandle & that) const
     {
-        // TODO: Temporarily keep the old logic, check why only those two fields are used in comparison.
-        return mPeerNodeId == that.mPeerNodeId && mPeerSessionId == that.mPeerSessionId;
-    }
-
-    bool MatchIncomingSession(const SessionHandle & that) const
-    {
         if (IsSecure())
         {
             return that.IsSecure() && mLocalSessionId.Value() == that.mLocalSessionId.Value();

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -1,0 +1,67 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/Optional.h>
+#include <transport/SessionDelegate.h>
+#include <transport/SessionHandle.h>
+
+namespace chip {
+
+/** @brief
+ *    Managed session reference. The object is used to store a session, the stored session will be automatically
+ *    released when the underlying session is released. One must verify it is available before use. The object can be
+ *    created using SessionHandle.Grab()
+ *
+ *    TODO: release holding session when the session is released. This will be implemented by following PRs
+ */
+class SessionHolder : public SessionReleaseDelegate
+{
+public:
+    SessionHolder() {}
+    SessionHolder(SessionHandle session) : mSession(session) {}
+    ~SessionHolder() { Release(); }
+
+    SessionHolder(const SessionHolder &);
+    SessionHolder operator=(const SessionHolder &);
+    SessionHolder(SessionHolder && that);
+    SessionHolder operator=(SessionHolder && that);
+
+    void Grab(SessionHandle sessionHandle)
+    {
+        Release();
+        mSession.SetValue(sessionHandle);
+    }
+
+    void Release() { mSession.ClearValue(); }
+
+    // TODO: call this function when the underlying session is released
+    // Implement SessionReleaseDelegate
+    void OnSessionReleased(SessionHandle session) override { Release(); }
+
+    // Check whether the SessionHolder contains a session matching given session
+    bool Contains(const SessionHandle & session) const { return mSession.HasValue() && mSession.Value() == session; }
+
+    operator bool() const { return mSession.HasValue(); }
+    SessionHandle Get() const { return mSession.Value(); }
+    Optional<SessionHandle> ToOptional() const { return mSession; }
+
+private:
+    Optional<SessionHandle> mSession;
+};
+
+} // namespace chip

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -297,8 +297,9 @@ void SessionManager::ExpireAllPairingsForFabric(FabricIndex fabric)
     });
 }
 
-CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
-                                      PairingSession * pairing, CryptoContext::SessionRole direction, FabricIndex fabric)
+CHIP_ERROR SessionManager::NewPairing(SessionHolder & sessionHolder, const Optional<Transport::PeerAddress> & peerAddr,
+                                      NodeId peerNodeId, PairingSession * pairing, CryptoContext::SessionRole direction,
+                                      FabricIndex fabric)
 {
     uint16_t peerSessionId  = pairing->GetPeerSessionId();
     uint16_t localSessionId = pairing->GetLocalSessionId();
@@ -335,11 +336,7 @@ CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & p
     ReturnErrorOnFailure(pairing->DeriveSecureSession(session->GetCryptoContext(), direction));
 
     session->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
-    SessionHandle sessionHandle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(), fabric);
-    mSessionCreationDelegates.ForEachActiveObject([&](std::reference_wrapper<SessionCreationDelegate> * cb) {
-        cb->get().OnNewSession(sessionHandle);
-        return Loop::Continue;
-    });
+    sessionHolder.Grab(SessionHandle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(), fabric));
 
     return CHIP_NO_ERROR;
 }

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -38,6 +38,7 @@
 #include <transport/SecureSessionTable.h>
 #include <transport/SessionDelegate.h>
 #include <transport/SessionHandle.h>
+#include <transport/SessionHolder.h>
 #include <transport/SessionMessageDelegate.h>
 #include <transport/TransportMgr.h>
 #include <transport/UnauthenticatedSessionTable.h>
@@ -148,31 +149,6 @@ public:
     /// ExchangeManager)
     void SetMessageDelegate(SessionMessageDelegate * cb) { mCB = cb; }
 
-    /// @brief Set the delegate for handling session creation.
-    void RegisterCreationDelegate(SessionCreationDelegate & cb)
-    {
-#ifndef NDEBUG
-        mSessionCreationDelegates.ForEachActiveObject([&](std::reference_wrapper<SessionCreationDelegate> * i) {
-            VerifyOrDie(std::addressof(cb) != std::addressof(i->get()));
-            return Loop::Continue;
-        });
-#endif
-        std::reference_wrapper<SessionCreationDelegate> * slot = mSessionCreationDelegates.CreateObject(cb);
-        VerifyOrDie(slot != nullptr);
-    }
-
-    void UnregisterCreationDelegate(SessionCreationDelegate & cb)
-    {
-        mSessionCreationDelegates.ForEachActiveObject([&](std::reference_wrapper<SessionCreationDelegate> * i) {
-            if (std::addressof(cb) == std::addressof(i->get()))
-            {
-                mSessionCreationDelegates.ReleaseObject(i);
-                return Loop::Break;
-            }
-            return Loop::Continue;
-        });
-    }
-
     /// @brief Set the delegate for handling session release.
     void RegisterReleaseDelegate(SessionReleaseDelegate & cb)
     {
@@ -211,8 +187,8 @@ public:
      *   establishes the security keys for secure communication with the
      *   peer node.
      */
-    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PairingSession * pairing,
-                          CryptoContext::SessionRole direction, FabricIndex fabric);
+    CHIP_ERROR NewPairing(SessionHolder & sessionHolder, const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
+                          PairingSession * pairing, CryptoContext::SessionRole direction, FabricIndex fabric);
 
     void ExpirePairing(SessionHandle session);
     void ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric);
@@ -261,6 +237,12 @@ public:
         return session.HasValue() ? MakeOptional<SessionHandle>(session.Value()) : NullOptional;
     }
 
+    // TODO: placeholder function for creating GroupSession. Implements a GroupSession class in the future
+    Optional<SessionHandle> CreateGroupSession(NodeId peerNodeId, GroupId groupId, FabricIndex fabricIndex)
+    {
+        return MakeOptional(SessionHandle(peerNodeId, groupId, fabricIndex));
+    }
+
     // TODO: this is a temporary solution for legacy tests which use nodeId to send packets
     SessionHandle FindSecureSessionForNode(NodeId peerNodeId);
 
@@ -286,12 +268,9 @@ private:
     State mState;                                                                         // < Initialization state of the object
 
     SessionMessageDelegate * mCB = nullptr;
-    BitMapObjectPool<std::reference_wrapper<SessionCreationDelegate>, CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES,
-                     OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>
-        mSessionCreationDelegates;
 
     // TODO: This is a temporary solution to release sessions, in the near future, SessionReleaseDelegate will be
-    //       directly associated with the every SessionHandle. Then the callback function is called on over the handle
+    //       directly associated with the every SessionHolder. Then the callback function is called on over the handle
     //       delegate directly, in order to prevent dangling handles.
     BitMapObjectPool<std::reference_wrapper<SessionReleaseDelegate>, CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES,
                      OnObjectPoolDestruction::IgnoreUnsafeDoNotUseInNewCode>

--- a/src/transport/tests/TestSessionHandle.cpp
+++ b/src/transport/tests/TestSessionHandle.cpp
@@ -38,10 +38,13 @@ using namespace chip;
 
 void TestMatchSession(nlTestSuite * inSuite, void * inContext)
 {
+    SessionHandle session2(chip::kTestDeviceNodeId, 1, 1, 0);
     SessionHandle session3(chip::kTestDeviceNodeId, 1, 1, 0);
     SessionHandle session4(chip::kTestDeviceNodeId, 1, 2, 0);
-    NL_TEST_ASSERT(inSuite, !(session3 == session4));
-    NL_TEST_ASSERT(inSuite, session3.MatchIncomingSession(session4));
+    SessionHandle session5(chip::kTestDeviceNodeId, 2, 2, 0);
+    NL_TEST_ASSERT(inSuite, session2 == session3);
+    NL_TEST_ASSERT(inSuite, session2 == session4);
+    NL_TEST_ASSERT(inSuite, !(session2 == session5));
 }
 
 // Test Suite

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -59,14 +59,14 @@ constexpr NodeId kDestinationNodeId = 111222333;
 
 const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
 
-class TestSessMgrCallback : public SessionCreationDelegate, public SessionReleaseDelegate, public SessionMessageDelegate
+class TestSessMgrCallback : public SessionReleaseDelegate, public SessionMessageDelegate
 {
 public:
     void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SessionHandle session,
                            const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
                            System::PacketBufferHandle && msgBuf) override
     {
-        NL_TEST_ASSERT(mSuite, session == mRemoteToLocalSession.Value()); // Packet received by remote peer
+        NL_TEST_ASSERT(mSuite, mRemoteToLocalSession.Contains(session)); // Packet received by remote peer
 
         size_t data_len = msgBuf->DataLength();
 
@@ -84,25 +84,15 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    void OnNewSession(SessionHandle session) override
-    {
-        // Preset the MessageCounter
-        if (NewConnectionHandlerCallCount == 0)
-            mRemoteToLocalSession.SetValue(session);
-        if (NewConnectionHandlerCallCount == 1)
-            mLocalToRemoteSession.SetValue(session);
-        NewConnectionHandlerCallCount++;
-    }
-
     void OnSessionReleased(SessionHandle session) override { mOldConnectionDropped = true; }
 
     bool mOldConnectionDropped = false;
 
-    nlTestSuite * mSuite                          = nullptr;
-    Optional<SessionHandle> mRemoteToLocalSession = Optional<SessionHandle>::Missing();
-    Optional<SessionHandle> mLocalToRemoteSession = Optional<SessionHandle>::Missing();
-    int ReceiveHandlerCallCount                   = 0;
-    int NewConnectionHandlerCallCount             = 0;
+    nlTestSuite * mSuite = nullptr;
+    SessionHolder mRemoteToLocalSession;
+    SessionHolder mLocalToRemoteSession;
+    int ReceiveHandlerCallCount       = 0;
+    int NewConnectionHandlerCallCount = 0;
 
     bool LargeMessageSent = false;
 };
@@ -152,20 +142,21 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     callback.mSuite = inSuite;
 
-    sessionManager.RegisterCreationDelegate(callback);
     sessionManager.SetMessageDelegate(&callback);
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     SecurePairingUsingTestSecret pairing1(1, 2);
-    err = sessionManager.NewPairing(peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
+    err = sessionManager.NewPairing(callback.mRemoteToLocalSession, peer, kSourceNodeId, &pairing1,
+                                    CryptoContext::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(2, 1);
-    err = sessionManager.NewPairing(peer, kDestinationNodeId, &pairing2, CryptoContext::SessionRole::kResponder, 0);
+    err = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kDestinationNodeId, &pairing2,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession.Value();
+    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession.Get();
 
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;
@@ -241,20 +232,21 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     callback.mSuite = inSuite;
 
-    sessionManager.RegisterCreationDelegate(callback);
     sessionManager.SetMessageDelegate(&callback);
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     SecurePairingUsingTestSecret pairing1(1, 2);
-    err = sessionManager.NewPairing(peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
+    err = sessionManager.NewPairing(callback.mRemoteToLocalSession, peer, kSourceNodeId, &pairing1,
+                                    CryptoContext::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(2, 1);
-    err = sessionManager.NewPairing(peer, kDestinationNodeId, &pairing2, CryptoContext::SessionRole::kResponder, 0);
+    err = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kDestinationNodeId, &pairing2,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession.Value();
+    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession.Get();
 
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;
@@ -277,7 +269,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Reset receive side message counter, or duplicated message will be denied.
-    Transport::SecureSession * state = sessionManager.GetSecureSession(callback.mRemoteToLocalSession.Value());
+    Transport::SecureSession * state = sessionManager.GetSecureSession(callback.mRemoteToLocalSession.Get());
     state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
 
     NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
@@ -316,20 +308,21 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     callback.mSuite = inSuite;
 
-    sessionManager.RegisterCreationDelegate(callback);
     sessionManager.SetMessageDelegate(&callback);
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     SecurePairingUsingTestSecret pairing1(1, 2);
-    err = sessionManager.NewPairing(peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
+    err = sessionManager.NewPairing(callback.mRemoteToLocalSession, peer, kSourceNodeId, &pairing1,
+                                    CryptoContext::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(2, 1);
-    err = sessionManager.NewPairing(peer, kDestinationNodeId, &pairing2, CryptoContext::SessionRole::kResponder, 0);
+    err = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kDestinationNodeId, &pairing2,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession.Value();
+    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession.Get();
 
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;
@@ -355,7 +348,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     /* -------------------------------------------------------------------------------------------*/
     // Reset receive side message counter, or duplicated message will be denied.
-    Transport::SecureSession * state = sessionManager.GetSecureSession(callback.mRemoteToLocalSession.Value());
+    Transport::SecureSession * state = sessionManager.GetSecureSession(callback.mRemoteToLocalSession.Get());
     state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
 
     PacketHeader packetHeader;
@@ -422,7 +415,6 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
     TestSessMgrCallback callback;
     callback.mSuite = inSuite;
 
-    sessionManager.RegisterCreationDelegate(callback);
     sessionManager.RegisterReleaseDelegate(callback);
     sessionManager.SetMessageDelegate(&callback);
 
@@ -431,35 +423,40 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
     // First pairing
     SecurePairingUsingTestSecret pairing1(1, 1);
     callback.mOldConnectionDropped = false;
-    err = sessionManager.NewPairing(peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
+    err                            = sessionManager.NewPairing(callback.mRemoteToLocalSession, peer, kSourceNodeId, &pairing1,
+                                    CryptoContext::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !callback.mOldConnectionDropped);
 
     // New pairing with different peer node ID and different local key ID (same peer key ID)
     SecurePairingUsingTestSecret pairing2(1, 2);
     callback.mOldConnectionDropped = false;
-    err = sessionManager.NewPairing(peer, kSourceNodeId, &pairing2, CryptoContext::SessionRole::kResponder, 0);
+    err                            = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kSourceNodeId, &pairing2,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !callback.mOldConnectionDropped);
 
     // New pairing with undefined node ID and different local key ID (same peer key ID)
     SecurePairingUsingTestSecret pairing3(1, 3);
     callback.mOldConnectionDropped = false;
-    err = sessionManager.NewPairing(peer, kUndefinedNodeId, &pairing3, CryptoContext::SessionRole::kResponder, 0);
+    err                            = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kUndefinedNodeId, &pairing3,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !callback.mOldConnectionDropped);
 
     // New pairing with same local key ID, and a given node ID
     SecurePairingUsingTestSecret pairing4(1, 2);
     callback.mOldConnectionDropped = false;
-    err = sessionManager.NewPairing(peer, kSourceNodeId, &pairing4, CryptoContext::SessionRole::kResponder, 0);
+    err                            = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kSourceNodeId, &pairing4,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, callback.mOldConnectionDropped);
 
     // New pairing with same local key ID, and undefined node ID
     SecurePairingUsingTestSecret pairing5(1, 1);
     callback.mOldConnectionDropped = false;
-    err = sessionManager.NewPairing(peer, kUndefinedNodeId, &pairing5, CryptoContext::SessionRole::kResponder, 0);
+    err                            = sessionManager.NewPairing(callback.mLocalToRemoteSession, peer, kUndefinedNodeId, &pairing5,
+                                    CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, callback.mOldConnectionDropped);
 }


### PR DESCRIPTION
#### Problem
On the road to eliminate dangling session handle.

#### Change overview
* Add a `SessionHolder` class in order to store a session.
  * `SessionHolder` is designed to store a session.
  * A `SessionHandle` can be retrieved from a `SessionHolder` if it holds a valid session.
  * The `SessionHolder` will become invalid when the underlying session is released.
* In the future `SessionHandle` will be non-copyable, its instance will be only available on stack, it is not allowed to store `SessionHandle` anywhere. Only `SessionHolder` can store a session.

An extra argument of `SessionHolder &` is added to `NewPairing` API. The newly created session will be stored in the argument. Remove `SessionCreationDelegate`, because it is not needed anymore, the newly created session is already assigned to the `SessionHolder`

Do not allow creating `SessionHandle` on the fly. The `SessionHandle` can be only created inside `SessionManager` or `SessionHolder`, to ensure that all `SessionHandle` are valid, not dangling.

#### Testing
Verified using unit-tests.