### PR TITLE
[Android] Handle CharString command responses for cluster info mapping

### DIFF
--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -249,20 +249,21 @@ public class ClusterInfoMapping {
         @Override
         public void onSuccess(List<{{#>list_attribute_callback_type}}ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{/list_attribute_callback_type}}> valueList) {
           Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
+          CommandResponseInfo commandResponseInfo = 
           {{#if isStruct}}
-            CommandResponseInfo commandResponseInfo = new CommandResponseInfo("valueList", "List<ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{asUpperCamelCase name}}Attribute>");
+            new CommandResponseInfo("valueList", "List<ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{asUpperCamelCase name}}Attribute>");
           {{else}}
             {{#if (isOctetString type)}}
-            CommandResponseInfo commandResponseInfo = new CommandResponseInfo("valueList", "List<byte[]>");
+            new CommandResponseInfo("valueList", "List<byte[]>");
             {{else if (isCharString type)}}
-            // Add String field here after ByteSpan is properly emitted in C++ layer
+            new CommandResponseInfo("valueList", "List<String>");
             {{else}}
             {{! NOTE: asJavaBasicTypeForZclType does not handle isArray well, so
                 add an inline partial to force isArray to false when we want the
                 types of list entries. }}
             {{~#*inline "asBoxedJavaBasicType"}}{{asJavaBasicTypeForZclType type true}}{{/inline~}}
             {{~#*inline "asBoxedJavaBasicTypeForEntry"}}{{> asBoxedJavaBasicType isArray=false}}{{/inline~}}
-            CommandResponseInfo commandResponseInfo = new CommandResponseInfo("valueList", "List<{{>asBoxedJavaBasicTypeForEntry}}>");
+            new CommandResponseInfo("valueList", "List<{{>asBoxedJavaBasicTypeForEntry}}>");
             {{/if}}
           {{/if}}
 


### PR DESCRIPTION
#### Problem
* `CommandResponseInfo` is not produced for list of CharString attribute types, resulting in build failures if any attribute of this type is activated.

#### Change overview
* Handle CharString case (`List<String>`)

#### Testing
* CI
