### PR TITLE
Sync basic cluster write: NodeLabel, Location and LocalConfigDisabled

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -101,7 +101,9 @@ public:
             {
                 CharSpan span(location, codeLen);
                 aEncoder.Encode(span);
-            } else {
+            }
+            else
+            {
                 // "XX" is the default value of the location attribute
                 aEncoder.Encode(CharSpan("XX", strlen("XX")));
             }

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -106,7 +106,7 @@ public:
                 aEncoder.Encode(CharSpan("XX", strlen("XX")));
             }
         }
-        else if(aPath.mAttributeId == app::Clusters::Basic::Attributes::LocalConfigDisabled::Id)
+        else if (aPath.mAttributeId == app::Clusters::Basic::Attributes::LocalConfigDisabled::Id)
         {
             bool localConfigDisabled;
             if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
@@ -118,14 +118,15 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder) override 
+    CHIP_ERROR Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder) override
     {
         CHIP_ERROR err;
         if (aPath.mAttributeId == app::Clusters::Basic::Attributes::NodeLabel::Id)
         {
             CharSpan span;
             err = aDecoder.Decode(span);
-            if (err == CHIP_NO_ERROR) {
+            if (err == CHIP_NO_ERROR)
+            {
                 ConfigurationMgr().StoreNodeLabel(span.data(), span.size());
             }
         }
@@ -133,15 +134,17 @@ public:
         {
             CharSpan span;
             err = aDecoder.Decode(span);
-            if (err == CHIP_NO_ERROR) {
+            if (err == CHIP_NO_ERROR)
+            {
                 ConfigurationMgr().StoreCountryCode(span.data(), span.size());
             }
         }
-        else if(aPath.mAttributeId == app::Clusters::Basic::Attributes::LocalConfigDisabled::Id)
+        else if (aPath.mAttributeId == app::Clusters::Basic::Attributes::LocalConfigDisabled::Id)
         {
             bool localConfigDisabled;
             err = aDecoder.Decode(localConfigDisabled);
-            if (err == CHIP_NO_ERROR) {
+            if (err == CHIP_NO_ERROR)
+            {
                 ConfigurationMgr().StoreLocalConfigDisabled(localConfigDisabled);
             }
         }

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -78,38 +78,85 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
 
 PlatformMgrDelegate gPlatformMgrDelegate;
 
+class BasicAttrAccess : public app::AttributeAccessInterface
+{
+public:
+    BasicAttrAccess() : app::AttributeAccessInterface(Optional<EndpointId>::Missing(), app::Clusters::Basic::Id) {}
+    CHIP_ERROR Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder) override
+    {
+        if (aPath.mAttributeId == app::Clusters::Basic::Attributes::NodeLabel::Id)
+        {
+            char nodeLabel[DeviceLayer::ConfigurationManager::kMaxNodeLabelLength + 1];
+            if (ConfigurationMgr().GetNodeLabel(nodeLabel, sizeof(nodeLabel)) == CHIP_NO_ERROR)
+            {
+                CharSpan span(nodeLabel, strlen(nodeLabel));
+                aEncoder.Encode(span);
+            }
+        }
+        else if (aPath.mAttributeId == app::Clusters::Basic::Attributes::Location::Id)
+        {
+            char location[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1];
+            size_t codeLen = 0;
+            if (ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR && codeLen > 0)
+            {
+                CharSpan span(location, codeLen);
+                aEncoder.Encode(span);
+            } else {
+                // "XX" is the default value of the location attribute
+                aEncoder.Encode(CharSpan("XX", strlen("XX")));
+            }
+        }
+        else if(aPath.mAttributeId == app::Clusters::Basic::Attributes::LocalConfigDisabled::Id)
+        {
+            bool localConfigDisabled;
+            if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
+            {
+                aEncoder.Encode(localConfigDisabled);
+            }
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder) override 
+    {
+        CHIP_ERROR err;
+        if (aPath.mAttributeId == app::Clusters::Basic::Attributes::NodeLabel::Id)
+        {
+            CharSpan span;
+            err = aDecoder.Decode(span);
+            if (err == CHIP_NO_ERROR) {
+                ConfigurationMgr().StoreNodeLabel(span.data(), span.size());
+            }
+        }
+        else if (aPath.mAttributeId == app::Clusters::Basic::Attributes::Location::Id)
+        {
+            CharSpan span;
+            err = aDecoder.Decode(span);
+            if (err == CHIP_NO_ERROR) {
+                ConfigurationMgr().StoreCountryCode(span.data(), span.size());
+            }
+        }
+        else if(aPath.mAttributeId == app::Clusters::Basic::Attributes::LocalConfigDisabled::Id)
+        {
+            bool localConfigDisabled;
+            err = aDecoder.Decode(localConfigDisabled);
+            if (err == CHIP_NO_ERROR) {
+                ConfigurationMgr().StoreLocalConfigDisabled(localConfigDisabled);
+            }
+        }
+
+        return CHIP_NO_ERROR;
+    }
+};
+
+static BasicAttrAccess gBasicAttrAttrAccess;
+
 } // anonymous namespace
 
 void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
 {
     EmberAfStatus status;
-
-    char nodeLabel[DeviceLayer::ConfigurationManager::kMaxNodeLabelLength + 1];
-    if (ConfigurationMgr().GetNodeLabel(nodeLabel, sizeof(nodeLabel)) == CHIP_NO_ERROR)
-    {
-        status = Attributes::NodeLabel::Set(endpoint, chip::CharSpan(nodeLabel, strlen(nodeLabel)));
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Node Label: 0x%02x", status));
-    }
-
-    char location[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1];
-    size_t codeLen = 0;
-    if (ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR)
-    {
-        if (codeLen == 0)
-        {
-            status = Attributes::Location::Set(endpoint, chip::CharSpan("XX", strlen("XX")));
-        }
-        else
-        {
-            status = Attributes::Location::Set(endpoint, chip::CharSpan(location, strlen(location)));
-        }
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
-    }
-    else
-    {
-        status = Attributes::Location::Set(endpoint, chip::CharSpan("XX", strlen("XX")));
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
-    }
 
     char vendorName[DeviceLayer::ConfigurationManager::kMaxVendorNameLength + 1];
     if (ConfigurationMgr().GetVendorName(vendorName, sizeof(vendorName)) == CHIP_NO_ERROR)
@@ -208,13 +255,6 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Label: 0x%02x", status));
     }
 
-    bool localConfigDisabled;
-    if (ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR)
-    {
-        status = Attributes::LocalConfigDisabled::Set(endpoint, localConfigDisabled);
-        VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Local Config Disabled: 0x%02x", status));
-    }
-
     bool reachable;
     if (ConfigurationMgr().GetReachable(reachable) == CHIP_NO_ERROR)
     {
@@ -227,6 +267,13 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     {
         status = Attributes::UniqueID::Set(endpoint, CharSpan(uniqueId, strlen(uniqueId)));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Unique Id: 0x%02x", status));
+    }
+
+    static bool attrAccessRegistered = false;
+    if (!attrAccessRegistered)
+    {
+        registerAttributeAccessOverride(&gBasicAttrAttrAccess);
+        attrAccessRegistered = true;
     }
 }
 

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -271,16 +271,10 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
         status = Attributes::UniqueID::Set(endpoint, CharSpan(uniqueId, strlen(uniqueId)));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Unique Id: 0x%02x", status));
     }
-
-    static bool attrAccessRegistered = false;
-    if (!attrAccessRegistered)
-    {
-        registerAttributeAccessOverride(&gBasicAttrAttrAccess);
-        attrAccessRegistered = true;
-    }
 }
 
 void MatterBasicPluginServerInitCallback()
 {
     PlatformMgr().SetDelegate(&gPlatformMgrDelegate);
+    registerAttributeAccessOverride(&gBasicAttrAttrAccess);
 }

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -51,7 +51,7 @@ tests:
       command: "readAttribute"
       attribute: "location"
       response:
-          value: ""
+          value: "XX"
 
     - label: "Turn On the light to see attribute change"
       cluster: "On/Off"

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -875,7 +875,7 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
         ChipLogDetail(Zcl, "Failed to prepare data to write: %s", ErrorStr(preparationError));
         return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::InvalidValue);
     }
