### PR TITLE
[nrfconnect] Fix OTAImageProcessorImpl

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -143,6 +143,7 @@ int AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
+    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestor.SetOtaRequestorDriver(&sOTARequestorDriver);
     sOTARequestor.SetBDXDownloader(&sBDXDownloader);

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -21,12 +21,17 @@
 #include <platform/OTAImageProcessor.h>
 
 namespace chip {
+
+class OTADownloader;
+
 namespace DeviceLayer {
 
 class OTAImageProcessorImpl : public OTAImageProcessorInterface
 {
 public:
     static constexpr size_t kBufferSize = CONFIG_CHIP_OTA_REQUESTOR_BUFFER_SIZE;
+
+    void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; };
 
     CHIP_ERROR PrepareDownload() override;
     CHIP_ERROR Finalize() override;
@@ -35,6 +40,9 @@ public:
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
 
 private:
+    CHIP_ERROR PrepareDownloadImpl();
+
+    OTADownloader * mDownloader = nullptr;
     uint8_t mBuffer[kBufferSize];
 };
 


### PR DESCRIPTION
#### Problem
`OTAImageProcessorImpl` for nRF Connect platform does not report BDX processing result back to `BdxDownloader`. Hence the BDX can't transfer can't move forward.

#### Change overview
Use asynchronous API to report result of the download initialization or a block write back to the BDXDownloader.

#### Testing
Performed OTA on nRF Connect lighting-app.
