### PR TITLE
Fix iOS CHIPTool commissioning

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -35,6 +35,7 @@ BOOL CHIPIsDevicePaired(uint64_t id);
 BOOL CHIPGetConnectedDevice(CHIPDeviceConnectionCallback completionHandler);
 BOOL CHIPGetConnectedDeviceWithID(uint64_t deviceId, CHIPDeviceConnectionCallback completionHandler);
 void CHIPUnpairDeviceWithID(uint64_t deviceId);
+CHIPDevice * CHIPGetDeviceBeingCommissioned(void);
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
 

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -99,8 +99,7 @@ CHIPDevice * CHIPGetDeviceBeingCommissioned(void)
     NSError * error;
     CHIPDeviceController * controller = InitializeCHIP();
     CHIPDevice * device = [controller getDeviceBeingCommissioned:CHIPGetLastPairedDeviceId() error:&error];
-    if (error)
-    {
+    if (error) {
         NSLog(@"Error retrieving device being commissioned for deviceId %llu", CHIPGetLastPairedDeviceId());
         return nil;
     }

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -76,18 +76,35 @@ CHIPDeviceController * InitializeCHIP(void)
     return controller;
 }
 
+uint64_t CHIPGetLastPairedDeviceId(void)
+{
+    uint64_t deviceId = CHIPGetNextAvailableDeviceID();
+    if (deviceId > 1) {
+        deviceId--;
+    }
+    return deviceId;
+}
+
 BOOL CHIPGetConnectedDevice(CHIPDeviceConnectionCallback completionHandler)
 {
     CHIPDeviceController * controller = InitializeCHIP();
 
-    uint64_t deviceId = CHIPGetNextAvailableDeviceID();
-    if (deviceId > 1) {
-        // Let's use the last device that was paired
-        deviceId--;
-        return [controller getConnectedDevice:deviceId queue:dispatch_get_main_queue() completionHandler:completionHandler];
-    }
+    // Let's use the last device that was paired
+    uint64_t deviceId = CHIPGetLastPairedDeviceId();
+    return [controller getConnectedDevice:deviceId queue:dispatch_get_main_queue() completionHandler:completionHandler];
+}
 
-    return NO;
+CHIPDevice * CHIPGetDeviceBeingCommissioned(void)
+{
+    NSError * error;
+    CHIPDeviceController * controller = InitializeCHIP();
+    CHIPDevice * device = [controller getDeviceBeingCommissioned:CHIPGetLastPairedDeviceId() error:&error];
+    if (error)
+    {
+        NSLog(@"Error retrieving device being commissioned for deviceId %llu", CHIPGetLastPairedDeviceId());
+        return nil;
+    }
+    return device;
 }
 
 BOOL CHIPGetConnectedDeviceWithID(uint64_t deviceId, CHIPDeviceConnectionCallback completionHandler)

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -539,20 +539,19 @@
     CHIPDevice * chipDevice = CHIPGetDeviceBeingCommissioned();
     if (chipDevice) {
         self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
-        __auto_type * params = [[CHIPNetworkCommissioningClusterAddWiFiNetworkParams alloc] init];
+        __auto_type * params = [[CHIPNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams alloc] init];
         params.ssid = [ssid dataUsingEncoding:NSUTF8StringEncoding];
         params.credentials = [password dataUsingEncoding:NSUTF8StringEncoding];
         params.breadcrumb = @(0);
 
         __weak typeof(self) weakSelf = self;
-        [self->_cluster addWiFiNetworkWithParams:params
-                               completionHandler:^(CHIPNetworkCommissioningClusterAddWiFiNetworkResponseParams * _Nullable response,
-                                   NSError * _Nullable error) {
-                                   // TODO: addWiFiNetworkWithParams
-                                   // returns status in its response,
-                                   // not via the NSError!
-                                   [weakSelf onAddNetworkResponse:error isWiFi:YES];
-                               }];
+        [self->_cluster addOrUpdateWiFiNetworkWithParams:params
+                                       completionHandler:^(CHIPNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable response, NSError * _Nullable error) {
+            // TODO: addWiFiNetworkWithParams
+            // returns status in its response,
+            // not via the NSError!
+            [weakSelf onAddNetworkResponse:error isWiFi:YES];
+        }];
     } else {
         NSLog(@"Status: Failed to find a device being commissioned");
     }
