### PR TITLE
Stop throwing exceptions from the CallbackBridge constructor on Darwin.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
@@ -41,12 +41,12 @@ public:
         });
 
         if (CHIP_NO_ERROR != err) {
-            dispatch_async(queue, ^{
-                handler(nil, [CHIPError errorForCHIPErrorCode:err]);
-            });
+            NSLog(@"Failure performing action. C++-mangled success callback type: '%s', error: %s", typeid(T).name(),
+                chip::ErrorStr(err));
 
-            NSString * errorStr = [NSString stringWithFormat:@"%s: %s", typeid(T).name(), chip::ErrorStr(err)];
-            @throw [NSException exceptionWithName:errorStr reason:nil userInfo:nil];
+            // Take the normal async error-reporting codepath.  This will also
+            // handle cleaning us up properly.
+            DispatchFailure(this, [CHIPError errorForCHIPErrorCode:err]);
         }
     };
 


### PR DESCRIPTION
This leads to a weird situation where depending on exactly what the
action block does we might throw from the call _and_ queue up an async
error report, or maybe we'll just do an async error report.

Instead, just reuse our normal async error report machinery to report
the error we ran into.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Gets me one step closer to passing darwin tests in #13072