### PR TITLE
fix tv ( only supports ethernet commission ) always DeleteAllFabrics 

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -102,6 +102,10 @@ class TestDefinition:
             if os.path.exists('/tmp/chip_tool_config.ini'):
                 os.unlink('/tmp/chip_tool_config.ini')
 
+            # Remove server all_clusters_app or tv_app storage, so it will be commissionable again
+            if os.path.exists('/tmp/chip_kvs'):
+                os.unlink('/tmp/chip_kvs')
+
             discriminator = str(randrange(1, 4096))
             logging.debug(
                 'Executing application under test with discriminator %s.' % discriminator)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -194,12 +194,13 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
         ChipLogProgress(AppServer, "Rendezvous and secure pairing skipped");
         SuccessOrExit(err = AddTestCommissioning());
     }
-    else if ((DeviceLayer::ConnectivityMgr().IsWiFiStationProvisioned() || DeviceLayer::ConnectivityMgr().IsThreadProvisioned()) &&
-             (GetFabricTable().FabricCount() != 0))
+    else if (GetFabricTable().FabricCount() != 0)
     {
         // The device is already commissioned, proactively disable BLE advertisement.
         ChipLogProgress(AppServer, "Fabric already commissioned. Disabling BLE advertisement");
+#if CONFIG_NETWORK_LAYER_BLE
         chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
+#endif
     }
     else
     {


### PR DESCRIPTION
#### Problem
* On TV which supports only ethernet commission, we will always DeleteAllFabrics everytime restart the server

#### Change overview
* Fix this issue, do not check if it supports wifi or  ble Provisioned

#### Testing
* chip-tool paring