### PR TITLE
Fix SessionHandle args so they are const ref

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -112,7 +112,7 @@ CHIP_ERROR CASESessionManager::GetPeerAddress(FabricInfo * fabric, NodeId nodeId
     return CHIP_NO_ERROR;
 }
 
-void CASESessionManager::OnSessionReleased(SessionHandle sessionHandle)
+void CASESessionManager::OnSessionReleased(const SessionHandle & sessionHandle)
 {
     OperationalDeviceProxy * session = FindSession(sessionHandle);
     VerifyOrReturn(session != nullptr, ChipLogDetail(Controller, "OnSessionReleased was called for unknown device, ignoring it."));
@@ -120,7 +120,7 @@ void CASESessionManager::OnSessionReleased(SessionHandle sessionHandle)
     session->OnSessionReleased(sessionHandle);
 }
 
-OperationalDeviceProxy * CASESessionManager::FindSession(SessionHandle session)
+OperationalDeviceProxy * CASESessionManager::FindSession(const SessionHandle & session)
 {
     return mConfig.devicePool->FindDevice(session);
 }

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -106,7 +106,7 @@ public:
     CHIP_ERROR GetPeerAddress(FabricInfo * fabric, NodeId nodeId, Transport::PeerAddress & addr);
 
     //////////// SessionReleaseDelegate Implementation ///////////////
-    void OnSessionReleased(SessionHandle session) override;
+    void OnSessionReleased(const SessionHandle & session) override;
 
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData) override;
@@ -114,7 +114,7 @@ public:
     void OnNodeDiscoveryComplete(const Dnssd::DiscoveredNodeData & nodeData) override {}
 
 private:
