### PR TITLE
Fix YAML Scripts Fail - "Location" Attribute value read fails

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -33,9 +33,97 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Basic;
+using namespace chip::app::Clusters::Basic::Attributes;
 using namespace chip::DeviceLayer;
 
 namespace {
+
+class BasicAttrAccess : public AttributeAccessInterface
+{
+public:
+    // Register for the Basic cluster on all endpoints.
+    BasicAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), Basic::Id) {}
+
+    CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder) override;
+
+private:
+    CHIP_ERROR ReadLocation(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR WriteLocation(AttributeValueDecoder & aDecoder);
+};
+
+BasicAttrAccess gAttrAccess;
+
+CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
+{
+    if (aPath.mClusterId != Basic::Id)
+    {
+        // We shouldn't have been called at all.
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    switch (aPath.mAttributeId)
+    {
+    case Location::Id:
+        return ReadLocation(aEncoder);
+    default:
+        break;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BasicAttrAccess::ReadLocation(AttributeValueEncoder & aEncoder)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    char location[DeviceLayer::ConfigurationManager::kMaxLocationLength + 1];
+    size_t codeLen = 0;
+
+    if (ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR)
+    {
+        if (codeLen == 0)
+        {
+            err = aEncoder.Encode(chip::CharSpan("XX", strlen("XX")));
+        }
+        else
+        {
+            err = aEncoder.Encode(chip::CharSpan(location, strlen(location)));
+        }
+    }
+    else
+    {
+        err = aEncoder.Encode(chip::CharSpan("XX", strlen("XX")));
+    }
+
+    return err;
+}
+
+CHIP_ERROR BasicAttrAccess::Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
+{
+    VerifyOrDie(aPath.mClusterId == Basic::Id);
+
+    switch (aPath.mAttributeId)
+    {
+    case Location::Id:
+        return WriteLocation(aDecoder);
+    default:
+        break;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BasicAttrAccess::WriteLocation(AttributeValueDecoder & aDecoder)
+{
+    chip::CharSpan location;
+
+    ReturnErrorOnFailure(aDecoder.Decode(location));
+    VerifyOrReturnError(location.size() <= DeviceLayer::ConfigurationManager::kMaxLocationLength,
+                        CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+
+    return DeviceLayer::ConfigurationMgr().StoreCountryCode(location.data(), location.size());
+}
 
 class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
 {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
```
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667362][992378:992383] CHIP:TOO:  ***** Test Failure: location value mismatch, expected 'us' but got 'XX'
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : 
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667449][992378:992383] CHIP:DMG: Client[0] moving to [UNINIT]
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667467][992378:992383] CHIP:EM: Sending Standalone Ack for MessageCounter:14374360 on exchange 45455i
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667534][992378:992383] CHIP:IN: Prepared encrypted message 0x7fcca0dba380 to 0x0000000012344321 (1)  of type 0x10 and protocolId (0, 0) on exchange 45455i with MessageCounter:12038928.
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667572][992378:992383] CHIP:IN: Sending encrypted msg 0x7fcca0dba380 with MessageCounter:12038928 to 0x0000000012344321 (1) at monotonic time: 937872202 msec
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667650][992378:992383] CHIP:EM: Flushed pending ack for MessageCounter:14374360 on exchange 45455i
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - APP  OUT  : [1639431092.667815][992361:992361] CHIP:EM: Received message of type 0x10 with protocolId (0, 0) and MessageCounter:12038928 on exchange 45455r
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - APP  OUT  : [1639431092.667835][992361:992361] CHIP:EM: Found matching exchange: 45455r, Delegate: (nil)
2021-12-13 13:31:32.867 ERROR   13:31:32.667 - APP  OUT  : [1639431092.667874][992361:992361] CHIP:EM: Rxd Ack; Removing MessageCounter:14374360 from Retrans Table on exchange 45455r
2021-12-13 13:31:32.868 ERROR   13:31:32.667 - APP  OUT  : [1639431092.667881][992361:992361] CHIP:EM: Removed CHIP MessageCounter:14374360 from RetransTable on exchange 45455r
2021-12-13 13:31:32.868 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667822][992378:992378] CHIP:-: ../../examples/chip-tool/commands/tests/TestCommand.cpp:85: CHIP Error 0x000000AC: Internal error at ../../examples/chip-tool/commands/common/CHIPCommand.cpp:54
2021-12-13 13:31:32.868 ERROR   13:31:32.667 - TEST OUT  : [1639431092.667842][992378:992378] CHIP:TOO: Run command failure: ../../examples/chip-tool/commands/tests/TestCommand.cpp:85: CHIP Error 0x000000AC: Internal error
2021-12-13 13:31:32.868 ERROR   13:31:32.676 - TEST OUT  : [1639431092.676529][992378:992378] CHIP:SPT: VerifyOrDie failure at ../../examples/chip-tool/third_party/connectedhomeip/src/inet/InetLayer.h:119: sEndPointPool.Allocated() == 0
2021-12-13 13:31:32.868 ERROR   ================ CAPTURED LOG END ====================
2021-12-13 13:31:32.868 ERROR   TestGroupMessaging - FAILED in 2.07 seconds
Traceback (most recent call last):
  File "./scripts/tests/run_test_suite.py", line 203, in cmd_run
    test.Run(runner, paths)
  File "/home/yufengw/connectedhomeip/scripts/tests/chiptest/test_definition.py", line 129, in Run
    runner.RunSubprocess(tool_cmd + ['tests', self.run_name, TEST_NODE_ID],
  File "/home/yufengw/connectedhomeip/scripts/tests/chiptest/runner.py", line 109, in RunSubprocess
    raise Exception('Command %r failed: %d' % (cmd, code))
Exception: Command ['ip', 'netns', 'exec', 'tool', './out/linux-x64-chip-tool-no-ble-tsan/chip-tool', 'tests', 'TestGroupMessaging', '0x12344321'] failed: -6
```
Fixes Issue #12983 

#### Change overview
* Update the test case to match the latest spec update


#### Testing
How was this tested? (at least one bullet point required)
* ./scripts/build/build_examples.py --target linux-x64-chip-tool-no-ble-tsan --target linux-x64-all-clusters-no-ble-tsan --target linux-x64-tv-app-no-ble-tsan build --copy-artifacts-to objdir-clone   

* ./scripts/tests/run_test_suite.py --chip-tool ./out/linux-x64-chip-tool-no-ble-tsan/chip-tool run --iterations 1 --all-clusters-app ./out/linux-x64-all-clusters-no-ble-tsan/chip-all-clusters-app --tv-app ./out/linux-x64-tv-app-no-ble-tsan/chip-tv-app                           

