### PR TITLE
Move to QPG6105 platform

### DIFF
--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -60,30 +60,30 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Build example QPG6100 Lock App
+            - name: Build example QPG6105 Lock App
               timeout-minutes: 5
               run: |
-                  scripts/examples/gn_build_example.sh examples/lock-app/qpg out/lock_app_debug qpg_target_ic=\"qpg6100\"
+                  scripts/examples/gn_build_example.sh examples/lock-app/qpg out/lock_app_debug qpg_target_ic=\"qpg6105\"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    qpg qpg6100+debug lock-app \
-                    out/lock_app_debug/chip-qpg6100-lock-example.out \
+                    qpg qpg6105+debug lock-app \
+                    out/lock_app_debug/chip-qpg6105-lock-example.out \
                     /tmp/bloat_reports/
-            - name: Build example QPG6100 Lighting App
+            - name: Build example QPG6105 Lighting App
               timeout-minutes: 5
               run: |
-                  scripts/examples/gn_build_example.sh examples/lighting-app/qpg out/lighting_app_debug qpg_target_ic=\"qpg6100\"
+                  scripts/examples/gn_build_example.sh examples/lighting-app/qpg out/lighting_app_debug qpg_target_ic=\"qpg6105\"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    qpg qpg6100+debug lighting-app \
-                    out/lighting_app_debug/chip-qpg6100-lighting-example.out \
+                    qpg qpg6105+debug lighting-app \
+                    out/lighting_app_debug/chip-qpg6105-lighting-example.out \
                     /tmp/bloat_reports/
-            - name: Build example QPG6100 persistent-storage
+            - name: Build example QPG6105 persistent-storage
               timeout-minutes: 5
               run: |
                   scripts/examples/gn_build_example.sh examples/persistent-storage/qpg out/persistent-storage_app_debug \
-                    qpg_target_ic=\"qpg6100\"
+                    qpg_target_ic=\"qpg6105\"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    qpg qpg6100+debug persistent-storage-app \
-                    out/persistent-storage_app_debug/chip-qpg6100-persistent_storage-example.out \
+                    qpg qpg6105+debug persistent-storage-app \
+                    out/persistent-storage_app_debug/chip-qpg6105-persistent_storage-example.out \
                     /tmp/bloat_reports/
             - name: Build Matter SDK library
               timeout-minutes: 5

--- a/examples/lighting-app/qpg/APPLICATION.md
+++ b/examples/lighting-app/qpg/APPLICATION.md
@@ -1,16 +1,16 @@
-# Matter QPG6100 Lighting Example Application
+# Matter QPG6105 Lighting Example Application
 
 ## Lighting-app
 
 A lighting example application showing the use of
