### PR TITLE
[Inet] Prune code for LwIP version 1

### DIFF
--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -46,13 +46,8 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
 #if INET_CONFIG_ENABLE_IPV4
     if (IsIPv4())
     {
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         ip4_addr_t ip4_addr = ToIPv4();
         ip4addr_ntoa_r(&ip4_addr, buf, (int) bufSize);
-#else  // LWIP_VERSION_MAJOR <= 1
-        ip_addr_t ip4_addr = ToIPv4();
-        ipaddr_ntoa_r(&ip4_addr, buf, (int) bufSize);
-#endif // LWIP_VERSION_MAJOR <= 1
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -93,15 +88,9 @@ bool IPAddress::FromString(const char * str, IPAddress & output)
     if (strchr(str, ':') == nullptr)
     {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         ip4_addr_t ipv4Addr;
         if (!ip4addr_aton(str, &ipv4Addr))
             return false;
-#else  // LWIP_VERSION_MAJOR <= 1
-        ip_addr_t ipv4Addr;
-        if (!ipaddr_aton(str, &ipv4Addr))
-            return false;
-#endif // LWIP_VERSION_MAJOR <= 1
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
         struct in_addr ipv4Addr;
         if (inet_pton(AF_INET, str, &ipv4Addr) < 1)

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -119,7 +119,6 @@ ip4_addr_t IPAddress::ToIPv4() const
 
 #endif // INET_CONFIG_ENABLE_IPV4
 
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 ip_addr_t IPAddress::ToLwIPAddr(void) const
 {
     ip_addr_t ret;
@@ -173,7 +172,6 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 
     return ret;
 }
-#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
 ip6_addr_t IPAddress::ToIPv6() const
 {

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -61,24 +61,6 @@
 #define NL_INET_IPV6_ADDR_LEN_IN_BYTES (16)
 #define NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES (14)
 
-/**
- * @brief   Adaptation for LwIP ip4_addr_t type.
- *
- * @details
- *  Before LwIP 2.0.0, the \c ip_addr_t type alias referred to a structure comprising
- *  an IPv4 address. At LwIP 2.0.0 and thereafter, this type alias is renamed \c ip4_addr_t
- *  and \c ip_addr_t is replaced with an alias to a union of both. Here, the \c ip4_addr_t
- *  type alias is provided even when the LwIP version is earlier than 2.0.0 so as to prepare
- *  for the import of the new logic.
- */
-#if CHIP_SYSTEM_CONFIG_USE_LWIP && INET_CONFIG_ENABLE_IPV4 && LWIP_VERSION_MAJOR < 2 && LWIP_VERSION_MINOR < 5
-typedef ip_addr_t ip4_addr_t;
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && INET_CONFIG_ENABLE_IPV4 && LWIP_VERSION_MAJOR < 2 && LWIP_VERSION_MINOR < 5
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR == 1 && LWIP_VERSION_MINOR >= 5
-typedef u8_t lwip_ip_addr_type;
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR == 1 && LWIP_VERSION_MINOR >= 5
-
 namespace chip {
 namespace Inet {
 
@@ -489,7 +471,6 @@ public:
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     /**
      * @fn      ToLwIPAddr() const
      *
@@ -508,10 +489,9 @@ public:
      *
      * @details
      *  Use <tt>ToLwIPAddrType(IPAddressType)</tt> to convert the IP address type
-     *  to its underlying LwIP address type code. (LWIP_VERSION_MAJOR > 1 only).
+     *  to its underlying LwIP address type code.
      */
     static lwip_ip_addr_type ToLwIPAddrType(IPAddressType);
-#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
     ip6_addr_t ToIPv6(void) const;
 

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & i
         return INET_ERROR_UNKNOWN_INTERFACE;
     }
     struct netif * intf;
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+#if defined(NETIF_FOREACH)
     NETIF_FOREACH(intf)
 #else
     for (intf = netif_list; intf != NULL; intf = intf->next)
@@ -120,7 +120,7 @@ bool InterfaceIterator::Next()
     // Verify the previous netif is still on the list if netifs.  If so,
     // advance to the next nextif.
     struct netif * prevNetif = mCurNetif;
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+#if defined(NETIF_FOREACH)
     NETIF_FOREACH(mCurNetif)
 #else
     for (mCurNetif = netif_list; mCurNetif != NULL; mCurNetif = mCurNetif->next)
@@ -152,12 +152,7 @@ bool InterfaceIterator::IsUp()
 
 bool InterfaceIterator::SupportsMulticast()
 {
-    return HasCurrent() &&
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        (mCurNetif->flags & (NETIF_FLAG_IGMP | NETIF_FLAG_MLD6 | NETIF_FLAG_BROADCAST)) != 0;
-#else
-        (mCurNetif->flags & NETIF_FLAG_POINTTOPOINT) == 0;
-#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+    return HasCurrent() && (mCurNetif->flags & (NETIF_FLAG_IGMP | NETIF_FLAG_MLD6 | NETIF_FLAG_BROADCAST)) != 0;
 }
 
 bool InterfaceIterator::HasBroadcastAddress()

--- a/src/inet/TCPEndPointImplLwIP.cpp
+++ b/src/inet/TCPEndPointImplLwIP.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR TCPEndPointImplLwIP::GetPeerInfo(IPAddress * retAddr, uint16_t * retP
     {
         *retPort = mTCP->remote_port;
         *retAddr = IPAddress(mTCP->remote_ip);
-        res = CHIP_NO_ERROR;
+        res      = CHIP_NO_ERROR;
     }
 
     // Unlock LwIP stack
@@ -205,7 +205,7 @@ CHIP_ERROR TCPEndPointImplLwIP::GetLocalInfo(IPAddress * retAddr, uint16_t * ret
     {
         *retPort = mTCP->local_port;
         *retAddr = IPAddress(mTCP->local_ip);
-        res = CHIP_NO_ERROR;
+        res      = CHIP_NO_ERROR;
     }
 
     // Unlock LwIP stack

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -372,9 +372,9 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
     {
         pktInfo->SrcAddress  = IPAddress(*addr);
         pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
-        pktInfo->Interface = InterfaceId(ip_current_netif());
-        pktInfo->SrcPort   = port;
-        pktInfo->DestPort  = pcb->local_port;
+        pktInfo->Interface   = InterfaceId(ip_current_netif());
+        pktInfo->SrcPort     = port;
+        pktInfo->DestPort    = pcb->local_port;
     }
 
     ep->Retain();

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -39,6 +39,8 @@
 #include <lwip/tcpip.h>
 #include <lwip/udp.h>
 
+static_assert(LWIP_VERSION_MAJOR > 1, "CHIP requires LwIP 2.0 or later");
+
 #if !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||                       \
     !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
 #define HAVE_LWIP_MULTICAST_LOOP 0

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -72,7 +72,6 @@ CHIP_ERROR UDPEndPointImplLwIP::BindImpl(IPAddressType addressType, const IPAddr
     // Bind the PCB to the specified address/port.
     if (res == CHIP_NO_ERROR)
     {
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         ip_addr_t ipAddr = address.ToLwIPAddr();
 
         // TODO: IPAddress ANY has only one constant state, however addressType
@@ -88,22 +87,6 @@ CHIP_ERROR UDPEndPointImplLwIP::BindImpl(IPAddressType addressType, const IPAddr
         }
 
         res = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipAddr, port));
-#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-        if (addressType == IPAddressType::kIPv6)
-        {
-            ip6_addr_t ipv6Addr = address.ToIPv6();
-            res                 = chip::System::MapErrorLwIP(udp_bind_ip6(mUDP, &ipv6Addr, port));
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else if (addressType == IPAddressType::kIPv4)
-        {
-            ip4_addr_t ipv4Addr = address.ToIPv4();
-            res                 = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipv4Addr, port));
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-        else
-            res = INET_ERROR_WRONG_ADDRESS_TYPE;
-#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
     }
 
     if (res == CHIP_NO_ERROR)
@@ -172,18 +155,7 @@ CHIP_ERROR UDPEndPointImplLwIP::ListenImpl()
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     udp_recv(mUDP, LwIPReceiveUDPMessage, this);
-#else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-    if (PCB_ISIPV6(mUDP))
-    {
-        udp_recv_ip6(mUDP, LwIPReceiveUDPMessage, this);
-    }
-    else
-    {
-        udp_recv(mUDP, LwIPReceiveUDPMessage, this);
-    }
-#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
@@ -228,8 +200,6 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
     const uint16_t & destPort  = pktInfo->DestPort;
     const InterfaceId & intfId = pktInfo->Interface;
 
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-
     ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
     ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
 
@@ -252,60 +222,6 @@ CHIP_ERROR UDPEndPointImplLwIP::SendMsgImpl(const IPPacketInfo * pktInfo, System
     }
 
     ip_addr_copy(mUDP->local_ip, boundAddr);
-
-#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-
-    ipX_addr_t boundAddr;
-    ipX_addr_copy(boundAddr, mUDP->local_ip);
-
-    if (PCB_ISIPV6(mUDP))
-    {
-        ip6_addr_t lwipSrcAddr  = srcAddr.ToIPv6();
-        ip6_addr_t lwipDestAddr = destAddr.ToIPv6();
-
-        if (!ip6_addr_isany(&lwipSrcAddr))
-        {
-            ipX_addr_copy(mUDP->local_ip, *ip6_2_ipX(&lwipSrcAddr));
-        }
-
-        if (intfId.IsPresent())
-        {
-            lwipErr =
-                udp_sendto_if_ip6(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
-        }
-        else
-        {
-            lwipErr = udp_sendto_ip6(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
-        }
-    }
-
-#if INET_CONFIG_ENABLE_IPV4
-
-    else
-    {
-        ip4_addr_t lwipSrcAddr  = srcAddr.ToIPv4();
-        ip4_addr_t lwipDestAddr = destAddr.ToIPv4();
-        ipX_addr_t boundAddr;
-
-        if (!ip_addr_isany(&lwipSrcAddr))
-        {
-            ipX_addr_copy(mUDP->local_ip, *ip_2_ipX(&lwipSrcAddr));
-        }
-
-        if (intfId.IsPresent())
-        {
-            lwipErr = udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
-        }
-        else
-        {
-            lwipErr = udp_sendto(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
-        }
-    }
-
-    ipX_addr_copy(mUDP->local_ip, boundAddr);
-
-#endif // INET_CONFIG_ENABLE_IPV4
-#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
@@ -375,20 +291,12 @@ CHIP_ERROR UDPEndPointImplLwIP::GetPCB(IPAddressType addrType)
         // Allocate a PCB of the appropriate type.
         if (addrType == IPAddressType::kIPv6)
         {
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
             mUDP = udp_new_ip_type(IPADDR_TYPE_V6);
-#else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-            mUDP = udp_new_ip6();
-#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if (addrType == IPAddressType::kIPv4)
         {
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
             mUDP = udp_new_ip_type(IPADDR_TYPE_V4);
-#else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-            mUDP = udp_new();
-#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
         }
 #endif // INET_CONFIG_ENABLE_IPV4
         else
@@ -413,7 +321,6 @@ CHIP_ERROR UDPEndPointImplLwIP::GetPCB(IPAddressType addrType)
         IPAddressType pcbAddrType;
 
         // Get the address type of the existing PCB.
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         switch (static_cast<lwip_ip_addr_type>(IP_GET_TYPE(&mUDP->local_ip)))
         {
         case IPADDR_TYPE_V6:
@@ -427,13 +334,6 @@ CHIP_ERROR UDPEndPointImplLwIP::GetPCB(IPAddressType addrType)
         default:
             return INET_ERROR_WRONG_ADDRESS_TYPE;
         }
-#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-#if INET_CONFIG_ENABLE_IPV4
-        pcbAddrType = PCB_ISIPV6(mUDP) ? IPAddressType::kIPv6 : IPAddressType::kIPv4;
-#else  // !INET_CONFIG_ENABLE_IPV4
-        pcbAddrType = IPAddressType::kIPv6;
-#endif // !INET_CONFIG_ENABLE_IPV4
-#endif // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
 
         // Fail if the existing PCB is not the correct type.
         VerifyOrReturnError(addrType == pcbAddrType, INET_ERROR_WRONG_ADDRESS_TYPE);
@@ -442,12 +342,8 @@ CHIP_ERROR UDPEndPointImplLwIP::GetPCB(IPAddressType addrType)
     return CHIP_NO_ERROR;
 }
 
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr,
                                                 u16_t port)
-#else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, ip_addr_t * addr, u16_t port)
-#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 {
     UDPEndPointImplLwIP * ep       = static_cast<UDPEndPointImplLwIP *>(arg);
     IPPacketInfo * pktInfo         = nullptr;
@@ -474,24 +370,8 @@ void UDPEndPointImplLwIP::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb
     pktInfo = GetPacketInfo(buf);
     if (pktInfo != nullptr)
     {
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         pktInfo->SrcAddress  = IPAddress(*addr);
         pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
-#else // LWIP_VERSION_MAJOR <= 1
-        if (PCB_ISIPV6(pcb))
-        {
-            pktInfo->SrcAddress  = IPAddress(*(ip6_addr_t *) addr);
-            pktInfo->DestAddress = IPAddress(*ip6_current_dest_addr());
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else
-        {
-            pktInfo->SrcAddress  = IPAddress(*addr);
-            pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-#endif // LWIP_VERSION_MAJOR <= 1
-
         pktInfo->Interface = InterfaceId(ip_current_netif());
         pktInfo->SrcPort   = port;
         pktInfo->DestPort  = pcb->local_port;
@@ -579,7 +459,7 @@ struct netif * UDPEndPointImplLwIP::FindNetifFromInterfaceId(InterfaceId aInterf
 {
     struct netif * lRetval = nullptr;
 
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+#if defined(NETIF_FOREACH)
     NETIF_FOREACH(lRetval)
     {
         if (lRetval == aInterfaceId.GetPlatformInterface())
@@ -587,10 +467,10 @@ struct netif * UDPEndPointImplLwIP::FindNetifFromInterfaceId(InterfaceId aInterf
             break;
         }
     }
-#else  // LWIP_VERSION_MAJOR < 2 || !defined(NETIF_FOREACH)
+#else  // defined(NETIF_FOREACH)
     for (lRetval = netif_list; lRetval != nullptr && lRetval != aInterfaceId.GetPlatformInterface(); lRetval = lRetval->next)
         ;
-#endif // LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+#endif // defined(NETIF_FOREACH)
 
     return (lRetval);
 }

--- a/src/inet/UDPEndPointImplLwIP.h
+++ b/src/inet/UDPEndPointImplLwIP.h
@@ -79,11 +79,7 @@ private:
     static IPPacketInfo * GetPacketInfo(const chip::System::PacketBufferHandle & aBuffer);
 
     CHIP_ERROR GetPCB(IPAddressType addrType4);
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr, u16_t port);
-#else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-    static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, ip_addr_t * addr, u16_t port);
-#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
     udp_pcb * mUDP; // LwIP User datagram protocol (UDP) control block.
 };

--- a/src/inet/arpa-inet-compatibility.h
+++ b/src/inet/arpa-inet-compatibility.h
@@ -25,18 +25,17 @@
 
 #else // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-// NOTE WELL: when LWIP_VERSION_MAJOR == 1, LWIP_PREFIX_BYTEORDER_FUNCS instead of LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #include <lwip/def.h>
 #include <lwip/opt.h>
 
-#if (defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS) || defined(LWIP_PREFIX_BYTEORDER_FUNCS))
+#if defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS)
 #define htons(x) lwip_htons(x)
 #define ntohs(x) lwip_ntohs(x)
 #define htonl(x) lwip_htonl(x)
 #define ntohl(x) lwip_ntohl(x)
-#endif // (defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS) || defined(LWIP_PREFIX_BYTEORDER_FUNCS))
+#endif // defined(LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS)
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 #endif // !CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -55,9 +55,9 @@
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/dns.h>
-#if !(LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
+#if (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 #include <lwip/ip6_route_table.h>
-#endif // !(LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
+#endif // (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 #include <lwip/init.h>
 #include <lwip/netif.h>
 #include <lwip/sys.h>
@@ -97,7 +97,7 @@ static void AcquireLwIP(void)
 
 static void ReleaseLwIP(void)
 {
-#if !(LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
+#if (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
     if (sLwIPAcquireCount > 0 && --sLwIPAcquireCount == 0)
     {
 #if defined(INCLUDE_vTaskDelete) && INCLUDE_vTaskDelete
@@ -107,7 +107,7 @@ static void ReleaseLwIP(void)
         tcpip_finish(NULL, NULL);
 #endif // defined(INCLUDE_vTaskDelete) && INCLUDE_vTaskDelete
     }
-#endif
+#endif // (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 }
 
 #if CHIP_TARGET_STYLE_UNIX
@@ -325,11 +325,7 @@ void InitNetwork()
         IPAddress ip4Gateway = (j < gNetworkOptions.IPv4GatewayAddr.size()) ? gNetworkOptions.IPv4GatewayAddr[j] : IPAddress::Any;
 
         {
-#if LWIP_VERSION_MAJOR > 1
             ip4_addr_t ip4AddrLwIP, ip4NetmaskLwIP, ip4GatewayLwIP;
-#else  // LWIP_VERSION_MAJOR <= 1
-            ip_addr_t ip4AddrLwIP, ip4NetmaskLwIP, ip4GatewayLwIP;
-#endif // LWIP_VERSION_MAJOR <= 1
 
             ip4AddrLwIP = ip4Addr.ToIPv4();
             IP4_ADDR(&ip4NetmaskLwIP, 255, 255, 255, 0);
@@ -343,7 +339,7 @@ void InitNetwork()
 
         netif_create_ip6_linklocal_address(&(sNetIFs[j]), 1);
 
-#if !(LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
+#if (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
         if (j < gNetworkOptions.LocalIPv6Addr.size())
         {
             ip6_addr_t ip6addr = gNetworkOptions.LocalIPv6Addr[j].ToIPv6();
@@ -381,7 +377,7 @@ void InitNetwork()
                 }
             }
         }
-#endif
+#endif // (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 
         netif_set_up(&(sNetIFs[j]));
         netif_set_link_up(&(sNetIFs[j]));

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -733,15 +733,15 @@ void ConnectivityManagerImpl::OnStationIPv4AddressLost(void)
 
 void ConnectivityManagerImpl::OnIPv6AddressAvailable(void)
 {
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1
+#if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 #if LWIP_IPV6
     uint8_t * ipv6_0 = LwIP_GetIPv6_linklocal(&xnetif[0]);
     uint8_t * ipv6_1 = LwIP_GetIPv6_global(&xnetif[0]);
 #endif
-#endif
+#endif // LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 #if CHIP_PROGRESS_LOGGING
     {
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1
+#if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 #if LWIP_IPV6
         ChipLogProgress(DeviceLayer,
                         "\n\r\tLink-local IPV6 => %02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
@@ -752,7 +752,7 @@ void ConnectivityManagerImpl::OnIPv6AddressAvailable(void)
                         ipv6_1[0], ipv6_1[1], ipv6_1[2], ipv6_1[3], ipv6_1[4], ipv6_1[5], ipv6_1[6], ipv6_1[7], ipv6_1[8],
                         ipv6_1[9], ipv6_1[10], ipv6_1[11], ipv6_1[12], ipv6_1[13], ipv6_1[14], ipv6_1[15]);
 #endif
-#endif
+#endif // LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
     }
 #endif // CHIP_PROGRESS_LOGGING
 
@@ -782,14 +782,14 @@ void ConnectivityManagerImpl::DHCPProcessThread(void * param)
     PlatformMgr().LockChipStack();
     sInstance.OnStationIPv4AddressAvailable();
     PlatformMgr().UnlockChipStack();
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1
+#if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 #if LWIP_IPV6
     LwIP_DHCP6(0, DHCP6_START);
     PlatformMgr().LockChipStack();
     sInstance.OnIPv6AddressAvailable();
     PlatformMgr().UnlockChipStack();
 #endif
-#endif
+#endif // LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
     vTaskDelete(NULL);
 }
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -275,9 +275,9 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::DoInitThreadNetI
     netif->name[0]    = CHIP_DEVICE_CONFIG_LWIP_THREAD_IF_NAME[0];
     netif->name[1]    = CHIP_DEVICE_CONFIG_LWIP_THREAD_IF_NAME[1];
     netif->output_ip6 = SendPacket;
-#if LWIP_IPV4 || LWIP_VERSION_MAJOR < 2
+#if LWIP_IPV4
     netif->output = NULL;
-#endif /* LWIP_IPV4 || LWIP_VERSION_MAJOR < 2 */
+#endif // LWIP_IPV4
     netif->linkoutput = NULL;
     netif->flags      = NETIF_FLAG_UP | NETIF_FLAG_LINK_UP | NETIF_FLAG_BROADCAST;
     netif->mtu        = CHIP_DEVICE_CONFIG_THREAD_IF_MTU;
@@ -293,13 +293,8 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::DoInitThreadNetI
  * NB: This method is called in the LwIP TCPIP thread with the LwIP core lock held.
  */
 template <class ImplClass>
-#if LWIP_VERSION_MAJOR < 2
-err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::SendPacket(struct netif * netif, struct pbuf * pktPBuf,
-                                                                           struct ip6_addr * ipaddr)
-#else
 err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::SendPacket(struct netif * netif, struct pbuf * pktPBuf,
                                                                            const struct ip6_addr * ipaddr)
-#endif
 {
     err_t lwipErr = ERR_OK;
     otError otErr;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.h
@@ -73,11 +73,7 @@ private:
     bool mAddrAssigned[LWIP_IPV6_NUM_ADDRESSES];
 
     static err_t DoInitThreadNetIf(struct netif * netif);
-#if LWIP_VERSION_MAJOR < 2
-    static err_t SendPacket(struct netif * netif, struct pbuf * pkt, struct ip6_addr * ipaddr);
-#else
     static err_t SendPacket(struct netif * netif, struct pbuf * pkt, const struct ip6_addr * ipaddr);
-#endif
     static void ReceivePacket(otMessage * pkt, void * context);
 
     inline ImplClass * Impl() { return static_cast<ImplClass *>(this); }

--- a/src/system/SystemStats.cpp
+++ b/src/system/SystemStats.cpp
@@ -107,13 +107,6 @@ bool Difference(Snapshot & result, Snapshot & after, Snapshot & before)
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_STATS && MEMP_STATS
 
-// To use LwIP 1.x, some additional definitions are required here.
-#if LWIP_VERSION_MAJOR < 2
-#ifndef MEMP_STATS_GET
-#define MEMP_STATS_GET(FIELD, INDEX) (lwip_stats.memp[INDEX].FIELD)
-#endif // !defined(MEMP_STATS_GET)
-#endif // LWIP_VERSION_MAJOR
-
 void UpdateLwipPbufCounts(void)
 {
 #if LWIP_PBUF_FROM_CUSTOM_POOLS

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -48,11 +48,11 @@
 #include <nlunit-test.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if (LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
-#define PBUF_TYPE(pbuf) (pbuf)->type_internal
-#else
+#if (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 #define PBUF_TYPE(pbuf) (pbuf)->type
-#endif // (LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
+#else // (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
+#define PBUF_TYPE(pbuf) (pbuf)->type_internal
+#endif // (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 using ::chip::Encoding::PacketBufferWriter;

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -442,12 +442,12 @@ static int TestSetup(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR == 2 && LWIP_VERSION_MINOR == 0
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
     sys_mbox_new(sLwIPEventQueue, 100);
     tcpip_init(NULL, NULL);
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR == 2 && LWIP_VERSION_MINOR == 0
 
     sLayer.Init();
 
@@ -467,11 +467,9 @@ static int TestTeardown(void * aContext)
 
     lContext.mLayer->Shutdown();
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if !(LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
     tcpip_finish(NULL, NULL);
-#endif
-#endif
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 
     return (SUCCESS);
 }


### PR DESCRIPTION
#### Problem

CHIP can't build with LwIP version 1, but there are a number of inherited conditional `#if` blocks for it.

#### Change overview

- Remove conditional code for LwIP version 1
- Fix conditions that were meant to catch LwIP 2.0 but actually would
  apply to any LwIP x.0

#### Testing

CI; no change to functionality intended
