### PR TITLE
Group Data Provider: Listener added.

### DIFF
--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -61,7 +61,8 @@ public:
     CHIP_ERROR SetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, const GroupKey & info) override;
     CHIP_ERROR GetGroupKeyAt(chip::FabricIndex fabric_index, size_t index, GroupKey & info) override;
     CHIP_ERROR RemoveGroupKeyAt(chip::FabricIndex fabric_index, size_t index) override;
-    GroupKeyIterator * IterateGroupKey(chip::FabricIndex fabric_index) override;
+    CHIP_ERROR RemoveGroupKeys(chip::FabricIndex fabric_index) override;
+    GroupKeyIterator * IterateGroupKeys(chip::FabricIndex fabric_index) override;
 
     //
     // Key Sets


### PR DESCRIPTION
#### Problem
The group data provider is missing a listener to detect changes in the group mappings.

#### Change overview
* Added new listener class.
* Added listener events for the endpoint add/remove.
* Added method to remove all the group mappings for a given endpoint.
* Added unit test for the new functionality.

#### Testing
Unit tests pass successfully.