-[Matter](https://github.com/project-chip/connectedhomeip) on the Qorvo QPG6100
+[Matter](https://github.com/project-chip/connectedhomeip) on the Qorvo QPG6105
 can be found in the
 [Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/examples/lighting-app/APPLICATION.md).
 
 ## Qorvo SDK
 
 More detailed information on the Qorvo SDK can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6100/doc/README.md).
+[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6105/doc/README.md).
 
 ## More information
 

--- a/examples/lock-app/qpg/APPLICATION.md
+++ b/examples/lock-app/qpg/APPLICATION.md
@@ -1,16 +1,16 @@
-# Matter QPG6100 Lock Example Application
+# Matter QPG6105 Lock Example Application
 
 ## Lock-app
 
 A lock example application showing the use of
-[Matter](https://github.com/project-chip/connectedhomeip) on the Qorvo QPG6100
+[Matter](https://github.com/project-chip/connectedhomeip) on the Qorvo QPG6105
 can be found in the
 [Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/examples/lock-app/APPLICATION.md).
 
 ## Qorvo SDK
 
 More detailed information on the Qorvo SDK can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6100/doc/README.md).
+[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6105/doc/README.md).
 
 ## More information
 

--- a/examples/persistent-storage/qpg/APPLICATION.md
+++ b/examples/persistent-storage/qpg/APPLICATION.md
@@ -1,7 +1,7 @@
-# CHIP QPG6100 Persistent Storage Application
+# CHIP QPG6105 Persistent Storage Application
 
 An example application showing the use of key value storage API on the Qorvo
-QPG6100.
+QPG6105.
 
 More detailed information to be included in
 [SDK Documentation](../../platform/qpg/README.md).

--- a/examples/platform/qpg/README.md
+++ b/examples/platform/qpg/README.md
@@ -1,9 +1,9 @@
-# Matter QPG6100 SDK
+# Matter QPG6105 SDK
 
 ## Qorvo SDK
 
 More detailed information on the Qorvo SDK can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6100/doc/README.md).
+[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6105/doc/README.md).
 
 ## More information
 

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -27,7 +27,7 @@ class QpgBuilder(GnBuilder):
     def build_outputs(self):
         return {
             'chip-qpg-lock-example.out':
-                os.path.join(self.output_dir, 'chip-qpg6100-lock-example.out'),
+                os.path.join(self.output_dir, 'chip-qpg6105-lock-example.out'),
             'chip-qpg-lock-example.out.map':
                 os.path.join(self.output_dir,
                              'chip-qpg6100-lock-example.out.map'),

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -29,6 +29,5 @@ class QpgBuilder(GnBuilder):
             'chip-qpg-lock-example.out':
                 os.path.join(self.output_dir, 'chip-qpg6105-lock-example.out'),
             'chip-qpg-lock-example.out.map':
-                os.path.join(self.output_dir,
-                             'chip-qpg6100-lock-example.out.map'),
+                os.path.join(self.output_dir, 'chip-qpg6105-lock-example.out.map'),
         }

--- a/src/platform/qpg/qpgConfig.cpp
+++ b/src/platform/qpg/qpgConfig.cpp
@@ -40,7 +40,7 @@ namespace Internal {
 
 CHIP_ERROR QPGConfig::Init()
 {
-    qvCHIP_Nvm_Init();
+    qvCHIP_KvsInit();
 
     return CHIP_NO_ERROR;
 }

--- a/third_party/openthread/platforms/qpg/BUILD.gn
+++ b/third_party/openthread/platforms/qpg/BUILD.gn
@@ -19,7 +19,8 @@ import("//build_overrides/qpg_sdk.gni")
 import("${qpg_sdk_build_root}/qpg_sdk.gni")
 
 # QPGxxxx settings and OT glue code
-openthread_qpg_family = "${qpg_target_ic}"
+#openthread_qpg_family = "${qpg_target_ic}"
+openthread_qpg_family = "qpg6100"
 openthread_qpg_root = "${chip_root}/third_party/openthread/ot-qorvo"
 
 config("openthread_qpg_config") {

--- a/third_party/openthread/platforms/qpg/BUILD.gn
+++ b/third_party/openthread/platforms/qpg/BUILD.gn
@@ -19,8 +19,7 @@ import("//build_overrides/qpg_sdk.gni")
 import("${qpg_sdk_build_root}/qpg_sdk.gni")
 
 # QPGxxxx settings and OT glue code
-#openthread_qpg_family = "${qpg_target_ic}"
-openthread_qpg_family = "qpg6100"
+openthread_qpg_family = "qpg6100" # pointing to qpg6100 for now, until ot-qorvo is updated with qpg6105 files
 openthread_qpg_root = "${chip_root}/third_party/openthread/ot-qorvo"
 
 config("openthread_qpg_config") {

--- a/third_party/openthread/platforms/qpg/BUILD.gn
+++ b/third_party/openthread/platforms/qpg/BUILD.gn
@@ -19,7 +19,8 @@ import("//build_overrides/qpg_sdk.gni")
 import("${qpg_sdk_build_root}/qpg_sdk.gni")
 
 # QPGxxxx settings and OT glue code
-openthread_qpg_family = "qpg6100" # pointing to qpg6100 for now, until ot-qorvo is updated with qpg6105 files
+openthread_qpg_family = "qpg6100"  # pointing to qpg6100 for now, until ot-qorvo
+                                   # is updated with qpg6105 files
 openthread_qpg_root = "${chip_root}/third_party/openthread/ot-qorvo"
 
 config("openthread_qpg_config") {

--- a/third_party/qpg_sdk/BUILD.gn
+++ b/third_party/qpg_sdk/BUILD.gn
@@ -34,7 +34,7 @@ group("qpg_sdk") {
 config("qpg_freertos_config") {
   include_dirs = [
     "${qpg_sdk_root}/${qpg_target_ic}/comps/gpFreeRTOS/config",
-    "${chip_root}/third_party/qpg_sdk/repo/qpg6100/comps/lwip",
+    "${chip_root}/third_party/qpg_sdk/repo/${qpg_target_ic}/comps/lwip",
     "${freertos_root}/repo/portable/GCC/ARM_CM3",
   ]
 }

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -23,7 +23,7 @@ declare_args() {
   qpg_sdk_root = "${chip_root}/third_party/qpg_sdk/repo"
 
   # Target IC for QPG SDK
-  qpg_target_ic = "qpg6100"
+  qpg_target_ic = "qpg6105"
 }
 
 assert(qpg_sdk_root != "", "qpg_sdk_root must be specified")


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* QPG6100 chip is being replaced by QPG6105 and some adjustments are necessary in the platform files

#### Change overview
* changes specific to QPG6105

#### Testing
* testing was done by compiling lighting app and running on the QPG6105 DK
* running TE7 test cases 
