### PR TITLE
Stop referring to 'tokens' for non-volatile attributes.

### DIFF
--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -149,7 +149,7 @@ static void resetCurrentQueueRetryParams(void)
 // Forward declarations
 
 static void setZoneId(EndpointId endpoint, uint8_t zoneId);
-static bool areZoneServerAttributesTokenized(EndpointId endpoint);
+static bool areZoneServerAttributesNonVolatile(EndpointId endpoint);
 static bool isValidEnrollmentMode(EmberAfIasZoneEnrollmentMode method);
 #if defined(EMBER_AF_PLUGIN_IAS_ZONE_SERVER_ENABLE_QUEUE)
 static uint16_t computeElapsedTimeQs(IasZoneStatusQueueEntry * entry);
@@ -540,7 +540,7 @@ void emberAfPluginIasZoneServerManageQueueEventHandler(void)
 void emberAfIasZoneClusterServerInitCallback(EndpointId endpoint)
 {
     EmberAfIasZoneType zoneType;
-    if (!areZoneServerAttributesTokenized(endpoint))
+    if (!areZoneServerAttributesNonVolatile(endpoint))
     {
         emberAfAppPrint("WARNING: ATTRIBUTES ARE NOT BEING STORED IN FLASH! ");
         emberAfAppPrintln("DEVICE WILL NOT FUNCTION PROPERLY AFTER REBOOTING!!");
@@ -587,37 +587,37 @@ uint8_t emberAfPluginIasZoneServerGetZoneId(EndpointId endpoint)
 //
 // This function will verify that all attributes necessary for the IAS zone
 // server to properly retain functionality through a power failure are
-// tokenized.
+// non-volatile.
 //
 //------------------------------------------------------------------------------
-static bool areZoneServerAttributesTokenized(EndpointId endpoint)
+static bool areZoneServerAttributesNonVolatile(EndpointId endpoint)
 {
     EmberAfAttributeMetadata * metadata;
 
     metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_IAS_CIE_ADDRESS_ATTRIBUTE_ID,
                                               CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
     metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_STATE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
     metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_TYPE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
     metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_ID_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -70,7 +70,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::LevelControl;
 
 #ifdef ZCL_USING_LEVEL_CONTROL_CLUSTER_START_UP_CURRENT_LEVEL_ATTRIBUTE
-static bool areStartUpLevelControlServerAttributesTokenized(EndpointId endpoint);
+static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoint);
 #endif
 
 #if (EMBER_AF_PLUGIN_LEVEL_CONTROL_RATE == 0)
@@ -970,8 +970,8 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
 void emberAfLevelControlClusterServerInitCallback(EndpointId endpoint)
 {
 #ifdef ZCL_USING_LEVEL_CONTROL_CLUSTER_START_UP_CURRENT_LEVEL_ATTRIBUTE
-    // StartUp behavior relies StartUpCurrentLevel attributes being tokenized.
-    if (areStartUpLevelControlServerAttributesTokenized(endpoint))
+    // StartUp behavior relies StartUpCurrentLevel attributes being non-volatile.
+    if (areStartUpLevelControlServerAttributesNonVolatile(endpoint))
     {
         // Read the StartUpOnOff attribute and set the OnOff attribute as per
         // following from zcl 7 14-0127-20i-zcl-ch-3-general.doc.
@@ -1030,20 +1030,20 @@ void emberAfLevelControlClusterServerInitCallback(EndpointId endpoint)
 }
 
 #ifdef ZCL_USING_LEVEL_CONTROL_CLUSTER_START_UP_CURRENT_LEVEL_ATTRIBUTE
-static bool areStartUpLevelControlServerAttributesTokenized(EndpointId endpoint)
+static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoint)
 {
     EmberAfAttributeMetadata * metadata;
 
     metadata = emberAfLocateAttributeMetadata(endpoint, LevelControl::Id, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
     metadata = emberAfLocateAttributeMetadata(endpoint, LevelControl::Id, ZCL_START_UP_CURRENT_LEVEL_ATTRIBUTE_ID,
                                               CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -195,8 +195,8 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, uint8_t comm
 void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
 {
 #ifdef ZCL_USING_ON_OFF_CLUSTER_START_UP_ON_OFF_ATTRIBUTE
-    // StartUp behavior relies on OnOff and StartUpOnOff attributes being tokenized.
-    if (areStartUpOnOffServerAttributesTokenized(endpoint))
+    // StartUp behavior relies on OnOff and StartUpOnOff attributes being non-volatile.
+    if (areStartUpOnOffServerAttributesNonVolatile(endpoint))
     {
         // Read the StartUpOnOff attribute and set the OnOff attribute as per
         // following from zcl 7 14-0127-20i-zcl-ch-3-general.doc.
@@ -482,20 +482,20 @@ void OnOffServer::updateOnOffTimeCommand(chip::EndpointId endpoint)
 }
 
 #ifdef ZCL_USING_ON_OFF_CLUSTER_START_UP_ON_OFF_ATTRIBUTE
-bool OnOffServer::areStartUpOnOffServerAttributesTokenized(EndpointId endpoint)
+bool OnOffServer::areStartUpOnOffServerAttributesNonVolatile(EndpointId endpoint)
 {
     EmberAfAttributeMetadata * metadata;
 
     metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::OnOff::Id, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
     metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::StartUpOnOff::Id, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
-    if (!emberAfAttributeIsTokenized(metadata))
+    if (!metadata->IsNonVolatile())
     {
         return false;
     }

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -63,7 +63,7 @@ private:
      *********************************************************/
 
 #ifdef ZCL_USING_ON_OFF_CLUSTER_START_UP_ON_OFF_ATTRIBUTE
-    bool areStartUpOnOffServerAttributesTokenized(chip::EndpointId endpoint);
+    bool areStartUpOnOffServerAttributesNonVolatile(chip::EndpointId endpoint);
 #endif // ZCL_USING_ON_OFF_CLUSTER_START_UP_ON_OFF_ATTRIBUTE
     EmberEventControl * getEventControl(chip::EndpointId endpoint);
     EmberEventControl * configureEventControl(chip::EndpointId endpoint);

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -382,13 +382,6 @@ uint8_t emberAfGetDataSize(uint8_t dataType);
 #define emberAfAttributeIsClient(metadata) (((metadata)->mask & ATTRIBUTE_MASK_CLIENT) != 0)
 
 /**
- * @brief macro that returns true if attribute is saved to token.
- *
- * @param metadata EmberAfAttributeMetadata* to consider.
- */
-#define emberAfAttributeIsTokenized(metadata) (((metadata)->mask & ATTRIBUTE_MASK_TOKENIZE) != 0)
-
-/**
  * @brief macro that returns true if attribute is saved in external storage.
  *
  * @param metadata EmberAfAttributeMetadata* to consider.

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -208,19 +208,19 @@ EmberAfGenericClusterFunction emberAfFindClusterFunction(EmberAfCluster * cluste
 void emberAfInitializeAttributes(chip::EndpointId endpoint);
 void emberAfResetAttributes(chip::EndpointId endpoint);
 
-// Loads the attributes from built-in default and / or tokens
-void emAfLoadAttributeDefaults(chip::EndpointId endpoint, bool writeTokens);
+// Loads the attributes from built-in default and / or storage.  If
+// ignoreStorage is true, only defaults will be read, and the storage for
+// non-volatile attributes will be overwritten with those defaults.
+void emAfLoadAttributeDefaults(chip::EndpointId endpoint, bool ignoreStorage);
 
-// This function loads from tokens all the attributes that
-// are defined to be stored in tokens.
-void emAfLoadAttributesFromTokens(chip::EndpointId endpoint);
+// This function loads from storage all the attributes that
+// are defined to be non-volatile.
+void emAfLoadAttributesFromStorage(chip::EndpointId endpoint);
 
-// After the RAM value has changed, code should call this
-// function. If this attribute has been
-// tagged as stored-to-token, then code will store
-// the attribute to token.
-void emAfSaveAttributeToToken(uint8_t * data, chip::EndpointId endpoint, chip::ClusterId clusterId,
-                              EmberAfAttributeMetadata * metadata);
+// After the RAM value has changed, code should call this function. If this
+// attribute has been tagged as non-volatile, its value will be stored.
+void emAfSaveAttributeToStorageIfNeeded(uint8_t * data, chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                        EmberAfAttributeMetadata * metadata);
 
 // Calls the attribute changed callback
 void emAfClusterAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t clientServerMask);

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -287,11 +287,10 @@ void emberAfPrintAttributeTable(void)
                                        (emberAfAttributeIsClient(metaData) ? "clnt" : "srvr"),
                                        ChipLogValueMEI(metaData->attributeId));
                 emberAfAttributesPrint("----");
-                emberAfAttributesPrint(" / %x (%x) / %p / %p / ", metaData->attributeType, emberAfAttributeSize(metaData),
-                                       (metaData->IsReadOnly() ? "RO" : "RW"),
-                                       (emberAfAttributeIsTokenized(metaData)
-                                            ? " token "
-                                            : (emberAfAttributeIsExternal(metaData) ? "extern " : "  RAM  ")));
+                emberAfAttributesPrint(
+                    " / %x (%x) / %p / %p / ", metaData->attributeType, emberAfAttributeSize(metaData),
+                    (metaData->IsReadOnly() ? "RO" : "RW"),
+                    (metaData->IsNonVolatile() ? " nonvolatile " : (metaData->IsExternal() ? " extern " : "  RAM  ")));
                 emberAfAttributesFlush();
                 status = emAfReadAttribute(ep->endpoint, cluster->clusterId, metaData->attributeId,
                                            (emberAfAttributeIsClient(metaData) ? CLUSTER_MASK_CLIENT : CLUSTER_MASK_SERVER),
@@ -655,9 +654,9 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
             return status;
         }
 
-        // Save the attribute to token if needed
-        // Function itself will weed out tokens that are not tokenized.
-        emAfSaveAttributeToToken(data, endpoint, cluster, metadata);
+        // Save the attribute to persistent storage if needed
+        // The callee will weed out attributes that do not need to be stored.
+        emAfSaveAttributeToStorageIfNeeded(data, endpoint, cluster, metadata);
 
         MatterReportingAttributeChangeCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataType, data);
 


### PR DESCRIPTION
Our actual storage for these may or may not use something like
'tokens'.

#### Problem
We're going to have a slightly more flexible storage setup for attributes; they may get "tokenized" or they may not.

#### Change overview
Rename the terminology to focus on the important part: is the attribute non-volatile.

#### Testing
No behavior changes.