### PR TITLE
[TestCluster] Test cluster use negative defaults for ints types

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -15748,7 +15748,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "-20",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -15778,7 +15778,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "-100",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -16288,7 +16288,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "-20",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -16318,7 +16318,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "-100",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -19580,5 +19580,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 22
     }
-  ]
+  ],
+  "log": []
 }

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -3010,7 +3010,7 @@ tests:
       command: "readAttribute"
       attribute: "range_restricted_int8s"
       response:
-          value: 0 # ZAP won't allow setting a negative default!
+          value: -20
 
     - label: "Write min value to a range-restricted signed 8-bit integer"
       command: "writeAttribute"
@@ -3053,7 +3053,7 @@ tests:
       command: "readAttribute"
       attribute: "range_restricted_int8s"
       response:
-          value: 0
+          value: -20
 
     - label: "Write min valid value to a range-restricted signed 8-bit integer"
       command: "writeAttribute"
@@ -3099,7 +3099,7 @@ tests:
       command: "readAttribute"
       attribute: "range_restricted_int16s"
       response:
-          value: 0 # ZAP won't allow setting a negative default!
+          value: -100
 
     - label: "Write min value to a range-restricted signed 16-bit integer"
       command: "writeAttribute"
@@ -3142,7 +3142,7 @@ tests:
       command: "readAttribute"
       attribute: "range_restricted_int16s"
       response:
-          value: 0
+          value: -100
 
     - label: "Write min valid value to a range-restricted signed 16-bit integer"
       command: "writeAttribute"
@@ -3422,7 +3422,7 @@ tests:
       command: "readAttribute"
       attribute: "nullable_range_restricted_int8s"
       response:
-          value: 0 # ZAP won't allow setting a negative default!
+          value: -20
 
     - label:
           "Write min value to a nullable range-restricted signed 8-bit integer"
@@ -3468,7 +3468,7 @@ tests:
       command: "readAttribute"
       attribute: "nullable_range_restricted_int8s"
       response:
-          value: 0
+          value: -20
 
     - label:
           "Write min valid value to a nullable range-restricted signed 8-bit
@@ -3537,7 +3537,7 @@ tests:
       command: "readAttribute"
       attribute: "nullable_range_restricted_int16s"
       response:
-          value: 0 # ZAP won't allow setting a negative default!
+          value: -100
 
     - label:
           "Write min value to a nullable range-restricted signed 16-bit integer"
@@ -3583,7 +3583,7 @@ tests:
       command: "readAttribute"
       attribute: "nullable_range_restricted_int16s"
       response:
-          value: 0
+          value: -100
 
     - label:
           "Write min valid value to a nullable range-restricted signed 16-bit

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -29855,7 +29855,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
 
         {
             id actualValue = value;
-            XCTAssertEqual([actualValue charValue], 0);
+            XCTAssertEqual([actualValue charValue], -20);
         }
 
         [expectation fulfill];
@@ -29976,7 +29976,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
 
         {
             id actualValue = value;
-            XCTAssertEqual([actualValue charValue], 0);
+            XCTAssertEqual([actualValue charValue], -20);
         }
 
         [expectation fulfill];
@@ -30147,7 +30147,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
 
         {
             id actualValue = value;
-            XCTAssertEqual([actualValue shortValue], 0);
+            XCTAssertEqual([actualValue shortValue], -100);
         }
 
         [expectation fulfill];
@@ -30268,7 +30268,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
 
         {
             id actualValue = value;
-            XCTAssertEqual([actualValue shortValue], 0);
+            XCTAssertEqual([actualValue shortValue], -100);
         }
 
         [expectation fulfill];
@@ -31154,7 +31154,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
         {
             id actualValue = value;
             XCTAssertFalse(actualValue == nil);
-            XCTAssertEqual([actualValue charValue], 0);
+            XCTAssertEqual([actualValue charValue], -20);
         }
 
         [expectation fulfill];
@@ -31282,7 +31282,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
         {
             id actualValue = value;
             XCTAssertFalse(actualValue == nil);
-            XCTAssertEqual([actualValue charValue], 0);
+            XCTAssertEqual([actualValue charValue], -20);
         }
 
         [expectation fulfill];
@@ -31512,7 +31512,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
             {
                 id actualValue = value;
                 XCTAssertFalse(actualValue == nil);
-                XCTAssertEqual([actualValue shortValue], 0);
+                XCTAssertEqual([actualValue shortValue], -100);
             }
 
             [expectation fulfill];
@@ -31639,7 +31639,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
             {
                 id actualValue = value;
                 XCTAssertFalse(actualValue == nil);
-                XCTAssertEqual([actualValue shortValue], 0);
+                XCTAssertEqual([actualValue shortValue], -100);
             }
 
             [expectation fulfill];

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -1446,15 +1446,15 @@
             { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF }, /* start up color temperature mireds */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Test Cluster (server) */                                                                      \
