### PR TITLE
Convert OTAQueryStatus to an enum class

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -40,6 +40,7 @@ using chip::Optional;
 using chip::Server;
 using chip::Span;
 using chip::app::Clusters::OTAProviderDelegate;
+using namespace chip::app::Clusters::OtaSoftwareUpdateProvider;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
 constexpr uint8_t kUpdateTokenLen    = 32;                      // must be between 8 and 32
@@ -89,7 +90,7 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 {
     // TODO: add confiuration for returning BUSY status
 
-    EmberAfOTAQueryStatus queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
+    OTAQueryStatus queryStatus  = OTAQueryStatus::kNotAvailable;
     uint32_t newSoftwareVersion = commandData.softwareVersion + 1; // This implementation will always indicate that an update is
                                                                    // available (if the user provides a file).
     constexpr char kExampleSoftwareString[] = "Example-Image-V0.1";
@@ -122,25 +123,25 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     case kRespondWithUpdateAvailable: {
         if (strlen(mOTAFilePath) != 0)
         {
-            queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_UPDATE_AVAILABLE;
+            queryStatus = OTAQueryStatus::kUpdateAvailable;
         }
         else
         {
-            queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
+            queryStatus = OTAQueryStatus::kNotAvailable;
             ChipLogError(SoftwareUpdate, "No OTA file configured on the Provider");
         }
         break;
     }
     case kRespondWithBusy: {
-        queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_BUSY;
+        queryStatus = OTAQueryStatus::kBusy;
         break;
     }
     case kRespondWithNotAvailable: {
-        queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
+        queryStatus = OTAQueryStatus::kNotAvailable;
         break;
     }
     default:
-        queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
+        queryStatus = OTAQueryStatus::kNotAvailable;
     }
 
     QueryImageResponse::Type response;

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -658,7 +658,6 @@ function isWeaklyTypedEnum(label)
     "OTAAnnouncementReason",
     "OTAApplyUpdateAction",
     "OTADownloadProtocol",
-    "OTAQueryStatus",
     "OnOffDelayedAllOffEffectVariant",
     "OnOffDyingLightEffectVariant",
     "OnOffEffectIdentifier",

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -7696,9 +7696,6 @@ enum class OTADownloadProtocol : uint8_t
 #else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using OTADownloadProtocol             = EmberAfOTADownloadProtocol;
 #endif
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for OTAQueryStatus
 enum class OTAQueryStatus : uint8_t
 {
@@ -7706,9 +7703,6 @@ enum class OTAQueryStatus : uint8_t
     kBusy            = 0x01,
     kNotAvailable    = 0x02,
 };
-#else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using OTAQueryStatus                  = EmberAfOTAQueryStatus;
-#endif
 
 namespace Commands {
 // Forward-declarations so we can reference these later.

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -588,14 +588,6 @@ enum EmberAfOTADownloadProtocol : uint8_t
     EMBER_ZCL_OTA_DOWNLOAD_PROTOCOL_VENDOR_SPECIFIC  = 3,
 };
 
-// Enum for OTAQueryStatus
-enum EmberAfOTAQueryStatus : uint8_t
-{
-    EMBER_ZCL_OTA_QUERY_STATUS_UPDATE_AVAILABLE = 0,
-    EMBER_ZCL_OTA_QUERY_STATUS_BUSY             = 1,
-    EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE    = 2,
-};
-
 // Enum for OnOffDelayedAllOffEffectVariant
 enum EmberAfOnOffDelayedAllOffEffectVariant : uint8_t
 {


### PR DESCRIPTION
#### Problem
The OTA Query Status is currently not an enum class

#### Change overview
Convert OTAQueryStatus to enum class

#### Testing
No behavior change, tree compiles. Manually tested OTA provider/requestor scenario to verify basic case not broken.
