### PR TITLE
Fix esp Docker build -  now it will stay fixed

### DIFF
--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,8 +10,8 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --depth 1 --recursive -b release/v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
-    && git -C /tmp/esp-idf checkout e104dd7f27d2e73ab0e9b614dd7b9295099069bf \
+    && git clone --recursive -b release/v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git -C /tmp/esp-idf checkout f23dcd3555cd59dfd44f4d7fbf2242c9827f91f1 \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.38 Version bump reason: [Ameba] Support pigweed-app
+0.5.39 Version bump reason: Push ESP forward, stop using 'depth 1' for checkouts


### PR DESCRIPTION
#### Problem
ESP checkouts with depth 1, however for branches this makes checkouts of specific revisions not work (because shallow depth)

#### Change overview
do not use depth 1
update sha to latest 4.4 branch sha

#### Testing
Docker image build will validate this.
