### PR TITLE
Update some names in Dnssd to be more consistent across the board

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -54,7 +54,7 @@ class PairOnNetworkShort : public PairingCommand
 public:
     PairOnNetworkShort() :
         PairingCommand("onnetwork-short", PairingMode::OnNetwork, PairingNetworkType::None,
-                       chip::Dnssd::DiscoveryFilterType::kShort)
+                       chip::Dnssd::DiscoveryFilterType::kShortDiscriminator)
     {}
 };
 
@@ -62,7 +62,8 @@ class PairOnNetworkLong : public PairingCommand
 {
 public:
     PairOnNetworkLong() :
-        PairingCommand("onnetwork-long", PairingMode::OnNetwork, PairingNetworkType::None, chip::Dnssd::DiscoveryFilterType::kLong)
+        PairingCommand("onnetwork-long", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Dnssd::DiscoveryFilterType::kLongDiscriminator)
     {}
 };
 
@@ -71,7 +72,7 @@ class PairOnNetworkVendor : public PairingCommand
 public:
     PairOnNetworkVendor() :
         PairingCommand("onnetwork-vendor", PairingMode::OnNetwork, PairingNetworkType::None,
-                       chip::Dnssd::DiscoveryFilterType::kVendor)
+                       chip::Dnssd::DiscoveryFilterType::kVendorId)
     {}
 };
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -108,10 +108,10 @@ CHIP_ERROR PairingCommand::PairWithMdns(NodeId remoteId)
     {
     case chip::Dnssd::DiscoveryFilterType::kNone:
         break;
-    case chip::Dnssd::DiscoveryFilterType::kShort:
-    case chip::Dnssd::DiscoveryFilterType::kLong:
+    case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
+    case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
     case chip::Dnssd::DiscoveryFilterType::kCompressedFabricId:
-    case chip::Dnssd::DiscoveryFilterType::kVendor:
+    case chip::Dnssd::DiscoveryFilterType::kVendorId:
     case chip::Dnssd::DiscoveryFilterType::kDeviceType:
         filter.code = mDiscoveryFilterCode;
         break;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -105,13 +105,13 @@ public:
         {
         case chip::Dnssd::DiscoveryFilterType::kNone:
             break;
-        case chip::Dnssd::DiscoveryFilterType::kShort:
+        case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
             AddArgument("discriminator", 0, 15, &mDiscoveryFilterCode);
             break;
-        case chip::Dnssd::DiscoveryFilterType::kLong:
+        case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
             AddArgument("discriminator", 0, 4096, &mDiscoveryFilterCode);
             break;
-        case chip::Dnssd::DiscoveryFilterType::kVendor:
+        case chip::Dnssd::DiscoveryFilterType::kVendorId:
             AddArgument("vendor-id", 0, UINT16_MAX, &mDiscoveryFilterCode);
             break;
         case chip::Dnssd::DiscoveryFilterType::kCompressedFabricId:

--- a/examples/minimal-mdns/advertiser.cpp
+++ b/examples/minimal-mdns/advertiser.cpp
@@ -277,8 +277,8 @@ int main(int argc, char ** args)
                                                                        .SetCommissioningMode(gOptions.commissioningMode)
                                                                        .SetDeviceType(gOptions.deviceType)
                                                                        .SetDeviceName(gOptions.deviceName)
-                                                                       .SetRotatingId(gOptions.rotatingId)
-                                                                       .SetPairingInstr(gOptions.pairingInstr)
+                                                                       .SetRotatingDeviceId(gOptions.rotatingId)
+                                                                       .SetPairingInstruction(gOptions.pairingInstr)
                                                                        .SetPairingHint(gOptions.pairingHint));
     }
     else if (gOptions.advertisingMode == AdvertisingMode::kOperational)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -360,7 +360,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         }
         else
         {
-            advertiseParameters.SetPairingInstr(chip::Optional<const char *>::Value(pairingInst));
+            advertiseParameters.SetPairingInstruction(chip::Optional<const char *>::Value(pairingInst));
         }
     }
     else
@@ -380,7 +380,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         }
         else
         {
-            advertiseParameters.SetPairingInstr(chip::Optional<const char *>::Value(pairingInst));
+            advertiseParameters.SetPairingInstruction(chip::Optional<const char *>::Value(pairingInst));
         }
     }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -260,7 +260,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
     ChipLogDetail(AppServer, "SendUserDirectedCommissioningRequest2");
 
     CHIP_ERROR err;
-    char nameBuffer[chip::Dnssd::Commissionable::kInstanceNameMaxLength + 1];
+    char nameBuffer[chip::Dnssd::Commission::kInstanceNameMaxLength + 1];
     err = app::DnssdServer::Instance().GetCommissionableInstanceName(nameBuffer, sizeof(nameBuffer));
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -107,7 +107,7 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverBle()
 CHIP_ERROR SetUpCodePairer::StartDiscoverOverIP(uint16_t discriminator, bool isShort)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    currentFilter.type = isShort ? Dnssd::DiscoveryFilterType::kShort : Dnssd::DiscoveryFilterType::kLong;
+    currentFilter.type = isShort ? Dnssd::DiscoveryFilterType::kShortDiscriminator : Dnssd::DiscoveryFilterType::kLongDiscriminator;
     currentFilter.code = discriminator;
     return mCommissioner->DiscoverCommissionableNodes(currentFilter);
 #else
@@ -166,9 +166,9 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
 {
     switch (currentFilter.type)
     {
-    case Dnssd::DiscoveryFilterType::kShort:
+    case Dnssd::DiscoveryFilterType::kShortDiscriminator:
         return ((nodeData.longDiscriminator >> 8) & 0x0F) == currentFilter.code;
-    case Dnssd::DiscoveryFilterType::kLong:
+    case Dnssd::DiscoveryFilterType::kLongDiscriminator:
         return nodeData.longDiscriminator == currentFilter.code;
     default:
         return false;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -410,7 +410,7 @@ ChipError::StorageType
 pychip_DeviceController_DiscoverCommissionableNodesLongDiscriminator(chip::Controller::DeviceCommissioner * devCtrl,
                                                                      uint16_t long_discriminator)
 {
-    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kLong, long_discriminator);
+    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kLongDiscriminator, long_discriminator);
     return devCtrl->DiscoverCommissionableNodes(filter).AsInteger();
 }
 
@@ -418,14 +418,14 @@ ChipError::StorageType
 pychip_DeviceController_DiscoverCommissionableNodesShortDiscriminator(chip::Controller::DeviceCommissioner * devCtrl,
                                                                       uint16_t short_discriminator)
 {
-    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kShort, short_discriminator);
+    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kShortDiscriminator, short_discriminator);
     return devCtrl->DiscoverCommissionableNodes(filter).AsInteger();
 }
 
 ChipError::StorageType pychip_DeviceController_DiscoverCommissionableNodesVendor(chip::Controller::DeviceCommissioner * devCtrl,
                                                                                  uint16_t vendor)
 {
-    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kVendor, vendor);
+    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kVendorId, vendor);
     return devCtrl->DiscoverCommissionableNodes(filter).AsInteger();
 }
 

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -121,6 +121,8 @@ public:
     }
     PeerId GetPeerId() const { return mPeerId; }
 
+    CompressedFabricId GetCompressedFabricId() const { return mPeerId.GetCompressedFabricId(); }
+
 private:
     PeerId mPeerId;
 };
@@ -194,7 +196,7 @@ public:
         return mDeviceNameHasValue ? Optional<const char *>::Value(mDeviceName) : Optional<const char *>::Missing();
     }
 
-    CommissionAdvertisingParameters & SetRotatingId(Optional<const char *> rotatingId)
+    CommissionAdvertisingParameters & SetRotatingDeviceId(Optional<const char *> rotatingId)
     {
         if (rotatingId.HasValue())
         {
@@ -207,12 +209,12 @@ public:
         }
         return *this;
     }
-    Optional<const char *> GetRotatingId() const
+    Optional<const char *> GetRotatingDeviceId() const
     {
         return mRotatingIdHasValue ? Optional<const char *>::Value(mRotatingId) : Optional<const char *>::Missing();
     }
 
