### PR TITLE
[Inet] Test EndPoint statistics

### DIFF
--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -255,11 +255,15 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     PacketBufferHandle buf   = PacketBufferHandle::New(PacketBuffer::kMaxSize);
 
     // init all the EndPoints
+    SYSTEM_STATS_RESET(System::Stats::kInetLayer_NumUDPEps);
     err = gUDP.NewEndPoint(&testUDPEP);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, 1));
 
+    SYSTEM_STATS_RESET(System::Stats::kInetLayer_NumTCPEps);
     err = gTCP.NewEndPoint(&testTCPEP1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, 1));
 
     err = InterfaceId::Null().GetLinkLocalAddr(&addr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -294,16 +298,20 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     err = testUDPEP->BindInterface(IPAddressType::kIPv6, intId);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
     testUDPEP->Free();
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, 0));
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_HIGH_WATER_MARK(System::Stats::kInetLayer_NumUDPEps, 1));
 
     err = gUDP.NewEndPoint(&testUDPEP);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, 1));
 #if INET_CONFIG_ENABLE_IPV4
     err = testUDPEP->Bind(IPAddressType::kIPv4, addr_v4, 3000, intId);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
     buf = PacketBufferHandle::New(PacketBuffer::kMaxSize);
     err = testUDPEP->SendTo(addr_v4, 3000, std::move(buf));
-    testUDPEP->Free();
 #endif // INET_CONFIG_ENABLE_IPV4
+    testUDPEP->Free();
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, 0));
 
     // TcpEndPoint special cases to cover the error branch
     err = testTCPEP1->GetPeerInfo(nullptr, nullptr);
@@ -342,6 +350,8 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
 #endif // INET_CONFIG_ENABLE_IPV4
 
     testTCPEP1->Free();
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumTCPEps, 0));
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_HIGH_WATER_MARK(System::Stats::kInetLayer_NumTCPEps, 1));
 }
 
 #if !CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
@@ -353,17 +363,27 @@ static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    int udpCount = 0;
+    SYSTEM_STATS_RESET(System::Stats::kInetLayer_NumUDPEps);
     for (int i = INET_CONFIG_NUM_UDP_ENDPOINTS; i >= 0; --i)
     {
         err = gUDP.NewEndPoint(&testUDPEP[i]);
         NL_TEST_ASSERT(inSuite, err == (i ? CHIP_NO_ERROR : CHIP_ERROR_ENDPOINT_POOL_FULL));
+        NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumUDPEps, ++udpCount));
     }
+    const int udpHighWaterMark = udpCount;
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_HIGH_WATER_MARK(System::Stats::kInetLayer_NumUDPEps, udpHighWaterMark));
 
+    int tcpCount = 0;
+    SYSTEM_STATS_RESET(System::Stats::kInetLayer_NumTCPEps);
     for (int i = INET_CONFIG_NUM_TCP_ENDPOINTS; i >= 0; --i)
     {
         err = gTCP.NewEndPoint(&testTCPEP[i]);
         NL_TEST_ASSERT(inSuite, err == (i ? CHIP_NO_ERROR : CHIP_ERROR_ENDPOINT_POOL_FULL));
+        NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumTCPEps, ++tcpCount));
     }
+    const int tcpHighWaterMark = tcpCount;
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_HIGH_WATER_MARK(System::Stats::kInetLayer_NumTCPEps, tcpHighWaterMark));
 
 #if CHIP_SYSTEM_CONFIG_NUM_TIMERS
     // Verify same aComplete and aAppState args do not exhaust timer pool
@@ -385,8 +405,10 @@ static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
         if (testUDPEP[i] != nullptr)
         {
             testUDPEP[i]->Free();
+            NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumTCPEps, --udpCount));
         }
     }
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_HIGH_WATER_MARK(System::Stats::kInetLayer_NumUDPEps, udpHighWaterMark));
 
     // Release TCP endpoints
     for (int i = 0; i <= INET_CONFIG_NUM_TCP_ENDPOINTS; i++)
@@ -394,8 +416,10 @@ static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
         if (testTCPEP[i] != nullptr)
         {
             testTCPEP[i]->Free();
+            NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_IN_USE(System::Stats::kInetLayer_NumTCPEps, --tcpCount));
         }
     }
+    NL_TEST_ASSERT(inSuite, SYSTEM_STATS_TEST_HIGH_WATER_MARK(System::Stats::kInetLayer_NumTCPEps, tcpHighWaterMark));
 
     ShutdownNetwork();
     ShutdownSystemLayer();

--- a/src/system/SystemStats.h
+++ b/src/system/SystemStats.h
@@ -113,19 +113,19 @@ const Label * GetStrings();
         {                                                                                                                          \
             chip::System::Stats::GetHighWatermarks()[entry] = new_value;                                                           \
         }                                                                                                                          \
-    } while (0);
+    } while (0)
 
 #define SYSTEM_STATS_DECREMENT(entry)                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
         chip::System::Stats::GetResourcesInUse()[entry]--;                                                                         \
-    } while (0);
+    } while (0)
 
 #define SYSTEM_STATS_DECREMENT_BY_N(entry, count)                                                                                  \
     do                                                                                                                             \
     {                                                                                                                              \
         chip::System::Stats::GetResourcesInUse()[entry] -= (count);                                                                \
-    } while (0);
+    } while (0)
 
 #define SYSTEM_STATS_SET(entry, count)                                                                                             \
     do                                                                                                                             \
@@ -135,23 +135,27 @@ const Label * GetStrings();
         {                                                                                                                          \
             chip::System::Stats::GetHighWatermarks()[entry] = new_value;                                                           \
         }                                                                                                                          \
-    } while (0);
+    } while (0)
 
 #define SYSTEM_STATS_RESET(entry)                                                                                                  \
     do                                                                                                                             \
     {                                                                                                                              \
         chip::System::Stats::GetResourcesInUse()[entry] = 0;                                                                       \
-    } while (0);
+    } while (0)
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_STATS && MEMP_STATS
 #define SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS()                                                                                     \
     do                                                                                                                             \
     {                                                                                                                              \
         chip::System::Stats::UpdateLwipPbufCounts();                                                                               \
-    } while (0);
+    } while (0)
 #else // CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_STATS && MEMP_STATS
 #define SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS()
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_STATS && MEMP_STATS
+
+// Additional macros for testing.
+#define SYSTEM_STATS_TEST_IN_USE(entry, expected) (chip::System::Stats::GetResourcesInUse()[entry] == (expected))
+#define SYSTEM_STATS_TEST_HIGH_WATER_MARK(entry, expected) (chip::System::Stats::GetHighWatermarks()[entry] == (expected))
 
 #else // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
 
@@ -164,5 +168,8 @@ const Label * GetStrings();
 #define SYSTEM_STATS_RESET(entry)
 
 #define SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS()
+
+#define SYSTEM_STATS_TEST_IN_USE(entry, expected) (true)
+#define SYSTEM_STATS_TEST_HIGH_WATER_MARK(entry, expected) (true)
 
 #endif // CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS


### PR DESCRIPTION
#### Problem

Fixes #12378 Use the Impl's underlying ObjectPool statistics

#### Change overview

Decided to fix the existing method, with a deletion wrapper.

Added stats macros for unit testing.

#### Testing

Added unit test assertions.
