### PR TITLE
ESP32: Update ESP-IDF in CHIP to v4.4-beta1 pre-release

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -40,14 +40,14 @@ the riscv-esp32-elf toolchain for ESP32C3 modules.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -83,14 +83,14 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/ipv6only-app/esp32/README.md
+++ b/examples/ipv6only-app/esp32/README.md
@@ -20,14 +20,14 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -23,14 +23,14 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -42,14 +42,14 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -35,14 +35,14 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -23,14 +23,14 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout branch
-    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
+-   Clone the Espressif ESP-IDF and checkout
+    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout release/v4.4
+          $ git checkout v4.4-beta1
           $ git submodule update --init
           $ ./install.sh
 

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,8 +10,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b release/v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
-    && git -C /tmp/esp-idf checkout f23dcd3555cd59dfd44f4d7fbf2242c9827f91f1 \
+    && git clone --recursive -b v4.4-beta1 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.40 Version bump reason: nRF Connect SDK update
+0.5.41 Version bump reason: ESP-IDF update to v4.4-beta1 pre-release


### PR DESCRIPTION
#### Problem
Currently, ESP-IDF used with CHIP is from release/v4.4 branch.

#### Change overview
Update ESP-IDF to v4.4-beta1 pre-release

#### Testing
Compilation of all-clusters-app on ESP32 and ESP32-C3
Sanity testing (commissioning and cluster control) on ESP32 and ESP32-C3