### PR TITLE
Add retries on avahi resolve failure

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -659,13 +659,20 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     resolveContext->mInstance = this;
     resolveContext->mCallback = callback;
     resolveContext->mContext  = context;
+
     if (!interface.IsPresent())
     {
         avahiInterface = AVAHI_IF_UNSPEC;
     }
 
-    resolver = avahi_service_resolver_new(mClient, avahiInterface, ToAvahiProtocol(transportType), name,
-                                          GetFullType(type, protocol).c_str(), nullptr, ToAvahiProtocol(addressType),
+    Platform::CopyString(resolveContext->mName, name);
+    resolveContext->mInterface   = avahiInterface;
+    resolveContext->mTransport   = ToAvahiProtocol(transportType);
+    resolveContext->mAddressType = ToAvahiProtocol(addressType);
+    resolveContext->mFullType    = GetFullType(type, protocol);
+
+    resolver = avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name,
+                                          resolveContext->mFullType.c_str(), nullptr, resolveContext->mAddressType,
                                           static_cast<AvahiLookupFlags>(0), HandleResolve, resolveContext);
     // Otherwise the resolver will be freed in the callback
     if (resolver == nullptr)
@@ -688,6 +695,21 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
     switch (event)
     {
     case AVAHI_RESOLVER_FAILURE:
+        if (context->mAttempts++ < 3)
+        {
+            ChipLogProgress(DeviceLayer, "Re-trying resolve");
+            avahi_service_resolver_free(resolver);
+            resolver = avahi_service_resolver_new(context->mInstance->mClient, context->mInterface, context->mTransport,
+                                                  context->mName, context->mFullType.c_str(), nullptr, context->mAddressType,
+                                                  static_cast<AvahiLookupFlags>(0), HandleResolve, context);
+            if (resolver == nullptr)
+            {
+                ChipLogError(DeviceLayer, "Avahi resolve failed on retry");
+                context->mCallback(context->mContext, nullptr, CHIP_ERROR_INTERNAL);
+                chip::Platform::Delete(context);
+            }
+            return;
+        }
         ChipLogError(DeviceLayer, "Avahi resolve failed");
         context->mCallback(context->mContext, nullptr, CHIP_ERROR_INTERNAL);
         break;

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 
 #include <avahi-client/client.h>
@@ -133,6 +134,12 @@ private:
         MdnsAvahi * mInstance;
         DnssdResolveCallback mCallback;
         void * mContext;
+        char mName[Common::kInstanceNameMaxLength + 1];
+        AvahiIfIndex mInterface;
+        AvahiProtocol mTransport;
+        AvahiProtocol mAddressType;
+        std::string mFullType;
+        uint8_t mAttempts = 0;
     };
 
     MdnsAvahi() : mClient(nullptr), mGroup(nullptr) {}


### PR DESCRIPTION
#### Problem
M5 sometimes takes a long time to get an address after the network has been enabled.

#### Change overview
Adds retry on resolve on avahi

#### Testing
Tested with M5 BLE commissioning - saw retry text.