### PR TITLE
Add port config in App Lauch with define flag.

### DIFF
--- a/examples/placeholder/linux/apps/app1/include/CHIPProjectConfig.h
+++ b/examples/placeholder/linux/apps/app1/include/CHIPProjectConfig.h
@@ -31,3 +31,6 @@
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF02
 #define CHIP_PORT 5542
+
+// Allows app options (ports) to be configure on launch of app.
+#define CHIP_DEVICE_ENABLE_PORT_PARAMS 1

--- a/examples/placeholder/linux/apps/app1/include/CHIPProjectConfig.h
+++ b/examples/placeholder/linux/apps/app1/include/CHIPProjectConfig.h
@@ -32,5 +32,5 @@
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF02
 #define CHIP_PORT 5542
 
-// Allows app options (ports) to be configure on launch of app.
+// Allows app options (ports) to be configured on launch of app.
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 1

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -401,7 +401,7 @@ void ChipLinuxAppMainLoop()
     uint16_t securePort   = CHIP_PORT;
     uint16_t unsecurePort = CHIP_UDC_PORT;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE || CHIP_DEVICE_ENABLE_PORT_PARAMS
     // use a different service port to make testing possible with other sample devices running on same host
     securePort   = LinuxDeviceOptions::GetInstance().securedDevicePort;
     unsecurePort = LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort;


### PR DESCRIPTION
#### Problem
Update Linux app to allow parameters for ports. Address this issue #13070

#### Change overview
- Add a new define to enable port setting in app.

#### Testing
Manually tested with chip and ports update as expected.
`./out/simulated/chip-app1 --secured-device-port 5540 --discriminator 3840`
