### PR TITLE
Add eleven missing clusters to chip-tool to enable their testing

### DIFF
--- a/notice
+++ b/notice
@@ -1,0 +1,2 @@
+PR withdrawn
+


### PR DESCRIPTION
Fix up the XML, zap_cluster_list.py, src/controller/data_model/controller-clusters.zap, regen
To bring the chip-tool cluster list into agreement with the spec.
https://github.com/project-chip/connectedhomeip/issues/12899

These missing clusters now appear in chip-tool which enables the ability to write test cases for them.

Ballast Configuration
Fan Control
Localization Configuration
Localization Time Format
Localization Unit
OTA Software Update Requestor
Proxy Configuration
Proxy Discovery
Proxy Valid
Time Synchronization
User Label

Add basic cluster definitions for:
localization-configuration-cluster.xml
localization-time-format-cluster.xml
localization-unit-cluster.xml
proxy-configuration-cluster.xml
proxy-discovery-cluster.xml
proxy-valid-cluster.xml
time-synchronization-cluster.xml

Tested by building chip tool and observing the clusters are there now.
