### PR TITLE
[Inet] Miscellaneous cleanup

### DIFF
--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -32,22 +32,13 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
+/**
+ * Definitions shared by all LwIP EndPoint classes.
+ */
 class DLL_EXPORT EndPointStateLwIP
 {
 protected:
     EndPointStateLwIP() : mLwIPEndPointType(LwIPEndPointType::Unknown) {}
-
-    /** Encapsulated LwIP protocol control block */
-    union
-    {
-        const void * mVoid; /**< An untyped protocol control buffer reference */
-#if INET_CONFIG_ENABLE_UDP_ENDPOINT
-        udp_pcb * mUDP; /**< User datagram protocol (UDP) control */
-#endif                  // INET_CONFIG_ENABLE_UDP_ENDPOINT
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-        tcp_pcb * mTCP; /**< Transmission control protocol (TCP) control */
-#endif                  // INET_CONFIG_ENABLE_TCP_ENDPOINT
-    };
 
     enum class LwIPEndPointType : uint8_t
     {

--- a/src/inet/EndPointStateSockets.h
+++ b/src/inet/EndPointStateSockets.h
@@ -30,6 +30,9 @@
 namespace chip {
 namespace Inet {
 
+/**
+ * Definitions shared by all sockets-based EndPoint classes.
+ */
 class DLL_EXPORT EndPointStateSockets
 {
 protected:

--- a/src/inet/IANAConstants.h
+++ b/src/inet/IANAConstants.h
@@ -45,20 +45,6 @@ typedef enum
 } IPVersion;
 
 /**
- *  @enum IPProtocol
- *
- *  The numbers of some of the protocols in the IP family.
- *
- */
-typedef enum
-{
-    kIPProtocol_ICMPv6 = 58, /**< ICMPv6 */
-#if INET_CONFIG_ENABLE_IPV4
-    kIPProtocol_ICMPv4 = 1, /**< ICMPv4 */
-#endif                      // INET_CONFIG_ENABLE_IPV4
-} IPProtocol;
-
-/**
  * @brief   Internet protocol multicast address scope
  *
  * @details

--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -88,32 +88,6 @@
 #endif // INET_CONFIG_MAX_IP_AND_UDP_HEADER_SIZE
 
 /**
- *  @def INET_CONFIG_WILL_OVERRIDE_OS_ERROR_FUNCS
- *
- *  @brief
- *    This defines whether (1) or not (0) your platform will override
- *    the platform- and system-specific INET_MapOSError,
- *    INET_DescribeOSError, and INET_IsOSError functions.
- *
- */
-#ifndef INET_CONFIG_WILL_OVERRIDE_OS_ERROR_FUNCS
-#define INET_CONFIG_WILL_OVERRIDE_OS_ERROR_FUNCS            0
-#endif // INET_CONFIG_WILL_OVERRIDE_OS_ERROR_FUNCS
-
-/**
- *  @def INET_CONFIG_WILL_OVERRIDE_LWIP_ERROR_FUNCS
- *
- *  @brief
- *    This defines whether (1) or not (0) your platform will override
- *    the platform- and system-specific INET_MapLwIPError,
- *    INET_DescribeLwIPError, and INET_IsLwIPError functions.
- *
- */
-#ifndef INET_CONFIG_WILL_OVERRIDE_LWIP_ERROR_FUNCS
-#define INET_CONFIG_WILL_OVERRIDE_LWIP_ERROR_FUNCS          0
-#endif // INET_CONFIG_WILL_OVERRIDE_LWIP_ERROR_FUNCS
-
-/**
  *  @def INET_CONFIG_NUM_TCP_ENDPOINTS
  *
  *  @brief
@@ -176,32 +150,6 @@
 #ifndef INET_CONFIG_ENABLE_UDP_ENDPOINT
 #define INET_CONFIG_ENABLE_UDP_ENDPOINT                     0
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
-
-/**
- *  @def INET_CONFIG_EVENT_RESERVED
- *
- *  @brief
- *      This defines the first number in the default chip System Layer event code space reserved for use by the Inet Layer.
- *      Event codes used by each layer must not overlap.
- */
-#ifndef INET_CONFIG_EVENT_RESERVED
-#define INET_CONFIG_EVENT_RESERVED                          1000
-#endif /* INET_CONFIG_EVENT_RESERVED */
-
-/**
- *  @def _INET_CONFIG_EVENT
- *
- *  @brief
- *    This defines a mapping function for InetLayer event types that allows
- *    mapping such event types into a platform- or system-specific range.
- *
- *  @note
- *    By default, this definition is a copy of _CHIP_SYSTEM_CONFIG_LWIP_EVENT.
- *
- */
-#ifndef _INET_CONFIG_EVENT
-#define _INET_CONFIG_EVENT(e)                               _CHIP_SYSTEM_CONFIG_LWIP_EVENT(INET_CONFIG_EVENT_RESERVED + (e))
-#endif // _INET_CONFIG_EVENT
 
 /**
  *  @def INET_CONFIG_TEST

--- a/src/inet/InetError.h
+++ b/src/inet/InetError.h
@@ -23,9 +23,6 @@
  *      Error types, ranges, and mappings overrides may be made by
  *      defining the appropriate INET_CONFIG_* or _INET_CONFIG_*
  *      macros.
- *
- *  NOTE WELL: On some platforms, this header is included by C-language programs.
- *
  */
 
 #pragma once

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -691,8 +691,9 @@ protected:
 template <>
 struct EndPointProperties<TCPEndPoint>
 {
-    static constexpr const char * Name  = "TCP";
-    static constexpr int SystemStatsKey = System::Stats::kInetLayer_NumTCPEps;
+    static constexpr const char * kName   = "TCP";
+    static constexpr size_t kNumEndPoints = INET_CONFIG_NUM_TCP_ENDPOINTS;
+    static constexpr int kSystemStatsKey  = System::Stats::kInetLayer_NumTCPEps;
 };
 
 } // namespace Inet

--- a/src/inet/TCPEndPointImpl.h
+++ b/src/inet/TCPEndPointImpl.h
@@ -34,7 +34,7 @@
 namespace chip {
 namespace Inet {
 
-using TCPEndPointManagerImpl = EndPointManagerImplPool<TCPEndPointImpl, INET_CONFIG_NUM_TCP_ENDPOINTS>;
+using TCPEndPointManagerImpl = EndPointManagerImplPool<TCPEndPointImpl>;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/TCPEndPointImplLwIP.h
+++ b/src/inet/TCPEndPointImplLwIP.h
@@ -40,7 +40,9 @@ namespace Inet {
 class TCPEndPointImplLwIP : public TCPEndPoint, public EndPointStateLwIP
 {
 public:
-    TCPEndPointImplLwIP(EndPointManager<TCPEndPoint> & endPointManager) : TCPEndPoint(endPointManager), mUnackedLength(0) {}
+    TCPEndPointImplLwIP(EndPointManager<TCPEndPoint> & endPointManager) :
+        TCPEndPoint(endPointManager), mUnackedLength(0), mTCP(nullptr)
+    {}
 
     // TCPEndPoint overrides.
     CHIP_ERROR GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const override;
@@ -79,6 +81,7 @@ private:
 
     uint16_t mUnackedLength; // Amount sent but awaiting ACK. Used as a form of reference count
                              // to hang-on to backing packet buffers until they are no longer needed.
+    tcp_pcb * mTCP;          // LwIP Transmission control protocol (TCP) control block.
 
     uint16_t RemainingToSend();
     BufferOffset FindStartOfUnsent();

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -292,8 +292,9 @@ protected:
 template <>
 struct EndPointProperties<UDPEndPoint>
 {
-    static constexpr const char * Name  = "UDP";
-    static constexpr int SystemStatsKey = System::Stats::kInetLayer_NumUDPEps;
+    static constexpr const char * kName   = "UDP";
+    static constexpr size_t kNumEndPoints = INET_CONFIG_NUM_UDP_ENDPOINTS;
+    static constexpr int kSystemStatsKey  = System::Stats::kInetLayer_NumUDPEps;
 };
 
 } // namespace Inet

--- a/src/inet/UDPEndPointImpl.h
+++ b/src/inet/UDPEndPointImpl.h
@@ -34,7 +34,7 @@
 namespace chip {
 namespace Inet {
 
-using UDPEndPointManagerImpl = EndPointManagerImplPool<UDPEndPointImpl, INET_CONFIG_NUM_UDP_ENDPOINTS>;
+using UDPEndPointManagerImpl = EndPointManagerImplPool<UDPEndPointImpl>;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -32,7 +32,7 @@ namespace Inet {
 class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
 {
 public:
-    UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager) : UDPEndPoint(endPointManager) {}
+    UDPEndPointImplLwIP(EndPointManager<UDPEndPoint> & endPointManager) : UDPEndPoint(endPointManager), mUDP(nullptr) {}
 
     // UDPEndPoint overrides.
     CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
@@ -84,6 +84,8 @@ private:
 #else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
     static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, ip_addr_t * addr, u16_t port);
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+
+    udp_pcb * mUDP; // LwIP User datagram protocol (UDP) control block.
 };
 
 using UDPEndPointImpl = UDPEndPointImplLwIP;

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -558,6 +558,7 @@ int TestAdvertiser(void)
     mdnsAdvertiser.Init(context.GetUDPEndPointManager());
     nlTestRunner(&theSuite, &server);
     server.Shutdown();
+    context.Shutdown();
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -65,5 +65,6 @@ void ShutdownChip(void)
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();
     gSessionManager.Shutdown();
+    (void) chip::DeviceLayer::TCPEndPointManager()->Shutdown();
     chip::DeviceLayer::PlatformMgr().Shutdown();
 }

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -33,7 +33,6 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/LambdaBridge.h>
-#include <lib/support/ObjectLifeCycle.h>
 #include <system/SystemClock.h>
 #include <system/SystemError.h>
 #include <system/SystemEvent.h>

--- a/src/system/SystemLayerImplLwIP.h
+++ b/src/system/SystemLayerImplLwIP.h
@@ -33,7 +33,7 @@ class LayerImplLwIP : public LayerLwIP
 {
 public:
     LayerImplLwIP();
-    ~LayerImplLwIP() = default;
+    ~LayerImplLwIP() { VerifyOrDie(mLayerState.Destroy()); }
 
     // Layer overrides.
     CHIP_ERROR Init() override;

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -40,8 +40,8 @@ namespace System {
 class LayerImplSelect : public LayerSocketsLoop
 {
 public:
-    LayerImplSelect()  = default;
-    ~LayerImplSelect() = default;
+    LayerImplSelect() = default;
+    ~LayerImplSelect() { VerifyOrDie(mLayerState.Destroy()); }
 
     // Layer overrides.
     CHIP_ERROR Init() override;


### PR DESCRIPTION
#### Change overview

- Remove the pointer `union` from `EndPointStateLwIP`; the members can be safe private members of the respective EndPoint classes.
- Remove some unused InetConfig definitions.
- Remove the unused `IPProtocol` enum.
- Streamline `EndPointManagerImplPool` size. Add `k` to constants.
- Additional init/shutdown order checks; fixed `TestAdvertiser` and `messaging/tests/echo` shutdown.

#### Testing

CI; no additional functionality.
