### PR TITLE
Create an iterator over endpoints matching a cluster.

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -44,21 +44,17 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
     {
         ChipLogProgress(Zcl, "PlatformMgrDelegate: OnStartUp");
 
-        ForAllEndpointsWithServerCluster(
-            Basic::Id,
-            [](EndpointId endpoint, intptr_t context) -> Loop {
-                // If Basic cluster is implemented on this endpoint
-                Events::StartUp::Type event{ static_cast<uint32_t>(context) };
-                EventNumber eventNumber;
+        for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
+        {
+            // If Basic cluster is implemented on this endpoint
+            Events::StartUp::Type event{ softwareVersion };
+            EventNumber eventNumber;
 
-                if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent))
-                {
-                    ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record StartUp event");
-                }
-
-                return Loop::Continue;
-            },
-            static_cast<intptr_t>(softwareVersion));
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent))
+            {
+                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record StartUp event");
+            }
+        }
     }
 
     // Gets called by the current Node prior to any orderly shutdown sequence on a best-effort basis.
@@ -66,7 +62,8 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
     {
         ChipLogProgress(Zcl, "PlatformMgrDelegate: OnShutDown");
 
-        ForAllEndpointsWithServerCluster(Basic::Id, [](EndpointId endpoint, intptr_t context) -> Loop {
+        for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
+        {
             // If Basic cluster is implemented on this endpoint
             Events::ShutDown::Type event;
             EventNumber eventNumber;
@@ -75,9 +72,7 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             {
                 ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record ShutDown event");
             }
-
-            return Loop::Continue;
-        });
+        }
     }
 };
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -230,8 +230,10 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%" PRIu8 " was deleted from fabric storage.", fabricId);
         fabricListChanged();
 
-        // The Leave event SHOULD be emitted by a Node prior to permanently leaving the Fabric.
-        ForAllEndpointsWithServerCluster(Basic::Id, [](EndpointId endpoint, intptr_t context) -> Loop {
+        // The Leave event SHOULD be emitted by a Node prior to permanently
+        // leaving the Fabric.
+        for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
+        {
             // If Basic cluster is implemented on this endpoint
             Basic::Events::Leave::Type event;
             EventNumber eventNumber;
@@ -240,9 +242,7 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
             {
                 ChipLogError(Zcl, "OpCredsFabricTableDelegate: Failed to record Leave event");
             }
-
-            return Loop::Continue;
-        });
+        }
     }
 
     // Gets called when a fabric is loaded into the FabricTable from KVS store.

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -132,24 +132,17 @@ class SoftwareDiagnosticsDelegate : public DeviceLayer::SoftwareDiagnosticsDeleg
     {
         ChipLogProgress(Zcl, "SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected");
 
-        ForAllEndpointsWithServerCluster(
-            SoftwareDiagnostics::Id,
-            [](EndpointId endpoint, intptr_t context) -> Loop {
-                // If Software Diagnostics cluster is implemented on this endpoint
-                SoftwareDiagnostics::Structs::SoftwareFault::Type * pSoftwareFault =
-                    reinterpret_cast<SoftwareDiagnostics::Structs::SoftwareFault::Type *>(context);
+        for (auto endpoint : EnabledEndpointsWithServerCluster(SoftwareDiagnostics::Id))
+        {
+            // If Software Diagnostics cluster is implemented on this endpoint
+            EventNumber eventNumber;
+            Events::SoftwareFault::Type event{ softwareFault };
 
-                EventNumber eventNumber;
-                Events::SoftwareFault::Type event{ *pSoftwareFault };
-
-                if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
-                {
-                    ChipLogError(Zcl, "SoftwareDiagnosticsDelegate: Failed to record SoftwareFault event");
-                }
-
-                return Loop::Continue;
-            },
-            reinterpret_cast<intptr_t>(&softwareFault));
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+            {
+                ChipLogError(Zcl, "SoftwareDiagnosticsDelegate: Failed to record SoftwareFault event");
+            }
+        }
     }
 };
 

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -154,21 +154,17 @@ class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
     {
         ChipLogProgress(Zcl, "WiFiDiagnosticsDelegate: OnDisconnectionDetected");
 
-        ForAllEndpointsWithServerCluster(
-            WiFiNetworkDiagnostics::Id,
-            [](EndpointId endpoint, intptr_t context) -> Loop {
-                // If WiFi Network Diagnostics cluster is implemented on this endpoint
-                Events::Disconnection::Type event{ static_cast<uint16_t>(context) };
-                EventNumber eventNumber;
+        for (auto endpoint : EnabledEndpointsWithServerCluster(WiFiNetworkDiagnostics::Id))
+        {
+            // If WiFi Network Diagnostics cluster is implemented on this endpoint
+            Events::Disconnection::Type event{ reasonCode };
+            EventNumber eventNumber;
 
-                if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
-                {
-                    ChipLogError(Zcl, "WiFiDiagnosticsDelegate: Failed to record Disconnection event");
-                }
-
-                return Loop::Continue;
-            },
-            static_cast<intptr_t>(reasonCode));
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+            {
+                ChipLogError(Zcl, "WiFiDiagnosticsDelegate: Failed to record Disconnection event");
+            }
+        }
     }
 
     // Gets called when the Node fails to associate or authenticate an access point.
