### PR TITLE
Cleanup legacy unused declarations

### DIFF
--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -46,8 +46,6 @@ class ThreadStackManagerImpl;
 class TimeSyncManager;
 
 namespace Internal {
-class FabricProvisioningServer;
-class ServiceProvisioningServer;
 class BLEManagerImpl;
 template <class>
 class GenericConfigurationManagerImpl;
@@ -199,8 +197,6 @@ private:
     friend class TraitManager;
     friend class ThreadStackManagerImpl;
     friend class TimeSyncManager;
-    friend class Internal::FabricProvisioningServer;
-    friend class Internal::ServiceProvisioningServer;
     friend class Internal::BLEManagerImpl;
     template <class>
     friend class Internal::GenericPlatformManagerImpl;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Those code is not used at all, seems inherited from Weave

#### Change overview
Cleanup legacy unused declarations

#### Testing
How was this tested? (at least one bullet point required)
* Cleanup only