-    OperationalDeviceProxy * FindSession(SessionHandle session);
+    OperationalDeviceProxy * FindSession(const SessionHandle & session);
     void ReleaseSession(OperationalDeviceProxy * device);
 
     CASESessionManagerConfig mConfig;

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR CommandSender::AllocateBuffer()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CommandSender::SendCommandRequest(SessionHandle session, System::Clock::Timeout timeout)
+CHIP_ERROR CommandSender::SendCommandRequest(const SessionHandle & session, System::Clock::Timeout timeout)
 {
     VerifyOrReturnError(mState == State::AddedCommand, CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -213,7 +213,7 @@ public:
     // Client can specify the maximum time to wait for response (in milliseconds) via timeout parameter.
     // Default timeout value will be used otherwise.
     //
-    CHIP_ERROR SendCommandRequest(SessionHandle session, System::Clock::Timeout timeout = kImMessageTimeout);
+    CHIP_ERROR SendCommandRequest(const SessionHandle & session, System::Clock::Timeout timeout = kImMessageTimeout);
 
 private:
     friend class TestCommandInteraction;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -290,7 +290,7 @@ void OperationalDeviceProxy::DeferCloseCASESession()
     mSystemLayer->ScheduleWork(CloseCASESessionTask, this);
 }
 
-void OperationalDeviceProxy::OnSessionReleased(SessionHandle session)
+void OperationalDeviceProxy::OnSessionReleased(const SessionHandle & session)
 {
     VerifyOrReturn(mSecureSession.Contains(session),
                    ChipLogDetail(Controller, "Connection expired, but it doesn't match the current session"));

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -124,7 +124,7 @@ public:
      *   Called when a connection is closing.
      *   The object releases all resources associated with the connection.
      */
-    void OnSessionReleased(SessionHandle session) override;
+    void OnSessionReleased(const SessionHandle & session) override;
 
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeResolutionData)
     {
@@ -155,7 +155,7 @@ public:
 
     PeerId GetPeerId() const { return mPeerId; }
 
-    bool MatchesSession(SessionHandle session) const { return mSecureSession.Contains(session); }
+    bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
 
     uint8_t GetNextSequenceNumber() override { return mSequenceNumber++; };
 

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -33,7 +33,7 @@ public:
 
     virtual void Release(OperationalDeviceProxy * device) = 0;
 
-    virtual OperationalDeviceProxy * FindDevice(SessionHandle session) = 0;
+    virtual OperationalDeviceProxy * FindDevice(const SessionHandle & session) = 0;
 
     virtual OperationalDeviceProxy * FindDevice(NodeId id) = 0;
 
@@ -59,7 +59,7 @@ public:
 
     void Release(OperationalDeviceProxy * device) override { mDevicePool.ReleaseObject(device); }
 
-    OperationalDeviceProxy * FindDevice(SessionHandle session) override
+    OperationalDeviceProxy * FindDevice(const SessionHandle & session) override
     {
         OperationalDeviceProxy * foundDevice = nullptr;
         mDevicePool.ForEachActiveObject([&](auto * activeDevice) {

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -40,7 +40,7 @@ struct ReadPrepareParams
     uint16_t mMaxIntervalCeilingSeconds             = 0;
     bool mKeepSubscriptions                         = true;
 
-    ReadPrepareParams(SessionHandle sessionHandle) : mSessionHandle(sessionHandle) {}
+    ReadPrepareParams(const SessionHandle & sessionHandle) : mSessionHandle(sessionHandle) {}
     ReadPrepareParams(ReadPrepareParams && other) : mSessionHandle(other.mSessionHandle)
     {
         mKeepSubscriptions                 = other.mKeepSubscriptions;

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -211,7 +211,7 @@ void WriteClient::ClearState()
     MoveToState(State::Uninitialized);
 }
 
-CHIP_ERROR WriteClient::SendWriteRequest(SessionHandle session, System::Clock::Timeout timeout)
+CHIP_ERROR WriteClient::SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -385,7 +385,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR WriteClientHandle::SendWriteRequest(SessionHandle session, System::Clock::Timeout timeout)
+CHIP_ERROR WriteClientHandle::SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout)
 {
     CHIP_ERROR err = mpWriteClient->SendWriteRequest(session, timeout);
 

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -149,7 +149,7 @@ private:
      *  If SendWriteRequest is never called, or the call fails, the API
      *  consumer is responsible for calling Shutdown on the WriteClient.
      */
-    CHIP_ERROR SendWriteRequest(SessionHandle session, System::Clock::Timeout timeout);
+    CHIP_ERROR SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout);
 
     /**
      *  Initialize the client object. Within the lifetime
@@ -249,7 +249,7 @@ public:
      *  Finalize the message and send it to the desired node. The underlying write object will always be released, and the user
      * should not use this object after calling this function.
      */
-    CHIP_ERROR SendWriteRequest(SessionHandle session, System::Clock::Timeout timeout = kImMessageTimeout);
+    CHIP_ERROR SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout = kImMessageTimeout);
 
     /**
      *  Encode an attribute value that can be directly encoded using TLVWriter::Put

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -268,7 +268,7 @@ void DeviceController::ReleaseOperationalDevice(NodeId remoteDeviceId)
     mCASESessionManager->ReleaseSession(remoteDeviceId);
 }
 
-void DeviceController::OnSessionReleased(SessionHandle session)
+void DeviceController::OnSessionReleased(const SessionHandle & session)
 {
     VerifyOrReturn(mState == State::Initialized, ChipLogError(Controller, "OnConnectionExpired was called in incorrect state"));
     mCASESessionManager->OnSessionReleased(session);
@@ -684,7 +684,7 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     return CHIP_NO_ERROR;
 }
 
-void DeviceCommissioner::OnSessionReleased(SessionHandle session)
+void DeviceCommissioner::OnSessionReleased(const SessionHandle & session)
 {
     VerifyOrReturn(mState == State::Initialized, ChipLogError(Controller, "OnConnectionExpired was called in incorrect state"));
 
@@ -694,7 +694,7 @@ void DeviceCommissioner::OnSessionReleased(SessionHandle session)
     device->OnSessionReleased(session);
 }
 
-CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(SessionHandle session)
+CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(const SessionHandle & session)
 {
     CommissioneeDeviceProxy * foundDevice = nullptr;
     mCommissioneeDevicePool.ForEachActiveObject([&](auto * deviceProxy) {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -375,7 +375,7 @@ protected:
     ReliableMessageProtocolConfig mMRPConfig = gDefaultMRPConfig;
 
     //////////// SessionReleaseDelegate Implementation ///////////////
-    void OnSessionReleased(SessionHandle session) override;
+    void OnSessionReleased(const SessionHandle & session) override;
 
     //////////// SessionRecoveryDelegate Implementation ///////////////
     void OnFirstMessageDeliveryFailed(const SessionHandle & session) override;
@@ -682,7 +682,7 @@ private:
     void OnSessionEstablishmentTimeout();
 
     //////////// SessionReleaseDelegate Implementation ///////////////
-    void OnSessionReleased(SessionHandle session) override;
+    void OnSessionReleased(const SessionHandle & session) override;
 
     static void OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState);
 
@@ -777,7 +777,7 @@ private:
 
     void HandleAttestationResult(CHIP_ERROR err);
 
-    CommissioneeDeviceProxy * FindCommissioneeDevice(SessionHandle session);
+    CommissioneeDeviceProxy * FindCommissioneeDevice(const SessionHandle & session);
     CommissioneeDeviceProxy * FindCommissioneeDevice(NodeId id);
     void ReleaseCommissioneeDevice(CommissioneeDeviceProxy * device);
 

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR CommissioneeDeviceProxy::SendCommands(app::CommandSender * commandObj
     return commandObj->SendCommandRequest(mSecureSession.Get());
 }
 
-void CommissioneeDeviceProxy::OnSessionReleased(SessionHandle session)
+void CommissioneeDeviceProxy::OnSessionReleased(const SessionHandle & session)
 {
     VerifyOrReturn(mSecureSession.Contains(session),
                    ChipLogDetail(Controller, "Connection expired, but it doesn't match the current session"));

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -164,7 +164,7 @@ public:
      *
      * @param session A handle to the secure session
      */
-    void OnSessionReleased(SessionHandle session) override;
+    void OnSessionReleased(const SessionHandle & session) override;
 
     /**
      *  In case there exists an open session to the device, mark it as expired.
@@ -204,7 +204,7 @@ public:
 
     NodeId GetDeviceId() const override { return mDeviceId; }
 
-    bool MatchesSession(SessionHandle session) const { return mSecureSession.Contains(session); }
+    bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
 
     SessionHolder & GetSecureSessionHolder() { return mSecureSession; }
     chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }

--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -44,7 +44,7 @@ namespace Controller {
  */
 template <typename RequestObjectT>
 CHIP_ERROR
-InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, SessionHandle sessionHandle, chip::EndpointId endpointId,
+InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, const SessionHandle & sessionHandle, chip::EndpointId endpointId,
                      const RequestObjectT & requestCommandData,
                      typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnSuccessCallbackType onSuccessCb,
                      typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnErrorCallbackType onErrorCb,
@@ -91,7 +91,7 @@ InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, SessionHandle se
 
 template <typename RequestObjectT>
 CHIP_ERROR
-InvokeCommandRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle sessionHandle, chip::EndpointId endpointId,
+InvokeCommandRequest(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, chip::EndpointId endpointId,
                      const RequestObjectT & requestCommandData,
                      typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnSuccessCallbackType onSuccessCb,
                      typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnErrorCallbackType onErrorCb,
@@ -103,7 +103,7 @@ InvokeCommandRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle ses
 
 template <typename RequestObjectT, typename std::enable_if_t<!RequestObjectT::MustUseTimedInvoke(), int> = 0>
 CHIP_ERROR
-InvokeCommandRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle sessionHandle, chip::EndpointId endpointId,
+InvokeCommandRequest(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, chip::EndpointId endpointId,
                      const RequestObjectT & requestCommandData,
                      typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnSuccessCallbackType onSuccessCb,
                      typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnErrorCallbackType onErrorCb)

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -30,7 +30,10 @@ namespace detail {
 template <typename DecodableAttributeType>
 struct ReportAttributeParams : public app::ReadPrepareParams
 {
-    ReportAttributeParams(SessionHandle sessionHandle) : app::ReadPrepareParams(sessionHandle) { mKeepSubscriptions = false; }
+    ReportAttributeParams(const SessionHandle & sessionHandle) : app::ReadPrepareParams(sessionHandle)
+    {
+        mKeepSubscriptions = false;
+    }
     typename TypedReadAttributeCallback<DecodableAttributeType>::OnSuccessCallbackType mOnReportCb;
     typename TypedReadAttributeCallback<DecodableAttributeType>::OnErrorCallbackType mOnErrorCb;
     typename TypedReadAttributeCallback<DecodableAttributeType>::OnSubscriptionEstablishedCallbackType
@@ -84,7 +87,7 @@ CHIP_ERROR ReportAttribute(Messaging::ExchangeManager * exchangeMgr, EndpointId 
  * basis, we have a helper that's just templated on the type.
  */
 template <typename DecodableAttributeType>
-CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, EndpointId endpointId,
                          ClusterId clusterId, AttributeId attributeId,
                          typename TypedReadAttributeCallback<DecodableAttributeType>::OnSuccessCallbackType onSuccessCb,
                          typename TypedReadAttributeCallback<DecodableAttributeType>::OnErrorCallbackType onErrorCb)
@@ -106,7 +109,7 @@ CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * exchangeMgr, const Session
  */
 template <typename AttributeTypeInfo>
 CHIP_ERROR
-ReadAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+ReadAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, EndpointId endpointId,
               typename TypedReadAttributeCallback<typename AttributeTypeInfo::DecodableType>::OnSuccessCallbackType onSuccessCb,
               typename TypedReadAttributeCallback<typename AttributeTypeInfo::DecodableType>::OnErrorCallbackType onErrorCb)
 {
@@ -117,7 +120,7 @@ ReadAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle sess
 
 // Helper for SubscribeAttribute to reduce the amount of code generated.
 template <typename DecodableAttributeType>
-CHIP_ERROR SubscribeAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+CHIP_ERROR SubscribeAttribute(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, EndpointId endpointId,
                               ClusterId clusterId, AttributeId attributeId,
                               typename TypedReadAttributeCallback<DecodableAttributeType>::OnSuccessCallbackType onReportCb,
                               typename TypedReadAttributeCallback<DecodableAttributeType>::OnErrorCallbackType onErrorCb,
@@ -142,7 +145,7 @@ CHIP_ERROR SubscribeAttribute(Messaging::ExchangeManager * exchangeMgr, const Se
  */
 template <typename AttributeTypeInfo>
 CHIP_ERROR SubscribeAttribute(
-    Messaging::ExchangeManager * exchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+    Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, EndpointId endpointId,
     typename TypedReadAttributeCallback<typename AttributeTypeInfo::DecodableType>::OnSuccessCallbackType onReportCb,
     typename TypedReadAttributeCallback<typename AttributeTypeInfo::DecodableType>::OnErrorCallbackType onErrorCb,
     uint16_t aMinIntervalFloorSeconds, uint16_t aMaxIntervalCeilingSeconds,
@@ -159,7 +162,7 @@ namespace detail {
 template <typename DecodableEventType>
 struct ReportEventParams : public app::ReadPrepareParams
 {
-    ReportEventParams(SessionHandle sessionHandle) : app::ReadPrepareParams(sessionHandle) { mKeepSubscriptions = false; }
+    ReportEventParams(const SessionHandle & sessionHandle) : app::ReadPrepareParams(sessionHandle) { mKeepSubscriptions = false; }
     typename TypedReadEventCallback<DecodableEventType>::OnSuccessCallbackType mOnReportCb;
     typename TypedReadEventCallback<DecodableEventType>::OnErrorCallbackType mOnErrorCb;
     typename TypedReadEventCallback<DecodableEventType>::OnSubscriptionEstablishedCallbackType mOnSubscriptionEstablishedCb =
@@ -220,7 +223,7 @@ CHIP_ERROR ReportEvent(Messaging::ExchangeManager * apExchangeMgr, EndpointId en
  * GetEventId() methods is expected to work.
  */
 template <typename DecodableEventType>
-CHIP_ERROR ReadEvent(Messaging::ExchangeManager * exchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+CHIP_ERROR ReadEvent(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, EndpointId endpointId,
                      typename TypedReadEventCallback<DecodableEventType>::OnSuccessCallbackType onSuccessCb,
                      typename TypedReadEventCallback<DecodableEventType>::OnErrorCallbackType onErrorCb)
 {
@@ -235,7 +238,7 @@ CHIP_ERROR ReadEvent(Messaging::ExchangeManager * exchangeMgr, const SessionHand
  * similarly to ReadEvent but keeps reporting events as they are emitted.
  */
 template <typename DecodableEventType>
-CHIP_ERROR SubscribeEvent(Messaging::ExchangeManager * exchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+CHIP_ERROR SubscribeEvent(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle, EndpointId endpointId,
                           typename TypedReadEventCallback<DecodableEventType>::OnSuccessCallbackType onReportCb,
                           typename TypedReadEventCallback<DecodableEventType>::OnErrorCallbackType onErrorCb,
                           uint16_t minIntervalFloorSeconds, uint16_t maxIntervalCeilingSeconds,

--- a/src/controller/WriteInteraction.h
+++ b/src/controller/WriteInteraction.h
@@ -95,8 +95,8 @@ private:
  * with a small number of instantiations (one per type).
  */
 template <typename AttrType>
-CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
-                          const AttrType & requestData, WriteCallback::OnSuccessCallbackType onSuccessCb,
+CHIP_ERROR WriteAttribute(const SessionHandle & sessionHandle, chip::EndpointId endpointId, ClusterId clusterId,
+                          AttributeId attributeId, const AttrType & requestData, WriteCallback::OnSuccessCallbackType onSuccessCb,
                           WriteCallback::OnErrorCallbackType onErrorCb, const Optional<uint16_t> & aTimedWriteTimeoutMs,
                           WriteCallback::OnDoneCallbackType onDoneCb = nullptr)
 {
@@ -124,7 +124,7 @@ CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpoint
 }
 
 template <typename AttributeInfo>
-CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpointId,
+CHIP_ERROR WriteAttribute(const SessionHandle & sessionHandle, chip::EndpointId endpointId,
                           const typename AttributeInfo::Type & requestData, WriteCallback::OnSuccessCallbackType onSuccessCb,
                           WriteCallback::OnErrorCallbackType onErrorCb, const Optional<uint16_t> & aTimedWriteTimeoutMs,
                           WriteCallback::OnDoneCallbackType onDoneCb = nullptr)
@@ -134,7 +134,7 @@ CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpoint
 }
 
 template <typename AttributeInfo>
-CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpointId,
+CHIP_ERROR WriteAttribute(const SessionHandle & sessionHandle, chip::EndpointId endpointId,
                           const typename AttributeInfo::Type & requestData, WriteCallback::OnSuccessCallbackType onSuccessCb,
                           WriteCallback::OnErrorCallbackType onErrorCb, uint16_t aTimedWriteTimeoutMs,
                           WriteCallback::OnDoneCallbackType onDoneCb = nullptr)
@@ -144,7 +144,7 @@ CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpoint
 }
 
 template <typename AttributeInfo, typename std::enable_if_t<!AttributeInfo::MustUseTimedWrite(), int> = 0>
-CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpointId,
+CHIP_ERROR WriteAttribute(const SessionHandle & sessionHandle, chip::EndpointId endpointId,
                           const typename AttributeInfo::Type & requestData, WriteCallback::OnSuccessCallbackType onSuccessCb,
                           WriteCallback::OnErrorCallbackType onErrorCb, WriteCallback::OnDoneCallbackType onDoneCb = nullptr)
 {

--- a/src/messaging/ApplicationExchangeDispatch.cpp
+++ b/src/messaging/ApplicationExchangeDispatch.cpp
@@ -26,14 +26,14 @@
 namespace chip {
 namespace Messaging {
 
-CHIP_ERROR ApplicationExchangeDispatch::PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR ApplicationExchangeDispatch::PrepareMessage(const SessionHandle & session, PayloadHeader & payloadHeader,
                                                        System::PacketBufferHandle && message,
                                                        EncryptedPacketBufferHandle & preparedMessage)
 {
     return mSessionManager->PrepareMessage(session, payloadHeader, std::move(message), preparedMessage);
 }
 
-CHIP_ERROR ApplicationExchangeDispatch::SendPreparedMessage(SessionHandle session,
+CHIP_ERROR ApplicationExchangeDispatch::SendPreparedMessage(const SessionHandle & session,
                                                             const EncryptedPacketBufferHandle & preparedMessage) const
 {
     return mSessionManager->SendPreparedMessage(session, preparedMessage);

--- a/src/messaging/ApplicationExchangeDispatch.h
+++ b/src/messaging/ApplicationExchangeDispatch.h
@@ -45,9 +45,9 @@ public:
         return ExchangeMessageDispatch::Init();
     }
 
-    CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
+    CHIP_ERROR PrepareMessage(const SessionHandle & session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
                               EncryptedPacketBufferHandle & preparedMessage) override;
-    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & message) const override;
+    CHIP_ERROR SendPreparedMessage(const SessionHandle & session, const EncryptedPacketBufferHandle & message) const override;
 
     SessionManager * GetSessionManager() const { return mSessionManager; }
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -248,7 +248,7 @@ void ExchangeContextDeletor::Release(ExchangeContext * ec)
     ec->mExchangeMgr->ReleaseContext(ec);
 }
 
-ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SessionHandle session, bool Initiator,
+ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, const SessionHandle & session, bool Initiator,
                                  ExchangeDelegate * delegate)
 {
     VerifyOrDie(mExchangeMgr == nullptr);
@@ -312,7 +312,8 @@ ExchangeContext::~ExchangeContext()
     SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumContexts);
 }
 
-bool ExchangeContext::MatchExchange(SessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader)
+bool ExchangeContext::MatchExchange(const SessionHandle & session, const PacketHeader & packetHeader,
+                                    const PayloadHeader & payloadHeader)
 {
     // A given message is part of a particular exchange if...
     return

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -63,7 +63,8 @@ class DLL_EXPORT ExchangeContext : public ReliableMessageContext, public Referen
 public:
     typedef System::Clock::Timeout Timeout; // Type used to express the timeout in this ExchangeContext
 
-    ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SessionHandle session, bool Initiator, ExchangeDelegate * delegate);
+    ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, const SessionHandle & session, bool Initiator,
+                    ExchangeDelegate * delegate);
 
     ~ExchangeContext();
 
@@ -226,7 +227,7 @@ private:
      *  @retval  true                                       If a match is found.
      *  @retval  false                                      If a match is not found.
      */
-    bool MatchExchange(SessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
+    bool MatchExchange(const SessionHandle & session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
 
     /**
      * Notify the exchange that its connection has expired.

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -41,7 +41,7 @@
 namespace chip {
 namespace Messaging {
 
-CHIP_ERROR ExchangeMessageDispatch::SendMessage(SessionHandle session, uint16_t exchangeId, bool isInitiator,
+CHIP_ERROR ExchangeMessageDispatch::SendMessage(const SessionHandle & session, uint16_t exchangeId, bool isInitiator,
                                                 ReliableMessageContext * reliableMessageContext, bool isReliableTransmission,
                                                 Protocols::Id protocol, uint8_t type, System::PacketBufferHandle && message)
 {

--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -43,7 +43,7 @@ public:
 
     virtual bool IsEncryptionRequired() const { return true; }
 
-    CHIP_ERROR SendMessage(SessionHandle session, uint16_t exchangeId, bool isInitiator,
+    CHIP_ERROR SendMessage(const SessionHandle & session, uint16_t exchangeId, bool isInitiator,
                            ReliableMessageContext * reliableMessageContext, bool isReliableTransmission, Protocols::Id protocol,
                            uint8_t type, System::PacketBufferHandle && message);
 
@@ -56,9 +56,10 @@ public:
      * @param message         The payload to be sent
      * @param preparedMessage The handle to hold the prepared message
      */
-    virtual CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
-                                      EncryptedPacketBufferHandle & preparedMessage)                                         = 0;
-    virtual CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const = 0;
+    virtual CHIP_ERROR PrepareMessage(const SessionHandle & session, PayloadHeader & payloadHeader,
+                                      System::PacketBufferHandle && message, EncryptedPacketBufferHandle & preparedMessage) = 0;
+    virtual CHIP_ERROR SendPreparedMessage(const SessionHandle & session,
+                                           const EncryptedPacketBufferHandle & preparedMessage) const                       = 0;
 
     virtual CHIP_ERROR OnMessageReceived(uint32_t messageCounter, const PayloadHeader & payloadHeader,
                                          const Transport::PeerAddress & peerAddress, MessageFlags msgFlags,

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -116,7 +116,7 @@ CHIP_ERROR ExchangeManager::Shutdown()
     return CHIP_NO_ERROR;
 }
 
-ExchangeContext * ExchangeManager::NewContext(SessionHandle session, ExchangeDelegate * delegate)
+ExchangeContext * ExchangeManager::NewContext(const SessionHandle & session, ExchangeDelegate * delegate)
 {
     return mContextPool.CreateObject(this, mNextExchangeId++, session, true, delegate);
 }
@@ -188,8 +188,8 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgT
 }
 
 void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                        SessionHandle session, const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
-                                        System::PacketBufferHandle && msgBuf)
+                                        const SessionHandle & session, const Transport::PeerAddress & source,
+                                        DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf)
 {
     UnsolicitedMessageHandler * matchingUMH = nullptr;
 
@@ -314,12 +314,12 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     }
 }
 
-void ExchangeManager::OnSessionReleased(SessionHandle session)
+void ExchangeManager::OnSessionReleased(const SessionHandle & session)
 {
     ExpireExchangesForSession(session);
 }
 
-void ExchangeManager::ExpireExchangesForSession(SessionHandle session)
+void ExchangeManager::ExpireExchangesForSession(const SessionHandle & session)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->mSession.Contains(session))

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -99,7 +99,7 @@ public:
      *  @return   A pointer to the created ExchangeContext object On success. Otherwise NULL if no object
      *            can be allocated or is available.
      */
-    ExchangeContext * NewContext(SessionHandle session, ExchangeDelegate * delegate);
+    ExchangeContext * NewContext(const SessionHandle & session, ExchangeDelegate * delegate);
 
     void ReleaseContext(ExchangeContext * ec) { mContextPool.ReleaseObject(ec); }
 
@@ -195,7 +195,7 @@ public:
 
     // TODO: this should be test only, after OnSessionReleased is move to SessionHandle within the exchange context
     // Expire all exchanges associated with the given session
-    void ExpireExchangesForSession(SessionHandle session);
+    void ExpireExchangesForSession(const SessionHandle & session);
 
 private:
     enum class State
@@ -243,11 +243,11 @@ private:
     CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate);
     CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
 
-    void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SessionHandle session,
+    void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,
                            const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
                            System::PacketBufferHandle && msgBuf) override;
 
-    void OnSessionReleased(SessionHandle session) override;
+    void OnSessionReleased(const SessionHandle & session) override;
 };
 
 } // namespace Messaging

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -67,7 +67,7 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr, SessionHandle session);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & session);
 
     /**
      *  Shutdown the EchoClient. This terminates this instance

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -32,7 +32,7 @@ namespace Echo {
 // The Echo message timeout value in milliseconds.
 constexpr System::Clock::Timeout kEchoMessageTimeout = System::Clock::Milliseconds32(800);
 
-CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SessionHandle session)
+CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, const SessionHandle & session)
 {
     // Error if already initialized.
     if (mExchangeMgr != nullptr)

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -60,7 +60,7 @@ void MessageCounterManager::Shutdown()
     }
 }
 
-CHIP_ERROR MessageCounterManager::StartSync(SessionHandle session, Transport::SecureSession * state)
+CHIP_ERROR MessageCounterManager::StartSync(const SessionHandle & session, Transport::SecureSession * state)
 {
     // Initiate message counter synchronization if no message counter synchronization is in progress.
     Transport::PeerMessageCounter & counter = state->GetSessionMessageCounter().GetPeerMessageCounter();
@@ -72,7 +72,7 @@ CHIP_ERROR MessageCounterManager::StartSync(SessionHandle session, Transport::Se
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
+CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, const SessionHandle & session,
                                                                    Transport::SecureSession * state,
                                                                    const Transport::PeerAddress & peerAddress,
                                                                    System::PacketBufferHandle && msgBuf)
@@ -175,7 +175,7 @@ void MessageCounterManager::ProcessPendingMessages(NodeId peerNodeId)
     }
 }
 
-CHIP_ERROR MessageCounterManager::SendMsgCounterSyncReq(SessionHandle session, Transport::SecureSession * state)
+CHIP_ERROR MessageCounterManager::SendMsgCounterSyncReq(const SessionHandle & session, Transport::SecureSession * state)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -46,8 +46,8 @@ public:
     void Shutdown();
 
     // Implement MessageCounterManagerInterface
-    CHIP_ERROR StartSync(SessionHandle session, Transport::SecureSession * state) override;
-    CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
+    CHIP_ERROR StartSync(const SessionHandle & session, Transport::SecureSession * state) override;
+    CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, const SessionHandle & session,
                                                 Transport::SecureSession * state, const Transport::PeerAddress & peerAddress,
                                                 System::PacketBufferHandle && msgBuf) override;
 
@@ -63,7 +63,7 @@ public:
      * @retval  #CHIP_NO_ERROR                On success.
      *
      */
-    CHIP_ERROR SendMsgCounterSyncReq(SessionHandle session, Transport::SecureSession * state);
+    CHIP_ERROR SendMsgCounterSyncReq(const SessionHandle & session, Transport::SecureSession * state);
 
     /**
      *  Add a CHIP message into the cache table to queue the incoming messages that trigger message counter synchronization

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -28,14 +28,14 @@ namespace chip {
 
 using namespace Messaging;
 
-CHIP_ERROR SessionEstablishmentExchangeDispatch::PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR SessionEstablishmentExchangeDispatch::PrepareMessage(const SessionHandle & session, PayloadHeader & payloadHeader,
                                                                 System::PacketBufferHandle && message,
                                                                 EncryptedPacketBufferHandle & preparedMessage)
 {
     return mSessionManager->PrepareMessage(session, payloadHeader, std::move(message), preparedMessage);
 }
 
-CHIP_ERROR SessionEstablishmentExchangeDispatch::SendPreparedMessage(SessionHandle session,
+CHIP_ERROR SessionEstablishmentExchangeDispatch::SendPreparedMessage(const SessionHandle & session,
                                                                      const EncryptedPacketBufferHandle & preparedMessage) const
 {
     return mSessionManager->SendPreparedMessage(session, preparedMessage);

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -43,9 +43,10 @@ public:
         return ExchangeMessageDispatch::Init();
     }
 
-    CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
+    CHIP_ERROR PrepareMessage(const SessionHandle & session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
                               EncryptedPacketBufferHandle & out) override;
-    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const override;
+    CHIP_ERROR SendPreparedMessage(const SessionHandle & session,
+                                   const EncryptedPacketBufferHandle & preparedMessage) const override;
 
     CHIP_ERROR OnMessageReceived(uint32_t messageCounter, const PayloadHeader & payloadHeader,
                                  const Transport::PeerAddress & peerAddress, Messaging::MessageFlags msgFlags,

--- a/src/transport/MessageCounterManagerInterface.h
+++ b/src/transport/MessageCounterManagerInterface.h
@@ -31,13 +31,13 @@ public:
     /**
      * Start sync if the sync procedure is not started yet.
      */
-    virtual CHIP_ERROR StartSync(SessionHandle session, Transport::SecureSession * state) = 0;
+    virtual CHIP_ERROR StartSync(const SessionHandle & session, Transport::SecureSession * state) = 0;
 
     /**
      * Called when have received a message but session message counter is not synced.  It will queue the message and start sync if
      * the sync procedure is not started yet.
      */
-    virtual CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
+    virtual CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, const SessionHandle & session,
                                                         Transport::SecureSession * state,
                                                         const Transport::PeerAddress & peerAddress,
                                                         System::PacketBufferHandle && msgBuf) = 0;

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -31,7 +31,7 @@ public:
      *
      * @param session   The handle to the secure session
      */
-    virtual void OnSessionReleased(SessionHandle session) = 0;
+    virtual void OnSessionReleased(const SessionHandle & session) = 0;
 };
 
 class DLL_EXPORT SessionRecoveryDelegate

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -33,7 +33,7 @@ class SessionHolder : public SessionReleaseDelegate
 {
 public:
     SessionHolder() {}
-    SessionHolder(SessionHandle session) : mSession(session) {}
+    SessionHolder(const SessionHandle & session) : mSession(session) {}
     ~SessionHolder() { Release(); }
 
     SessionHolder(const SessionHolder &);
@@ -41,7 +41,7 @@ public:
     SessionHolder(SessionHolder && that);
     SessionHolder operator=(SessionHolder && that);
 
-    void Grab(SessionHandle sessionHandle)
+    void Grab(const SessionHandle & sessionHandle)
     {
         Release();
         mSession.SetValue(sessionHandle);
@@ -51,13 +51,13 @@ public:
 
     // TODO: call this function when the underlying session is released
     // Implement SessionReleaseDelegate
-    void OnSessionReleased(SessionHandle session) override { Release(); }
+    void OnSessionReleased(const SessionHandle & session) override { Release(); }
 
     // Check whether the SessionHolder contains a session matching given session
     bool Contains(const SessionHandle & session) const { return mSession.HasValue() && mSession.Value() == session; }
 
     operator bool() const { return mSession.HasValue(); }
-    SessionHandle Get() const { return mSession.Value(); }
+    const SessionHandle & Get() const { return mSession.Value(); }
     Optional<SessionHandle> ToOptional() const { return mSession; }
 
 private:

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -106,7 +106,7 @@ void SessionManager::Shutdown()
     mCB           = nullptr;
 }
 
-CHIP_ERROR SessionManager::PrepareMessage(SessionHandle sessionHandle, PayloadHeader & payloadHeader,
+CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, PayloadHeader & payloadHeader,
                                           System::PacketBufferHandle && message, EncryptedPacketBufferHandle & preparedMessage)
 {
     PacketHeader packetHeader;
@@ -189,7 +189,8 @@ CHIP_ERROR SessionManager::PrepareMessage(SessionHandle sessionHandle, PayloadHe
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SessionManager::SendPreparedMessage(SessionHandle sessionHandle, const EncryptedPacketBufferHandle & preparedMessage)
+CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHandle,
+                                               const EncryptedPacketBufferHandle & preparedMessage)
 {
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(!preparedMessage.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
@@ -265,7 +266,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(SessionHandle sessionHandle, cons
     }
 }
 
-void SessionManager::ExpirePairing(SessionHandle sessionHandle)
+void SessionManager::ExpirePairing(const SessionHandle & sessionHandle)
 {
     SecureSession * session = GetSecureSession(sessionHandle);
     if (session != nullptr)
@@ -632,7 +633,7 @@ void SessionManager::ExpiryTimerCallback(System::Layer * layer, void * param)
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
 }
 
-SecureSession * SessionManager::GetSecureSession(SessionHandle session)
+SecureSession * SessionManager::GetSecureSession(const SessionHandle & session)
 {
     if (session.mLocalSessionId.HasValue())
     {

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -134,16 +134,16 @@ public:
      *    3. Encode the packet header and prepend it to message.
      *   Returns a encrypted message in encryptedMessage.
      */
-    CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf,
+    CHIP_ERROR PrepareMessage(const SessionHandle & session, PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf,
                               EncryptedPacketBufferHandle & encryptedMessage);
 
     /**
      * @brief
      *   Send a prepared message to a currently connected peer.
      */
-    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage);
+    CHIP_ERROR SendPreparedMessage(const SessionHandle & session, const EncryptedPacketBufferHandle & preparedMessage);
 
-    Transport::SecureSession * GetSecureSession(SessionHandle session);
+    Transport::SecureSession * GetSecureSession(const SessionHandle & session);
 
     /// @brief Set the delegate for handling incoming messages. There can be only one message delegate (probably the
     /// ExchangeManager)
@@ -190,7 +190,7 @@ public:
     CHIP_ERROR NewPairing(SessionHolder & sessionHolder, const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                           PairingSession * pairing, CryptoContext::SessionRole direction, FabricIndex fabric);
 
-    void ExpirePairing(SessionHandle session);
+    void ExpirePairing(const SessionHandle & session);
     void ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric);
     void ExpireAllPairingsForFabric(FabricIndex fabric);
 

--- a/src/transport/SessionMessageDelegate.h
+++ b/src/transport/SessionMessageDelegate.h
@@ -50,9 +50,9 @@ public:
      * @param isDuplicate   The message is a duplicate of previously received message
      * @param msgBuf        The received message
      */
-    virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SessionHandle session,
-                                   const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
-                                   System::PacketBufferHandle && msgBuf) = 0;
+    virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                                   const SessionHandle & session, const Transport::PeerAddress & source,
+                                   DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf) = 0;
 };
 
 } // namespace chip

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -62,7 +62,7 @@ const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
 class TestSessMgrCallback : public SessionReleaseDelegate, public SessionMessageDelegate
 {
 public:
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SessionHandle session,
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, const SessionHandle & session,
                            const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
                            System::PacketBufferHandle && msgBuf) override
     {
@@ -84,7 +84,7 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    void OnSessionReleased(SessionHandle session) override { mOldConnectionDropped = true; }
+    void OnSessionReleased(const SessionHandle & session) override { mOldConnectionDropped = true; }
 
     bool mOldConnectionDropped = false;
 


### PR DESCRIPTION
#### Problem
SessionHandle args sometimes passed by value (costly) and even const value
(mistake?) in addition to const reference (preferred).

#### Change overview
Change SessionHandle args to const reference.

Decreases size on 11 of 12 builds, by about 1K (but notably 6K for p6).

#### Testing
Build, unit tests, CI.
