### PR TITLE
Extend PoolInterface to heap pools

### DIFF
--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -228,7 +228,8 @@ private:
 
 // The PoolImpl impl is used as a base class because its destructor must be called after ServerBase's destructor.
 template <size_t kCount>
-class Server : private chip::PoolImpl<ServerBase::EndpointInfo, kCount, ServerBase::EndpointInfoPoolType::Interface>,
+class Server : private chip::PoolImpl<ServerBase::EndpointInfo, kCount, chip::ObjectPoolMem::kStatic,
+                                      ServerBase::EndpointInfoPoolType::Interface>,
                public ServerBase
 {
 public:

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -71,7 +71,8 @@ void MakePrintableName(char (&location)[N], FullQName name)
 
 } // namespace
 
-class CheckOnlyServer : private chip::PoolImpl<ServerBase::EndpointInfo, 0, ServerBase::EndpointInfoPoolType::Interface>,
+class CheckOnlyServer : private chip::PoolImpl<ServerBase::EndpointInfo, 0, chip::ObjectPoolMem::kStatic,
+                                               ServerBase::EndpointInfoPoolType::Interface>,
                         public ServerBase,
                         public ParserDelegate,
                         public TxtRecordDelegate

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -336,33 +336,28 @@ private:
 
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
-#if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-template <typename T, unsigned int N>
-using ObjectPool = HeapObjectPool<T>;
-#else  // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-template <typename T, unsigned int N>
-using ObjectPool = BitMapObjectPool<T, N>;
-#endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-
 enum class ObjectPoolMem
 {
     kStatic,
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-    kDynamic
+    kDynamic,
+    kDefault = kDynamic
+#else  // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+    kDefault = kStatic
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 };
 
-template <typename T, size_t N, ObjectPoolMem P>
-class MemTypeObjectPool;
+template <typename T, size_t N, ObjectPoolMem P = ObjectPoolMem::kDefault>
+class ObjectPool;
 
 template <typename T, size_t N>
-class MemTypeObjectPool<T, N, ObjectPoolMem::kStatic> : public BitMapObjectPool<T, N>
+class ObjectPool<T, N, ObjectPoolMem::kStatic> : public BitMapObjectPool<T, N>
 {
 };
 
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 template <typename T, size_t N>
-class MemTypeObjectPool<T, N, ObjectPoolMem::kDynamic> : public HeapObjectPool<T>
+class ObjectPool<T, N, ObjectPoolMem::kDynamic> : public HeapObjectPool<T>
 {
 };
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -53,11 +53,11 @@ protected:
     virtual Loop ForEachActiveObjectInner(void * context, Lambda lambda) = 0;
 };
 
-template <class T, size_t N, typename Interface>
+template <class T, size_t N, ObjectPoolMem M, typename Interface>
 class PoolProxy;
 
-template <class T, size_t N, typename U, typename... ConstructorArguments>
-class PoolProxy<T, N, std::tuple<U, ConstructorArguments...>> : public PoolInterface<U, ConstructorArguments...>
+template <class T, size_t N, ObjectPoolMem M, typename U, typename... ConstructorArguments>
+class PoolProxy<T, N, M, std::tuple<U, ConstructorArguments...>> : public PoolInterface<U, ConstructorArguments...>
 {
 public:
     static_assert(std::is_base_of<U, T>::value, "Interface type is not derived from Pool type");
@@ -83,7 +83,7 @@ protected:
         return Impl().ForEachActiveObject([&](T * target) { return lambda(context, static_cast<U *>(target)); });
     }
 
-    virtual BitMapObjectPool<T, N> & Impl() = 0;
+    virtual ObjectPool<T, N, M> & Impl() = 0;
 };
 
 /*
@@ -92,23 +92,24 @@ protected:
  *
  *  @tparam T          a subclass of element to be allocated.
  *  @tparam N          a positive integer max number of elements the pool provides.
+ *  @tparam M          an ObjectPoolMem constant selecting static vs heap allocation.
  *  @tparam Interfaces a list of parameters which defines PoolInterface's. each interface is defined by a
  *                     std::tuple<U, ConstructorArguments...>. The PoolImpl is derived from every
  *                     PoolInterface<U, ConstructorArguments...>, the PoolImpl can be converted to the interface type
  *                     and passed around
  */
-template <class T, size_t N, typename... Interfaces>
-class PoolImpl : public PoolProxy<T, N, Interfaces>...
+template <class T, size_t N, ObjectPoolMem M, typename... Interfaces>
+class PoolImpl : public PoolProxy<T, N, M, Interfaces>...
 {
 public:
     PoolImpl() {}
     virtual ~PoolImpl() override {}
 
 protected:
-    virtual BitMapObjectPool<T, N> & Impl() override { return mImpl; }
+    virtual ObjectPool<T, N, M> & Impl() override { return mImpl; }
 
 private:
-    BitMapObjectPool<T, N> mImpl;
+    ObjectPool<T, N, M> mImpl;
 };
 
 } // namespace chip

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -281,7 +281,7 @@ public:
 private:
     friend class TCPTest;
     TCPBase::ActiveConnectionState mConnectionsBuffer[kActiveConnectionsSize];
-    PoolImpl<PendingPacket, kPendingPacketSize, PendingPacketPoolType::Interface> mPendingPackets;
+    PoolImpl<PendingPacket, kPendingPacketSize, ObjectPoolMem::kStatic, PendingPacketPoolType::Interface> mPendingPackets;
 };
 
 } // namespace Transport


### PR DESCRIPTION
#### Problem

PR #11834 added `PoolInterface`, a useful helper for passing object
pools, but it only supports `BitMapObjectPool`.

#### Change overview

Generalize `PoolInterface` to handle both static and heap pools.

#### Testing

Added a unit test.
