### PR TITLE
ObjectPool: Use Platform::New and rename modes

### DIFF
--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -228,7 +228,7 @@ private:
 
 // The PoolImpl impl is used as a base class because its destructor must be called after ServerBase's destructor.
 template <size_t kCount>
-class Server : private chip::PoolImpl<ServerBase::EndpointInfo, kCount, chip::ObjectPoolMem::kStatic,
+class Server : private chip::PoolImpl<ServerBase::EndpointInfo, kCount, chip::ObjectPoolMem::kInline,
                                       ServerBase::EndpointInfoPoolType::Interface>,
                public ServerBase
 {

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -71,7 +71,7 @@ void MakePrintableName(char (&location)[N], FullQName name)
 
 } // namespace
 
-class CheckOnlyServer : private chip::PoolImpl<ServerBase::EndpointInfo, 0, chip::ObjectPoolMem::kStatic,
+class CheckOnlyServer : private chip::PoolImpl<ServerBase::EndpointInfo, 0, chip::ObjectPoolMem::kInline,
                                                ServerBase::EndpointInfoPoolType::Interface>,
                         public ServerBase,
                         public ParserDelegate,

--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -151,7 +151,7 @@ Loop HeapObjectList::ForEachNode(void * context, Lambda lambda)
             if (p->mObject == nullptr)
             {
                 p->Remove();
-                delete p;
+                Platform::Delete(p);
             }
             p = next;
         }

