### PR TITLE
Add Verhoeff algorithm check/generate in chip-tool

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -45,6 +45,7 @@ executable("chip-tool") {
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
+    "commands/payload/SetupPayloadVerhoeff.cpp",
     "commands/tests/TestCommand.cpp",
     "config/PersistentStorage.cpp",
     "main.cpp",
@@ -66,6 +67,7 @@ executable("chip-tool") {
   include_dirs = [
     ".",
     "${chip_root}/zzz_generated/chip-tool",
+    "${chip_root}/src/lib",
   ]
 
   if (chip_enable_transport_trace) {

--- a/examples/chip-tool/commands/payload/Commands.h
+++ b/examples/chip-tool/commands/payload/Commands.h
@@ -20,11 +20,17 @@
 
 #include "AdditionalDataParseCommand.h"
 #include "SetupPayloadParseCommand.h"
+#include "SetupPayloadVerhoeff.h"
 
 void registerCommandsPayload(Commands & commands)
 {
     const char * clusterName      = "Payload";
-    commands_list clusterCommands = { make_unique<SetupPayloadParseCommand>(), make_unique<AdditionalDataParseCommand>() };
+    commands_list clusterCommands = {
+        make_unique<SetupPayloadParseCommand>(),
+        make_unique<AdditionalDataParseCommand>(),
+        make_unique<SetupPayloadVerhoeffVerify>(),
+        make_unique<SetupPayloadVerhoeffGenerate>(),
+    };
 
     commands.Register(clusterName, clusterCommands);
 }

--- a/examples/chip-tool/commands/payload/SetupPayloadVerhoeff.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadVerhoeff.cpp
@@ -1,0 +1,76 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "SetupPayloadVerhoeff.h"
+#include "SetupPayloadParseCommand.h"
+#include <setup_payload/SetupPayload.h>
+#include <support/verhoeff/Verhoeff.h>
+
+using namespace ::chip;
+
+CHIP_ERROR SetupPayloadVerhoeffVerify::Run()
+{
+    std::string codeString(mSetupCode);
+
+    bool isQRCode = SetupPayloadParseCommand::IsQRCode(codeString);
+
+    VerifyOrReturnError(codeString.length() > mPos && mPos >= 0, CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrReturnError(!isQRCode, CHIP_ERROR_NOT_IMPLEMENTED);
+
+    ChipLogProgress(SetupPayload, "%s is %sVALID at position %u", codeString.c_str(), Verify(codeString) ? "" : "IN", mPos);
+
+    return CHIP_NO_ERROR;
+}
+
+bool SetupPayloadVerhoeffVerify::Verify(std::string codeString)
+{
+    char checkChar;
+    bool result;
+
+    checkChar = codeString.at(mPos);
+    codeString.erase(mPos, mPos);
+    ChipLogDetail(SetupPayload, "Verifying Manual Code: %s", codeString.c_str());
+
+    result = Verhoeff10::ValidateCheckChar(checkChar, codeString.c_str());
+
+    return result;
+}
+
+CHIP_ERROR SetupPayloadVerhoeffGenerate::Run()
+{
+    std::string codeString(mSetupCode);
+    char generatedChar;
+
+    ReturnErrorOnFailure(GenerateChar(codeString, generatedChar));
+    ChipLogProgress(SetupPayload, "Generated Char: %c", generatedChar);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SetupPayloadVerhoeffGenerate::GenerateChar(std::string codeString, char & generatedChar)
+{
+    bool isQRCode = SetupPayloadParseCommand::IsQRCode(codeString);
+
+    VerifyOrReturnError(!isQRCode, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ChipLogDetail(SetupPayload, "Generating Character for: %s", codeString.c_str());
+    generatedChar = Verhoeff10::ComputeCheckChar(codeString.c_str());
+
+    return CHIP_NO_ERROR;
+}
+//

--- a/examples/chip-tool/commands/payload/SetupPayloadVerhoeff.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadVerhoeff.h
@@ -21,15 +21,29 @@
 #include "../common/Command.h"
 #include <setup_payload/SetupPayload.h>
 
-class SetupPayloadParseCommand : public Command
+class SetupPayloadVerhoeffVerify : public Command
 {
 public:
-    SetupPayloadParseCommand() : Command("parse-setup-payload") { AddArgument("payload", &mCode); }
+    SetupPayloadVerhoeffVerify() : Command("verhoeff-verify")
+    {
+        AddArgument("payload", &mSetupCode);
+        AddArgument("position", 0, UINT8_MAX, &mPos);
+    }
     CHIP_ERROR Run() override;
-    static bool IsQRCode(std::string codeString);
 
 private:
-    char * mCode;
-    CHIP_ERROR Parse(std::string codeString, chip::SetupPayload & payload);
-    CHIP_ERROR Print(chip::SetupPayload payload);
+    char * mSetupCode;
+    uint8_t mPos;
+    bool Verify(std::string codeString);
+};
+
+class SetupPayloadVerhoeffGenerate : public Command
+{
+public:
+    SetupPayloadVerhoeffGenerate() : Command("verhoeff-generate") { AddArgument("payload", &mSetupCode); }
+    CHIP_ERROR Run() override;
+
+private:
+    char * mSetupCode;
+    CHIP_ERROR GenerateChar(std::string codeString, char & generatedChar);
 };


### PR DESCRIPTION
#### Problem
Add Verhoeff algorithm check/generate for the following issue #13025


#### Change overview
- Adds check/generate of the Verhoeff from lib/support

#### Testing
Tested using chip-tool and generated manual pairing code.