@@ -563,14 +562,14 @@
     CHIPDevice * chipDevice = CHIPGetDeviceBeingCommissioned();
     if (chipDevice) {
         self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
-        __auto_type * params = [[CHIPNetworkCommissioningClusterAddThreadNetworkParams alloc] init];
+        __auto_type * params = [[CHIPNetworkCommissioningClusterAddOrUpdateThreadNetworkParams alloc] init];
         params.operationalDataset = threadDataSet;
         params.breadcrumb = @(0);
 
         __weak typeof(self) weakSelf = self;
         [self->_cluster
-            addThreadNetworkWithParams:params
-                     completionHandler:^(CHIPNetworkCommissioningClusterAddThreadNetworkResponseParams * _Nullable response,
+         addOrUpdateThreadNetworkWithParams:params
+                     completionHandler:^(CHIPNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable response,
                          NSError * _Nullable error) {
                          // TODO: addThreadNetworkWithParams
                          // returns status in its response,

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -536,66 +536,49 @@
 
 - (void)addOrUpdateWiFiNetwork:(NSString *)ssid password:(NSString *)password
 {
-    if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
-            if (chipDevice) {
-                self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice
-                                                                       endpoint:0
-                                                                          queue:dispatch_get_main_queue()];
-                __auto_type * params = [[CHIPNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams alloc] init];
-                params.ssid = [ssid dataUsingEncoding:NSUTF8StringEncoding];
-                params.credentials = [password dataUsingEncoding:NSUTF8StringEncoding];
-                params.breadcrumb = @(0);
+    CHIPDevice * chipDevice = CHIPGetDeviceBeingCommissioned();
+    if (chipDevice) {
+        self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
+        __auto_type * params = [[CHIPNetworkCommissioningClusterAddWiFiNetworkParams alloc] init];
+        params.ssid = [ssid dataUsingEncoding:NSUTF8StringEncoding];
+        params.credentials = [password dataUsingEncoding:NSUTF8StringEncoding];
+        params.breadcrumb = @(0);
 
-                __weak typeof(self) weakSelf = self;
-                [self->_cluster
-                    addOrUpdateWiFiNetworkWithParams:params
-                                   completionHandler:^(
-                                       CHIPNetworkCommissioningClusterAddOrUpdateWiFiNetworkResponseParams * _Nullable response,
-                                       NSError * _Nullable error) {
-                                       // TODO: addOrUpdateWiFiNetworkWithParams
-                                       // returns status in its response,
-                                       // not via the NSError!
-                                       [weakSelf onAddNetworkResponse:error isWiFi:YES];
-                                   }];
-            } else {
-                NSLog(@"Status: Failed to establish a connection with the device");
-            }
-        })) {
-        NSLog(@"Status: Waiting for connection with the device");
+        __weak typeof(self) weakSelf = self;
+        [self->_cluster addWiFiNetworkWithParams:params
+                               completionHandler:^(CHIPNetworkCommissioningClusterAddWiFiNetworkResponseParams * _Nullable response,
+                                   NSError * _Nullable error) {
+                                   // TODO: addWiFiNetworkWithParams
+                                   // returns status in its response,
+                                   // not via the NSError!
+                                   [weakSelf onAddNetworkResponse:error isWiFi:YES];
+                               }];
     } else {
-        NSLog(@"Status: Failed to trigger the connection with the device");
+        NSLog(@"Status: Failed to find a device being commissioned");
     }
 }
 
 - (void)addOrUpdateThreadNetwork:(NSData *)threadDataSet
 {
-    if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
-            if (chipDevice) {
-                self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice
-                                                                       endpoint:0
-                                                                          queue:dispatch_get_main_queue()];
-                __auto_type * params = [[CHIPNetworkCommissioningClusterAddOrUpdateThreadNetworkParams alloc] init];
-                params.operationalDataset = threadDataSet;
-                params.breadcrumb = @(0);
+    CHIPDevice * chipDevice = CHIPGetDeviceBeingCommissioned();
+    if (chipDevice) {
+        self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
+        __auto_type * params = [[CHIPNetworkCommissioningClusterAddThreadNetworkParams alloc] init];
+        params.operationalDataset = threadDataSet;
+        params.breadcrumb = @(0);
 
-                __weak typeof(self) weakSelf = self;
-                [self->_cluster
-                    addOrUpdateThreadNetworkWithParams:params
-                                     completionHandler:^(
-                                         CHIPNetworkCommissioningClusterAddOrUpdateThreadNetworkResponseParams * _Nullable response,
-                                         NSError * _Nullable error) {
-                                         // TODO: addOrUpdateThreadNetworkWithParams
-                                         // returns status in its response,
-                                         // not via the NSError!
-                                         [weakSelf onAddNetworkResponse:error isWiFi:NO];
-                                     }];
-            } else {
-                NSLog(@"Status: Failed to establish a connection with the device");
-            }
-        })) {
-        NSLog(@"Status: Waiting for connection with the device");
+        __weak typeof(self) weakSelf = self;
+        [self->_cluster
+            addThreadNetworkWithParams:params
+                     completionHandler:^(CHIPNetworkCommissioningClusterAddThreadNetworkResponseParams * _Nullable response,
+                         NSError * _Nullable error) {
+                         // TODO: addThreadNetworkWithParams
+                         // returns status in its response,
+                         // not via the NSError!
+                         [weakSelf onAddNetworkResponse:error isWiFi:NO];
+                     }];
     } else {
-        NSLog(@"Status: Failed to trigger the connection with the device");
+        NSLog(@"Status: Failed to find a device being  commissioned");
     }
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -545,13 +545,15 @@
         params.breadcrumb = @(0);
 
         __weak typeof(self) weakSelf = self;