--- a/src/lib/support/tests/TestPool.cpp
+++ b/src/lib/support/tests/TestPool.cpp
@@ -62,20 +62,20 @@ void TestReleaseNull(nlTestSuite * inSuite, void * inContext)
 
 void TestReleaseNullStatic(nlTestSuite * inSuite, void * inContext)
 {
-    TestReleaseNull<uint32_t, 10, ObjectPoolMem::kStatic>(inSuite, inContext);
+    TestReleaseNull<uint32_t, 10, ObjectPoolMem::kInline>(inSuite, inContext);
 }
 
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 void TestReleaseNullDynamic(nlTestSuite * inSuite, void * inContext)
 {
-    TestReleaseNull<uint32_t, 10, ObjectPoolMem::kDynamic>(inSuite, inContext);
+    TestReleaseNull<uint32_t, 10, ObjectPoolMem::kHeap>(inSuite, inContext);
 }
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
 template <typename T, size_t N, ObjectPoolMem P>
 void TestCreateReleaseObject(nlTestSuite * inSuite, void * inContext)
 {
-    ObjectPool<uint32_t, N, ObjectPoolMem::kStatic> pool;
+    ObjectPool<uint32_t, N, ObjectPoolMem::kInline> pool;
     uint32_t * obj[N];
 
     NL_TEST_ASSERT(inSuite, pool.Allocated() == 0);
@@ -104,9 +104,9 @@ void TestCreateReleaseObject(nlTestSuite * inSuite, void * inContext)
 void TestCreateReleaseObjectStatic(nlTestSuite * inSuite, void * inContext)
 {
     constexpr const size_t kSize = 100;
-    TestCreateReleaseObject<uint32_t, kSize, ObjectPoolMem::kStatic>(inSuite, inContext);
+    TestCreateReleaseObject<uint32_t, kSize, ObjectPoolMem::kInline>(inSuite, inContext);
 
-    ObjectPool<uint32_t, kSize, ObjectPoolMem::kStatic> pool;
+    ObjectPool<uint32_t, kSize, ObjectPoolMem::kInline> pool;
     uint32_t * obj[kSize];
 
     for (size_t i = 0; i < kSize; ++i)
@@ -144,7 +144,7 @@ void TestCreateReleaseObjectStatic(nlTestSuite * inSuite, void * inContext)
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 void TestCreateReleaseObjectDynamic(nlTestSuite * inSuite, void * inContext)
 {
-    TestCreateReleaseObject<uint32_t, 100, ObjectPoolMem::kDynamic>(inSuite, inContext);
+    TestCreateReleaseObject<uint32_t, 100, ObjectPoolMem::kHeap>(inSuite, inContext);
 }
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
@@ -201,13 +201,13 @@ void TestCreateReleaseStruct(nlTestSuite * inSuite, void * inContext)
 
 void TestCreateReleaseStructStatic(nlTestSuite * inSuite, void * inContext)
 {
-    TestCreateReleaseStruct<ObjectPoolMem::kStatic>(inSuite, inContext);
+    TestCreateReleaseStruct<ObjectPoolMem::kInline>(inSuite, inContext);
 }
 
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 void TestCreateReleaseStructDynamic(nlTestSuite * inSuite, void * inContext)
 {
-    TestCreateReleaseStruct<ObjectPoolMem::kDynamic>(inSuite, inContext);
+    TestCreateReleaseStruct<ObjectPoolMem::kHeap>(inSuite, inContext);
 }
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
@@ -334,13 +334,13 @@ void TestForEachActiveObject(nlTestSuite * inSuite, void * inContext)
 
 void TestForEachActiveObjectStatic(nlTestSuite * inSuite, void * inContext)
 {
-    TestForEachActiveObject<ObjectPoolMem::kStatic>(inSuite, inContext);
+    TestForEachActiveObject<ObjectPoolMem::kInline>(inSuite, inContext);
 }
 
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 void TestForEachActiveObjectDynamic(nlTestSuite * inSuite, void * inContext)
 {
-    TestForEachActiveObject<ObjectPoolMem::kDynamic>(inSuite, inContext);
+    TestForEachActiveObject<ObjectPoolMem::kHeap>(inSuite, inContext);
 }
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
@@ -397,23 +397,24 @@ void TestPoolInterface(nlTestSuite * inSuite, void * inContext)
 
 void TestPoolInterfaceStatic(nlTestSuite * inSuite, void * inContext)
 {
-    TestPoolInterface<ObjectPoolMem::kStatic>(inSuite, inContext);
+    TestPoolInterface<ObjectPoolMem::kInline>(inSuite, inContext);
 }
 
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 void TestPoolInterfaceDynamic(nlTestSuite * inSuite, void * inContext)
 {
-    TestPoolInterface<ObjectPoolMem::kDynamic>(inSuite, inContext);
+    TestPoolInterface<ObjectPoolMem::kHeap>(inSuite, inContext);
 }
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
 int Setup(void * inContext)
 {
-    return SUCCESS;
+    return ::chip::Platform::MemoryInit() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
 }
 
 int Teardown(void * inContext)
 {
+    ::chip::Platform::MemoryShutdown();
     return SUCCESS;
 }
 

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -442,6 +442,11 @@ static int TestSetup(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
 
+    if (::chip::Platform::MemoryInit() != CHIP_NO_ERROR)
+    {
+        return FAILURE;
+    }
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR == 2 && LWIP_VERSION_MINOR == 0
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
@@ -471,6 +476,7 @@ static int TestTeardown(void * aContext)
     tcpip_finish(NULL, NULL);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP && (LWIP_VERSION_MAJOR == 2) && (LWIP_VERSION_MINOR == 0)
 
+    ::chip::Platform::MemoryShutdown();
     return (SUCCESS);
 }
 

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -281,7 +281,7 @@ public:
 private:
     friend class TCPTest;
     TCPBase::ActiveConnectionState mConnectionsBuffer[kActiveConnectionsSize];
-    PoolImpl<PendingPacket, kPendingPacketSize, ObjectPoolMem::kStatic, PendingPacketPoolType::Interface> mPendingPackets;
+    PoolImpl<PendingPacket, kPendingPacketSize, ObjectPoolMem::kInline, PendingPacketPoolType::Interface> mPendingPackets;
 };
 
 } // namespace Transport


### PR DESCRIPTION
#### Problem

- Heap allocations should use `Platform::New` rather than raw `new`.
- `ObjectPoolMem::kStatic` could be misleading, since the pool memory is
  part of the enclosing context, not static unless also declared `static`.

#### Change overview

- Use `Platform::New` and `Platform::Delete`.
- Rename `ObjectPoolMem::kStatic` → `kInline` and `kDynamic` → `kHeap`.

#### Testing

CI
