### PR TITLE
[chip-tool] Optional argument parsing does not work after #12732

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -48,7 +48,7 @@ traces should go:
 For example:
 
 ```
-out/with_trace/chip-tool --trace_file trace.log pairing <pairing_args>
+out/with_trace/chip-tool pairing <pairing_args> --trace_file trace.log
 ```
 
 ## Using the Client to commission a device

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -41,7 +41,14 @@ public:
     using NodeId                 = ::chip::NodeId;
     using PeerAddress            = ::chip::Transport::PeerAddress;
 
-    CHIPCommand(const char * commandName) : Command(commandName) { AddArgument("commissioner-name", &mCommissionerName); }
+    CHIPCommand(const char * commandName) : Command(commandName)
+    {
+        AddArgument("commissioner-name", &mCommissionerName);
+#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+        AddArgument("trace_file", &mTraceFile);
+        AddArgument("trace_log", 0, 1, &mTraceLog);
+#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+    }
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
@@ -100,4 +107,12 @@ private:
     std::mutex cvWaitingForResponseMutex;
     bool mWaitingForResponse{ true };
 #endif // CONFIG_USE_SEPARATE_EVENTLOOP
+
+    void StartTracing();
+    void StopTracing();
+
+#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+    chip::Optional<char *> mTraceFile;
+    chip::Optional<bool> mTraceLog;
+#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 };

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -26,79 +26,6 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 
-#include <lib/support/CHIPArgParser.hpp>
-
-#include <core/CHIPBuildConfig.h>
-
-#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-#include "TraceHandlers.h"
-#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-
-namespace {
-
-#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-enum
-{
-    kOptionTraceFile = 0x1000,
-    kOptionTraceLog,
-};
-
-bool HandleTraceOptions(const char * program, chip::ArgParser::OptionSet * options, int identifier, const char * name,
-                        const char * value)
-{
-    switch (identifier)
-    {
-    case kOptionTraceLog:
-        chip::trace::SetTraceStream(new chip::trace::TraceStreamLog());
-        return true;
-    case kOptionTraceFile:
-        chip::trace::SetTraceStream(new chip::trace::TraceStreamFile(value));
-        return true;
-    default:
-        chip::ArgParser::PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", program, name);
-        return false;
-    }
-}
-
-chip::ArgParser::OptionDef traceCmdLineOptionDefs[] = { { "trace_file", chip::ArgParser::kArgumentRequired, kOptionTraceFile },
-                                                        { "trace_log", chip::ArgParser::kNoArgument, kOptionTraceLog },
-                                                        {} };
-
-const char * traceOptionHelp = "  --trace_file <file>\n"
-                               "       Output trace data to the specified file.\n"
-                               "  --trace_log\n"
-                               "       Output trace data to the log stream.\n"
-                               "\n";
-chip::ArgParser::OptionSet traceCmdLineOptions = { HandleTraceOptions, traceCmdLineOptionDefs, "TRACE OPTIONS", traceOptionHelp };
-#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-
-const char * kAppName     = "chip-tool";
-const char * kUsage       = "Usage: chip-tool [options] cluster command_name [param1] [param2]";
-const char * kVersion     = nullptr; // Unknown
-const char * kDescription = "A command line tool that uses Matter to send messages to a Matter server.";
-chip::ArgParser::HelpOptions helpOptions(kAppName, kUsage, kVersion, kDescription);
-
-chip::ArgParser::OptionSet * allOptions[] = {
-#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-    &traceCmdLineOptions,
-#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-    &helpOptions, nullptr
-};
-
-int gPositionalArgc       = 0;
-char ** gPositionalArgv   = nullptr;
-const char * gProgramName = nullptr;
-
-bool GetPositionalArgs(const char * prog, int argc, char * argv[])
-{
-    gProgramName    = prog;
-    gPositionalArgc = argc;
-    gPositionalArgv = argv;
-    return true;
-}
-
-} // namespace
-
 void Commands::Register(const char * clusterName, commands_list commandsList)
 {
     for (auto & command : commandsList)
@@ -119,81 +46,71 @@ int Commands::Run(int argc, char ** argv)
 
     chip::Logging::SetLogFilter(mStorage.GetLoggingLevel());
 
-    VerifyOrExit(chip::ArgParser::ParseArgs("chip-tool", argc, argv, allOptions, GetPositionalArgs),
-                 ChipLogError(chipTool, "Error parsing arguments"));
-
-#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-    chip::trace::InitTrace();
-#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-
-    err = RunCommand();
+    err = RunCommand(argc, argv);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Run command failure: %s", chip::ErrorStr(err)));
 
 exit:
-#if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-    chip::trace::DeInitTrace();
-#endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
     return (err == CHIP_NO_ERROR) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-CHIP_ERROR Commands::RunCommand()
+CHIP_ERROR Commands::RunCommand(int argc, char ** argv)
 {
     std::map<std::string, CommandsVector>::iterator cluster;
     Command * command = nullptr;
 
-    if (gPositionalArgc <= 0)
+    if (argc <= 1)
     {
         ChipLogError(chipTool, "Missing cluster name");
-        ShowClusters(gProgramName);
+        ShowClusters(argv[0]);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    cluster = GetCluster(gPositionalArgv[0]);
+    cluster = GetCluster(argv[1]);
     if (cluster == mClusters.end())
     {
-        ChipLogError(chipTool, "Unknown cluster: %s", gPositionalArgv[1]);
-        ShowClusters(gProgramName);
+        ChipLogError(chipTool, "Unknown cluster: %s", argv[1]);
+        ShowClusters(argv[0]);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (gPositionalArgc <= 1)
+    if (argc <= 2)
     {
         ChipLogError(chipTool, "Missing command name");
-        ShowCluster(gProgramName, gPositionalArgv[0], cluster->second);
+        ShowCluster(argv[0], argv[1], cluster->second);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (!IsGlobalCommand(gPositionalArgv[1]))
+    if (!IsGlobalCommand(argv[2]))
     {
-        command = GetCommand(cluster->second, gPositionalArgv[1]);
+        command = GetCommand(cluster->second, argv[2]);
         if (command == nullptr)
         {
-            ChipLogError(chipTool, "Unknown command: %s", gPositionalArgv[1]);
-            ShowCluster(gProgramName, gPositionalArgv[0], cluster->second);
+            ChipLogError(chipTool, "Unknown command: %s", argv[2]);
+            ShowCluster(argv[0], argv[1], cluster->second);
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
     }
     else
     {
-        if (gPositionalArgc <= 2)
+        if (argc <= 3)
         {
             ChipLogError(chipTool, "Missing attribute name");
-            ShowClusterAttributes(gProgramName, gPositionalArgv[0], gPositionalArgv[1], cluster->second);
+            ShowClusterAttributes(argv[0], argv[1], argv[2], cluster->second);
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
 
-        command = GetGlobalCommand(cluster->second, gPositionalArgv[1], gPositionalArgv[2]);
+        command = GetGlobalCommand(cluster->second, argv[2], argv[3]);
         if (command == nullptr)
         {
-            ChipLogError(chipTool, "Unknown attribute: %s", gPositionalArgv[2]);
-            ShowClusterAttributes(gProgramName, gPositionalArgv[0], gPositionalArgv[1], cluster->second);
+            ChipLogError(chipTool, "Unknown attribute: %s", argv[3]);
+            ShowClusterAttributes(argv[0], argv[1], argv[2], cluster->second);
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
     }
 
-    if (!command->InitArguments(gPositionalArgc - 2, &gPositionalArgv[2]))
+    if (!command->InitArguments(argc - 3, &argv[3]))
     {
-        ShowCommand(gProgramName, gPositionalArgv[0], command);
+        ShowCommand(argv[0], argv[1], command);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -31,7 +31,7 @@ public:
     int Run(int argc, char ** argv);
 
 private:
-    CHIP_ERROR RunCommand();
+    CHIP_ERROR RunCommand(int argc, char ** argv);
 
     std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);


### PR DESCRIPTION
#### Problem

Optional arguments parsing is broken in `chip-tool` after #12732.

#### Change overview
 * Fix the argument parsing to work with `chip-tool` custom parsing...

#### Testing
Tried with `./out/debug/standalone/chip-tool pairing onnetwork-long 0x12345 20202021 3840 --trace_file /tmp/foo.log --commissioner-name alpha` locally.

Fixes #13016