### PR TITLE
Adjust priority of Shutdown event in basic cluster

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -68,7 +68,7 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             Events::ShutDown::Type event;
             EventNumber eventNumber;
 
-            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent))
             {
                 ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record ShutDown event");
             }

--- a/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
@@ -48,7 +48,7 @@ limitations under the License.
       <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>
       <field id="0" name="SoftwareVersion" type="INT32U"/>
     </event>
-    <event side="server" code="0x01" name="ShutDown" priority="info" optional="false">
+    <event side="server" code="0x01" name="ShutDown" priority="critical" optional="false">
       <description>The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence on a best-effort basis.</description>
     </event>
     <event side="server" code="0x02" name="Leave" priority="info" optional="false">

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -8037,7 +8037,7 @@ public:
 };
 } // namespace StartUp
 namespace ShutDown {
-static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
+static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Critical;
 static constexpr EventId kEventId             = 0x00000001;
 
 enum class Fields


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, the Shutdown event always get lost and never get a chance to be sent out to subscribers.
* The priority of ShutDown event should be adjusted to CRITICAL as Startup event, since this is the event get logged right before the device shutdown, if we don't mark it as CRITICAL, it will not get sent out immediately as Urgent, and it will get lost during shut down since the event circular buffer is not in persistent memory.

#### Change overview
Adjust priority of Shutdown event in basic cluster

#### Testing
How was this tested? (at least one bullet point required)
* Confirm the Shutdown event is logged as Urgent event from log.
