### PR TITLE
Make it harder to misuse Clusters.

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -27,7 +27,7 @@ const path              = require('path');
 const templateUtil = require(zapPath + 'dist/src-electron/generator/template-util.js')
 
 const { getClusters, getCommands, getAttributes, isTestOnlyCluster } = require('./simulated-clusters/SimulatedClusters.js');
-const { asBlocks, initClusters }                                     = require('./ClustersHelper.js');
+const { asBlocks, ensureClusters }                                   = require('./ClustersHelper.js');
 
 const kIdentityName           = 'identity';
 const kClusterName            = 'cluster';
@@ -365,7 +365,7 @@ function printErrorAndExit(context, msg)
 function assertCommandOrAttribute(context)
 {
   const clusterName = context.cluster;
-  return getClusters().then(clusters => {
+  return getClusters(context).then(clusters => {
     if (!clusters.find(cluster => cluster.name == clusterName)) {
       const names = clusters.map(item => item.name);
       printErrorAndExit(context, 'Missing cluster "' + clusterName + '" in: \n\t* ' + names.join('\n\t* '));
@@ -376,10 +376,10 @@ function assertCommandOrAttribute(context)
 
     if (context.isCommand) {
       filterName = context.command;
-      items      = getCommands(clusterName);
+      items      = getCommands(context, clusterName);
     } else if (context.isAttribute) {
       filterName = context.attribute;
-      items      = getAttributes(clusterName);
+      items      = getAttributes(context, clusterName);
     } else {
       printErrorAndExit(context, 'Unsupported command type: ', context);
     }
@@ -435,12 +435,14 @@ function chip_tests_pics(options)
 
 async function chip_tests(list, options)
 {
-  initClusters.call(this);
+  // Set a global on our items so assertCommandOrAttribute can work.
+  let global  = this.global;
   const items = Array.isArray(list) ? list : list.split(',');
   const names = items.map(name => name.trim());
   let tests   = names.map(item => parse(item));
   tests       = await Promise.all(tests.map(async function(test) {
     test.tests = await Promise.all(test.tests.map(async function(item) {
+      item.global = global;
       if (item.isCommand) {
         let command        = await assertCommandOrAttribute(item);
         item.commandObject = command;

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -30,6 +30,16 @@ const ListHelper      = require('./ListHelper.js');
 const StringHelper    = require('./StringHelper.js');
 const ChipTypesHelper = require('./ChipTypesHelper.js');
 
+// Helper for better error reporting.
+function ensureState(condition, error)
+{
+  if (!condition) {
+    let err = new Error(error);
+    console.log(`${error}: ` + err.stack);
+    throw err;
+  }
+}
+
 //
 // Load Step 1
 //
@@ -431,12 +441,14 @@ const Clusters = {
   ready : new Deferred()
 };
 
-Clusters.init = function(context, packageId) {
+Clusters.init = async function(context) {
   if (this.ready.running)
   {
     return this.ready;
   }
   this.ready.running = true;
+
+  let packageId = await templateUtil.ensureZclPackageId(context).catch(err => { console.log(err); throw err; });
 
   const loadTypes = [
     loadAtomics.call(context, packageId),
@@ -468,19 +480,17 @@ Clusters.init = function(context, packageId) {
 //
 function asBlocks(promise, options)
 {
-  const fn = pkgId => Clusters.init(this, pkgId).then(() => promise.then(data => templateUtil.collectBlocks(data, options, this)));
-  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => { console.log(err); throw err; });
+  return promise.then(data => templateUtil.collectBlocks(data, options, this))
 }
 
-function asPromise(promise)
+function ensureClusters(context)
 {
-  const fn = pkgId => Clusters.init(this, pkgId).then(() => promise);
-  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => { console.log(err); throw err; });
-}
-function initClusters()
-{
-  const fn = pkgId => Clusters.init(this, pkgId);
-  templateUtil.ensureZclPackageId(this).then(fn).catch(err => { console.log(err); throw err; });
+  // Kick off Clusters initialization.  This is async, but that's fine: all the
+  // getters on Clusters wait on that initialziation to complete.
+  ensureState(context, "Don't have a context");
+
+  Clusters.init(context);
+  return Clusters;
 }
 
 //
@@ -488,24 +498,30 @@ function initClusters()
 //
 const kResponseFilter = (isResponse, item) => isResponse == item.isResponse;
 
+Clusters.ensureReady = function()
+{
+    ensureState(this.ready.running);
+    return this.ready;
+}
+
 Clusters.getClusters = function()
 {
-    return this.ready.then(() => this._clusters);
+    return this.ensureReady().then(() => this._clusters);
 }
 
 Clusters.getCommands = function()
 {
-    return this.ready.then(() => this._commands.filter(kResponseFilter.bind(null, false)));
+    return this.ensureReady().then(() => this._commands.filter(kResponseFilter.bind(null, false)));
 }
 
 Clusters.getResponses = function()
 {
-    return this.ready.then(() => this._commands.filter(kResponseFilter.bind(null, true)));
+    return this.ensureReady().then(() => this._commands.filter(kResponseFilter.bind(null, true)));
 }
 
 Clusters.getAttributes = function()
 {
-    return this.ready.then(() => this._attributes);
+    return this.ensureReady().then(() => this._attributes);
 }
 
 //
@@ -525,7 +541,7 @@ Clusters.getResponsesByClusterName = function(name)
 
 Clusters.getAttributesByClusterName = function(name)
 {
-    return this.ready.then(() => {
+    return this.ensureReady().then(() => {
       const clusterId = this._clusters.find(kNameFilter.bind(null, name)).id;
       const filter = attribute => attribute.clusterId == clusterId;
       return this.getAttributes().then(items => items.filter(filter));
@@ -606,7 +622,5 @@ Clusters.getServerAttributes = function(name)
 //
 // Module exports
 //
-exports.Clusters     = Clusters;
-exports.asBlocks     = asBlocks;
-exports.asPromise    = asPromise;
-exports.initClusters = initClusters
+exports.asBlocks = asBlocks;
+exports.ensureClusters = ensureClusters;

--- a/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
+++ b/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
@@ -15,9 +15,9 @@
  *    limitations under the License.
  */
 
-const { Clusters }      = require('../ClustersHelper.js');
-const { DelayCommands } = require('./TestDelayCommands.js');
-const { LogCommands }   = require('./TestLogCommands.js');
+const { ensureClusters } = require('../ClustersHelper.js');
+const { DelayCommands }  = require('./TestDelayCommands.js');
+const { LogCommands }    = require('./TestLogCommands.js');
 
 const SimulatedClusters = [
   DelayCommands,
@@ -29,21 +29,21 @@ function getSimulatedCluster(clusterName)
   return SimulatedClusters.find(cluster => cluster.name == clusterName);
 }
 
-function getClusters()
+function getClusters(context)
 {
-  return Clusters.getClusters().then(clusters => clusters.concat(SimulatedClusters).flat(1));
+  return ensureClusters(context).getClusters().then(clusters => clusters.concat(SimulatedClusters).flat(1));
 }
 
-function getCommands(clusterName)
+function getCommands(context, clusterName)
 {
   const cluster = getSimulatedCluster(clusterName);
-  return cluster ? Promise.resolve(cluster.commands) : Clusters.getClientCommands(clusterName);
+  return cluster ? Promise.resolve(cluster.commands) : ensureClusters(context).getClientCommands(clusterName);
 }
 
-function getAttributes(clusterName)
+function getAttributes(context, clusterName)
 {
   const cluster = getSimulatedCluster(clusterName);
-  return cluster ? Promise.resolve(cluster.attributes) : Clusters.getServerAttributes(clusterName);
+  return cluster ? Promise.resolve(cluster.attributes) : ensureClusters(context).getServerAttributes(clusterName);
 }
 
 function isTestOnlyCluster(clusterName)


### PR DESCRIPTION
This ensures that we throw on any attempt to use Clusters without
calling init on it, which can end up waiting forever on promises that
never resolve.

#### Problem
See #12826 for the sort of things that can fail in non-obvious ways.

#### Change overview
Make things fail in loud obvious ways when they fail, with stacks.  Fix all the "false positives" that were not failing due to kicking off init _after_ starting async tasks that depend on init.  Now we just kick off init up front.

#### Testing
Ran codegen, everything worked.