### PR TITLE
[Size reports] Script improvements (3/3)

### DIFF
--- a/scripts/tools/memory/gh_sizes_environment.py
+++ b/scripts/tools/memory/gh_sizes_environment.py
@@ -59,7 +59,13 @@ elif github['event_name'] == 'push':
     parent = github['event']['before']
     timestamp = dateutil.parser.isoparse(
         github['event']['head_commit']['timestamp']).timestamp()
-    pr = 0
+
+    # Try to find the PR being committed by scraping the commit message.
+    m = re.search(r'\(#(\d+)\)', github['event']['head_commit']['message'])
+    if m:
+        pr = m.group(1)
+    else:
+        pr = 0
 
 # Environment variables for subsequent workflow steps are set by
 # writing to the file named by `$GITHUB_ENV`.


### PR DESCRIPTION
#### Problem

Recent memory size investigations suggest some improvements:

- Scripts use PR==0 to distinguish pull requests from master commits
  (push events), but it would be useful to record the associated PR
  along with commits.
- Sometimes push events run on pull requests, and those are not
  currently distinguishable from master push events.
- Sorting by build timestamp is inaccurate, since CI runs may finish
  in a different order than the commits.

#### Change overview

This is the third of three steps. The first step (#12886) added `event`
and `ref` handling, and the second (#12947) added the `event` to artifact
names.

This step adds the PR number for pushes to master, extracted
from the commit message.

#### Testing

Manually checked offline, but final confirmation requires live CI.
