### PR TITLE
Use the right types for Target fields in ACL cluster.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -35,9 +35,9 @@ limitations under the License.
 
   <struct name="Target">
     <cluster code="0x001F"/>
-    <item fieldId="0" name="Cluster" type="INT32U" isNullable="true"/>
-    <item fieldId="1" name="Endpoint" type="INT16U" isNullable="true"/>
-    <item fieldId="2" name="DeviceType" type="INT32U" isNullable="true"/>
+    <item fieldId="0" name="Cluster" type="cluster_id" isNullable="true"/>
+    <item fieldId="1" name="Endpoint" type="endpoint_no" isNullable="true"/>
+    <item fieldId="2" name="DeviceType" type="devtype_id" isNullable="true"/>
   </struct>
 
   <struct name="AccessControlEntry">

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -143,9 +143,9 @@ typedef struct _ApplicationLauncherEndpoint
 // Struct for Target
 typedef struct _Target
 {
-    uint32_t Cluster;
-    uint16_t Endpoint;
-    uint32_t DeviceType;
+    chip::ClusterId Cluster;
+    chip::EndpointId Endpoint;
+    chip::DeviceTypeId DeviceType;
 } Target;
 
 // Struct for AccessControlEntry

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -6384,9 +6384,9 @@ enum class Fields
 struct Type
 {
 public:
-    DataModel::Nullable<uint32_t> cluster;
-    DataModel::Nullable<uint16_t> endpoint;
-    DataModel::Nullable<uint32_t> deviceType;
+    DataModel::Nullable<chip::ClusterId> cluster;
+    DataModel::Nullable<chip::EndpointId> endpoint;
+    DataModel::Nullable<chip::DeviceTypeId> deviceType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);


### PR DESCRIPTION
#### Problem
Hardcoded integer types instead of the spec's semantic types.

#### Change overview
Use types that match the spec.

#### Testing
Made sure the tree compiles.