### PR TITLE
[Size reports] Remove .heap section from reports

### DIFF
--- a/scripts/tools/memory/platform/mbed.cfg
+++ b/scripts/tools/memory/platform/mbed.cfg
@@ -18,7 +18,7 @@
     'section': {
         # By default, only these sections will be included
         # when operating by sections.
-        'default': ['.text', '.data', '.bss', '.heap'],
+        'default': ['.text', '.data', '.bss'],
     },
 #   'symbol': {
 #       'free': {

--- a/scripts/tools/memory/platform/p6.cfg
+++ b/scripts/tools/memory/platform/p6.cfg
@@ -18,7 +18,7 @@
     'section': {
         # By default, only these sections will be included
         # when operating by sections.
-        'default': ['.text', '.data', '.bss', '.heap'],
+        'default': ['.text', '.data', '.bss'],
     },
 #   'symbol': {
 #       'free': {


### PR DESCRIPTION
#### Problem

For platforms that use it, the `.heap` section indicates memory
available for the heap, that is, RAM not otherwise in use.
Including it in size reports is confusing because a `.heap` increase
is good.

#### Change overview

Remove `.heap` from the default section list of the platforms
where it currently appears, namely Mbed and P6.

#### Testing

Manually checked on a P6 binary.
