### PR TITLE
Fixed a couple of memory leaks in chip-im-initiator and echo-requester example apps

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -186,7 +186,7 @@ public:
         gLastCommandResult = TestCommandResult::kFailure;
         printf("CommandResponseError happens with %" CHIP_ERROR_FORMAT, aError.Format());
     }
-    void OnDone(chip::app::CommandSender * apCommandSender) override {}
+    void OnDone(chip::app::CommandSender * apCommandSender) override { delete apCommandSender; }
 
     void OnResponse(const chip::app::WriteClient * apWriteClient, const chip::app::ConcreteAttributePath & path,
                     chip::app::StatusIB status) override
@@ -444,6 +444,10 @@ exit:
     else
     {
         printf("Establish secure session succeeded\n");
+    }
+    if (testSecurePairingSecret)
+    {
+        chip::Platform::Delete(testSecurePairingSecret);
     }
 
     return err;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -180,6 +180,10 @@ exit:
     {
         printf("Establish secure session succeeded\n");
     }
+    if (testSecurePairingSecret)
+    {
+        chip::Platform::Delete(testSecurePairingSecret);
+    }
 
     return err;
 }


### PR DESCRIPTION
#### Problem
A couple of memory leaks in chip-im-initiator and echo-requester examples

#### Change overview
- Noticed the memory leaks during a regular valgrind run and fixed them.

#### Testing
- Ran both the applications with valgrind (Linux) and verified that the memory was being freed properly.
- Excerpts from the valgrind logs below for each of the applications.

chip-echo-Requester (BEFORE)
==3617== LEAK SUMMARY:
==3617==    **definitely lost: 88 bytes in 1 blocks**
==3617==    indirectly lost: 0 bytes in 0 blocks
==3617==      possibly lost: 3,408 bytes in 29 blocks
==3617==    still reachable: 92,413 bytes in 1,074 blocks
==3617==                       of which reachable via heuristic:
==3617==                         length64           : 768 bytes in 15 blocks
==3617==                         newarray           : 1,728 bytes in 28 blocks
==3617==         suppressed: 0 bytes in 0 blocks
==3617== 
==3617== ERROR SUMMARY: 30 errors from 30 contexts (suppressed: 0 from 0)

chip-echo-Requester (AFTER)
==4242== LEAK SUMMARY:
==4242==    **definitely lost: 0 bytes in 0 blocks**
==4242==    indirectly lost: 0 bytes in 0 blocks
==4242==      possibly lost: 3,400 bytes in 29 blocks
==4242==    still reachable: 98,081 bytes in 1,095 blocks
==4242==                       of which reachable via heuristic:
==4242==                         length64           : 768 bytes in 15 blocks
==4242==                         newarray           : 1,728 bytes in 28 blocks
==4242==         suppressed: 0 bytes in 0 blocks
==4242== 
==4242== ERROR SUMMARY: 29 errors from 29 contexts (suppressed: 0 from 0)


chip-im-initiator (BEFORE)
==4620== LEAK SUMMARY:
==4620==    **definitely lost: 1,344 bytes in 4 blocks**
==4620==    indirectly lost: 0 bytes in 0 blocks
==4620==      possibly lost: 3,400 bytes in 29 blocks
==4620==    still reachable: 110,488 bytes in 1,225 blocks
==4620==                       of which reachable via heuristic:
==4620==                         length64           : 768 bytes in 15 blocks
==4620==                         newarray           : 1,728 bytes in 28 blocks
==4620==         suppressed: 0 bytes in 0 blocks
==4620== 
==4620== ERROR SUMMARY: 31 errors from 31 contexts (suppressed: 0 from 0)

chip-im-initiator (AFTER)
==11462== LEAK SUMMARY:
==11462==    **definitely lost: 0 bytes in 0 blocks**
==11462==    indirectly lost: 0 bytes in 0 blocks
==11462==      possibly lost: 3,400 bytes in 29 blocks
==11462==    still reachable: 97,745 bytes in 1,081 blocks
==11462==                       of which reachable via heuristic:
==11462==                         length64           : 768 bytes in 15 blocks
==11462==                         newarray           : 1,728 bytes in 28 blocks
==11462==         suppressed: 0 bytes in 0 blocks
==11462== 
==11462== ERROR SUMMARY: 29 errors from 29 contexts (suppressed: 0 from 0)