### PR TITLE
Reset device controller state after cleanup

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1886,6 +1886,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         {
             mPairingDelegate->OnCommissioningComplete(proxy->GetDeviceId(), CHIP_NO_ERROR);
         }
+        mCommissioningStage = CommissioningStage::kSecurePairing;
         break;
     case CommissioningStage::kSecurePairing:
     case CommissioningStage::kError:


### PR DESCRIPTION
#### Problem
Commissioning state doesn't get reset at the end of commissioning so it prevents a second commissioning from being run after 

#### Change overview
Resets state at the end of commissioing.

#### Testing

