### PR TITLE
Increase cloudbuild "build all" timeout from 2h to 4h

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -31,7 +31,7 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 7200s
+timeout: 14400s
 
 artifacts:
     objects:


### PR DESCRIPTION
#### Problem
Current build all takes 1:53 (last build yesterday) which  is very close to the set timeout.

#### Change overview
Double the timeout, so that we do not need to worry about  it for  a long time.

#### Testing
N/A (cloudbuild)