### PR TITLE
Remove INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS

### DIFF
--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -193,25 +193,6 @@
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
 /**
- *  @def INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
- *
- *  @brief
- *    When this flag is set, the InetLayer enables
- *    callbacks to the upper layer notifying it when
- *    the send channel of the TCP connection changes
- *    between being idle or not idle.
- *
- *  @note
- *    When enabled, the TCP send queue is actively
- *    polled to determine if sent data has been
- *    acknowledged.
- *
- */
-#ifndef INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-#define INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS         0
-#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-
-/**
  *  @def INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC
  *
  *  @brief

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -467,40 +467,9 @@ void TCPEndPoint::ScheduleNextTCPUserTimeoutPoll(uint32_t aTimeOut)
     GetSystemLayer().StartTimer(System::Clock::Milliseconds32(aTimeOut), TCPUserTimeoutHandler, this);
 }
 
-#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-void TCPEndPoint::SetTCPSendIdleAndNotifyChange(bool aIsTCPSendIdle)
-{
-    if (mIsTCPSendIdle != aIsTCPSendIdle)
-    {
-        ChipLogDetail(Inet, "TCP con send channel idle state changed : %s", aIsTCPSendIdle ? "false->true" : "true->false");
-
-        // Set the current Idle state
-        mIsTCPSendIdle = aIsTCPSendIdle;
-
-        if (OnTCPSendIdleChanged)
-        {
-            OnTCPSendIdleChanged(this, mIsTCPSendIdle);
-        }
-    }
-}
-#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-
 void TCPEndPoint::StartTCPUserTimeoutTimer()
 {
-    uint32_t timeOut = mUserTimeoutMillis;
-
-#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-    // Set timeout to the poll interval
-
-    timeOut = mTCPSendQueuePollPeriodMillis;
-
-    // Reset the poll count
-
-    mTCPSendQueueRemainingPollCount = MaxTCPSendQueuePolls();
-#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-
-    ScheduleNextTCPUserTimeoutPoll(timeOut);
-
+    ScheduleNextTCPUserTimeoutPoll(mUserTimeoutMillis);
     mUserTimeoutTimerRunning = true;
 }
 

--- a/src/inet/TCPEndPointImplLwIP.cpp
+++ b/src/inet/TCPEndPointImplLwIP.cpp
@@ -683,14 +683,7 @@ void TCPEndPointImplLwIP::HandleDataSent(uint16_t lenSent)
             if (RemainingToSend() == 0)
             {
                 // If the output queue has been flushed then stop the timer.
-
                 StopTCPUserTimeoutTimer();
-
-#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-                // Notify up if all outstanding data has been acknowledged
-
-                SetTCPSendIdleAndNotifyChange(true);
-#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
             }
             else
             {


### PR DESCRIPTION
#### Problem

The option `INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS` is not
enabled by any configuration in tree, and clutters up TCP code.

Fixes #12939 INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS unused

#### Change overview

- Remove `INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS` and associated code

#### Testing

CI/build. No functional change since the option is unused.