-    //else, can not prepare and check data yet, let the AccessOverride to handle it.
+    // else, can not prepare and check data yet, let the AccessOverride to handle it.
 
     if (auto * attrOverride = findAttributeAccessOverride(aClusterInfo.mEndpointId, aClusterInfo.mClusterId))
     {

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -860,17 +860,6 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
         return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::NeedsTimedInteraction);
     }
 
-    if (auto * attrOverride = findAttributeAccessOverride(aClusterInfo.mEndpointId, aClusterInfo.mClusterId))
-    {
-        AttributeValueDecoder valueDecoder(aReader, apWriteHandler->GetAccessingFabricIndex());
-        ReturnErrorOnFailure(attrOverride->Write(aPath, valueDecoder));
-
-        if (valueDecoder.TriedDecode())
-        {
-            return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::Success);
-        }
-    }
-
     CHIP_ERROR preparationError = CHIP_NO_ERROR;
     uint16_t dataLen            = 0;
     if ((preparationError = prepareWriteData(attributeMetadata, aReader, dataLen)) != CHIP_NO_ERROR)
@@ -883,6 +872,17 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
     {
         ChipLogDetail(Zcl, "Data to write exceedes the attribute size claimed.");
         return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::InvalidValue);
+    }
+
+    if (auto * attrOverride = findAttributeAccessOverride(aClusterInfo.mEndpointId, aClusterInfo.mClusterId))
+    {
+        AttributeValueDecoder valueDecoder(aReader, apWriteHandler->GetAccessingFabricIndex());
+        ReturnErrorOnFailure(attrOverride->Write(aPath, valueDecoder));
+
+        if (valueDecoder.TriedDecode())
+        {
+            return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::Success);
+        }
     }
 
     auto status = ToInteractionModelStatus(emberAfWriteAttributeExternal(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId,

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -124,6 +124,7 @@ public:
     virtual CHIP_ERROR GetLocalConfigDisabled(bool & disabled)                         = 0;
     virtual CHIP_ERROR GetReachable(bool & reachable)                                  = 0;
     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
+    virtual CHIP_ERROR StoreLocalConfigDisabled(bool disabled)                         = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -430,6 +430,12 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf,
 }
 
 template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreLocalConfigDisabled(bool disabled)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -108,6 +108,7 @@ public:
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
     CHIP_ERROR GetReachable(bool & reachable) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreLocalConfigDisabled(bool disabled) override;
     CHIP_ERROR RunUnitTests(void) override;
     bool IsFullyProvisioned() override;
     void InitiateFactoryReset() override;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -73,7 +73,6 @@ const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 uint16_t PosixConfig::mPosixSetupDiscriminator = 0xF00; // CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
 char PosixConfig::mLocation[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1] = { 0 };
 
-
 CHIP_ERROR PosixConfig::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -116,11 +115,11 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
 
     if (key == kConfigKey_CountryCode)
     {
-        strncpy(buf,mLocation,bufSize);
+        strncpy(buf, mLocation, bufSize);
         outLen = strlen(mLocation);
         return CHIP_NO_ERROR;
     }
-    
+
     return err;
 }
 
