### PR TITLE
[OTA] Align StatusEnum data type with spec

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -140,7 +140,8 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
         break;
     case OTAQueryStatus::kNotAvailable:
         break;
-    // TODO: Add download protocol not supported
+    case OTAQueryStatus::kDownloadProtocolNotSupported:
+        break;
     // Issue #9524 should handle all response status appropriately
     default:
         break;

--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -21,6 +21,7 @@ limitations under the License.
         <item name="UpdateAvailable" value="0x0"/>
         <item name="Busy" value="0x1"/>
         <item name="NotAvailable" value="0x2"/>
+        <item name="DownloadProtocolNotSupported" value="0x3"/>
     </enum>
     <enum name="OTAApplyUpdateAction" type="ENUM8">
         <cluster code="0x0029"/>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -6535,6 +6535,7 @@ class OtaSoftwareUpdateProvider(Cluster):
             kUpdateAvailable = 0x00
             kBusy = 0x01
             kNotAvailable = 0x02
+            kDownloadProtocolNotSupported = 0x03
 
 
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -7699,9 +7699,10 @@ using OTADownloadProtocol             = EmberAfOTADownloadProtocol;
 // Enum for OTAQueryStatus
 enum class OTAQueryStatus : uint8_t
 {
-    kUpdateAvailable = 0x00,
-    kBusy            = 0x01,
-    kNotAvailable    = 0x02,
+    kUpdateAvailable              = 0x00,
+    kBusy                         = 0x01,
+    kNotAvailable                 = 0x02,
+    kDownloadProtocolNotSupported = 0x03,
 };
 
 namespace Commands {


### PR DESCRIPTION
#### Problem
The StatusEnum data type is missing the `DownloadProtocolNotSupported` type
Fixes: https://github.com/project-chip/connectedhomeip/issues/12776

#### Change overview
Add `DownloadProtocolNotSupported` to the StatusEnum data type and add the type to OTA Requestor

#### Testing
No behavior change, tree compiles
