### PR TITLE
Fix Python Chip Controller: set pairing thread credential

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -920,7 +920,7 @@ class DeviceMgrCmd(Cmd):
                 print("Usage:")
                 self.do_help("set-pairing-thread-credential")
                 return
-            self.devCtrl.SetThreadOperationalDataset(args[0].encode("utf-8"))
+            self.devCtrl.SetThreadOperationalDataset(bytes.fromhex(args[0]))
         except Exception as ex:
             print(str(ex))
             return


### PR DESCRIPTION
#### Problem
OperationalThreadDataset is not correctly cast from user output.
Base on cirque tests the value should be cast on bytes from hex https://github.com/cecille/connectedhomeip/blob/31d1255c84b79dc9590a0a88414c4b2d60ca8abd/src/controller/python/test/test_scripts/base.py#L155.

#### Change overview
Align Python chip controller with correct casting in set-pairing-thread-credential.

#### Testing
Tested on python chip controller with nrfconnect Lock example.

```
set-pairing-thread-credential  0e080000000000010000000300000f35060004001fffe0020811111111222222220708fde45c379df327f5051000112233445566778899aabbccddeeff030a4f70656e54687265616401021234041003c6c9f356a973a5961c20e75374e07a0c0402a0fff8

connect -ble 3840 20202021 1
```