@@ -178,21 +174,16 @@ class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
 
         Events::AssociationFailure::Type event{ static_cast<AssociationFailureCause>(associationFailureCause), status };
 
-        ForAllEndpointsWithServerCluster(
-            WiFiNetworkDiagnostics::Id,
-            [](EndpointId endpoint, intptr_t context) -> Loop {
-                // If WiFi Network Diagnostics cluster is implemented on this endpoint
-                Events::AssociationFailure::Type * pEvent = reinterpret_cast<Events::AssociationFailure::Type *>(context);
-                EventNumber eventNumber;
+        for (auto endpoint : EnabledEndpointsWithServerCluster(WiFiNetworkDiagnostics::Id))
+        {
+            // If WiFi Network Diagnostics cluster is implemented on this endpoint
+            EventNumber eventNumber;
 
-                if (CHIP_NO_ERROR != LogEvent(*pEvent, endpoint, eventNumber))
-                {
-                    ChipLogError(Zcl, "WiFiDiagnosticsDelegate: Failed to record AssociationFailure event");
-                }
-
-                return Loop::Continue;
-            },
-            reinterpret_cast<intptr_t>(&event));
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+            {
+                ChipLogError(Zcl, "WiFiDiagnosticsDelegate: Failed to record AssociationFailure event");
+            }
+        }
     }
 
     // Gets when the Node’s connection status to a Wi-Fi network has changed.
@@ -200,21 +191,17 @@ class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
     {
         ChipLogProgress(Zcl, "WiFiDiagnosticsDelegate: OnConnectionStatusChanged");
 
-        ForAllEndpointsWithServerCluster(
-            WiFiNetworkDiagnostics::Id,
-            [](EndpointId endpoint, intptr_t context) -> Loop {
-                // If WiFi Network Diagnostics cluster is implemented on this endpoint
-                Events::ConnectionStatus::Type event{ static_cast<WiFiConnectionStatus>(context) };
-                EventNumber eventNumber;
+        Events::ConnectionStatus::Type event{ static_cast<WiFiConnectionStatus>(connectionStatus) };
+        for (auto endpoint : EnabledEndpointsWithServerCluster(WiFiNetworkDiagnostics::Id))
+        {
+            // If WiFi Network Diagnostics cluster is implemented on this endpoint
+            EventNumber eventNumber;
 
-                if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
-                {
-                    ChipLogError(Zcl, "WiFiDiagnosticsDelegate: Failed to record ConnectionStatus event");
-                }
-
-                return Loop::Continue;
-            },
-            static_cast<intptr_t>(connectionStatus));
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+            {
+                ChipLogError(Zcl, "WiFiDiagnosticsDelegate: Failed to record ConnectionStatus event");
+            }
+        }
     }
 };
 

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -775,28 +775,31 @@ bool emberAfContainsServerFromIndex(uint16_t index, ClusterId clusterId)
 namespace chip {
 namespace app {
 
-Loop ForAllEndpointsWithServerCluster(ClusterId clusterId, EndpointCallback callback, intptr_t context)
+EnabledEndpointsWithServerCluster::EnabledEndpointsWithServerCluster(ClusterId clusterId) : mClusterId(clusterId)
 {
-    uint16_t count = emberAfEndpointCount();
-    for (uint16_t index = 0; index < count; ++index)
+    EnsureMatchingEndpoint();
+}
+EnabledEndpointsWithServerCluster & EnabledEndpointsWithServerCluster::operator++()
+{
+    ++mEndpointIndex;
+    EnsureMatchingEndpoint();
+    return *this;
+}
+
+void EnabledEndpointsWithServerCluster::EnsureMatchingEndpoint()
+{
+    for (; mEndpointIndex < mEndpointCount; ++mEndpointIndex)
     {
-        if (!emberAfEndpointIndexIsEnabled(index))
+        if (!emberAfEndpointIndexIsEnabled(mEndpointIndex))
         {
             continue;
         }
 
-        if (!emberAfContainsServerFromIndex(index, clusterId))
+        if (!emberAfContainsServerFromIndex(mEndpointIndex, mClusterId))
         {
             continue;
-        }
-
-        if (callback(emberAfEndpointFromIndex(index), context) == Loop::Break)
-        {
-            return Loop::Break;
         }
     }
-
-    return Loop::Finish;
 }
 
 } // namespace app


### PR DESCRIPTION
Very slightly larger code, but nicer API than the current callback
function setup.

#### Problem
Existing callback function code is a bit of a pain to use if you have multiple data items you want to access in the loop body.

#### Change overview
Switch to an iterator over endpoints that have a given cluster on them.

#### Testing
No behavior changes.