### PR TITLE
Fix attribute change reporting for attribute accessor writes.

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -60,6 +60,15 @@ class {{filename}}: public TestCommand
     {{/chip_tests_item_response_parameters}}
     {{/chip_tests_items}}
 
+    {{! Helper around zapTypeToDecodableClusterObjectType that lets us set the
+        array/nullable/etc context appropriately.}}
+    {{~#*inline "subscribeResponseDataArgument"~}}
+      {{zapTypeToDecodableClusterObjectType type ns=cluster isArgument=true}} value
+    {{~/inline~}}
+    {{~#*inline "subscribeResponseArguments"~}}
+    {{> subscribeResponseDataArgument type=attr.type isArray=attr.isArray isNullable=attr.isNullable}}
+    {{~/inline~}}
+
     {{~#*inline "subscribeDataCallback"}}
     mTest_{{parent.filename}}_{{attribute}}_Reported
     {{/inline}}
@@ -68,7 +77,7 @@ class {{filename}}: public TestCommand
     {{/inline}}
     {{#chip_tests_items}}
     {{#if allocateSubscribeDataCallback}}
-    typedef void (*{{> subscribeDataCallbackType}})(void * context, {{zapTypeToDecodableClusterObjectType attributeObject.type ns=parent.cluster isArgument=true}} value);
+    typedef void (*{{> subscribeDataCallbackType}})(void * context, {{> subscribeResponseArguments attr=attributeObject}});
     {{> subscribeDataCallbackType}} {{> subscribeDataCallback}} = nullptr;
     {{/if}}
     {{/chip_tests_items}}
@@ -260,7 +269,7 @@ class {{filename}}: public TestCommand
     }
 
     {{#if isSubscribeAttribute}}
-    void {{>successResponse}}({{zapTypeToDecodableClusterObjectType attributeObject.type ns=parent.cluster isArgument=true}} value)
+    void {{>successResponse}}({{> subscribeResponseArguments attr=attributeObject}})
     {
         {{#if response.error}}
           ThrowSuccessResponse();

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -186,6 +186,13 @@ CHIP_ERROR TestAttrAccess::WriteListInt8uAttribute(AttributeValueDecoder & aDeco
 
     ReturnErrorOnFailure(aDecoder.Decode(list));
 
+    size_t size;
+    ReturnErrorOnFailure(list.ComputeSize(&size));
+
+    // We never change our length, so fail out attempts to change it.  This
+    // should really return one of the spec errors!
+    VerifyOrReturnError(size == kAttributeListLength, CHIP_ERROR_INVALID_ARGUMENT);
+
     uint8_t index = 0;
     auto iter     = list.begin();
     while (iter.Next())

--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <app/ConcreteAttributePath.h>
 #include <app/util/af-types.h>
 
 /** @brief Reporting Attribute Change
@@ -55,3 +56,8 @@ void MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::Clu
  * Same but with just an attribute path and no data available.
  */
 void MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId);
+
+/*
+ * Same but with a nicer attribute path.
+ */
+void MatterReportingAttributeChangeCallback(const chip::app::ConcreteAttributePath & aPath);

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -2388,3 +2388,24 @@ tests:
           values:
               - name: "arg1"
                 value: 1
+
+    # Tests for subscription to a complex attribute
+    - label: "Subscribe to list attribute"
+      command: "subscribeAttribute"
+      attribute: "list_int8u"
+      minInterval: 2
+      maxInterval: 10
+      response:
+          value: [1, 2, 3, 4]
+
+    - label: "Write subscribed-to list attribute"
+      command: "writeAttribute"
+      attribute: "list_int8u"
+      arguments:
+          value: [5, 6, 7, 8]
+
+    - label: "Check for list attribute report"
+      command: "waitForReport"
+      attribute: "list_int8u"
+      response:
+          value: [5, 6, 7, 8]

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -867,6 +867,7 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
 
         if (valueDecoder.TriedDecode())
         {
+            MatterReportingAttributeChangeCallback(aPath);
             return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::Success);
         }
     }
@@ -918,4 +919,9 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
     // has completed. This ensures that we can 'gather up' multiple attribute changes that have occurred in the same execution
     // context without requiring any explicit 'start' or 'end' change calls into the engine to book-end the change.
     InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
+}
+
+void MatterReportingAttributeChangeCallback(const ConcreteAttributePath & aPath)
+{
+    return MatterReportingAttributeChangeCallback(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
 }

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -27290,6 +27290,120 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
+bool testSendClusterTestCluster_000298_WaitForReport_Fulfilled = false;
+ResponseHandler test_TestCluster_list_int8u_Reported = nil;
+- (void)testSendClusterTestCluster_000298_WaitForReport
+{
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    test_TestCluster_list_int8u_Reported = ^(NSArray * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Report: Subscribe to list attribute Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue count], 4);
+            XCTAssertEqual([actualValue[0] unsignedCharValue], 1);
+            XCTAssertEqual([actualValue[1] unsignedCharValue], 2);
+            XCTAssertEqual([actualValue[2] unsignedCharValue], 3);
+            XCTAssertEqual([actualValue[3] unsignedCharValue], 4);
+        }
+
+        testSendClusterTestCluster_000298_WaitForReport_Fulfilled = true;
+    };
+}
+- (void)testSendClusterTestCluster_000299_SubscribeAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Subscribe to list attribute"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t minIntervalArgument = 2U;
+    uint16_t maxIntervalArgument = 10U;
+    [cluster subscribeAttributeListInt8uWithMinInterval:minIntervalArgument
+        maxInterval:maxIntervalArgument
+        subscriptionEstablished:^{
+            XCTAssertEqual(testSendClusterTestCluster_000298_WaitForReport_Fulfilled, true);
+            [expectation fulfill];
+        }
+        reportHandler:^(NSArray * _Nullable value, NSError * _Nullable err) {
+            NSLog(@"Subscribe to list attribute Error: %@", err);
+
+            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+            if (test_TestCluster_list_int8u_Reported != nil) {
+                ResponseHandler callback = test_TestCluster_list_int8u_Reported;
+                test_TestCluster_list_int8u_Reported = nil;
+                callback(value, err);
+            }
+        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000300_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write subscribed-to list attribute"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id listInt8uArgument;
+    {
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [NSNumber numberWithUnsignedChar:5];
+        temp_0[1] = [NSNumber numberWithUnsignedChar:6];
+        temp_0[2] = [NSNumber numberWithUnsignedChar:7];
+        temp_0[3] = [NSNumber numberWithUnsignedChar:8];
+        listInt8uArgument = temp_0;
+    }
+    [cluster writeAttributeListInt8uWithValue:listInt8uArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write subscribed-to list attribute Error: %@", err);
+
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                [expectation fulfill];
+                            }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000301_WaitForReport
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Check for list attribute report"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    test_TestCluster_list_int8u_Reported = ^(NSArray * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Check for list attribute report Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue count], 4);
+            XCTAssertEqual([actualValue[0] unsignedCharValue], 5);
+            XCTAssertEqual([actualValue[1] unsignedCharValue], 6);
+            XCTAssertEqual([actualValue[2] unsignedCharValue], 7);
+            XCTAssertEqual([actualValue[3] unsignedCharValue], 8);
+        }
+
+        [expectation fulfill];
+    };
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
 
 - (void)testSendClusterTestSaveAs_000000_WaitForCommissionee
 {

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -35461,6 +35461,22 @@ public:
                             " ***** Test Step 297 : Send a command that takes an optional parameter but do not set it.\n");
             err = TestSendACommandThatTakesAnOptionalParameterButDoNotSetIt_297();
             break;
+        case 298:
+            ChipLogProgress(chipTool, " ***** Test Step 298 : Report: Subscribe to list attribute\n");
+            err = TestReportSubscribeToListAttribute_298();
+            break;
+        case 299:
+            ChipLogProgress(chipTool, " ***** Test Step 299 : Subscribe to list attribute\n");
+            err = TestSubscribeToListAttribute_299();
+            break;
+        case 300:
+            ChipLogProgress(chipTool, " ***** Test Step 300 : Write subscribed-to list attribute\n");
+            err = TestWriteSubscribedToListAttribute_300();
+            break;
+        case 301:
+            ChipLogProgress(chipTool, " ***** Test Step 301 : Check for list attribute report\n");
+            err = TestCheckForListAttributeReport_301();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -35472,7 +35488,11 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 298;
+    const uint16_t mTestCount = 302;
+
+    typedef void (*Test_TestCluster_list_int8u_ReportCallback)(void * context,
+                                                               const chip::app::DataModel::DecodableList<uint8_t> & value);
+    Test_TestCluster_list_int8u_ReportCallback mTest_TestCluster_list_int8u_Reported = nullptr;
 
     static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
@@ -37808,6 +37828,52 @@ private:
     {
         (static_cast<TestCluster *>(context))->OnSuccessResponse_295(listInt8u);
     }
+
+    static void OnFailureCallback_298(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_298(status);
+    }
+
+    static void OnSuccessCallback_298(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_298(listInt8u);
+    }
+
+    bool mReceivedReport_298 = false;
+
+    static void OnFailureCallback_299(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_299(status);
+    }
+
+    static void OnSuccessCallback_299(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_299(listInt8u);
+    }
+
+    static void OnSubscriptionEstablished_299(void * context)
+    {
+        (static_cast<TestCluster *>(context))->OnSubscriptionEstablishedResponse_299();
+    }
+
+    static void OnFailureCallback_300(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_300(status);
+    }
+
+    static void OnSuccessCallback_300(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_300(); }
+
+    static void OnFailureCallback_301(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_301(status);
+    }
+
+    static void OnSuccessCallback_301(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_301(listInt8u);
+    }
+
+    bool mReceivedReport_301 = false;
 
     //
     // Tests methods
@@ -44369,6 +44435,123 @@ private:
     void OnFailureResponse_297(EmberAfStatus status) { ThrowFailureResponse(); }
 
     void OnSuccessResponse_297() { NextTest(); }
+
+    CHIP_ERROR TestReportSubscribeToListAttribute_298()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        mTest_TestCluster_list_int8u_Reported = OnSuccessCallback_298;
+        return WaitForMs(0);
+    }
+
+    void OnFailureResponse_298(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_298(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        mReceivedReport_298 = true;
+
+        auto iter = listInt8u.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 0));
+        VerifyOrReturn(CheckValue("listInt8u[0]", iter.GetValue(), 1));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 1));
+        VerifyOrReturn(CheckValue("listInt8u[1]", iter.GetValue(), 2));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 2));
+        VerifyOrReturn(CheckValue("listInt8u[2]", iter.GetValue(), 3));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 3));
+        VerifyOrReturn(CheckValue("listInt8u[3]", iter.GetValue(), 4));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(listInt8u)>("listInt8u", iter, 4));
+    }
+
+    CHIP_ERROR TestSubscribeToListAttribute_299()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint16_t minIntervalArgument;
+        minIntervalArgument = 2U;
+        uint16_t maxIntervalArgument;
+        maxIntervalArgument = 10U;
+
+        ReturnErrorOnFailure(cluster.SubscribeAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
+            this, OnSuccessCallback_299, OnFailureCallback_299, minIntervalArgument, maxIntervalArgument,
+            OnSubscriptionEstablished_299));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_299(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_299(const chip::app::DataModel::DecodableList<uint8_t> & value)
+    {
+        if (mTest_TestCluster_list_int8u_Reported)
+        {
+            auto callback                         = mTest_TestCluster_list_int8u_Reported;
+            mTest_TestCluster_list_int8u_Reported = nullptr;
+            callback(this, value);
+        }
+    }
+
+    void OnSubscriptionEstablishedResponse_299()
+    {
+        VerifyOrReturn(mReceivedReport_298, Exit("Initial report not received!"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteSubscribedToListAttribute_300()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        chip::app::DataModel::List<const uint8_t> listInt8uArgument;
+
+        uint8_t listInt8uList[4];
+        listInt8uList[0]  = 5;
+        listInt8uList[1]  = 6;
+        listInt8uList[2]  = 7;
+        listInt8uList[3]  = 8;
+        listInt8uArgument = listInt8uList;
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
+            listInt8uArgument, this, OnSuccessCallback_300, OnFailureCallback_300));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_300(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_300() { NextTest(); }
+
+    CHIP_ERROR TestCheckForListAttributeReport_301()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        mTest_TestCluster_list_int8u_Reported = OnSuccessCallback_301;
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_301(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_301(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        mReceivedReport_301 = true;
+
+        auto iter = listInt8u.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 0));
+        VerifyOrReturn(CheckValue("listInt8u[0]", iter.GetValue(), 5));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 1));
+        VerifyOrReturn(CheckValue("listInt8u[1]", iter.GetValue(), 6));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 2));
+        VerifyOrReturn(CheckValue("listInt8u[2]", iter.GetValue(), 7));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 3));
+        VerifyOrReturn(CheckValue("listInt8u[3]", iter.GetValue(), 8));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(listInt8u)>("listInt8u", iter, 4));
+
+        NextTest();
+    }
 };
 
 class TestClusterComplexTypes : public TestCommand


### PR DESCRIPTION
For attributes in the attr store, the attr store marks them dirty when
written.  But for attribute writes via AttributeAccessInterface
nothing was doing it.

#### Problem
When writing an attribute implemented via AttributeAccessInterface, no reporting is triggered.

#### Change overview
Trigger reporting appropriately.

#### Testing
YAML tests included.