### PR TITLE
[nrfconnect] Update nRF Connect SDK in Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION} as build
 
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=ffcf07fe4586634a6793a48e5444a7196e7ebac6
+ARG NCS_REVISION=v1.8.0
 
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.39 Version bump reason: Push ESP forward, stop using 'depth 1' for checkouts
+0.5.40 Version bump reason: nRF Connect SDK update


### PR DESCRIPTION
#### Problem
nRF Connect SDK version is outdated.

#### Change overview
Update nRF Connect SDK in Docker.

#### Testing
Docker only.
