### PR TITLE
Hook up args to access control check calls

### DIFF
--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -393,16 +393,14 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, c
     }
 
     {
-        Access::SubjectDescriptor subjectDescriptor; // TODO: get actual subject descriptor
         Access::RequestPath requestPath{ .cluster = aPath.mClusterId, .endpoint = aPath.mEndpointId };
         Access::Privilege requestPrivilege = Access::Privilege::kView; // TODO: get actual request privilege
-        bool pathWasExpanded               = false;                    // TODO: get actual expanded flag
-        CHIP_ERROR err                     = Access::GetAccessControl().Check(subjectDescriptor, requestPath, requestPrivilege);
+        CHIP_ERROR err                     = Access::GetAccessControl().Check(aSubjectDescriptor, requestPath, requestPrivilege);
         err                                = CHIP_NO_ERROR; // TODO: remove override
         if (err != CHIP_NO_ERROR)
         {
             ReturnErrorCodeIf(err != CHIP_ERROR_ACCESS_DENIED, err);
-            if (pathWasExpanded)
+            if (aPath.mExpanded)
             {
                 return CHIP_NO_ERROR;
             }
@@ -845,10 +843,9 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
     }
 
     {
-        Access::SubjectDescriptor subjectDescriptor; // TODO: get actual subject descriptor
         Access::RequestPath requestPath{ .cluster = aPath.mClusterId, .endpoint = aPath.mEndpointId };
         Access::Privilege requestPrivilege = Access::Privilege::kOperate; // TODO: get actual request privilege
-        CHIP_ERROR err                     = Access::GetAccessControl().Check(subjectDescriptor, requestPath, requestPrivilege);
+        CHIP_ERROR err                     = Access::GetAccessControl().Check(aSubjectDescriptor, requestPath, requestPrivilege);
         err                                = CHIP_NO_ERROR; // TODO: remove override
         if (err != CHIP_NO_ERROR)
         {


### PR DESCRIPTION
#### Problem
Calls with args, and plumbing to deliver args, came in different PRs
and require final hookup.

#### Change overview
- Hook up wildcard/group expansion flag in IM read attribute
- Hook up subject descriptor in IM read/write attribute

#### Testing
How was this tested? (at least one bullet point required)
* Built, tested in chip-tool.
