### PR TITLE
Add tracing service to example/platform/esp rpc

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -228,6 +228,7 @@ target_compile_options(${COMPONENT_LIB} PRIVATE
                        "-DPW_RPC_BUTTON_SERVICE=1"
                        "-DPW_RPC_DEVICE_SERVICE=1"
                        "-DPW_RPC_LIGHTING_SERVICE=1"
-                       "-DPW_RPC_LOCKING_SERVICE=1")
+                       "-DPW_RPC_LOCKING_SERVICE=1"
+                       "-DPW_RPC_TRACING_SERVICE=1")
 
 endif (CONFIG_ENABLE_PW_RPC)

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -53,8 +53,8 @@
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
-#include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
 #include "pw_trace/trace.h"
+#include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
 
 // Define trace time for pw_trace
 PW_TRACE_TIME_TYPE pw_trace_GetTraceTime()

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -52,6 +52,23 @@
 #include "pigweed/rpc_services/Locking.h"
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
+#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+#include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
+#include "pw_trace/trace.h"
+
+// Define trace time for pw_trace
+PW_TRACE_TIME_TYPE pw_trace_GetTraceTime()
+{
+    return (PW_TRACE_TIME_TYPE) chip::System::SystemClock().GetMonotonicMicroseconds64().count();
+}
+// Microsecond time source
+size_t pw_trace_GetTraceTimeTicksPerSecond()
+{
+    return 1000000;
+}
+
+#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+
 namespace chip {
 namespace rpc {
 
@@ -122,6 +139,10 @@ Lighting lighting_service;
 Locking locking;
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
+#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+pw::trace::TraceService trace_service;
+#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+
 void RegisterServices(pw::rpc::Server & server)
 {
 #if defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE
@@ -143,6 +164,10 @@ void RegisterServices(pw::rpc::Server & server)
 #if defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
     server.RegisterService(locking);
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
+
+#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+    server.RegisterService(trace_service);
+#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 }
 
 } // namespace


### PR DESCRIPTION
Problem
Add trace functionality to esp32 examples. This was reverted in #12686 and the issue is fixed by rolling up pigweed in #12648 

Change overview
Add trace service to RPC services

Testing
Build esp32 all cluster example with RPC turned on and off.