-        [self->_cluster addOrUpdateWiFiNetworkWithParams:params
-                                       completionHandler:^(CHIPNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable response, NSError * _Nullable error) {
-            // TODO: addWiFiNetworkWithParams
-            // returns status in its response,
-            // not via the NSError!
-            [weakSelf onAddNetworkResponse:error isWiFi:YES];
-        }];
+        [self->_cluster
+            addOrUpdateWiFiNetworkWithParams:params
+                           completionHandler:^(CHIPNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable response,
+                               NSError * _Nullable error) {
+                               // TODO: addWiFiNetworkWithParams
+                               // returns status in its response,
+                               // not via the NSError!
+                               [weakSelf onAddNetworkResponse:error isWiFi:YES];
+                           }];
     } else {
         NSLog(@"Status: Failed to find a device being commissioned");
     }
@@ -568,14 +570,14 @@
 
         __weak typeof(self) weakSelf = self;
         [self->_cluster
-         addOrUpdateThreadNetworkWithParams:params
-                     completionHandler:^(CHIPNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable response,
-                         NSError * _Nullable error) {
-                         // TODO: addThreadNetworkWithParams
-                         // returns status in its response,
-                         // not via the NSError!
-                         [weakSelf onAddNetworkResponse:error isWiFi:NO];
-                     }];
+            addOrUpdateThreadNetworkWithParams:params
+                             completionHandler:^(CHIPNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable response,
+                                 NSError * _Nullable error) {
+                                 // TODO: addThreadNetworkWithParams
+                                 // returns status in its response,
+                                 // not via the NSError!
+                                 [weakSelf onAddNetworkResponse:error isWiFi:NO];
+                             }];
     } else {
         NSLog(@"Status: Failed to find a device being  commissioned");
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
CHIPTool on iOS doesn't use the right APIs to commission devices.

#### Change overview
Fix CHIPTool on iOS 

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Manually tested that CHIPTool iOS can pair with accessories.