### PR TITLE
[hotfix] Change LwIP upstream in p6_sdk to a temporary mirror URL, fix cirque bootstrap failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -161,4 +161,4 @@
 	branch  = stable
 [submodule "p6/lwip"]
 	path = third_party/p6/p6_sdk/libs/lwip
-	url = https://git.savannah.nongnu.org/git/lwip
+	url = https://github.com/lwip-tcpip/lwip.git

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -104,18 +104,6 @@ function cirquetest_bootstrap() {
 
     __cirquetest_build_ot_lazy
     pip3 install -r requirements_nogrpc.txt
-
-    if [[ "x$GITHUB_ACTION_RUN" = "x1" ]]; then
-        # We may run Cirque tests locally, in that case, we will run
-        # CHIP bootstrap script elsewhere. Don't run bootstrap so we
-        # won't break local environment.
-        set +x
-
-        # Call activate here so the later tests can be faster
-        # set -e will cause error if activate.sh is sourced twice
-        # this is an expected behavior caused by pigweed/activate.sh
-        source "$REPO_DIR/scripts/bootstrap.sh"
-    fi
 }
 
 function cirquetest_run_test() {


### PR DESCRIPTION
#### Problem

LwIP official repo is down for a few hours, temporarily change the url to a non-official mirror to avoid blocking CI.

PLEASE REVERT ed3739d IN THIS PR IF LWIP REPO IS BACK ONLINE

Other thoughts: can we use a symlink to third_party/lwip/repo/lwip instead of git submodule?