### PR TITLE
Fix gh_sizes.py

### DIFF
--- a/scripts/tools/memory/gh_sizes.py
+++ b/scripts/tools/memory/gh_sizes.py
@@ -113,9 +113,9 @@ CONFIG: ConfigDescription = {
     'timestamp': {
         'help': 'Build timestamp',
         'metavar': 'TIME',
-        'default': int(
+        'default': int(float(
             os.environ.get('GH_EVENT_TIMESTAMP')
-            or datetime.datetime.now().timestamp()),
+            or datetime.datetime.now().timestamp())),
     },
 }
 


### PR DESCRIPTION
#### Problem

#12886 broke size report collection.

#### Change overview

Account for the GH_EVENT_TIMESTAMP environment variable not being python-parseable as an integer.

#### Testing

Manual check