### PR TITLE
Update cloudbuild from 33 to 40 docker image, otherwise after #13031 …

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -28,7 +28,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -62,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -79,7 +79,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.33"
+    - name: "connectedhomeip/chip-build-vscode:0.5.40"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
…it cannot build NRF

#### Problem
Build error as it requires a new SDK:

```
2021-12-15 22:57:42 INFO    Checking current nRF Connect SDK revision...
2021-12-15 22:57:42 INFO    ################################################################################
2021-12-15 22:57:42 INFO    # WARNING: Your current NCS revision (ffcf07fe4586634a6793a48e5444a7196e7ebac6)#
2021-12-15 22:57:42 INFO    # differs from the recommended (cfedfdfa08567b2252b511a4d1db15fbeba8152d).     #
2021-12-15 22:57:42 INFO    #                                                                              #
2021-12-15 22:57:42 INFO    # Please be aware that it may lead to encountering unexpected problems.        #
2021-12-15 22:57:42 INFO    # Consider updating NCS to the recommended revision, by calling:               #
2021-12-15 22:57:42 INFO    # /workspace/scripts/setup/nrfconnect/update_ncs.py --update                   #
2021-12-15 22:57:42 INFO    ################################################################################
```

