### PR TITLE
Fix mDNS UDP leak when JoinMulticastGroup fails

### DIFF
--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -243,6 +243,8 @@ CHIP_ERROR ServerBase::Listen(chip::Inet::EndPointManager<chip::Inet::UDPEndPoin
             // Log only as non-fatal error. Failure to join will mean we reply to unicast queries only.
             ChipLogError(DeviceLayer, "MDNS failed to join multicast group on %s for address type %s: %s", interfaceName,
                          AddressTypeStr(addressType), chip::ErrorStr(err));
+
+            endPointHolder.reset();
         }
 
 #if CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT


### PR DESCRIPTION
#### Problem
The UDP endpoint should be freed when `JoinMulticastGroup` fails

#### Change overview
Free the endpoint when `JoinMulticastGroup` fails

#### Testing
Checked by unit-tests