### PR TITLE
[Inet] Make tests fail on EADDRNOTAVAIL

### DIFF
--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -131,14 +131,6 @@ public:
 
         // Should be able to send a message to itself by just calling send.
         err = tcp.SendMessage(Transport::PeerAddress::TCP(addr), std::move(buffer));
-        if (err == CHIP_ERROR_POSIX(EADDRNOTAVAIL))
-        {
-            // TODO(#2698): the underlying system does not support IPV6. This early return
-            // should be removed and error should be made fatal.
-            printf("%s:%u: System does NOT support IPV6.\n", __FILE__, __LINE__);
-            return;
-        }
-
         NL_TEST_ASSERT(mSuite, err == CHIP_NO_ERROR);
 
         mContext.DriveIOUntil(chip::System::Clock::Seconds16(5), [this]() { return mReceiveHandlerCallCount != 0; });

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -140,14 +140,6 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
 
     // Should be able to send a message to itself by just calling send.
     err = udp.SendMessage(Transport::PeerAddress::UDP(addr, udp.GetBoundPort()), std::move(buffer));
-    if (err == CHIP_ERROR_POSIX(EADDRNOTAVAIL))
-    {
-        // TODO(#2698): the underlying system does not support IPV6. This early return
-        // should be removed and error should be made fatal.
-        printf("%s:%u: System does NOT support IPV6.\n", __FILE__, __LINE__);
-        return;
-    }
-
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DriveIOUntil(chip::System::Clock::Seconds16(1), []() { return ReceiveHandlerCallCount != 0; });


### PR DESCRIPTION
#### Problem

Fixes #2698 Once CI supports IPV6, TestTCP/UDP should make the 'EADDRNOTAVAIL' fatal

#### Change overview

Remove the special handling of `EADDRNOTAVAIL`.

#### Testing

CI
