### PR TITLE
Do not run unit tests in cloud build: failing IPv6 and intent is to o…

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -18,9 +18,8 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*'
-              --skip-target-glob '*-tests'
-              build --create-archives /workspace/artifacts/
+              --target-glob '*' --skip-target-glob '*-tests' build
+              --create-archives /workspace/artifacts/
       id: CompileAll
       waitFor:
           - Bootstrap

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -18,7 +18,9 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*' build --create-archives /workspace/artifacts/
+              --target-glob '*'
+              --skip-target-glob '*-tests'
+              build --create-archives /workspace/artifacts/
       id: CompileAll
       waitFor:
           - Bootstrap

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -14,7 +14,7 @@ steps:
 
     - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: ESP32
- -tests     env:
+      env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -14,7 +14,7 @@ steps:
 
     - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: ESP32
-      env:
+ -tests     env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
@@ -69,8 +69,10 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob 'linux-*' build --create-archives
-              /workspace/artifacts/
+              --target-glob 'linux-*'
+              --skip-target-glob '*-tests'
+              build
+              --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap
           - EFR32

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -69,9 +69,7 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob 'linux-*'
-              --skip-target-glob '*-tests'
-              build
+              --target-glob 'linux-*' --skip-target-glob '*-tests' build
               --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap


### PR DESCRIPTION
…nly have  compile artifacts

#### Problem
Cloudbuild gives:

```
Step #4 - "Linux": 2021-12-10 22:05:27 INFO    '#3:','InetEndPoint::TestInetError    ','PASSED'
Step #4 - "Linux": 2021-12-10 22:05:27 INFO        Interfaces:
Step #4 - "Linux": 2021-12-10 22:05:27 INFO         interface id: 0x1, interface name: lo, interface state: UP, no multicast, no broadcast addr
Step #4 - "Linux": 2021-12-10 22:05:27 INFO         interface id: 0x17, interface name: eth0, interface state: UP, supports multicast, has broadcast addr
Step #4 - "Linux": 2021-12-10 22:05:27 INFO        Addresses:
Step #4 - "Linux": 2021-12-10 22:05:27 INFO         127.0.0.1/8, interface id: 0x1, interface name: lo, interface state: UP, no multicast, no broadcast addr
Step #4 - "Linux": 2021-12-10 22:05:27 INFO         192.168.10.2/24, interface id: 0x17, interface name: eth0, interface state: UP, supports multicast, has broadcast addr
Step #4 - "Linux": 2021-12-10 22:05:27 INFO    '#3:','InetEndPoint::TestInetInterface','PASSED'
Step #4 - "Linux": 2021-12-10 22:05:27 INFO    ../../src/inet/tests/TestInetEndPoint.cpp:271: assertion failed: "intId.IsPresent()"
Step #4 - "Linux": 2021-12-10 22:05:27 INFO    ../../src/inet/tests/TestInetEndPoint.cpp:297: assertion failed: "err == CHIP_ERROR_INCORRECT_STATE"
Step #4 - "Linux": 2021-12-10 22:05:27 INFO    ../../src/inet/tests/TestInetEndPoint.cpp:299: assertion failed: "err == CHIP_ERROR_INCORRECT_STATE"
Step #4 - "Linux": 2021-12-10 22:05:27 INFO    '#3:','InetEndPoint::TestInetEndPoint ','FAILED'
```

Looks like a IPv6 error.

#### Change overview
Remove unit test running from cloudbuild

#### Testing
N/A (cloudbuild)