@@ -178,7 +177,7 @@ CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str, size_t st
 
     if (key == kConfigKey_CountryCode)
     {
-        strncpy(mLocation,str,sizeof(mLocation));
+        strncpy(mLocation, str, sizeof(mLocation));
         mLocation[strLen] = '\0';
         return CHIP_NO_ERROR;
     }

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -71,6 +71,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNam
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
 uint16_t PosixConfig::mPosixSetupDiscriminator = 0xF00; // CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
+char PosixConfig::mLocation[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1] = { 0 };
+
 
 CHIP_ERROR PosixConfig::Init()
 {
@@ -111,9 +113,14 @@ exit:
 CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    SuccessOrExit(err);
 
-exit:
+    if (key == kConfigKey_CountryCode)
+    {
+        strncpy(buf,mLocation,bufSize);
+        outLen = strlen(mLocation);
+        return CHIP_NO_ERROR;
+    }
+    
     return err;
 }
 
@@ -168,9 +175,13 @@ exit:
 CHIP_ERROR PosixConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    SuccessOrExit(err);
 
-exit:
+    if (key == kConfigKey_CountryCode)
+    {
+        strncpy(mLocation,str,sizeof(mLocation));
+        mLocation[strLen] = '\0';
+        return CHIP_NO_ERROR;
+    }
     return err;
 }
 

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <inttypes.h>
 