-            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },  /* range_restricted_int8u */                                   \
-            { (uint16_t) 0x0, (uint16_t) -0x28, (uint16_t) 0x32 },  /* range_restricted_int8s */                                   \
-            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 }, /* range_restricted_int16u */                                  \
-            { (uint16_t) 0x0, (uint16_t) -0x96, (uint16_t) 0xC8 },  /* range_restricted_int16s */                                  \
-            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },  /* nullable_range_restricted_int8u */                          \
-            { (uint16_t) 0x0, (uint16_t) -0x28, (uint16_t) 0x32 },  /* nullable_range_restricted_int8s */                          \
-            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 }, /* nullable_range_restricted_int16u */                         \
+            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* range_restricted_int8u */                                  \
+            { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* range_restricted_int8s */                                  \
+            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* range_restricted_int16u */                                 \
+            { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* range_restricted_int16s */                                 \
+            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* nullable_range_restricted_int8u */                         \
+            { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* nullable_range_restricted_int8s */                         \
+            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* nullable_range_restricted_int16u */                        \
         {                                                                                                                          \
-            (uint16_t) 0x0, (uint16_t) -0x96, (uint16_t) 0xC8                                                                      \
+            (uint16_t) - 0x64, (uint16_t) -0x96, (uint16_t) 0xC8                                                                   \
         } /* nullable_range_restricted_int16s */                                                                                   \
     }
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -48983,7 +48983,7 @@ private:
 
     void OnSuccessResponse_386(int8_t rangeRestrictedInt8s)
     {
-        VerifyOrReturn(CheckValue("rangeRestrictedInt8s", rangeRestrictedInt8s, 0));
+        VerifyOrReturn(CheckValue("rangeRestrictedInt8s", rangeRestrictedInt8s, -20));
 
         NextTest();
     }
@@ -49091,7 +49091,7 @@ private:
 
     void OnSuccessResponse_391(int8_t rangeRestrictedInt8s)
     {
-        VerifyOrReturn(CheckValue("rangeRestrictedInt8s", rangeRestrictedInt8s, 0));
+        VerifyOrReturn(CheckValue("rangeRestrictedInt8s", rangeRestrictedInt8s, -20));
 
         NextTest();
     }
@@ -49225,7 +49225,7 @@ private:
 
     void OnSuccessResponse_398(int16_t rangeRestrictedInt16s)
     {
-        VerifyOrReturn(CheckValue("rangeRestrictedInt16s", rangeRestrictedInt16s, 0));
+        VerifyOrReturn(CheckValue("rangeRestrictedInt16s", rangeRestrictedInt16s, -100));
 
         NextTest();
     }
@@ -49333,7 +49333,7 @@ private:
 
     void OnSuccessResponse_403(int16_t rangeRestrictedInt16s)
     {
-        VerifyOrReturn(CheckValue("rangeRestrictedInt16s", rangeRestrictedInt16s, 0));
+        VerifyOrReturn(CheckValue("rangeRestrictedInt16s", rangeRestrictedInt16s, -100));
 
         NextTest();
     }
@@ -50067,7 +50067,7 @@ private:
     void OnSuccessResponse_438(const chip::app::DataModel::Nullable<int8_t> & nullableRangeRestrictedInt8s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", nullableRangeRestrictedInt8s));
-        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", nullableRangeRestrictedInt8s.Value(), 0));
+        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", nullableRangeRestrictedInt8s.Value(), -20));
 
         NextTest();
     }
@@ -50181,7 +50181,7 @@ private:
     void OnSuccessResponse_443(const chip::app::DataModel::Nullable<int8_t> & nullableRangeRestrictedInt8s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", nullableRangeRestrictedInt8s));
-        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", nullableRangeRestrictedInt8s.Value(), 0));
+        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", nullableRangeRestrictedInt8s.Value(), -20));
 
         NextTest();
     }
@@ -50366,7 +50366,7 @@ private:
     void OnSuccessResponse_452(const chip::app::DataModel::Nullable<int16_t> & nullableRangeRestrictedInt16s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", nullableRangeRestrictedInt16s));
-        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", nullableRangeRestrictedInt16s.Value(), 0));
+        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", nullableRangeRestrictedInt16s.Value(), -100));
 
         NextTest();
     }
@@ -50480,7 +50480,7 @@ private:
     void OnSuccessResponse_457(const chip::app::DataModel::Nullable<int16_t> & nullableRangeRestrictedInt16s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", nullableRangeRestrictedInt16s));
-        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", nullableRangeRestrictedInt16s.Value(), 0));
+        VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", nullableRangeRestrictedInt16s.Value(), -100));
 
         NextTest();
     }


### PR DESCRIPTION
#### Problem

Some of the tests for reading attributes from `TestCluster` were expecting negative defaults. Not that ZAP has been updated this is possible.

#### Change overview
 * Search for `# ZAP won't allow setting a negative default!` in `src/app/tests/suites` and use the ZAP UI to use defaults for the linked attributes for the `all-clusters-app`
 * Update the tests to expect those negative defaults

#### Testing
Tests are green after everything has been regenerated.