### PR TITLE
[controller] Fix commissioning multiple devices

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1886,9 +1886,12 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         {
             mPairingDelegate->OnCommissioningComplete(proxy->GetDeviceId(), CHIP_NO_ERROR);
         }
+        mCommissioningStage = CommissioningStage::kSecurePairing;
+        break;
+    case CommissioningStage::kError:
+        mCommissioningStage = CommissioningStage::kSecurePairing;
         break;
     case CommissioningStage::kSecurePairing:
-    case CommissioningStage::kError:
         break;
     }
 }


### PR DESCRIPTION
#### Problem
Python CHIP Controller can only commission a single device. An attempt to commission a subsequent one results in an error.

#### Change overview
Clear the commissioning state on complete or failed commissioning.

#### Testing
Tested manually using Python CHIP Controller and two devices.
