### PR TITLE
ObjectPool: add const version for ForEachActiveObject

### DIFF
--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -84,7 +84,6 @@ size_t StaticAllocatorBitmap::IndexOf(void * element)
     return index;
 }
 
-using Lambda = Loop (*)(void *, void *);
 Loop StaticAllocatorBitmap::ForEachActiveObjectInner(void * context, Lambda lambda)
 {
     for (size_t word = 0; word * kBitChunkSize < Capacity(); ++word)
@@ -117,7 +116,6 @@ HeapObjectListNode * HeapObjectList::FindNode(void * object) const
     return nullptr;
 }
 
-using Lambda = Loop (*)(void *, void *);
 Loop HeapObjectList::ForEachNode(void * context, Lambda lambda)
 {
     ++mIterationDepth;

--- a/src/lib/support/tests/TestPool.cpp
+++ b/src/lib/support/tests/TestPool.cpp
@@ -35,10 +35,10 @@
 namespace chip {
 
 template <class POOL>
-size_t GetNumObjectsInUse(POOL & pool)
+size_t GetNumObjectsInUse(const POOL & pool)
 {
     size_t count = 0;
-    pool.ForEachActiveObject([&count](void *) {
+    pool.ForEachActiveObject([&count](const void *) {
         ++count;
         return Loop::Continue;
     });


### PR DESCRIPTION
#### Problem

Iterating a `const` pool can be useful.

#### Change overview

Add `const` overloads for `ForEachActiveObject` and associated internals.

#### Testing

Make the `TestPool` utility function `GetNumObjectsInUse()` take a `const` pool.
