### PR TITLE
Disable the watchdog in QEMU builds.

### DIFF
--- a/src/test_driver/esp32/sdkconfig_qemu.defaults
+++ b/src/test_driver/esp32/sdkconfig_qemu.defaults
@@ -44,3 +44,8 @@ CONFIG_ENABLE_WIFI_AP=n
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# No watchdog - we run on the host and tests have timeouts
+# Crypto tests generally take long enough for the watchdog to trigger
+# otherwise.
+CONFIG_ESP_TASK_WDT=n


### PR DESCRIPTION
#### Problem
The watchdog triggers during crypto tests (long running, full CPU tests)
and the warnings it shows both look scary and are not really actionable.
We know those tests take a long time, especially in emulation.

#### Change overview
Disable the watchdog when compiling for qemu.

#### Testing
Locally ran crypto tests and saw no more watchdog complains. CI should also show this.