### PR TITLE
[Size reports] Script improvements (1/3)

### DIFF
--- a/scripts/tools/memory/gh_sizes.py
+++ b/scripts/tools/memory/gh_sizes.py
@@ -31,11 +31,11 @@ Usage: gh_sizes.py ‹platform› ‹config› ‹target› ‹binary› [‹out
 This script also expects certain environment variables, which can be set in a
 github workflow as follows:
 
-  env:
-    BUILD_TYPE: nrfconnect
-    GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
-    GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-    GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+    - name: Set up environment for size reports
+      if: ${{ !env.ACT }}
+      env:
+        GH_CONTEXT: ${{ toJson(github) }}
+      run: gh_sizes_environment.py "${GH_CONTEXT}"
 
 Default output file is {platform}-{configname}-{buildname}-sizes.json in the
 binary's directory. This file has the form:
@@ -51,11 +51,16 @@ binary's directory. This file has the form:
     "parent": "20796f752061726520746f6f20636c6f73652e0a",
     "pr": 12345,
     "by": "section",
+    "ref": "refs/pull/12345/merge"
     "frames": {
         "section": [
           {"section": ".bss", "size": 260496},
           {"section": ".data", "size": 1648},
           {"section": ".text", "size": 740236}
+        ],
+        "wr": [
+          {"wr": 0, "size": 262144},
+          {"wr": 1, "size": 74023}
         ]
     }
   }
@@ -100,10 +105,17 @@ CONFIG: ConfigDescription = {
         'metavar': 'HASH',
         'default': os.environ.get('GH_EVENT_PARENT'),
     },
+    'ref': {
+        'help': 'Target ref',
+        'metavar': 'REF',
+        'default': os.environ.get('GH_EVENT_REF'),
+    },
     'timestamp': {
         'help': 'Build timestamp',
         'metavar': 'TIME',
-        'default': int(datetime.datetime.now().timestamp()),
+        'default': int(
+            os.environ.get('GH_EVENT_TIMESTAMP')
+            or datetime.datetime.now().timestamp()),
     },
 }
 
@@ -165,7 +177,7 @@ def main(argv):
         config.put('output.metadata.time', config['timestamp'])
         config.put('output.metadata.input', binary)
         config.put('output.metadata.by', 'section')
-        for key in ['event', 'hash', 'parent', 'pr']:
+        for key in ['event', 'hash', 'parent', 'pr', 'ref']:
             if value := config[key]:
                 config.putl(['output', 'metadata', key], value)
 

--- a/scripts/tools/memory/gh_sizes_environment.py
+++ b/scripts/tools/memory/gh_sizes_environment.py
@@ -16,10 +16,12 @@ Typically run as:
 
 Sets the following environment variables:
 
-- `GH_EVENT_PR`     For a pull request, the PR number; otherwise 0.
-- `GH_EVENT_HASH`   SHA of the commit under test.
-- `GH_EVENT_PARENT` SHA of the parent commit to which the commit under
-                    test is applied.
+- `GH_EVENT_PR`         For a pull request, the PR number; otherwise 0.
+- `GH_EVENT_HASH`       SHA of the commit under test.
+- `GH_EVENT_PARENT`     SHA of the parent commit to which the commit under
+                        test is applied.
+- `GH_EVENT_REF`        The branch or tag ref that triggered the workflow run.
+- `GH_EVENT_TIMESTAMP`  For `push` events only, the timestamp of the commit.
 """
 
 import json
@@ -28,11 +30,21 @@ import re
 import subprocess
 import sys
 
+import dateutil.parser
+
 github = json.loads(sys.argv[1])
 
+commit = None
+timestamp = None
+ref = github['ref']
+
 if github['event_name'] == 'pull_request':
+
     pr = github['event']['number']
     commit = github['event']['pull_request']['head']['sha']
+
+    # Try to find the actual commit against which the current PR compares
+    # by scraping the HEAD commit message.
     r = subprocess.run(['git', 'show', '--no-patch', '--format=%s', 'HEAD'],
                        capture_output=True, text=True, check=True)
     m = re.fullmatch('Merge [0-9a-f]+ into ([0-9a-f]+)', r.stdout)
@@ -40,17 +52,25 @@ if github['event_name'] == 'pull_request':
         parent = m.group(1)
     else:
         parent = github['event']['pull_request']['base']['sha']
-else:
-    pr = 0
+
+elif github['event_name'] == 'push':
+
     commit = github['sha']
     parent = github['event']['before']
+    timestamp = dateutil.parser.isoparse(
+        github['event']['head_commit']['timestamp']).timestamp()
+    pr = 0
 
 # Environment variables for subsequent workflow steps are set by
 # writing to the file named by `$GITHUB_ENV`.
 
-env = os.environ.get('GITHUB_ENV')
-assert env
-with open(env, 'at') as out:
-    print(f'GH_EVENT_PR={pr}', file=out)
-    print(f'GH_EVENT_HASH={commit}', file=out)
-    print(f'GH_EVENT_PARENT={parent}', file=out)
+if commit is not None:
+    env = os.environ.get('GITHUB_ENV')
+    assert env
+    with open(env, 'at') as out:
+        print(f'GH_EVENT_PR={pr}', file=out)
+        print(f'GH_EVENT_HASH={commit}', file=out)
+        print(f'GH_EVENT_PARENT={parent}', file=out)
+        print(f'GH_EVENT_REF={ref}', file=out)
+        if timestamp:
+            print(f'GH_EVENT_TIMESTAMP={timestamp}', file=out)


### PR DESCRIPTION
#### Problem

Recent memory size investigations suggest some improvements:

- Scripts use PR==0 to distinguish pull requests from master commits
  (push events), but it would be useful to record the associated PR
  along with commits.
- Sometimes push events run on pull requests, and those are not
  currently distinguishable from master push events.
- Sorting by build timestamp is inaccurate, since CI runs may finish
  in a different order than the commits.

#### Change overview

This is the first of three steps.

- Use `event` rather than PR number to distinguish PR builds from
  master commit builds.
- Record GitHub `event` and `ref` in the database representation, and
  add `ref` to the JSON (`event` was already present).
- For master commits, use the commit timestamp rather than the build
  time.

The second step will add the event to artifact names, so that it can
be used to filter artifact downloads instead of PR==0.

The third step will add the PR number from master commits, extracted
from the commit message.

#### Testing

Manually run offline, but final confirmation requires live CI runs.