+#include <platform/ConfigurationManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 namespace chip {
@@ -104,6 +105,7 @@ protected:
 private:
     // TODO: This is temporary until Darwin implements a proper ReadConfigValue
     static uint16_t mPosixSetupDiscriminator;
+    static char mLocation[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1];
 };
 
 struct PosixConfig::Key

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -365,5 +365,16 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     return err;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetNodeLabel(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return ReadConfigValueStr(PosixConfig::kConfigKey_NodeLabel, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreNodeLabel(const char * buf, size_t bufSize)
+{
+    return WriteConfigValueStr(PosixConfig::kConfigKey_NodeLabel, buf, bufSize);
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -45,6 +45,8 @@ public:
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
     CHIP_ERROR GetRegulatoryLocation(uint8_t & location) override;
     CHIP_ERROR GetLocationCapability(uint8_t & location) override;
+    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override;
     static ConfigurationManagerImpl & GetDefaultInstance();
 
 private:

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -57,7 +57,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_HardwareVersion     = { kConfigNa
 const PosixConfig::Key PosixConfig::kConfigKey_ManufacturingDate   = { kConfigNamespace_ChipFactory, "mfg-date" };
 const PosixConfig::Key PosixConfig::kConfigKey_SetupPinCode        = { kConfigNamespace_ChipFactory, "pin-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_SetupDiscriminator  = { kConfigNamespace_ChipFactory, "discriminator" };
-const PosixConfig::Key PosixConfig::kConfigKey_NodeLabel       = { kConfigNamespace_ChipFactory, "node-label" };
+const PosixConfig::Key PosixConfig::kConfigKey_NodeLabel           = { kConfigNamespace_ChipFactory, "node-label" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -57,6 +57,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_HardwareVersion     = { kConfigNa
 const PosixConfig::Key PosixConfig::kConfigKey_ManufacturingDate   = { kConfigNamespace_ChipFactory, "mfg-date" };
 const PosixConfig::Key PosixConfig::kConfigKey_SetupPinCode        = { kConfigNamespace_ChipFactory, "pin-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_SetupDiscriminator  = { kConfigNamespace_ChipFactory, "discriminator" };
+const PosixConfig::Key PosixConfig::kConfigKey_NodeLabel       = { kConfigNamespace_ChipFactory, "node-label" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -76,6 +76,7 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
     static const Key kConfigKey_LocationCapability;
+    static const Key kConfigKey_NodeLabel;
 
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -287,5 +287,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
     return ReadConfigValueStr(AndroidConfig::kConfigKey_UniqueId, buf, bufSize, dateLen);
 }
 
+CHIP_ERROR ConfigurationManagerImpl::StoreLocalConfigDisabled(bool disabled)
+{
+    return WriteConfigValue(AndroidConfig::kConfigKey_LocalConfigDisabled, disabled);
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -53,6 +53,7 @@ public:
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
     CHIP_ERROR GetReachable(bool & reachable) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreLocalConfigDisabled(bool disabled) override;
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -87,14 +87,15 @@ private:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetReachable(bool & reachable) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetReachable(bool & reachable) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreLocalConfigDisabled(bool disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if !defined(NDEBUG)
     CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -87,14 +87,14 @@ private:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetReachable(bool & reachable) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetReachable(bool & reachable) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreLocalConfigDisabled(bool disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if !defined(NDEBUG)
     CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -51046,7 +51046,7 @@ private:
 
     void OnSuccessResponse_4(chip::CharSpan location)
     {
-        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("", 0)));
+        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("XX", 2)));
 
         NextTest();
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* writeable attr NodeLabel, Location, and LocalConfigDisabled are not implemented in basic cluster

#### Change overview
* Added these Attributes

#### Testing
/chip-tool basic read/write [NodeLabel/Location/LocalConfigDisabled]