### PR TITLE
Fix infinite recursion if the bare-int-for-timeout version of InvokeCommandRequest is used.

### DIFF
--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -98,7 +98,7 @@ InvokeCommandRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle ses
                      uint16_t timedInvokeTimeoutMs)
 {
     return InvokeCommandRequest(exchangeMgr, sessionHandle, endpointId, requestCommandData, onSuccessCb, onErrorCb,
-                                timedInvokeTimeoutMs);
+                                MakeOptional(timedInvokeTimeoutMs));
 }
 
 template <typename RequestObjectT, typename std::enable_if_t<!RequestObjectT::MustUseTimedInvoke(), int> = 0>


### PR DESCRIPTION
We end up just calling the same function, which is not what we want:
we want to call the version that takes an Optional.

This codepath is not exercised in our CI (which all goes through the
CHIPClusters.h helpers), hence this problem wasn't caught.

#### Problem
See above.

#### Change overview
See above.

#### Testing
None so far; need to figure out some tests for this bit...