### PR TITLE
Fix the logic for endpoints matching a cluster

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -795,9 +795,9 @@ void EnabledEndpointsWithServerCluster::EnsureMatchingEndpoint()
             continue;
         }
 
-        if (!emberAfContainsServerFromIndex(mEndpointIndex, mClusterId))
+        if (emberAfContainsServerFromIndex(mEndpointIndex, mClusterId))
         {
-            continue;
+            break;
         }
     }
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We found the Startup event is not proper logged after using an iterator over endpoints matching a cluster

#### Change overview
Fix the logic for endpoints matching a cluster

#### Testing
How was this tested? (at least one bullet point required)
* Confirm the iteration loop of endpoint can be entered and Startup event is correctly logged from log
