### PR TITLE
Fix the check for duplicate endpoints

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -183,7 +183,7 @@ EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, EmberAfEn
     index = static_cast<uint16_t>(realIndex);
     for (uint16_t i = FIXED_ENDPOINT_COUNT; i < MAX_ENDPOINT_COUNT; i++)
     {
-        if (emAfEndpoints[i].endpoint == id)
+        if (emAfEndpoints[i].endpoint == id && emAfEndpoints[i].endpointType != NULL)
         {
             return EMBER_ZCL_STATUS_DUPLICATE_EXISTS;
         }


### PR DESCRIPTION
#### Problem
* When adding a dynamic endpoint with endpoint id 0, a duplicate endpoint exists is returned even if there are no endpoints with id 0.

#### Change overview
* For duplicate endpoints, in addition to checking for endpoint id, now also checking for `endpointType`, which ensures that it has actually been created.

#### Testing
* Tested that endpoint 0 is created successfully.
