### PR TITLE
Add test support to build_examples.py,  including fake platform compilation and run

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -175,8 +175,6 @@ jobs:
 
             - name: Fun fake linux tests
               timeout-minutes: 15
-              # NOTE: only vscode image contains the cross compile arm64 sysroot
-              #       so the build command below only compiles x64
               run: |
                 ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -158,12 +158,20 @@ jobs:
                       scripts/tests/gn_tests.sh
                   done
             - name: Build using build_examples.py
-              timeout-minutes: 30
+              timeout-minutes: 40
               # NOTE: only vscode image contains the cross compile arm64 sysroot
               #       so the build command below only compiles x64
               run: |
                 ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'linux-x64-*' build"
+
+            - name: Fun fake linux tests
+              timeout-minutes: 15
+              # NOTE: only vscode image contains the cross compile arm64 sysroot
+              #       so the build command below only compiles x64
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"
 
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
               run: scripts/run_in_build_env.sh "ninja -C ./out"
     build_linux:
         name: Build on Linux (gcc_release, clang, mbedtls, simulated)
-        timeout-minutes: 60
+        timeout-minutes: 90
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,13 +159,17 @@ jobs:
                   done
             - name: Build using build_examples.py
               timeout-minutes: 40
-              # NOTE: only vscode image contains the cross compile arm64 sysroot
-              #       so the build command below only compiles x64
               run: |
                 ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps \
-                     --target-glob 'linux-x64-*' \
-                     --skip-target-glob '*{tests,thermostat-ipv6only}*' \
+                     --target linux-x64-all-clusters \
+                     --target linux-x64-all-clusters-ipv6only \
+                     --target linux-x64-chip-tool \
+                     --target linux-x64-chip-tool-ipv6only \
+                     --target linux-x64-minmdns-ipv6only \
+                     --target linux-x64-rpc-console \
+                     --target linux-x64-thermostat-ipv6only \
+                     --target linux-x64-tv-app-ipv6only \
                      build \
                   "
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -163,7 +163,11 @@ jobs:
               #       so the build command below only compiles x64
               run: |
                 ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'linux-x64-*' build"
+                  "./scripts/build/build_examples.py --no-log-timestamps \
+                     --target-glob 'linux-x64-*' \
+                     --skip-target-glob '*{tests,thermostat-ipv6only}*' \
+                     build \
+                  "
 
             - name: Fun fake linux tests
               timeout-minutes: 15

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -196,10 +196,8 @@ def HostTargets():
                 yield variant_target
 
     test_target = Target(HostBoard.NATIVE.PlatformName(), HostBuilder)
-    test_target = test_target.Extend(HostBoard.NATIVE.BoardName(), board=HostBoard.NATIVE)
-    test_target = test_target.Extend('tests', app=HostApp.TESTS)
-
-    yield test_target
+    for board in [HostBoard.NATIVE, HostBoard.FAKE]:
+        yield test_target.Extend(board.BoardName() + '-tests', board=board, app=HostApp.TESTS)
 
 
 def Esp32Targets():

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -195,6 +195,12 @@ def HostTargets():
 
                 yield variant_target
 
+    test_target = Target(HostBoard.NATIVE.PlatformName(), HostBuilder)
+    test_target = test_target.Extend(HostBoard.NATIVE.BoardName(), board=HostBoard.NATIVE)
+    test_target = test_target.Extend('tests', app=HostApp.TESTS)
+
+    yield test_target
+
 
 def Esp32Targets():
     esp32_target = Target('esp32', Esp32Builder)

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -29,6 +29,8 @@ class GnBuilder(Builder):
         """
         super(GnBuilder, self).__init__(root, runner)
 
+        self.build_command = None
+
     def GnBuildArgs(self):
         """Extra gn build `--args`
 
@@ -73,5 +75,8 @@ class GnBuilder(Builder):
             self._Execute(cmd, title=title)
 
     def _build(self):
-        self._Execute(['ninja', '-C', self.output_dir],
-                      title='Building ' + self.identifier)
+        cmd = ['ninja', '-C', self.output_dir]
+        if self.build_command:
+            cmd.append(self.build_command)
+
+        self._Execute(cmd, title='Building ' + self.identifier)

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -170,6 +170,7 @@ class HostBuilder(GnBuilder):
                 [
                     'custom_toolchain="//build/toolchain/fake:fake_x64_gcc"',
                     'chip_link_tests=true',
+                    'chip_device_platform="fake"',
                 ]
             )
             return self.extra_gn_options

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -27,6 +27,7 @@ class HostApp(Enum):
     RPC_CONSOLE = auto()
     MIN_MDNS = auto()
     TV_APP = auto()
+    TESTS = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -37,10 +38,12 @@ class HostApp(Enum):
             return 'thermostat/linux'
         elif self == HostApp.RPC_CONSOLE:
             return 'common/pigweed/rpc_console'
-        if self == HostApp.MIN_MDNS:
+        elif self == HostApp.MIN_MDNS:
             return 'minimal-mdns'
-        if self == HostApp.TV_APP:
+        elif self == HostApp.TV_APP:
             return 'tv-app/linux'
+        elif self == HostApp.TESTS:
+            return '../'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -66,6 +69,8 @@ class HostApp(Enum):
         elif self == HostApp.TV_APP:
             yield 'chip-tv-app'
             yield 'chip-tv-app.map'
+        elif self == HostApp.TESTS:
+            pass
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -134,6 +139,10 @@ class HostBuilder(GnBuilder):
         if test_group:
             self.extra_gn_options.append(
                 'chip_enable_group_messaging_tests=true')
+
+        if app == HostApp.TESTS:
+            self.extra_gn_options.append('chip_build_tests=true')
+            self.build_command = 'check'
 
     def GnBuildArgs(self):
         if self.board == HostBoard.NATIVE:

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -42,7 +42,7 @@ PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
 
 # Generating linux-fake-tests
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true' {out}/linux-fake-tests
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true chip_device_platform="fake"' {out}/linux-fake-tests
 
 # Generating linux-x64-all-clusters
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -62,6 +62,9 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
+# Generating linux-x64-tests
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} --args=chip_build_tests=true {out}/linux-x64-tests
+
 # Generating linux-x64-thermostat
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux {out}/linux-x64-thermostat
 
@@ -118,6 +121,9 @@ ninja -C {out}/linux-x64-minmdns-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console
+
+# Building linux-x64-tests
+ninja -C {out}/linux-x64-tests check
 
 # Building linux-x64-thermostat
 ninja -C {out}/linux-x64-thermostat

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -41,6 +41,9 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
 
+# Generating linux-fake-tests
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true' {out}/linux-fake-tests
+
 # Generating linux-x64-all-clusters
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
 
@@ -100,6 +103,9 @@ ninja -C {out}/linux-arm64-thermostat
 
 # Building linux-arm64-thermostat-ipv6only
 ninja -C {out}/linux-arm64-thermostat-ipv6only
+
+# Building linux-fake-tests
+ninja -C {out}/linux-fake-tests check
 
 # Building linux-x64-all-clusters
 ninja -C {out}/linux-x64-all-clusters


### PR DESCRIPTION
#### Problem
build_examples does not build tests
fake platform builds are not supported except the large gn_build.sh script.

#### Change overview
Add linux-x64-tests and linux-fake-tests targets that run a 'check' (i.e. run tests as well, not only compile)

#### Testing
Manually ran build on linux using the new targets
added CI  targets for this.