-    CommissionAdvertisingParameters & SetPairingInstr(Optional<const char *> pairingInstr)
+    CommissionAdvertisingParameters & SetPairingInstruction(Optional<const char *> pairingInstr)
     {
         if (pairingInstr.HasValue())
         {
@@ -225,7 +227,7 @@ public:
         }
         return *this;
     }
-    Optional<const char *> GetPairingInstr() const
+    Optional<const char *> GetPairingInstruction() const
     {
         return mPairingInstrHasValue ? Optional<const char *>::Value(mPairingInstr) : Optional<const char *>::Missing();
     }
@@ -257,7 +259,7 @@ private:
     char mDeviceName[kKeyDeviceNameMaxLength + 1];
     bool mDeviceNameHasValue = false;
 
-    char mRotatingId[kKeyRotatingIdMaxLength + 1];
+    char mRotatingId[kKeyRotatingDeviceIdMaxLength + 1];
     bool mRotatingIdHasValue = false;
 
     char mPairingInstr[kKeyPairingInstructionMaxLength + 1];

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -151,7 +151,7 @@ private:
         char mrpRetryIntervalIdleBuf[KeySize(TxtFieldKey::kMrpRetryIntervalIdle) + ValSize(TxtFieldKey::kMrpRetryIntervalIdle) + 2];
         char mrpRetryIntervalActiveBuf[KeySize(TxtFieldKey::kMrpRetryIntervalActive) +
                                        ValSize(TxtFieldKey::kMrpRetryIntervalActive) + 2];
-        char tcpSupportedBuf[KeySize(TxtFieldKey::kTcpSupport) + ValSize(TxtFieldKey::kTcpSupport) + 2];
+        char tcpSupportedBuf[KeySize(TxtFieldKey::kTcpSupported) + ValSize(TxtFieldKey::kTcpSupported) + 2];
     };
     template <class Derived>
     CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,
