### PR TITLE
[chip-tool] Maintains multiple commissioners alive at the same time i…

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -55,7 +55,9 @@ CHIP_ERROR CHIPCommand::Run()
     factoryInitParams.listenPort    = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerIndex());
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
-    ReturnLogErrorOnFailure(InitializeCommissioner(GetIdentity(), CurrentCommissionerIndex()));
+    ReturnLogErrorOnFailure(InitializeCommissioner(kIdentityAlpha, kIdentityAlphaFabricId));
+    ReturnLogErrorOnFailure(InitializeCommissioner(kIdentityBeta, kIdentityBetaFabricId));
+    ReturnLogErrorOnFailure(InitializeCommissioner(kIdentityGamma, kIdentityGammaFabricId));
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(RunQueuedCommand, reinterpret_cast<intptr_t>(this));
     ReturnLogErrorOnFailure(StartWaiting(GetWaitDuration()));
@@ -67,7 +69,9 @@ CHIP_ERROR CHIPCommand::Run()
     // since the CHIP thread and event queue have been stopped, preventing any thread
     // races.
     //
-    ReturnLogErrorOnFailure(ShutdownCommissioner(GetIdentity()));
+    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityAlpha));
+    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityBeta));
+    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityGamma));
 
     StopTracing();
     return CHIP_NO_ERROR;
@@ -190,6 +194,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId f
     std::unique_ptr<ChipDeviceCommissioner> commissioner = std::make_unique<ChipDeviceCommissioner>();
     chip::Controller::SetupParams commissionerParams;
     commissionerParams.storageDelegate                = &mCommissionerStorage;
+    commissionerParams.fabricIndex                    = static_cast<chip::FabricIndex>(fabricId);
     commissionerParams.operationalCredentialsDelegate = &mOpCredsIssuer;
     commissionerParams.ephemeralKeypair               = &ephemeralKey;
     commissionerParams.controllerRCAC                 = rcacSpan;

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2732,21 +2732,12 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
- * @def CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES
- *
- * @brief Defines the max number of SessionCreationDelegates
- */
-#ifndef CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES
-#define CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES 2
-#endif
-
-/**
  * @def CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES
  *
  * @brief Defines the max number of SessionReleaseDelegate
  */
 #ifndef CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES
-#define CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES 2
+#define CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES 4
 #endif
 
 /**
@@ -2755,7 +2746,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief Defines the max number of SessionRecoveryDelegate
  */
 #ifndef CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES
-#define CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES 3
+#define CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES 4
 #endif
 
 /**


### PR DESCRIPTION
…n chip-tool

#### Problem

In order to write multi-admin tests, multiple commissioners are needed in `chip-tool`

#### Change overview
 * Add multiple instances of commissioners

