### PR TITLE
Fix broken tag handling in QRCodeSetupPayloadParser.

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -194,8 +194,9 @@ CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPay
             continue;
         }
 
-        const uint8_t tag = static_cast<uint8_t>(TLV::TagNumFromTag(reader.GetTag()));
-        VerifyOrReturnError(TLV::IsContextTag(tag) == true || TLV::IsProfileTag(tag) == true, CHIP_ERROR_INVALID_TLV_TAG);
+        TLV::Tag tag = reader.GetTag();
+        VerifyOrReturnError(TLV::IsContextTag(tag), CHIP_ERROR_INVALID_TLV_TAG);
+        const uint8_t tagNumber = static_cast<uint8_t>(TLV::TagNumFromTag(tag));
 
         optionalQRCodeInfoType elemType = optionalQRCodeInfoTypeUnknown;
         if (type == TLV::kTLVType_UTF8String)
@@ -204,13 +205,13 @@ CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPay
         }
         if (type == TLV::kTLVType_SignedInteger || type == TLV::kTLVType_UnsignedInteger)
         {
-            elemType = outPayload.getNumericTypeFor(tag);
+            elemType = outPayload.getNumericTypeFor(tagNumber);
         }
 
-        if (IsCHIPTag(tag))
+        if (IsCHIPTag(tagNumber))
         {
             OptionalQRCodeInfoExtension info;
-            info.tag = tag;
+            info.tag = tagNumber;
             ReturnErrorOnFailure(retrieveOptionalInfo(reader, info, elemType));
 
             ReturnErrorOnFailure(outPayload.addOptionalExtensionData(info));
@@ -218,7 +219,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPay
         else
         {
             OptionalQRCodeInfo info;
-            info.tag = tag;
+            info.tag = tagNumber;
             ReturnErrorOnFailure(retrieveOptionalInfo(reader, info, elemType));
 
             ReturnErrorOnFailure(outPayload.addOptionalVendorData(info));


### PR DESCRIPTION
The only reason this worked in any way is that TLV::IsProfileTag()
tests true for small integers, so the VerifyOrReturnError was a no-op,
even though we were testing IsContextTag() and IsProfileTag() on the
tag _number_, not the tag.

Per spec, only context tags are allowed here, so just allow those.

Fixes https://github.com/project-chip/connectedhomeip/issues/10188

#### Problem
Tag numbers being treated as tags.

#### Change overview
Fix that, so we can try to make TLV::Tag not be an integer anymore.

#### Testing
Not sure how to exercise this code...