@@ -437,7 +437,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
 
 CHIP_ERROR AdvertiserMinMdns::GetCommissionableInstanceName(char * instanceName, size_t maxLength)
 {
-    if (maxLength < (Commissionable::kInstanceNameMaxLength + 1))
+    if (maxLength < (Commission::kInstanceNameMaxLength + 1))
     {
         return CHIP_ERROR_NO_MEMORY;
     }
@@ -514,7 +514,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
     if (params.GetVendorId().HasValue())
     {
         MakeServiceSubtype(nameBuffer, sizeof(nameBuffer),
-                           DiscoveryFilter(DiscoveryFilterType::kVendor, params.GetVendorId().Value()));
+                           DiscoveryFilter(DiscoveryFilterType::kVendorId, params.GetVendorId().Value()));
         FullQName vendorServiceName =
             allocator->AllocateQName(nameBuffer, kSubtypeServiceNamePart, serviceType, kCommissionProtocol, kLocalDomain);
         ReturnErrorCodeIf(vendorServiceName.nameCount == 0, CHIP_ERROR_NO_MEMORY);
@@ -552,7 +552,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
     {
         {
             MakeServiceSubtype(nameBuffer, sizeof(nameBuffer),
-                               DiscoveryFilter(DiscoveryFilterType::kShort, params.GetShortDiscriminator()));
+                               DiscoveryFilter(DiscoveryFilterType::kShortDiscriminator, params.GetShortDiscriminator()));
             FullQName shortServiceName =
                 allocator->AllocateQName(nameBuffer, kSubtypeServiceNamePart, serviceType, kCommissionProtocol, kLocalDomain);
             ReturnErrorCodeIf(shortServiceName.nameCount == 0, CHIP_ERROR_NO_MEMORY);
@@ -569,7 +569,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
 
         {
             MakeServiceSubtype(nameBuffer, sizeof(nameBuffer),
-                               DiscoveryFilter(DiscoveryFilterType::kLong, params.GetLongDiscriminator()));
+                               DiscoveryFilter(DiscoveryFilterType::kLongDiscriminator, params.GetLongDiscriminator()));
             FullQName longServiceName =
                 allocator->AllocateQName(nameBuffer, kSubtypeServiceNamePart, serviceType, kCommissionProtocol, kLocalDomain);
             ReturnErrorCodeIf(longServiceName.nameCount == 0, CHIP_ERROR_NO_MEMORY);
@@ -682,7 +682,7 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
     {
         // a discriminator always exists
-        char txtDiscriminator[chip::Dnssd::kKeyDiscriminatorMaxLength + 3];
+        char txtDiscriminator[chip::Dnssd::kKeyLongDiscriminatorMaxLength + 3];
         snprintf(txtDiscriminator, sizeof(txtDiscriminator), "D=%d", params.GetLongDiscriminator());
         txtFields[numTxtFields++] = txtDiscriminator;
 
@@ -690,10 +690,10 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
         snprintf(txtCommissioningMode, sizeof(txtCommissioningMode), "CM=%d", static_cast<int>(params.GetCommissioningMode()));
         txtFields[numTxtFields++] = txtCommissioningMode;
 
-        char txtRotatingDeviceId[chip::Dnssd::kKeyRotatingIdMaxLength + 4];
-        if (params.GetRotatingId().HasValue())
+        char txtRotatingDeviceId[chip::Dnssd::kKeyRotatingDeviceIdMaxLength + 4];
+        if (params.GetRotatingDeviceId().HasValue())
         {
-            snprintf(txtRotatingDeviceId, sizeof(txtRotatingDeviceId), "RI=%s", params.GetRotatingId().Value());
+            snprintf(txtRotatingDeviceId, sizeof(txtRotatingDeviceId), "RI=%s", params.GetRotatingDeviceId().Value());
             txtFields[numTxtFields++] = txtRotatingDeviceId;
         }
 
@@ -705,9 +705,9 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
         }
 
         char txtPairingInstr[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
-        if (params.GetPairingInstr().HasValue())
+        if (params.GetPairingInstruction().HasValue())
         {
-            snprintf(txtPairingInstr, sizeof(txtPairingInstr), "PI=%s", params.GetPairingInstr().Value());
+            snprintf(txtPairingInstr, sizeof(txtPairingInstr), "PI=%s", params.GetPairingInstruction().Value());
             txtFields[numTxtFields++] = txtPairingInstr;
         }
     }

--- a/src/lib/dnssd/Constants.h
+++ b/src/lib/dnssd/Constants.h
@@ -37,7 +37,7 @@ constexpr size_t kHostNameMaxLength = 16; // MAC or 802.15.4 Extended Address in
 
 constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4;  // _S<dd>
 constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6;  // _L<dddd>
-constexpr size_t kSubTypeVendorMaxLength                  = 7;  // _V<ddddd>
+constexpr size_t kSubTypeVendorIdMaxLength                = 7;  // _V<ddddd>
 constexpr size_t kSubTypeDeviceTypeMaxLength              = 5;  // _T<ddd>
 constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _C<d>
 constexpr size_t kSubTypeAdditionalCommissioningMaxLength = 3;  // _A<d>
@@ -64,11 +64,11 @@ constexpr size_t kSubTypeTotalLength    = chip::Sum(SUBTYPES);
  * Matter commissionable/commissioner node service constants.
  */
 
-namespace Commissionable {
+namespace Commission {
 
 #define SUBTYPES                                                                                                                   \
     (std::initializer_list<size_t>{ kSubTypeShortDiscriminatorMaxLength, kSubTypeLongDiscriminatorMaxLength,                       \
-                                    kSubTypeVendorMaxLength, kSubTypeDeviceTypeMaxLength, kSubTypeCommissioningModeMaxLength,      \
+                                    kSubTypeVendorIdMaxLength, kSubTypeDeviceTypeMaxLength, kSubTypeCommissioningModeMaxLength,    \
                                     kSubTypeAdditionalCommissioningMaxLength })
 
 constexpr size_t kInstanceNameMaxLength = 16; // 64-bit random number in hex
@@ -78,7 +78,7 @@ constexpr size_t kSubTypeTotalLength    = chip::Sum(SUBTYPES);
 
 #undef SUBTYPES
 
-} // namespace Commissionable
+} // namespace Commission
 
 /*
  * Constants for any Matter service.
@@ -86,10 +86,10 @@ constexpr size_t kSubTypeTotalLength    = chip::Sum(SUBTYPES);
 
 namespace Common {
 
-constexpr size_t kInstanceNameMaxLength = std::max(Operational::kInstanceNameMaxLength, Commissionable::kInstanceNameMaxLength);
-constexpr size_t kSubTypeMaxNumber      = std::max(Operational::kSubTypeMaxNumber, Commissionable::kSubTypeMaxNumber);
-constexpr size_t kSubTypeMaxLength      = std::max(Operational::kSubTypeMaxLength, Commissionable::kSubTypeMaxLength);
-constexpr size_t kSubTypeTotalLength    = std::max(Operational::kSubTypeTotalLength, Commissionable::kSubTypeTotalLength);
+constexpr size_t kInstanceNameMaxLength = std::max(Operational::kInstanceNameMaxLength, Commission::kInstanceNameMaxLength);
+constexpr size_t kSubTypeMaxNumber      = std::max(Operational::kSubTypeMaxNumber, Commission::kSubTypeMaxNumber);
+constexpr size_t kSubTypeMaxLength      = std::max(Operational::kSubTypeMaxLength, Commission::kSubTypeMaxLength);
+constexpr size_t kSubTypeTotalLength    = std::max(Operational::kSubTypeTotalLength, Commission::kSubTypeTotalLength);
 
 } // namespace Common
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -145,6 +145,171 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         }
     }
 }
+
+CHIP_ERROR AddPtrRecord(DiscoveryFilter filter, const char ** entries, size_t & entriesCount, char * buffer, size_t bufferLen)
+{
+    ReturnErrorOnFailure(MakeServiceSubtype(buffer, bufferLen, filter));
+    entries[entriesCount++] = buffer;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AddPtrRecord(DiscoveryFilterType type, const char ** entries, size_t & entriesCount, char * buffer, size_t bufferLen,
+                        CommissioningMode value)
+{
+    VerifyOrReturnError(value != CommissioningMode::kDisabled, CHIP_NO_ERROR);
+    return AddPtrRecord(DiscoveryFilter(type), entries, entriesCount, buffer, bufferLen);
+}
+
+CHIP_ERROR AddPtrRecord(DiscoveryFilterType type, const char ** entries, size_t & entriesCount, char * buffer, size_t bufferLen,
+                        uint64_t value)
+{
+    return AddPtrRecord(DiscoveryFilter(type, value), entries, entriesCount, buffer, bufferLen);
+}
+
+template <class T>
+CHIP_ERROR AddPtrRecord(DiscoveryFilterType type, const char ** entries, size_t & entriesCount, char * buffer, size_t bufferLen,
+                        chip::Optional<T> value)
+{
+    VerifyOrReturnError(value.HasValue(), CHIP_NO_ERROR);
+    return AddPtrRecord(type, entries, entriesCount, buffer, bufferLen, value.Value());
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, int minCharactersWritten, const char * format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int charactersWritten = vsnprintf(buffer, bufferLen, format, args);
+    va_end(args);
+
+    return charactersWritten >= minCharactersWritten ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_STRING_LENGTH;
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, bool value)
+{
+    return CopyTextRecordValue(buffer, bufferLen, 1, "%d", value);
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, uint16_t value)
+{
+    return CopyTextRecordValue(buffer, bufferLen, 1, "%u", value);
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, uint32_t value)
+{
+    return CopyTextRecordValue(buffer, bufferLen, 1, "%" PRIu32, value);
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, uint16_t value1, uint16_t value2)
+{
+    return CopyTextRecordValue(buffer, bufferLen, 3, "%u+%u", value1, value2);
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, const char * value)
+{
+    return CopyTextRecordValue(buffer, bufferLen, 0, "%s", value);
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, CommissioningMode value)
+{
+    return CopyTextRecordValue(buffer, bufferLen, static_cast<uint16_t>(value));
+}
+
+template <class T>
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, chip::Optional<T> value)
+{
+    VerifyOrReturnError(value.HasValue(), CHIP_ERROR_WELL_UNINITIALIZED);
+    return CopyTextRecordValue(buffer, bufferLen, value.Value());
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, chip::Optional<uint16_t> value1, chip::Optional<uint16_t> value2)
+{
+    VerifyOrReturnError(value1.HasValue(), CHIP_ERROR_WELL_UNINITIALIZED);
+    return value2.HasValue() ? CopyTextRecordValue(buffer, bufferLen, value1.Value(), value2.Value())
+                             : CopyTextRecordValue(buffer, bufferLen, value1.Value());
+}
+
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, const chip::Optional<ReliableMessageProtocolConfig> optional,
+                               bool isIdle)
+{
+    VerifyOrReturnError(optional.HasValue(), CHIP_ERROR_WELL_UNINITIALIZED);
+
+    auto retryInterval = isIdle ? optional.Value().mIdleRetransTimeout : optional.Value().mActiveRetransTimeout;
+
+    // TODO: Issue #5833 - MRP retry intervals should be updated on the poll period value
+    // change or device type change.
+    // TODO: Is this really the best place to set these? Seems like it should be passed
+    // in with the correct values and set one level up from here.
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    chip::DeviceLayer::ConnectivityManager::SEDPollingConfig sedPollingConfig;
+    ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().GetSEDPollingConfig(sedPollingConfig));
+    // Increment default MRP retry intervals by SED poll period to be on the safe side
+    // and avoid unnecessary retransmissions.
+    retryInterval += isIdle ? sedPollingConfig.SlowPollingIntervalMS : sedPollingConfig.FastPollingIntervalMS;
+#endif
+
+    if (retryInterval > kMaxRetryInterval)
+    {
+        ChipLogProgress(Discovery, "MRP retry interval %s value exceeds allowed range of 1 hour, using maximum available",
+                        isIdle ? "idle" : "active");
+        retryInterval = kMaxRetryInterval;
+    }
+
+    return CopyTextRecordValue(buffer, bufferLen, retryInterval.count());
+}
+
+template <class T>
+CHIP_ERROR CopyTxtRecord(TxtFieldKey key, char * buffer, size_t bufferLen, const T & params)
+{
+    switch (key)
+    {
+    case TxtFieldKey::kTcpSupported:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetTcpSupported());
+    case TxtFieldKey::kMrpRetryIntervalIdle:
+    case TxtFieldKey::kMrpRetryIntervalActive:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetMRPConfig(), key == TxtFieldKey::kMrpRetryIntervalIdle);
+    default:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+}
+
+CHIP_ERROR CopyTxtRecord(TxtFieldKey key, char * buffer, size_t bufferLen, const CommissionAdvertisingParameters & params)
+{
+    switch (key)
+    {
+    case TxtFieldKey::kVendorProduct:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetVendorId(), params.GetProductId());
+    case TxtFieldKey::kDeviceType:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetDeviceType());
+    case TxtFieldKey::kDeviceName:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetDeviceName());
+    case TxtFieldKey::kLongDiscriminator:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetLongDiscriminator());
+    case TxtFieldKey::kRotatingDeviceId:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetRotatingDeviceId());
+    case TxtFieldKey::kPairingInstruction:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetPairingInstruction());
+    case TxtFieldKey::kPairingHint:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetPairingHint());
+    case TxtFieldKey::kCommissioningMode:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetCommissioningMode());
+    default:
+        return CopyTxtRecord(key, buffer, bufferLen, static_cast<BaseAdvertisingParams<CommissionAdvertisingParameters>>(params));
+    }
+}
+
+template <class T>
+CHIP_ERROR AddTxtRecord(TxtFieldKey key, TextEntry * entries, size_t & entriesCount, char * buffer, size_t bufferLen,
+                        const T & params)
+{
+    CHIP_ERROR error = CopyTxtRecord(key, buffer, bufferLen, params);
+    VerifyOrReturnError(CHIP_ERROR_WELL_UNINITIALIZED != error, CHIP_NO_ERROR);
+    VerifyOrReturnError(CHIP_NO_ERROR == error, error);
+
+    entries[entriesCount++] = { Internal::txtFieldInfo[static_cast<int>(key)].keyStr, reinterpret_cast<const uint8_t *>(buffer),
+                                strnlen(buffer, bufferLen) };
+    return CHIP_NO_ERROR;
+}
+
 } // namespace
 
 DiscoveryImplPlatform DiscoveryImplPlatform::sManager;
@@ -200,18 +365,21 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
     DiscoveryImplPlatform * publisher = static_cast<DiscoveryImplPlatform *>(context);
     if (error == CHIP_ERROR_FORCED_RESET)
     {
-        if (publisher->mIsOperationalPublishing)
+        if (publisher->mIsOperationalNodePublishing)
         {
-            publisher->Advertise(publisher->mOperationalAdvertisingParams);
+            publisher->Advertise(publisher->mOperationalNodeAdvertisingParams);
         }
+
         if (publisher->mIsCommissionableNodePublishing)
         {
             publisher->Advertise(publisher->mCommissionableNodeAdvertisingParams);
         }
-        if (publisher->mIsCommissionerPublishing)
+
+        if (publisher->mIsCommissionerNodePublishing)
         {
-            publisher->Advertise(publisher->mCommissionerAdvertisingParams);
+            publisher->Advertise(publisher->mCommissionerNodeAdvertisingParams);
         }
+
         publisher->FinalizeServiceUpdate();
     }
     else
@@ -222,7 +390,7 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
 
 CHIP_ERROR DiscoveryImplPlatform::GetCommissionableInstanceName(char * instanceName, size_t maxLength)
 {
-    if (maxLength < (chip::Dnssd::Commissionable::kInstanceNameMaxLength + 1))
+    if (maxLength < (chip::Dnssd::Commission::kInstanceNameMaxLength + 1))
     {
         return CHIP_ERROR_NO_MEMORY;
     }
@@ -231,330 +399,137 @@ CHIP_ERROR DiscoveryImplPlatform::GetCommissionableInstanceName(char * instanceN
                                                      instanceName, maxLength);
 }
 
-template <class Derived, size_t N_idle, size_t N_active, size_t N_tcp>
-CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, char (&mrpRetryIdleStorage)[N_idle],
-                                char (&mrpRetryActiveStorage)[N_active], char (&tcpSupportedStorage)[N_tcp],
-                                TextEntry txtEntryStorage[], size_t & txtEntryIdx)
+CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize,
+                                                 const char ** subTypes, size_t subTypeSize,
+                                                 const OperationalAdvertisingParameters & params)
 {
-    auto optionalMrp = params.GetMRPConfig();
+    return PublishService(serviceType, textEntries, textEntrySize, subTypes, subTypeSize, params.GetPort(), params.GetMac(),
+                          DnssdServiceProtocol::kDnssdProtocolTcp, params.GetPeerId());
+}
 
-    // TODO: Issue #5833 - MRP retry intervals should be updated on the poll period value
-    // change or device type change.
-    // TODO: Is this really the best place to set these? Seems like it should be passed
-    // in with the correct values and set one level up from here.
-#if CHIP_DEVICE_CONFIG_ENABLE_SED
-    chip::DeviceLayer::ConnectivityManager::SEDPollingConfig sedPollingConfig;
-    ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().GetSEDPollingConfig(sedPollingConfig));
-    // Increment default MRP retry intervals by SED poll period to be on the safe side
-    // and avoid unnecessary retransmissions.
-    if (optionalMrp.HasValue())
+CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize,
+                                                 const char ** subTypes, size_t subTypeSize,
+                                                 const CommissionAdvertisingParameters & params)
+{
+    return PublishService(serviceType, textEntries, textEntrySize, subTypes, subTypeSize, params.GetPort(), params.GetMac(),
+                          DnssdServiceProtocol::kDnssdProtocolUdp, PeerId());
+}
+
+CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize,
+                                                 const char ** subTypes, size_t subTypeSize, uint16_t port,
+                                                 const chip::ByteSpan & mac, DnssdServiceProtocol protocol, PeerId peerId)
+{
+    ReturnErrorCodeIf(mDnssdInitialized == false, CHIP_ERROR_INCORRECT_STATE);
+
+    DnssdService service;
+    ReturnErrorOnFailure(MakeHostName(service.mHostName, sizeof(service.mHostName), mac));
+    ReturnErrorOnFailure(protocol == DnssdServiceProtocol::kDnssdProtocolTcp
+                             ? MakeInstanceName(service.mName, sizeof(service.mName), peerId)
+                             : GetCommissionableInstanceName(service.mName, sizeof(service.mName)));
+    strncpy(service.mType, serviceType, sizeof(service.mType));
+    service.mAddressType   = Inet::IPAddressType::kAny;
+    service.mInterface     = Inet::InterfaceId::Null();
+    service.mProtocol      = protocol;
+    service.mPort          = port;
+    service.mTextEntries   = textEntries;
+    service.mTextEntrySize = textEntrySize;
+    service.mSubTypes      = subTypes;
+    service.mSubTypeSize   = subTypeSize;
+
+    ReturnErrorOnFailure(ChipDnssdPublishService(&service));
+
+#ifdef DETAIL_LOGGING
+    printf("printEntries port=%u, mTextEntrySize=%zu, mSubTypeSize=%zu\n", port, textEntrySize, subTypeSize);
+
+    for (size_t i = 0; i < textEntrySize; i++)
     {
-        auto mrp = optionalMrp.Value();
-        optionalMrp.SetValue(ReliableMessageProtocolConfig(mrp.mIdleRetransTimeout + sedPollingConfig.SlowPollingIntervalMS,
-                                                           mrp.mActiveRetransTimeout + sedPollingConfig.FastPollingIntervalMS));
+        printf(" entry [%zu] : %s %s\n", i, textEntries[i].mKey, (char *) (textEntries[i].mData));
+    }
+
+    for (size_t i = 0; i < subTypeSize; i++)
+    {
+        printf(" type [%zu] : %s\n", i, subTypes[i]);
     }
 #endif
-    if (optionalMrp.HasValue())
-    {
-        auto mrp = optionalMrp.Value();
-        {
-            if (mrp.mIdleRetransTimeout > kMaxRetryInterval)
-            {
-                ChipLogProgress(Discovery,
-                                "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available");
-                mrp.mIdleRetransTimeout = kMaxRetryInterval;
-            }
-            size_t writtenCharactersNumber =
-                snprintf(mrpRetryIdleStorage, sizeof(mrpRetryIdleStorage), "%" PRIu32, mrp.mIdleRetransTimeout.count());
-            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalIdleMaxLength),
-                                CHIP_ERROR_INVALID_STRING_LENGTH);
-            txtEntryStorage[txtEntryIdx++] = { "CRI", Uint8::from_const_char(mrpRetryIdleStorage), strlen(mrpRetryIdleStorage) };
-        }
 
-        {
-            if (mrp.mActiveRetransTimeout > kMaxRetryInterval)
-            {
-                ChipLogProgress(Discovery,
-                                "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available");
-                mrp.mActiveRetransTimeout = kMaxRetryInterval;
-            }
-            size_t writtenCharactersNumber =
-                snprintf(mrpRetryActiveStorage, sizeof(mrpRetryActiveStorage), "%" PRIu32, mrp.mActiveRetransTimeout.count());
-            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalActiveMaxLength),
-                                CHIP_ERROR_INVALID_STRING_LENGTH);
-            txtEntryStorage[txtEntryIdx++] = { "CRA", Uint8::from_const_char(mrpRetryActiveStorage),
-                                               strlen(mrpRetryActiveStorage) };
-        }
-    }
-    if (params.GetTcpSupported().HasValue())
-    {
-        size_t writtenCharactersNumber =
-            snprintf(tcpSupportedStorage, sizeof(tcpSupportedStorage), "%d", params.GetTcpSupported().Value());
-        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kKeyTcpSupportMaxLength),
-                            CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "T", reinterpret_cast<const uint8_t *>(tcpSupportedStorage),
-                                           strlen(tcpSupportedStorage) };
-    }
     return CHIP_NO_ERROR;
+}
+
+#define PREPARE_RECORDS(Type)                                                                                                      \
+    TextEntry textEntries[Type##AdvertisingParameters::kTxtMaxNumber];                                                             \
+    size_t textEntrySize = 0;                                                                                                      \
+    const char * subTypes[Type::kSubTypeMaxNumber];                                                                                \
+    size_t subTypeSize = 0;
+
+#define ADD_TXT_RECORD(Name)                                                                                                       \
+    char Name##Buf[kKey##Name##MaxLength + 1];                                                                                     \
+    ReturnErrorOnFailure(AddTxtRecord(TxtFieldKey::k##Name, textEntries, textEntrySize, Name##Buf, sizeof(Name##Buf), params));
+
+#define ADD_PTR_RECORD(Name)                                                                                                       \
+    char Name##SubTypeBuf[kSubType##Name##MaxLength + 1];                                                                          \
+    ReturnErrorOnFailure(AddPtrRecord(DiscoveryFilterType::k##Name, subTypes, subTypeSize, Name##SubTypeBuf,                       \
+                                      sizeof(Name##SubTypeBuf), params.Get##Name()));
+
+#define PUBLISH_RECORDS(Type)                                                                                                      \
+    ReturnErrorOnFailure(PublishService(k##Type##ServiceName, textEntries, textEntrySize, subTypes, subTypeSize, params));         \
+    m##Type##NodeAdvertisingParams = params;                                                                                       \
+    mIs##Type##NodePublishing      = true;                                                                                         \
+    return CHIP_NO_ERROR;
+
+CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParameters & params)
+{
+    PREPARE_RECORDS(Operational);
+
+    ADD_TXT_RECORD(MrpRetryIntervalIdle);
+    ADD_TXT_RECORD(MrpRetryIntervalActive);
+    ADD_TXT_RECORD(TcpSupported);
+
+    ADD_PTR_RECORD(CompressedFabricId);
+
+    PUBLISH_RECORDS(Operational);
 }
 
 CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameters & params)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    DnssdService service;
-    // add newline to lengths for TXT entries
-    char discriminatorBuf[kKeyDiscriminatorMaxLength + 1];
-    char vendorProductBuf[kKeyVendorProductMaxLength + 1];
-    char commissioningModeBuf[kKeyCommissioningModeMaxLength + 1];
-    char deviceTypeBuf[kKeyDeviceTypeMaxLength + 1];
-    char deviceNameBuf[kKeyDeviceNameMaxLength + 1];
-    char rotatingIdBuf[kKeyRotatingIdMaxLength + 1];
-    char pairingHintBuf[kKeyPairingHintMaxLength + 1];
-    char pairingInstrBuf[kKeyPairingInstructionMaxLength + 1];
-    char mrpRetryIntervalIdleBuf[kTxtRetryIntervalIdleMaxLength + 1];
-    char mrpRetryIntervalActiveBuf[kTxtRetryIntervalActiveMaxLength + 1];
-    char tcpSupportedBuf[kKeyTcpSupportMaxLength + 1];
-    // size of textEntries array should be count of Bufs above
-    TextEntry textEntries[CommissionAdvertisingParameters::kTxtMaxNumber];
-    size_t textEntrySize = 0;
-    // add null-character to the subtypes
-    char shortDiscriminatorSubtype[kSubTypeShortDiscriminatorMaxLength + 1];
-    char longDiscriminatorSubtype[kSubTypeLongDiscriminatorMaxLength + 1];
-    char vendorSubType[kSubTypeVendorMaxLength + 1];
-    char commissioningModeSubType[kSubTypeCommissioningModeMaxLength + 1];
-    char deviceTypeSubType[kSubTypeDeviceTypeMaxLength + 1];
-    // size of subTypes array should be count of SubTypes above
-    const char * subTypes[Commissionable::kSubTypeMaxNumber];
-    size_t subTypeSize = 0;
+    PREPARE_RECORDS(Commission);
 
-    if (!mDnssdInitialized)
+    ADD_TXT_RECORD(VendorProduct);
+    ADD_TXT_RECORD(DeviceType);
+    ADD_TXT_RECORD(DeviceName);
+    ADD_TXT_RECORD(MrpRetryIntervalIdle);
+    ADD_TXT_RECORD(MrpRetryIntervalActive);
+    ADD_TXT_RECORD(TcpSupported);
+
+    ADD_PTR_RECORD(VendorId);
+    ADD_PTR_RECORD(DeviceType);
+
+    if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissioner)
     {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    error = MakeHostName(service.mHostName, sizeof(service.mHostName), params.GetMac());
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "Failed to create dnssd hostname: %s", ErrorStr(error));
-        return error;
-    }
-
-    ReturnErrorOnFailure(GetCommissionableInstanceName(service.mName, sizeof(service.mName)));
-
-    if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
-    {
-        strncpy(service.mType, kCommissionableServiceName, sizeof(service.mType));
+        PUBLISH_RECORDS(Commissioner);
     }
     else
     {
-        strncpy(service.mType, kCommissionerServiceName, sizeof(service.mType));
+        ADD_TXT_RECORD(LongDiscriminator);
+        ADD_TXT_RECORD(CommissioningMode);
+        ADD_TXT_RECORD(RotatingDeviceId);
+        ADD_TXT_RECORD(PairingHint);
+        ADD_TXT_RECORD(PairingInstruction);
+
+        ADD_PTR_RECORD(ShortDiscriminator);
+        ADD_PTR_RECORD(LongDiscriminator);
+        ADD_PTR_RECORD(CommissioningMode);
+
+        PUBLISH_RECORDS(Commissionable);
     }
-    service.mProtocol = DnssdServiceProtocol::kDnssdProtocolUdp;
-
-    if (params.GetVendorId().HasValue())
-    {
-        if (params.GetProductId().HasValue())
-        {
-            snprintf(vendorProductBuf, sizeof(vendorProductBuf), "%u+%u", params.GetVendorId().Value(),
-                     params.GetProductId().Value());
-        }
-        else
-        {
-            snprintf(vendorProductBuf, sizeof(vendorProductBuf), "%u", params.GetVendorId().Value());
-        }
-        textEntries[textEntrySize++] = { "VP", reinterpret_cast<const uint8_t *>(vendorProductBuf),
-                                         strnlen(vendorProductBuf, sizeof(vendorProductBuf)) };
-    }
-
-    if (params.GetDeviceType().HasValue())
-    {
-        snprintf(deviceTypeBuf, sizeof(deviceTypeBuf), "%u", params.GetDeviceType().Value());
-        textEntries[textEntrySize++] = { "DT", reinterpret_cast<const uint8_t *>(deviceTypeBuf),
-                                         strnlen(deviceTypeBuf, sizeof(deviceTypeBuf)) };
-    }
-
-    if (params.GetDeviceName().HasValue())
-    {
-        snprintf(deviceNameBuf, sizeof(deviceNameBuf), "%s", params.GetDeviceName().Value());
-        textEntries[textEntrySize++] = { "DN", reinterpret_cast<const uint8_t *>(deviceNameBuf),
-                                         strnlen(deviceNameBuf, sizeof(deviceNameBuf)) };
-    }
-    AddCommonTxtElements<CommissionAdvertisingParameters>(params, mrpRetryIntervalIdleBuf, mrpRetryIntervalActiveBuf,
-                                                          tcpSupportedBuf, textEntries, textEntrySize);
-
-    // Following fields are for nodes and not for commissioners
-    if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
-    {
-        snprintf(discriminatorBuf, sizeof(discriminatorBuf), "%u", params.GetLongDiscriminator());
-        textEntries[textEntrySize++] = { "D", reinterpret_cast<const uint8_t *>(discriminatorBuf),
-                                         strnlen(discriminatorBuf, sizeof(discriminatorBuf)) };
-
-        snprintf(commissioningModeBuf, sizeof(commissioningModeBuf), "%u", static_cast<int>(params.GetCommissioningMode()));
-        textEntries[textEntrySize++] = { "CM", reinterpret_cast<const uint8_t *>(commissioningModeBuf),
-                                         strnlen(commissioningModeBuf, sizeof(commissioningModeBuf)) };
-
-        if (params.GetRotatingId().HasValue())
-        {
-            snprintf(rotatingIdBuf, sizeof(rotatingIdBuf), "%s", params.GetRotatingId().Value());
-            textEntries[textEntrySize++] = { "RI", reinterpret_cast<const uint8_t *>(rotatingIdBuf),
-                                             strnlen(rotatingIdBuf, sizeof(rotatingIdBuf)) };
-        }
-
-        if (params.GetPairingHint().HasValue())
-        {
-            snprintf(pairingHintBuf, sizeof(pairingHintBuf), "%u", params.GetPairingHint().Value());
-            textEntries[textEntrySize++] = { "PH", reinterpret_cast<const uint8_t *>(pairingHintBuf),
-                                             strnlen(pairingHintBuf, sizeof(pairingHintBuf)) };
-        }
-
-        if (params.GetPairingInstr().HasValue())
-        {
-            snprintf(pairingInstrBuf, sizeof(pairingInstrBuf), "%s", params.GetPairingInstr().Value());
-            textEntries[textEntrySize++] = { "PI", reinterpret_cast<const uint8_t *>(pairingInstrBuf),
-                                             strnlen(pairingInstrBuf, sizeof(pairingInstrBuf)) };
-        }
-
-        if (MakeServiceSubtype(shortDiscriminatorSubtype, sizeof(shortDiscriminatorSubtype),
-                               DiscoveryFilter(DiscoveryFilterType::kShort, params.GetShortDiscriminator())) == CHIP_NO_ERROR)
-        {
-            subTypes[subTypeSize++] = shortDiscriminatorSubtype;
-        }
-        if (MakeServiceSubtype(longDiscriminatorSubtype, sizeof(longDiscriminatorSubtype),
-                               DiscoveryFilter(DiscoveryFilterType::kLong, params.GetLongDiscriminator())) == CHIP_NO_ERROR)
-        {
-            subTypes[subTypeSize++] = longDiscriminatorSubtype;
-        }
-        if ((params.GetCommissioningMode() != CommissioningMode::kDisabled) &&
-            (MakeServiceSubtype(commissioningModeSubType, sizeof(commissioningModeSubType),
-                                DiscoveryFilter(DiscoveryFilterType::kCommissioningMode)) == CHIP_NO_ERROR))
-        {
-            subTypes[subTypeSize++] = commissioningModeSubType;
-        }
-    }
-
-    if (params.GetVendorId().HasValue())
-    {
-        if (MakeServiceSubtype(vendorSubType, sizeof(vendorSubType),
-                               DiscoveryFilter(DiscoveryFilterType::kVendor, params.GetVendorId().Value())) == CHIP_NO_ERROR)
-        {
-            subTypes[subTypeSize++] = vendorSubType;
-        }
-    }
-    if (params.GetDeviceType().HasValue())
-    {
-        if (MakeServiceSubtype(deviceTypeSubType, sizeof(deviceTypeSubType),
-                               DiscoveryFilter(DiscoveryFilterType::kDeviceType, params.GetDeviceType().Value())) == CHIP_NO_ERROR)
-        {
-            subTypes[subTypeSize++] = deviceTypeSubType;
-        }
-    }
-
-    service.mTextEntries   = textEntries;
-    service.mTextEntrySize = textEntrySize;
-    service.mPort          = params.GetPort();
-    service.mInterface     = Inet::InterfaceId::Null();
-    service.mSubTypes      = subTypes;
-    service.mSubTypeSize   = subTypeSize;
-    service.mAddressType   = Inet::IPAddressType::kAny;
-    error                  = ChipDnssdPublishService(&service);
-
-    if (error == CHIP_NO_ERROR)
-    {
-        if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
-        {
-            mCommissionableNodeAdvertisingParams = params;
-            mIsCommissionableNodePublishing      = true;
-        }
-        else
-        {
-            mCommissionerAdvertisingParams = params;
-            mIsCommissionerPublishing      = true;
-        }
-    }
-
-#ifdef DETAIL_LOGGING
-    PrintEntries(&service);
-#endif
-    return error;
-}
-
-#ifdef DETAIL_LOGGING
-void DiscoveryImplPlatform::PrintEntries(const DnssdService * service)
-{
-    printf("printEntries port=%d, mTextEntrySize=%d, mSubTypeSize=%d\n", (int) (service->mPort), (int) (service->mTextEntrySize),
-           (int) (service->mSubTypeSize));
-    for (int i = 0; i < (int) service->mTextEntrySize; i++)
-    {
-        printf(" entry [%d] : %s %s\n", i, service->mTextEntries[i].mKey, (char *) (service->mTextEntries[i].mData));
-    }
-
-    for (int i = 0; i < (int) service->mSubTypeSize; i++)
-    {
-        printf(" type [%d] : %s\n", i, service->mSubTypes[i]);
-    }
-}
-#endif
-
-CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParameters & params)
-{
-    DnssdService service;
-    CHIP_ERROR error = CHIP_NO_ERROR;
-
-    char compressedFabricIdSub[kSubTypeCompressedFabricIdMaxLength + 1];
-    const char * subTypes[Operational::kSubTypeMaxNumber];
-    size_t subTypeSize = 0;
-
-    mOperationalAdvertisingParams = params;
-    // TODO: There may be multilple device/fabric ids after multi-admin.
-
-    char mrpRetryIntervalIdleBuf[kTxtRetryIntervalIdleMaxLength + 1];
-    char mrpRetryIntervalActiveBuf[kTxtRetryIntervalActiveMaxLength + 1];
-    char tcpSupportedBuf[kKeyTcpSupportMaxLength + 1];
-    TextEntry txtEntries[OperationalAdvertisingParameters::kTxtMaxNumber];
-    size_t textEntrySize = 0;
-
-    ReturnLogErrorOnFailure(AddCommonTxtElements(params, mrpRetryIntervalIdleBuf, mrpRetryIntervalActiveBuf, tcpSupportedBuf,
-                                                 txtEntries, textEntrySize));
-
-    if (MakeServiceSubtype(compressedFabricIdSub, sizeof(compressedFabricIdSub),
-                           DiscoveryFilter(DiscoveryFilterType::kCompressedFabricId, params.GetPeerId().GetCompressedFabricId())) ==
-        CHIP_NO_ERROR)
-    {
-        subTypes[subTypeSize++] = compressedFabricIdSub;
-    }
-    error = MakeHostName(service.mHostName, sizeof(service.mHostName), params.GetMac());
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "Failed to create dnssd hostname: %s", ErrorStr(error));
-        return error;
-    }
-    ReturnErrorOnFailure(MakeInstanceName(service.mName, sizeof(service.mName), params.GetPeerId()));
-    strncpy(service.mType, kOperationalServiceName, sizeof(service.mType));
-    service.mProtocol      = DnssdServiceProtocol::kDnssdProtocolTcp;
-    service.mPort          = params.GetPort();
-    service.mTextEntries   = txtEntries;
-    service.mTextEntrySize = textEntrySize;
-    service.mInterface     = Inet::InterfaceId::Null();
-    service.mAddressType   = Inet::IPAddressType::kAny;
-    service.mSubTypes      = subTypes;
-    service.mSubTypeSize   = subTypeSize;
-    error                  = ChipDnssdPublishService(&service);
-
-    if (error == CHIP_NO_ERROR)
-    {
-        mIsOperationalPublishing = true;
-    }
-
-    return error;
 }
 
 CHIP_ERROR DiscoveryImplPlatform::RemoveServices()
 {
     ReturnErrorOnFailure(ChipDnssdRemoveServices());
 
-    mIsOperationalPublishing        = false;
+    mIsOperationalNodePublishing    = false;
     mIsCommissionableNodePublishing = false;
-    mIsCommissionerPublishing       = false;
+    mIsCommissionerNodePublishing   = false;
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -69,16 +69,20 @@ private:
     static void HandleDnssdInit(void * context, CHIP_ERROR initError);
     static void HandleDnssdError(void * context, CHIP_ERROR initError);
     static CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t & rotatingDeviceIdHexBufferSize);
-#ifdef DETAIL_LOGGING
-    static void PrintEntries(const DnssdService * service);
-#endif
+    CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
+                              size_t subTypeSize, const OperationalAdvertisingParameters & params);
+    CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
+                              size_t subTypeSize, const CommissionAdvertisingParameters & params);
+    CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
+                              size_t subTypeSize, uint16_t port, const chip::ByteSpan & mac, DnssdServiceProtocol procotol,
+                              PeerId peerId);
 
-    OperationalAdvertisingParameters mOperationalAdvertisingParams;
+    OperationalAdvertisingParameters mOperationalNodeAdvertisingParams;
     CommissionAdvertisingParameters mCommissionableNodeAdvertisingParams;
-    CommissionAdvertisingParameters mCommissionerAdvertisingParams;
-    bool mIsOperationalPublishing        = false;
+    CommissionAdvertisingParameters mCommissionerNodeAdvertisingParams;
+    bool mIsOperationalNodePublishing    = false;
     bool mIsCommissionableNodePublishing = false;
-    bool mIsCommissionerPublishing       = false;
+    bool mIsCommissionerNodePublishing   = false;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
 
     bool mDnssdInitialized = false;

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -96,7 +96,7 @@ struct DiscoveredNodeData
     // TODO(cecille): is 4 OK? IPv6 LL, GUA, ULA, IPv4?
     static constexpr int kMaxIPAddresses = 5;
     char hostName[kHostNameMaxLength + 1];
-    char instanceName[Commissionable::kInstanceNameMaxLength + 1];
+    char instanceName[Commission::kInstanceNameMaxLength + 1];
     uint16_t longDiscriminator;
     uint16_t vendorId;
     uint16_t productId;
@@ -227,9 +227,9 @@ struct DiscoveredNodeData
 enum class DiscoveryFilterType : uint8_t
 {
     kNone,
-    kShort,
-    kLong,
-    kVendor,
+    kShortDiscriminator,
+    kLongDiscriminator,
+    kVendorId,
     kDeviceType,
     kCommissioningMode,
     kInstanceName,

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -97,7 +97,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
     size_t requiredSize;
     switch (subtype.type)
     {
-    case DiscoveryFilterType::kShort:
+    case DiscoveryFilterType::kShortDiscriminator:
         // 4-bit number
         if (subtype.code >= 1 << 4)
         {
@@ -105,7 +105,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         }
         requiredSize = snprintf(buffer, bufferLen, "_S%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
-    case DiscoveryFilterType::kLong:
+    case DiscoveryFilterType::kLongDiscriminator:
         // 12-bit number
         if (subtype.code >= 1 << 12)
         {
@@ -113,7 +113,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         }
         requiredSize = snprintf(buffer, bufferLen, "_L%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
-    case DiscoveryFilterType::kVendor:
+    case DiscoveryFilterType::kVendorId:
         if (subtype.code >= 1 << 16)
         {
             return CHIP_ERROR_INVALID_ARGUMENT;

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -232,7 +232,7 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DiscoveredN
     case TxtFieldKey::kMrpRetryIntervalActive:
         nodeData.mrpRetryIntervalActive = Internal::GetRetryInterval(val);
         break;
-    case TxtFieldKey::kTcpSupport:
+    case TxtFieldKey::kTcpSupported:
         nodeData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(val);
         break;
     default:
@@ -250,7 +250,7 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, ResolvedN
     case TxtFieldKey::kMrpRetryIntervalActive:
         nodeData.mMrpRetryIntervalActive = Internal::GetRetryInterval(value);
         break;
-    case TxtFieldKey::kTcpSupport:
+    case TxtFieldKey::kTcpSupported:
         nodeData.mSupportsTcp = Internal::MakeBoolFromAsciiDecimal(value);
         break;
     default:

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -31,19 +31,19 @@ namespace Dnssd {
 using namespace System::Clock::Literals;
 
 // Operational node TXT entries
-static constexpr size_t kTxtRetryIntervalIdleMaxLength           = 7; // [CRI] 0-3600000
-static constexpr size_t kTxtRetryIntervalActiveMaxLength         = 7; // [CRA] 0-3600000
+static constexpr size_t kKeyMrpRetryIntervalIdleMaxLength        = 7; // [CRI] 0-3600000
+static constexpr size_t kKeyMrpRetryIntervalActiveMaxLength      = 7; // [CRA] 0-3600000
 static constexpr System::Clock::Milliseconds32 kMaxRetryInterval = 3600000_ms32;
-static constexpr size_t kKeyTcpSupportMaxLength                  = 1;
+static constexpr size_t kKeyTcpSupportedMaxLength                = 1;
 
 // Commissionable/commissioner node TXT entries
-static constexpr size_t kKeyDiscriminatorMaxLength           = 5;
+static constexpr size_t kKeyLongDiscriminatorMaxLength       = 5;
 static constexpr size_t kKeyVendorProductMaxLength           = 11;
 static constexpr size_t kKeyAdditionalCommissioningMaxLength = 1;
 static constexpr size_t kKeyCommissioningModeMaxLength       = 1;
 static constexpr size_t kKeyDeviceTypeMaxLength              = 5;
 static constexpr size_t kKeyDeviceNameMaxLength              = 32;
-static constexpr size_t kKeyRotatingIdMaxLength              = 100;
+static constexpr size_t kKeyRotatingDeviceIdMaxLength        = 100;
 static constexpr size_t kKeyPairingInstructionMaxLength      = 128;
 static constexpr size_t kKeyPairingHintMaxLength             = 10;
 
@@ -68,7 +68,7 @@ enum class TxtFieldKey : uint8_t
     kPairingHint,
     kMrpRetryIntervalIdle,
     kMrpRetryIntervalActive,
-    kTcpSupport,
+    kTcpSupported,
     kCount,
 };
 
@@ -83,18 +83,18 @@ struct TxtFieldInfo
 
 constexpr const TxtFieldInfo txtFieldInfo[static_cast<size_t>(TxtFieldKey::kCount)] = {
     { TxtFieldKey::kUnknown, 0, "", TxtKeyUse::kNone },
-    { TxtFieldKey::kLongDiscriminator, kKeyDiscriminatorMaxLength, "D", TxtKeyUse::kCommission },
+    { TxtFieldKey::kLongDiscriminator, kKeyLongDiscriminatorMaxLength, "D", TxtKeyUse::kCommission },
     { TxtFieldKey::kVendorProduct, kKeyVendorProductMaxLength, "VP", TxtKeyUse::kCommission },
     { TxtFieldKey::kAdditionalPairing, kKeyAdditionalCommissioningMaxLength, "AP", TxtKeyUse::kCommission },
     { TxtFieldKey::kCommissioningMode, kKeyCommissioningModeMaxLength, "CM", TxtKeyUse::kCommission },
     { TxtFieldKey::kDeviceType, kKeyDeviceTypeMaxLength, "DT", TxtKeyUse::kCommission },
     { TxtFieldKey::kDeviceName, kKeyDeviceNameMaxLength, "DN", TxtKeyUse::kCommission },
-    { TxtFieldKey::kRotatingDeviceId, kKeyRotatingIdMaxLength, "RI", TxtKeyUse::kCommission },
+    { TxtFieldKey::kRotatingDeviceId, kKeyRotatingDeviceIdMaxLength, "RI", TxtKeyUse::kCommission },
     { TxtFieldKey::kPairingInstruction, kKeyPairingInstructionMaxLength, "PI", TxtKeyUse::kCommission },
     { TxtFieldKey::kPairingHint, kKeyPairingHintMaxLength, "PH", TxtKeyUse::kCommission },
-    { TxtFieldKey::kMrpRetryIntervalIdle, kTxtRetryIntervalIdleMaxLength, "CRI", TxtKeyUse::kCommon },
-    { TxtFieldKey::kMrpRetryIntervalActive, kTxtRetryIntervalActiveMaxLength, "CRA", TxtKeyUse::kCommon },
-    { TxtFieldKey::kTcpSupport, kKeyTcpSupportMaxLength, "T", TxtKeyUse::kCommon },
+    { TxtFieldKey::kMrpRetryIntervalIdle, kKeyMrpRetryIntervalIdleMaxLength, "CRI", TxtKeyUse::kCommon },
+    { TxtFieldKey::kMrpRetryIntervalActive, kKeyMrpRetryIntervalActiveMaxLength, "CRA", TxtKeyUse::kCommon },
+    { TxtFieldKey::kTcpSupported, kKeyTcpSupportedMaxLength, "T", TxtKeyUse::kCommon },
 };
 #ifdef CHIP_CONFIG_TEST
 

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -154,9 +154,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetCommissioningMode(CommissioningMode::kEnabledBasic)
         .SetDeviceName(chip::Optional<const char *>("testy-test"))
         .SetPairingHint(chip::Optional<uint16_t>(3))
-        .SetPairingInstr(chip::Optional<const char *>("Pair me"))
+        .SetPairingInstruction(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingId(chip::Optional<const char *>("id_that_spins"));
+        .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"));
 QNamePart txtCommissionableNodeParamsLargeBasicParts[] = { "D=22",          "VP=555+897",       "CM=1",       "DT=25",
                                                            "DN=testy-test", "RI=id_that_spins", "PI=Pair me", "PH=3" };
 FullQName txtCommissionableNodeParamsLargeBasicName    = FullQName(txtCommissionableNodeParamsLargeBasicParts);
@@ -174,9 +174,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetCommissioningMode(CommissioningMode::kEnabledEnhanced)
         .SetDeviceName(chip::Optional<const char *>("testy-test"))
         .SetPairingHint(chip::Optional<uint16_t>(3))
-        .SetPairingInstr(chip::Optional<const char *>("Pair me"))
+        .SetPairingInstruction(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
+        .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"))
         .SetTcpSupported(chip::Optional<bool>(true))
         // 3600005 is more than the max so should be adjusted down
         .SetMRPConfig(ReliableMessageProtocolConfig(3600000_ms32, 3600005_ms32));

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -90,9 +90,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetCommissioningMode(CommissioningMode::kEnabledBasic)
         .SetDeviceName(chip::Optional<const char *>("testy-test"))
         .SetPairingHint(chip::Optional<uint16_t>(3))
-        .SetPairingInstr(chip::Optional<const char *>("Pair me"))
+        .SetPairingInstruction(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
+        .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"))
         .SetTcpSupported(chip::Optional<bool>(true))
         // 3600005 is over the max, so this should be adjusted by the platform
         .SetMRPConfig({ 3600000_ms32, 3600005_ms32 });
@@ -128,9 +128,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetCommissioningMode(CommissioningMode::kEnabledEnhanced)
         .SetDeviceName(chip::Optional<const char *>("testy-test"))
         .SetPairingHint(chip::Optional<uint16_t>(3))
-        .SetPairingInstr(chip::Optional<const char *>("Pair me"))
+        .SetPairingInstruction(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingId(chip::Optional<const char *>("id_that_spins"));
+        .SetRotatingDeviceId(chip::Optional<const char *>("id_that_spins"));
 
 test::ExpectedCall commissionableLargeEnhanced = test::ExpectedCall()
                                                      .SetProtocol(DnssdServiceProtocol::kDnssdProtocolUdp)

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -104,7 +104,7 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     DiscoveryFilter filter;
 
     // Long tests
-    filter.type = DiscoveryFilterType::kLong;
+    filter.type = DiscoveryFilterType::kLongDiscriminator;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L3") == 0);
@@ -117,7 +117,7 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) != CHIP_NO_ERROR);
 
     // Short tests
-    filter.type = DiscoveryFilterType::kShort;
+    filter.type = DiscoveryFilterType::kShortDiscriminator;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S3") == 0);
@@ -130,7 +130,7 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) != CHIP_NO_ERROR);
 
     // Vendor tests
-    filter.type = DiscoveryFilterType::kVendor;
+    filter.type = DiscoveryFilterType::kVendorId;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_V3") == 0);
@@ -178,7 +178,7 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     DiscoveryFilter filter;
 
     // Long tests
-    filter.type = DiscoveryFilterType::kLong;
+    filter.type = DiscoveryFilterType::kLongDiscriminator;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
@@ -194,7 +194,7 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) != CHIP_NO_ERROR);
 
     // Short tests
-    filter.type = DiscoveryFilterType::kShort;
+    filter.type = DiscoveryFilterType::kShortDiscriminator;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
@@ -210,7 +210,7 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) != CHIP_NO_ERROR);
 
     // Vendor tests
-    filter.type = DiscoveryFilterType::kVendor;
+    filter.type = DiscoveryFilterType::kVendorId;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -75,7 +75,7 @@ void TestGetTxtFieldKey(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kMrpRetryIntervalActive);
 
     strcpy(key, "T");
-    NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kTcpSupport);
+    NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kTcpSupported);
 
     strcpy(key, "XX");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kUnknown);

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -147,13 +147,13 @@ bool ParseSubType(int argc, char ** argv, Dnssd::DiscoveryFilter & filter)
     switch (subtype[1])
     {
     case 'S':
-        filterType = Dnssd::DiscoveryFilterType::kShort;
+        filterType = Dnssd::DiscoveryFilterType::kShortDiscriminator;
         break;
     case 'L':
-        filterType = Dnssd::DiscoveryFilterType::kLong;
+        filterType = Dnssd::DiscoveryFilterType::kLongDiscriminator;
         break;
     case 'V':
-        filterType = Dnssd::DiscoveryFilterType::kVendor;
+        filterType = Dnssd::DiscoveryFilterType::kVendorId;
         break;
     case 'T':
         filterType = Dnssd::DiscoveryFilterType::kDeviceType;

--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -108,7 +108,7 @@ public:
 
 private:
     PeerAddress mPeerAddress;
-    char mInstanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
+    char mInstanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
     char mDeviceName[Dnssd::kMaxDeviceNameLen + 1];
     uint16_t mLongDiscriminator = 0;
     uint16_t mVendorId;

--- a/src/protocols/user_directed_commissioning/UDCClients.h
+++ b/src/protocols/user_directed_commissioning/UDCClients.h
@@ -159,7 +159,7 @@ public:
             }
 
             // TODO: check length of instanceName
-            if (strncmp(stateiter.GetInstanceName(), instanceName, Dnssd::Commissionable::kInstanceNameMaxLength + 1) == 0)
+            if (strncmp(stateiter.GetInstanceName(), instanceName, Dnssd::Commission::kInstanceNameMaxLength + 1) == 0)
             {
                 state = &stateiter;
                 break;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -47,8 +47,8 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
     PayloadHeader payloadHeader;
     ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
 
-    char instanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
-    size_t instanceNameLength = std::min<size_t>(msg->DataLength(), Dnssd::Commissionable::kInstanceNameMaxLength);
+    char instanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    size_t instanceNameLength = std::min<size_t>(msg->DataLength(), Dnssd::Commission::kInstanceNameMaxLength);
     msg->Read(Uint8::from_char(instanceName), instanceNameLength);
 
     instanceName[instanceNameLength] = '\0';

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -140,7 +140,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
 
     // encode our client message
-    char nameBuffer[Dnssd::Commissionable::kInstanceNameMaxLength + 1] = "Chris";
+    char nameBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1] = "Chris";
     System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
     udcClient.EncodeUDCMessage(std::move(payloadBuf));
 
@@ -189,7 +189,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
 
 void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * inContext)
 {
-    char nameBuffer[Dnssd::Commissionable::kInstanceNameMaxLength + 1] = "Chris";
+    char nameBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1] = "Chris";
     System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
     UserDirectedCommissioningClient udcClient;
 
@@ -210,8 +210,8 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     NL_TEST_ASSERT(inSuite, payloadHeader.IsInitiator());
 
     // check the payload
-    char instanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
-    size_t instanceNameLength = std::min<size_t>(payloadBuf->DataLength(), Dnssd::Commissionable::kInstanceNameMaxLength);
+    char instanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
+    size_t instanceNameLength = std::min<size_t>(payloadBuf->DataLength(), Dnssd::Commission::kInstanceNameMaxLength);
     payloadBuf->Read(Uint8::from_char(instanceName), instanceNameLength);
     instanceName[instanceNameLength] = '\0';
     ChipLogProgress(Inet, "UDC instance=%s", instanceName);


### PR DESCRIPTION
#### Problem

There is a lot of code duplicated into `Discovery_ImplPlatform.cpp` and the dnssd naming for methods and variables is not always consistent which makes it harder to read than what it should be.
The 2 methods that I have focused on in this PR are the `Advertise` methods, both for operation and commissionable nodes.

#### Change overview
 * Update names so they are at least consistent
 * Update `Discovery_ImplPlatform.cpp` code to benefit from those consistent names and use some macros to help readability.

#### Testing
I have locally checked that discovering the node over mdns  is still successful.