### PR TITLE
Populate subject descriptor (in session handle)

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -255,11 +255,6 @@ CHIP_ERROR CommandHandler::ProcessCommandDataIB(CommandDataIB::Parser & aCommand
 
     {
         Access::SubjectDescriptor subjectDescriptor; // TODO: get actual subject descriptor
-        // TEMP just checking subject descriptor during development
-        if (mpExchangeCtx != nullptr && mpExchangeCtx->HasSessionHandle())
-        {
-            subjectDescriptor = mpExchangeCtx->GetSessionHandle().GetSubjectDescriptor();
-        }
         Access::RequestPath requestPath{ .cluster = concretePath.mClusterId, .endpoint = concretePath.mEndpointId };
         Access::Privilege requestPrivilege = Access::Privilege::kOperate; // TODO: get actual request privilege
         err                                = Access::GetAccessControl().Check(subjectDescriptor, requestPath, requestPrivilege);

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -255,6 +255,11 @@ CHIP_ERROR CommandHandler::ProcessCommandDataIB(CommandDataIB::Parser & aCommand
 
     {
         Access::SubjectDescriptor subjectDescriptor; // TODO: get actual subject descriptor
+        // TEMP just checking subject descriptor during development
+        if (mpExchangeCtx != nullptr && mpExchangeCtx->HasSessionHandle())
+        {
+            subjectDescriptor = mpExchangeCtx->GetSessionHandle().GetSubjectDescriptor();
+        }
         Access::RequestPath requestPath{ .cluster = concretePath.mClusterId, .endpoint = concretePath.mEndpointId };
         Access::Privilege requestPrivilege = Access::Privilege::kOperate; // TODO: get actual request privilege
         err                                = Access::GetAccessControl().Check(subjectDescriptor, requestPath, requestPrivilege);

--- a/src/lib/core/NodeId.h
+++ b/src/lib/core/NodeId.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <lib/core/NodeId.h>
+
 #include <cstdint>
 
 namespace chip {
@@ -69,6 +71,11 @@ constexpr bool IsCASEAuthTag(NodeId aNodeId)
 constexpr bool IsPAKEKeyId(NodeId aNodeId)
 {
     return (aNodeId >= kMinPAKEKeyId) && (aNodeId <= kMaxPAKEKeyId);
+}
+
+constexpr NodeId NodeIdFromGroupId(GroupId aGroupId)
+{
+    return kMinGroupNodeId | aGroupId;
 }
 
 } // namespace chip

--- a/src/lib/core/NodeId.h
+++ b/src/lib/core/NodeId.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <lib/core/NodeId.h>
+#include <lib/core/GroupId.h>
 
 #include <cstdint>
 

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -42,7 +42,7 @@ SubjectDescriptor SessionHandle::GetSubjectDescriptor() const
         {
             subjectDescriptor.authMode = AuthMode::kPase;
             subjectDescriptor.subject  = mPeerNodeId;
-            // TODO: there are cases where PASE can have a fabric, need to add that here
+            // TODO(#10242): PASE *can* have fabric in some situations
         }
         else if (mGroupId.HasValue())
         {

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -33,48 +33,22 @@ SubjectDescriptor SessionHandle::GetSubjectDescriptor() const
     {
         if (IsOperationalNodeId(mPeerNodeId))
         {
-            // Currently ending up here after commissioning (good)
             subjectDescriptor.authMode    = AuthMode::kCase;
             subjectDescriptor.subject     = mPeerNodeId;
-            subjectDescriptor.fabricIndex = mFabric; // have fabric here
-            // TODO: add CATs
-            ChipLogDetail(DataManagement, "@@@ #####################################  CASE  %lx  (%u)", subjectDescriptor.subject,
-                          subjectDescriptor.fabricIndex);
+            subjectDescriptor.fabricIndex = mFabric;
+            // TODO(#10243): add CATs
         }
         else if (IsPAKEKeyId(mPeerNodeId))
         {
-            // Should end up here during commissioning (but currently not)
-            subjectDescriptor.authMode    = AuthMode::kPase;
-            subjectDescriptor.subject     = mPeerNodeId;
-            subjectDescriptor.fabricIndex = mFabric; // also could have fabric here
-            ChipLogDetail(DataManagement, "@@@ #####################################  PASE  %lx  (%u)", subjectDescriptor.subject,
-                          subjectDescriptor.fabricIndex);
+            subjectDescriptor.authMode = AuthMode::kPase;
+            subjectDescriptor.subject  = mPeerNodeId;
+            // TODO: there are cases where PASE can have a fabric, need to add that here
         }
         else if (mGroupId.HasValue())
         {
-            // Should end up here during group messaging (how to test?)
             subjectDescriptor.authMode = AuthMode::kGroup;
             subjectDescriptor.subject  = kMinGroupNodeId | mGroupId.Value();
-            ChipLogDetail(DataManagement, "@@@ #####################################  Group  %lx", subjectDescriptor.subject);
         }
-        else if (mPeerNodeId == kUndefinedNodeId)
-        {
-            // Currently ending up here during commissioning (bad, should be above)
-            subjectDescriptor.authMode    = AuthMode::kPase;
-            subjectDescriptor.subject     = kMinPAKEKeyId | mPeerNodeId;
-            subjectDescriptor.fabricIndex = mFabric;
-            ChipLogDetail(DataManagement, "@@@ #####################################  assumed-pase  (%u)",
-                          subjectDescriptor.fabricIndex);
-        }
-        else
-        {
-            // Should never end up here
-            ChipLogDetail(DataManagement, "@@@ #####################################  unknown  %lx", mPeerNodeId);
-        }
-    }
-    else
-    {
-        ChipLogDetail(DataManagement, "@@@ #####################################  not secure");
     }
     return subjectDescriptor;
 }

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -23,12 +23,59 @@ namespace chip {
 
 using namespace Transport;
 
+using AuthMode          = Access::AuthMode;
 using SubjectDescriptor = Access::SubjectDescriptor;
 
 SubjectDescriptor SessionHandle::GetSubjectDescriptor() const
 {
-    SubjectDescriptor subjectDescriptor = { .fabricIndex = mFabric };
-    // TODO: fill subject descriptor with proper fields
+    SubjectDescriptor subjectDescriptor;
+    if (IsSecure())
+    {
+        if (IsOperationalNodeId(mPeerNodeId))
+        {
+            // Currently ending up here after commissioning (good)
+            subjectDescriptor.authMode    = AuthMode::kCase;
+            subjectDescriptor.subject     = mPeerNodeId;
+            subjectDescriptor.fabricIndex = mFabric; // have fabric here
+            // TODO: add CATs
+            ChipLogDetail(DataManagement, "@@@ #####################################  CASE  %lx  (%u)", subjectDescriptor.subject,
+                          subjectDescriptor.fabricIndex);
+        }
+        else if (IsPAKEKeyId(mPeerNodeId))
+        {
+            // Should end up here during commissioning (but currently not)
+            subjectDescriptor.authMode    = AuthMode::kPase;
+            subjectDescriptor.subject     = mPeerNodeId;
+            subjectDescriptor.fabricIndex = mFabric; // also could have fabric here
+            ChipLogDetail(DataManagement, "@@@ #####################################  PASE  %lx  (%u)", subjectDescriptor.subject,
+                          subjectDescriptor.fabricIndex);
+        }
+        else if (mGroupId.HasValue())
+        {
+            // Should end up here during group messaging (how to test?)
+            subjectDescriptor.authMode = AuthMode::kGroup;
+            subjectDescriptor.subject  = kMinGroupNodeId | mGroupId.Value();
+            ChipLogDetail(DataManagement, "@@@ #####################################  Group  %lx", subjectDescriptor.subject);
+        }
+        else if (mPeerNodeId == kUndefinedNodeId)
+        {
+            // Currently ending up here during commissioning (bad, should be above)
+            subjectDescriptor.authMode    = AuthMode::kPase;
+            subjectDescriptor.subject     = kMinPAKEKeyId | mPeerNodeId;
+            subjectDescriptor.fabricIndex = mFabric;
+            ChipLogDetail(DataManagement, "@@@ #####################################  assumed-pase  (%u)",
+                          subjectDescriptor.fabricIndex);
+        }
+        else
+        {
+            // Should never end up here
+            ChipLogDetail(DataManagement, "@@@ #####################################  unknown  %lx", mPeerNodeId);
+        }
+    }
+    else
+    {
+        ChipLogDetail(DataManagement, "@@@ #####################################  not secure");
+    }
     return subjectDescriptor;
 }
 

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -47,7 +47,7 @@ SubjectDescriptor SessionHandle::GetSubjectDescriptor() const
         else if (mGroupId.HasValue())
         {
             subjectDescriptor.authMode = AuthMode::kGroup;
-            subjectDescriptor.subject  = kMinGroupNodeId | mGroupId.Value();
+            subjectDescriptor.subject  = NodeIdFromGroupId(mGroupId.Value());
         }
     }
     return subjectDescriptor;


### PR DESCRIPTION
#### Problem
Subject descriptor values need to be populated (in the session handle).

#### Change overview
Populate subject descriptor values (when obtained from the session handle).

#### Testing
Build, unit tests, CI. Not otherwise tested, because upstream code changes still have to occur.
This is OK because access control is not turned on yet.