### PR TITLE
[Inet] ToLwIPAddr() with IPAddressType

### DIFF
--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <type_traits>
 
+#include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/DLLUtil.h>
 
@@ -483,6 +484,15 @@ public:
      * @return  An LwIP ip_addr_t structure corresponding to the IP address.
      */
     ip_addr_t ToLwIPAddr(void) const;
+
+    /**
+     * Extract the IP address as a LwIP ip_addr_t structure.
+     *
+     * If the IP address is Any, the result is IP6_ADDR_ANY unless the requested addressType is kIPv4.
+     * If the requested addressType is IPAddressType::kAny, extracts the IP address as an LwIP ip_addr_t structure.
+     * Otherwise, returns INET_ERROR_WRONG_ADDRESS_TYPE if the requested addressType does not match the IP address.
+     */
+    CHIP_ERROR ToLwIPAddr(IPAddressType addressType, ip_addr_t & outAddress) const;
 
     /**
      * @brief   Convert the INET layer address type to its underlying LwIP type.

--- a/src/inet/TCPEndPointImplLwIP.cpp
+++ b/src/inet/TCPEndPointImplLwIP.cpp
@@ -67,30 +67,18 @@ CHIP_ERROR TCPEndPointImplLwIP::BindImpl(IPAddressType addrType, const IPAddress
     CHIP_ERROR res = GetPCB(addrType);
 
     // Bind the PCB to the specified address/port.
+    ip_addr_t ipAddr;
     if (res == CHIP_NO_ERROR)
     {
         if (reuseAddr)
         {
             ip_set_option(mTCP, SOF_REUSEADDR);
         }
+        res = addr.ToLwIPAddr(addrType, ipAddr);
+    }
 
-        ip_addr_t ipAddr;
-        if (addr != IPAddress::Any)
-        {
-            ipAddr = addr.ToLwIPAddr();
-        }
-        else if (addrType == IPAddressType::kIPv6)
-        {
-            ipAddr = ip6_addr_any;
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == IPAddressType::kIPv4)
-        {
-            ipAddr = ip_addr_any;
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-        else
-            res = INET_ERROR_WRONG_ADDRESS_TYPE;
+    if (res == CHIP_NO_ERROR)
+    {
         res = chip::System::MapErrorLwIP(tcp_bind(mTCP, &ipAddr, port));
     }
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -72,22 +72,14 @@ CHIP_ERROR UDPEndPointImplLwIP::BindImpl(IPAddressType addressType, const IPAddr
     CHIP_ERROR res = GetPCB(addressType);
 
     // Bind the PCB to the specified address/port.
+    ip_addr_t ipAddr;
     if (res == CHIP_NO_ERROR)
     {
-        ip_addr_t ipAddr = address.ToLwIPAddr();
+        res = address.ToLwIPAddr(addressType, ipAddr);
+    }
 
-        // TODO: IPAddress ANY has only one constant state, however addressType
-        // has separate IPV4 and IPV6 'any' settings. This tries to correct
-        // for this as LWIP default if IPv4 is compiled in is to consider
-        // 'any == any_v4'
-        //
-        // We may want to consider having separate AnyV4 and AnyV6 constants
-        // inside CHIP to resolve this ambiguity
-        if ((address.Type() == IPAddressType::kAny) && (addressType == IPAddressType::kIPv6))
-        {
-            ipAddr = *IP6_ADDR_ANY;
-        }
-
+    if (res == CHIP_NO_ERROR)
+    {
         res = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipAddr, port));
     }
 


### PR DESCRIPTION
#### Problem

Fixes #11273 _IPAddress ANY has only one constant state, however addressType_

#### Change overview

Factor similar code in UDP and TCP into a new version of
`IPAddress::ToLwIPAddr()` that accounts for the requested
address type (IPv4 vs IPv6).

#### Testing

Added a unit test.
