### PR TITLE
Switch TLV::Tag to being a struct

### DIFF
--- a/src/app/AttributeCache.cpp
+++ b/src/app/AttributeCache.cpp
@@ -36,7 +36,7 @@ CHIP_ERROR AttributeCache::UpdateCache(const ConcreteDataAttributePath & aPath, 
 
         writer.Init(std::move(handle), false);
 
-        ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag, *apData));
+        ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag(), *apData));
         ReturnErrorOnFailure(writer.Finalize(&handle));
 
         //

--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -79,7 +79,7 @@ CHIP_ERROR BufferedReadCallback::GenerateListTLV(TLV::ScopedBufferTLVReader & aR
     VerifyOrReturnError(backingBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
 
     TLV::ScopedBufferTLVWriter writer(std::move(backingBuffer), totalBufSize);
-    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Array, outerType));
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, outerType));
 
     for (auto & bufHandle : mBufferedList)
     {
@@ -88,7 +88,7 @@ CHIP_ERROR BufferedReadCallback::GenerateListTLV(TLV::ScopedBufferTLVReader & aR
         reader.Init(std::move(bufHandle));
 
         ReturnErrorOnFailure(reader.Next());
-        ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag, reader));
+        ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag(), reader));
     }
 
     ReturnErrorOnFailure(writer.EndContainer(outerType));
@@ -120,7 +120,7 @@ CHIP_ERROR BufferedReadCallback::BufferListItem(TLV::TLVReader & reader)
 
     writer.Init(std::move(handle), false);
 
-    ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag, reader));
+    ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag(), reader));
     ReturnErrorOnFailure(writer.Finalize(&handle));
 
     // Compact the buffer down to a more reasonably sized packet buffer

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && pa
     invokeRequests.GetReader(&invokeRequestsReader);
     while (CHIP_NO_ERROR == (err = invokeRequestsReader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == invokeRequestsReader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == invokeRequestsReader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         CommandDataIB::Parser commandData;
         ReturnErrorOnFailure(commandData.Init(invokeRequestsReader));
         ReturnErrorOnFailure(ProcessCommandDataIB(commandData));

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -171,7 +171,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponse(System::PacketBufferHandle && pa
 
     while (CHIP_NO_ERROR == (err = invokeResponsesReader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == invokeResponsesReader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == invokeResponsesReader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         InvokeResponseIB::Parser invokeResponse;
         ReturnErrorOnFailure(invokeResponse.Init(invokeResponsesReader));
         ReturnErrorOnFailure(ProcessInvokeResponseIB(invokeResponse));

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -560,7 +560,7 @@ CHIP_ERROR EventManagement::CopyEvent(const TLVReader & aReader, TLVWriter & aWr
 
     reader.Init(aReader);
     ReturnErrorOnFailure(reader.EnterContainer(containerType));
-    ReturnErrorOnFailure(aWriter.StartContainer(AnonymousTag, kTLVType_Structure, containerType));
+    ReturnErrorOnFailure(aWriter.StartContainer(AnonymousTag(), kTLVType_Structure, containerType));
 
     ReturnErrorOnFailure(reader.Next());
     ReturnErrorOnFailure(reader.EnterContainer(containerType1));

--- a/src/app/MessageDef/ArrayBuilder.cpp
+++ b/src/app/MessageDef/ArrayBuilder.cpp
@@ -33,7 +33,7 @@ CHIP_ERROR ArrayBuilder::Init(TLV::TLVWriter * const apWriter, const uint8_t aCo
 CHIP_ERROR ArrayBuilder::Init(TLV::TLVWriter * const apWriter)
 {
     mpWriter = apWriter;
-    mError   = mpWriter->StartContainer(TLV::AnonymousTag, chip::TLV::kTLVType_Array, mOuterContainerType);
+    mError   = mpWriter->StartContainer(TLV::AnonymousTag(), chip::TLV::kTLVType_Array, mOuterContainerType);
 
     return mError;
 }

--- a/src/app/MessageDef/AttributeDataIBs.cpp
+++ b/src/app/MessageDef/AttributeDataIBs.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR AttributeDataIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrExit(chip::TLV::AnonymousTag == reader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrExit(chip::TLV::AnonymousTag() == reader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
         VerifyOrExit(chip::TLV::kTLVType_Structure == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
         {

--- a/src/app/MessageDef/AttributePathIBs.cpp
+++ b/src/app/MessageDef/AttributePathIBs.cpp
@@ -42,7 +42,7 @@ CHIP_ERROR AttributePathIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         VerifyOrReturnError(TLV::kTLVType_List == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
         {
             AttributePathIB::Parser path;

--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             AttributeReportIB::Parser AttributeReport;
             ReturnErrorOnFailure(AttributeReport.Init(reader));

--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR AttributeStatusIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             AttributeStatusIB::Parser status;
             ReturnErrorOnFailure(status.Init(reader));

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR DataVersionFilterIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             DataVersionFilterIB::Parser DataVersionFilter;
             ReturnErrorOnFailure(DataVersionFilter.Init(reader));

--- a/src/app/MessageDef/EventFilterIBs.cpp
+++ b/src/app/MessageDef/EventFilterIBs.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR EventFilterIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             EventFilterIB::Parser eventFilter;
             ReturnErrorOnFailure(eventFilter.Init(reader));

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR EventPathIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         VerifyOrReturnError(TLV::kTLVType_List == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
         {

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             EventReportIB::Parser eventReport;
             ReturnErrorOnFailure(eventReport.Init(reader));

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR InvokeRequests::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             CommandDataIB::Parser commandData;
             ReturnErrorOnFailure(commandData.Init(reader));

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR InvokeResponseIBs::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         {
             InvokeResponseIB::Parser invokeResponse;
             ReturnErrorOnFailure(invokeResponse.Init(reader));

--- a/src/app/MessageDef/ListBuilder.cpp
+++ b/src/app/MessageDef/ListBuilder.cpp
@@ -35,7 +35,7 @@ CHIP_ERROR ListBuilder::Init(TLV::TLVWriter * const apWriter, const uint8_t aCon
 CHIP_ERROR ListBuilder::Init(TLV::TLVWriter * const apWriter)
 {
     mpWriter = apWriter;
-    mError   = mpWriter->StartContainer(TLV::AnonymousTag, TLV::kTLVType_List, mOuterContainerType);
+    mError   = mpWriter->StartContainer(TLV::AnonymousTag(), TLV::kTLVType_List, mOuterContainerType);
 
     return mError;
 }

--- a/src/app/MessageDef/StructBuilder.cpp
+++ b/src/app/MessageDef/StructBuilder.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR StructBuilder::Init(TLV::TLVWriter * const apWriter, const uint8_t aC
 CHIP_ERROR StructBuilder::Init(TLV::TLVWriter * const apWriter)
 {
     mpWriter = apWriter;
-    mError   = mpWriter->StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, mOuterContainerType);
+    mError   = mpWriter->StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, mOuterContainerType);
     return mError;
 }
 } // namespace app

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -345,7 +345,7 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathIBs::Parser & aAtt
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrExit(TLV::AnonymousTag == reader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrExit(TLV::AnonymousTag() == reader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
         VerifyOrExit(TLV::kTLVType_List == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
         ClusterInfo clusterInfo;
         AttributePathIB::Parser path;
@@ -420,7 +420,7 @@ CHIP_ERROR ReadHandler::ProcessEventPaths(EventPathIBs::Parser & aEventPathsPars
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         ClusterInfo clusterInfo;
         EventPathIB::Parser path;
         ReturnErrorOnFailure(path.Init(reader));
@@ -477,7 +477,7 @@ CHIP_ERROR ReadHandler::ProcessEventFilters(EventFilterIBs::Parser & aEventFilte
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnError(TLV::AnonymousTag == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         EventFilterIB::Parser filter;
         ReturnErrorOnFailure(filter.Init(reader));
         // this is for current node, and would have only one event filter.

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -112,7 +112,7 @@ CHIP_ERROR WriteClient::ProcessWriteResponseMessage(System::PacketBufferHandle &
 
     while (CHIP_NO_ERROR == (err = attributeStatusesReader.Next()))
     {
-        VerifyOrExit(TLV::AnonymousTag == attributeStatusesReader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrExit(TLV::AnonymousTag() == attributeStatusesReader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
 
         AttributeStatusIB::Parser element;
 

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -163,7 +163,7 @@ struct AccessControlEntryCodec
                 {
                     NodeId subject;
                     ReturnErrorOnFailure(entry.GetSubject(i, subject));
-                    ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::AnonymousTag, subject));
+                    ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::AnonymousTag(), subject));
                 }
                 ReturnErrorOnFailure(aWriter.EndContainer(subjectsContainer));
             }
@@ -180,7 +180,7 @@ struct AccessControlEntryCodec
                 for (size_t i = 0; i < count; ++i)
                 {
                     TLV::TLVType targetContainer;
-                    ReturnErrorOnFailure(aWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, targetContainer));
+                    ReturnErrorOnFailure(aWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, targetContainer));
                     AccessControl::Entry::Target target;
                     ReturnErrorOnFailure(entry.GetTarget(i, target));
                     if (target.flags & AccessControl::Entry::Target::kCluster)

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -42,10 +42,18 @@ namespace {
 
 struct GroupKeyCodec
 {
-    static const TLV::Tag kTagFabric = TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupKey::Fields::kFabricIndex));
-    static const TLV::Tag kTagGroup  = TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupKey::Fields::kGroupId));
-    static const TLV::Tag kTagKeyset =
-        TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupKey::Fields::kGroupKeySetID));
+    static constexpr TLV::Tag TagFabric()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupKey::Fields::kFabricIndex));
+    }
+    static constexpr TLV::Tag TagGroup()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupKey::Fields::kGroupId));
+    }
+    static constexpr TLV::Tag TagKeyset()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupKey::Fields::kGroupKeySetID));
+    }
 
     chip::FabricIndex mFabric = 0;
     GroupDataProvider::GroupKey mMapping;
@@ -61,11 +69,11 @@ struct GroupKeyCodec
         ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
 
         // FabricIndex
-        ReturnErrorOnFailure(DataModel::Encode(writer, kTagFabric, mFabric));
+        ReturnErrorOnFailure(DataModel::Encode(writer, TagFabric(), mFabric));
         // GroupId
-        ReturnErrorOnFailure(DataModel::Encode(writer, kTagGroup, mMapping.group_id));
+        ReturnErrorOnFailure(DataModel::Encode(writer, TagGroup(), mMapping.group_id));
         // GroupKeySetID
-        ReturnErrorOnFailure(DataModel::Encode(writer, kTagKeyset, mMapping.keyset_id));
+        ReturnErrorOnFailure(DataModel::Encode(writer, TagKeyset(), mMapping.keyset_id));
 
         ReturnErrorOnFailure(writer.EndContainer(outer));
         return CHIP_NO_ERROR;
@@ -79,13 +87,13 @@ struct GroupKeyCodec
         ReturnErrorOnFailure(reader.EnterContainer(outer));
 
         // FabricIndex
-        ReturnErrorOnFailure(reader.Next(kTagFabric));
+        ReturnErrorOnFailure(reader.Next(TagFabric()));
         ReturnErrorOnFailure(reader.Get(mFabric));
         // GroupId
-        ReturnErrorOnFailure(reader.Next(kTagGroup));
+        ReturnErrorOnFailure(reader.Next(TagGroup()));
         ReturnErrorOnFailure(reader.Get(mMapping.group_id));
         // GroupKeySetID
-        ReturnErrorOnFailure(reader.Next(kTagKeyset));
+        ReturnErrorOnFailure(reader.Next(TagKeyset()));
         ReturnErrorOnFailure(reader.Get(mMapping.keyset_id));
 
         ReturnErrorOnFailure(reader.ExitContainer(outer));
@@ -95,12 +103,22 @@ struct GroupKeyCodec
 
 struct GroupTableCodec
 {
-    static const TLV::Tag kTagFabric = TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kFabricIndex));
-    static const TLV::Tag kTagGroup  = TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kGroupId));
-    static const TLV::Tag kTagEndpoints =
-        TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kEndpoints));
-    static const TLV::Tag kTagGroupName =
-        TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kGroupName));
+    static constexpr TLV::Tag TagFabric()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kFabricIndex));
+    }
+    static constexpr TLV::Tag TagGroup()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kGroupId));
+    }
+    static constexpr TLV::Tag TagEndpoints()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kEndpoints));
+    }
+    static constexpr TLV::Tag TagGroupName()
+    {
+        return TLV::ContextTag(to_underlying(GroupKeyManagement::Structs::GroupInfo::Fields::kGroupName));
+    }
 
     GroupDataProvider * mProvider = nullptr;
     chip::FabricIndex mFabric;
@@ -116,12 +134,12 @@ struct GroupTableCodec
         ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
 
         // FabricIndex
-        ReturnErrorOnFailure(DataModel::Encode(writer, kTagFabric, mFabric));
+        ReturnErrorOnFailure(DataModel::Encode(writer, TagFabric(), mFabric));
         // GroupId
-        ReturnErrorOnFailure(DataModel::Encode(writer, kTagGroup, mInfo.group_id));
+        ReturnErrorOnFailure(DataModel::Encode(writer, TagGroup(), mInfo.group_id));
         // Endpoints
         TLV::TLVType inner;
-        ReturnErrorOnFailure(writer.StartContainer(kTagEndpoints, TLV::kTLVType_Array, inner));
+        ReturnErrorOnFailure(writer.StartContainer(TagEndpoints(), TLV::kTLVType_Array, inner));
         GroupDataProvider::GroupEndpoint mapping;
         auto iter = mProvider->IterateEndpoints(mFabric);
         if (nullptr != iter)
@@ -138,7 +156,7 @@ struct GroupTableCodec
         ReturnErrorOnFailure(writer.EndContainer(inner));
         // GroupName
         uint32_t name_size = static_cast<uint32_t>(strnlen(mInfo.name, GroupDataProvider::GroupInfo::kGroupNameMax));
-        ReturnErrorOnFailure(writer.PutString(kTagGroupName, mInfo.name, name_size));
+        ReturnErrorOnFailure(writer.PutString(TagGroupName(), mInfo.name, name_size));
 
         ReturnErrorOnFailure(writer.EndContainer(outer));
         return CHIP_NO_ERROR;

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -148,7 +148,7 @@ struct GroupTableCodec
             {
                 if (mapping.group_id == mInfo.group_id)
                 {
-                    ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag, static_cast<uint16_t>(mapping.endpoint_id)));
+                    ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag(), static_cast<uint16_t>(mapping.endpoint_id)));
                 }
             }
             iter->Release();
@@ -508,7 +508,7 @@ struct KeySetReadAllIndicesResponse
         GroupDataProvider::KeySet keyset;
         while (mIterator && mIterator->Next(keyset))
         {
-            ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, keyset.keyset_id));
+            ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag(), keyset.keyset_id));
         }
 
         ReturnErrorOnFailure(writer.EndContainer(array));

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -237,7 +237,7 @@ struct GroupMembershipResponse
                     {
                         if (mapping.endpoint_id == mEndpoint)
                         {
-                            ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, mapping.group_id));
+                            ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag(), mapping.group_id));
                             matchCount++;
                             ChipLogDetail(Zcl, " 0x%02" PRIx16, mapping.group_id);
                         }
@@ -252,7 +252,7 @@ struct GroupMembershipResponse
                         {
                             if (mapping.endpoint_id == mEndpoint && mapping.group_id == iter.GetValue())
                             {
-                                ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag, mapping.group_id));
+                                ReturnErrorOnFailure(app::DataModel::Encode(writer, TLV::AnonymousTag(), mapping.group_id));
                                 matchCount++;
                                 ChipLogDetail(Zcl, " 0x%02" PRIx16, mapping.group_id);
                                 break;

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -338,7 +338,7 @@ void Instance::OnFinished(Status status, CharSpan debugText, ThreadScanResponseI
         result.extendedAddress = scanResponse.extendedAddress;
         result.rssi            = scanResponse.rssi;
         result.lqi             = scanResponse.lqi;
-        SuccessOrExit(err = DataModel::Encode(*writer, TLV::AnonymousTag, result));
+        SuccessOrExit(err = DataModel::Encode(*writer, TLV::AnonymousTag(), result));
     }
 
     SuccessOrExit(err = writer->EndContainer(listContainerType));
@@ -390,7 +390,7 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
         result.channel  = scanResponse.channel;
         result.wiFiBand = ToClusterObjectEnum(scanResponse.wiFiBand);
         result.rssi     = scanResponse.rssi;
-        SuccessOrExit(err = DataModel::Encode(*writer, TLV::AnonymousTag, result));
+        SuccessOrExit(err = DataModel::Encode(*writer, TLV::AnonymousTag(), result));
     }
 
     SuccessOrExit(err = writer->EndContainer(listContainerType));

--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -65,7 +65,7 @@ inline CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, List<X> list)
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Array, type));
     for (auto & item : list)
     {
-        ReturnErrorOnFailure(Encode(writer, TLV::AnonymousTag, item));
+        ReturnErrorOnFailure(Encode(writer, TLV::AnonymousTag(), item));
     }
     ReturnErrorOnFailure(writer.EndContainer(type));
 

--- a/src/app/data-model/TagBoundEncoder.h
+++ b/src/app/data-model/TagBoundEncoder.h
@@ -61,7 +61,7 @@ public:
         VerifyOrReturnError(mWriter != nullptr, CHIP_ERROR_INCORRECT_STATE);
         TLV::TLVType outerType;
         ReturnErrorOnFailure(mWriter->StartContainer(mTag, TLV::kTLVType_Array, outerType));
-        ReturnErrorOnFailure(aCallback(TagBoundEncoder(mWriter, TLV::AnonymousTag)));
+        ReturnErrorOnFailure(aCallback(TagBoundEncoder(mWriter, TLV::AnonymousTag())));
         return mWriter->EndContainer(outerType);
     }
 

--- a/src/app/tests/TestAttributeCache.cpp
+++ b/src/app/tests/TestAttributeCache.cpp
@@ -148,7 +148,7 @@ void DataSeriesGenerator::Generate()
                 ChipLogProgress(DataManagement, "\t -- Generating A");
 
                 Clusters::TestCluster::Attributes::Int16u::TypeInfo::Type value = instruction.mInstructionId;
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
                 break;
             }
 
@@ -159,7 +159,7 @@ void DataSeriesGenerator::Generate()
                 uint8_t buf[] = { 'h', 'e', 'l', 'l', 'o' };
                 value         = buf;
 
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
                 break;
             }
 
@@ -169,7 +169,7 @@ void DataSeriesGenerator::Generate()
                 Clusters::TestCluster::Attributes::StructAttr::TypeInfo::Type value;
                 value.a = instruction.mInstructionId;
                 value.b = true;
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
                 break;
             }
 
@@ -187,7 +187,7 @@ void DataSeriesGenerator::Generate()
                 path.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
 
                 value = buf;
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
                 break;
             }
 

--- a/src/app/tests/TestAttributeValueEncoder.cpp
+++ b/src/app/tests/TestAttributeValueEncoder.cpp
@@ -55,7 +55,7 @@ struct LimitedTestSetup
         writer.Init(buf);
         {
             TLVType ignored;
-            CHIP_ERROR err = writer.StartContainer(AnonymousTag, kTLVType_Structure, ignored);
+            CHIP_ERROR err = writer.StartContainer(AnonymousTag(), kTLVType_Structure, ignored);
             NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
         }
         {

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -321,7 +321,7 @@ void DataSeriesGenerator::Generate()
             Clusters::TestCluster::Attributes::Int8u::TypeInfo::Type value = index;
             path.mAttributeId                                              = Clusters::TestCluster::Attributes::Int8u::Id;
             path.mListOp                                                   = ConcreteDataAttributePath::ListOperation::NotList;
-            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
             break;
         }
 
@@ -331,7 +331,7 @@ void DataSeriesGenerator::Generate()
             Clusters::TestCluster::Attributes::Int32u::TypeInfo::Type value = index;
             path.mAttributeId                                               = Clusters::TestCluster::Attributes::Int32u::Id;
             path.mListOp                                                    = ConcreteDataAttributePath::ListOperation::NotList;
-            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
             break;
         }
 
@@ -341,7 +341,7 @@ void DataSeriesGenerator::Generate()
             Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo::Type value;
             path.mAttributeId = Clusters::TestCluster::Attributes::ListStructOctetString::Id;
             path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
-            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
             break;
         }
 
@@ -361,7 +361,7 @@ void DataSeriesGenerator::Generate()
             path.mAttributeId = Clusters::TestCluster::Attributes::ListStructOctetString::Id;
             path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
 
-            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
             break;
         }
 
@@ -371,7 +371,7 @@ void DataSeriesGenerator::Generate()
             Clusters::TestCluster::Attributes::ListInt8u::TypeInfo::Type value;
             path.mAttributeId = Clusters::TestCluster::Attributes::ListInt8u::Id;
             path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
-            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
             break;
         }
 
@@ -391,7 +391,7 @@ void DataSeriesGenerator::Generate()
             path.mAttributeId = Clusters::TestCluster::Attributes::ListInt8u::Id;
             path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
 
-            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
             break;
         }
 
@@ -426,7 +426,7 @@ void DataSeriesGenerator::Generate()
 
                 path.mAttributeId = Clusters::TestCluster::Attributes::ListStructOctetString::Id;
                 path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
 
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
@@ -449,7 +449,7 @@ void DataSeriesGenerator::Generate()
 
                 listItem.fabricIndex = (uint64_t) i;
 
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, listItem) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), listItem) == CHIP_NO_ERROR);
 
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
@@ -469,7 +469,7 @@ void DataSeriesGenerator::Generate()
 
                 path.mAttributeId = Clusters::TestCluster::Attributes::ListInt8u::Id;
                 path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, value) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), value) == CHIP_NO_ERROR);
 
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
@@ -488,7 +488,7 @@ void DataSeriesGenerator::Generate()
                 path.mAttributeId = Clusters::TestCluster::Attributes::ListInt8u::Id;
                 path.mListOp      = ConcreteDataAttributePath::ListOperation::AppendItem;
 
-                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag, (uint8_t)(i)) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(gSuite, DataModel::Encode(writer, TLV::AnonymousTag(), (uint8_t)(i)) == CHIP_NO_ERROR);
 
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));

--- a/src/app/tests/TestDataModelSerialization.cpp
+++ b/src/app/tests/TestDataModelSerialization.cpp
@@ -185,7 +185,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecSimpleStruc
 
         t.f.Set(TestCluster::SimpleBitmap::kValueC);
 
-        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag, t);
+        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag(), t);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
         err = _this->mWriter.Finalize();
@@ -246,7 +246,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecNestedStruc
 
         t.c.e = Span<char>{ strbuf, strlen(strbuf) };
 
-        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag, t);
+        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag(), t);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
         err = _this->mWriter.Finalize();
@@ -331,7 +331,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecDecodableNe
         t.c.e = Span<char>{ strbuf, strlen(strbuf) };
         t.d   = structList;
 
-        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag, t);
+        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag(), t);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
         err = _this->mWriter.Finalize();
@@ -460,7 +460,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecDecodableDo
             item.d = structList;
         }
 
-        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag, t);
+        err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag(), t);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
         err = _this->mWriter.Finalize();
@@ -532,7 +532,7 @@ void TestDataModelSerialization::TestDataModelSerialization_OptionalFields(nlTes
         // Encode every field manually except a.
         {
             err =
-                EncodeStruct(_this->mWriter, TLV::AnonymousTag,
+                EncodeStruct(_this->mWriter, TLV::AnonymousTag(),
                              MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kB)), t.b),
                              MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kC)), t.c),
                              MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kD)), t.d),
@@ -603,7 +603,7 @@ void TestDataModelSerialization::TestDataModelSerialization_ExtraField(nlTestSui
         // Encode every field + an extra field.
         {
             err = EncodeStruct(
-                _this->mWriter, TLV::AnonymousTag,
+                _this->mWriter, TLV::AnonymousTag(),
                 MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kA)), t.a),
                 MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kB)), t.b),
                 MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kC)), t.c),
@@ -676,7 +676,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidSimpleFieldTy
             // Encode every field manually except a.
             {
                 err = EncodeStruct(
-                    _this->mWriter, TLV::AnonymousTag,
+                    _this->mWriter, TLV::AnonymousTag(),
                     MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kA)), t.b),
                     MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kB)), t.b),
                     MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kC)), t.c),
@@ -728,7 +728,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidSimpleFieldTy
             // Encode every field manually except a.
             {
                 err = EncodeStruct(
-                    _this->mWriter, TLV::AnonymousTag,
+                    _this->mWriter, TLV::AnonymousTag(),
                     MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kA)), t.a),
                     MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kB)), t.b),
                     MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::SimpleStruct::Fields::kC)), t.c),
@@ -777,7 +777,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidListType(nlTe
         // Encode a list of integers for field d instead of a list of structs.
         {
             err = EncodeStruct(
-                _this->mWriter, TLV::AnonymousTag,
+                _this->mWriter, TLV::AnonymousTag(),
                 MakeTagValuePair(TLV::ContextTag(to_underlying(TestCluster::Structs::NestedStructList::Fields::kD)), t.e));
             NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         }
@@ -922,7 +922,7 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
             encodable.nullableList.SetNull();
         }
 
-        CHIP_ERROR err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag, encodable);
+        CHIP_ERROR err = DataModel::Encode(_this->mWriter, TLV::AnonymousTag(), encodable);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         err = _this->mWriter.Finalize();
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -317,7 +317,7 @@ CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDesc
 {
     TLV::TLVWriter writer;
     writer.Init(attributeDataTLV);
-    writer.CopyElement(TLV::AnonymousTag, aReader);
+    writer.CopyElement(TLV::AnonymousTag(), aReader);
     attributeDataTLVLen = writer.GetLengthWritten();
     return aWriteHandler->AddStatus(
         AttributePathParams(aClusterInfo.mEndpointId, aClusterInfo.mClusterId, aClusterInfo.mAttributeId),

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -153,7 +153,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
     }
 
     VerifyOrReturnError(reader.GetType() == kTLVType_Structure, CHIP_ERROR_WRONG_TLV_TYPE);
-    VerifyOrReturnError(reader.GetTag() == AnonymousTag, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrReturnError(reader.GetTag() == AnonymousTag(), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     TLVType containerType;
     ReturnErrorOnFailure(reader.EnterContainer(containerType));

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChain(const ByteSpan & csr
     }
 
     VerifyOrReturnError(reader.GetType() == kTLVType_Structure, CHIP_ERROR_WRONG_TLV_TYPE);
-    VerifyOrReturnError(reader.GetTag() == AnonymousTag, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrReturnError(reader.GetTag() == AnonymousTag(), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     TLVType containerType;
     ReturnErrorOnFailure(reader.EnterContainer(containerType));

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -98,7 +98,7 @@ public:
             // at the end.)
             TLV::TLVWriter writer;
             writer.Init(buffer.get(), bufferLen);
-            CHIP_ERROR err = writer.CopyElement(TLV::AnonymousTag, *apData);
+            CHIP_ERROR err = writer.CopyElement(TLV::AnonymousTag(), *apData);
             if (err != CHIP_NO_ERROR)
             {
                 app::StatusIB status;
@@ -133,7 +133,7 @@ public:
             // at the end.)
             TLV::TLVWriter writer;
             writer.Init(buffer);
-            err = writer.CopyElement(TLV::AnonymousTag, *apData);
+            err = writer.CopyElement(TLV::AnonymousTag(), *apData);
             if (err != CHIP_NO_ERROR)
             {
                 this->OnError(apReadClient, err);

--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -70,7 +70,7 @@ public:
             // Python need to read from full TLV data the TLVReader may contain some unclean states.
             TLV::TLVWriter writer;
             writer.Init(buffer);
-            CHIP_ERROR err = writer.CopyContainer(TLV::AnonymousTag, *aData);
+            CHIP_ERROR err = writer.CopyContainer(TLV::AnonymousTag(), *aData);
             if (err != CHIP_NO_ERROR)
             {
                 app::StatusIB status;

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -136,7 +136,7 @@ CHIP_ERROR ChipCertificateSet::LoadCert(const ByteSpan chipCert, BitFlags<CertDe
 
     reader.Init(chipCert);
 
-    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag));
+    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag()));
 
     return LoadCert(reader, decodeFlags, chipCert);
 }

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -480,7 +480,7 @@ static CHIP_ERROR ConvertExtension(ASN1Reader & reader, TLVWriter & writer)
                         VerifyOrExit(keyPurposeOID != kOID_Unknown, err = ASN1_ERROR_UNSUPPORTED_ENCODING);
                         VerifyOrExit(GetOIDCategory(keyPurposeOID) == kOIDCategory_KeyPurpose, err = ASN1_ERROR_INVALID_ENCODING);
 
-                        err = writer.Put(AnonymousTag, GetOIDEnum(keyPurposeOID));
+                        err = writer.Put(AnonymousTag(), GetOIDEnum(keyPurposeOID));
                         SuccessOrExit(err);
                     }
                     if (err != ASN1_END)
@@ -715,7 +715,7 @@ CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, MutableByteSpan & 
 
     writer.Init(chipCert);
 
-    ReturnErrorOnFailure(ConvertCertificate(reader, writer, AnonymousTag, issuer, subject, fabric));
+    ReturnErrorOnFailure(ConvertCertificate(reader, writer, AnonymousTag(), issuer, subject, fabric));
 
     ReturnErrorOnFailure(writer.Finalize());
 

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -396,7 +396,7 @@ static CHIP_ERROR DecodeConvertExtendedKeyUsageExtension(TLVReader & reader, ASN
 
         ReturnErrorOnFailure(reader.EnterContainer(outerContainer));
 
-        while ((err = reader.Next(AnonymousTag)) == CHIP_NO_ERROR)
+        while ((err = reader.Next(AnonymousTag())) == CHIP_NO_ERROR)
         {
             uint8_t keyPurposeId;
             ReturnErrorOnFailure(reader.Get(keyPurposeId));
@@ -666,7 +666,7 @@ static CHIP_ERROR DecodeConvertCert(TLVReader & reader, ASN1Writer & writer, Chi
         ReturnErrorOnFailure(reader.Next());
     }
     VerifyOrReturnError(reader.GetType() == kTLVType_Structure, CHIP_ERROR_WRONG_TLV_TYPE);
-    VerifyOrReturnError(reader.GetTag() == AnonymousTag, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrReturnError(reader.GetTag() == AnonymousTag(), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     ReturnErrorOnFailure(reader.EnterContainer(containerType));
 

--- a/src/credentials/CertificationDeclaration.cpp
+++ b/src/credentials/CertificationDeclaration.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR EncodeCertificationElements(const CertificationElements & certElement
 
     writer.Init(encodedCertElements);
 
-    ReturnErrorOnFailure(writer.StartContainer(AnonymousTag, kTLVType_Structure, outerContainer1));
+    ReturnErrorOnFailure(writer.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainer1));
 
     ReturnErrorOnFailure(writer.Put(ContextTag(kTag_FormatVersion), certElements.FormatVersion));
     ReturnErrorOnFailure(writer.Put(ContextTag(kTag_VendorId), certElements.VendorId));
@@ -80,7 +80,7 @@ CHIP_ERROR EncodeCertificationElements(const CertificationElements & certElement
     ReturnErrorOnFailure(writer.StartContainer(ContextTag(kTag_ProductIdArray), kTLVType_Array, outerContainer2));
     for (uint8_t i = 0; i < certElements.ProductIdsCount; i++)
     {
-        ReturnErrorOnFailure(writer.Put(AnonymousTag, certElements.ProductIds[i]));
+        ReturnErrorOnFailure(writer.Put(AnonymousTag(), certElements.ProductIds[i]));
     }
     ReturnErrorOnFailure(writer.EndContainer(outerContainer2));
 
@@ -114,7 +114,7 @@ CHIP_ERROR DecodeCertificationElements(const ByteSpan & encodedCertElements, Cer
 
     reader.Init(encodedCertElements);
 
-    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag));
+    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag()));
 
     ReturnErrorOnFailure(reader.EnterContainer(outerContainer1));
 
@@ -128,7 +128,7 @@ CHIP_ERROR DecodeCertificationElements(const ByteSpan & encodedCertElements, Cer
     ReturnErrorOnFailure(reader.EnterContainer(outerContainer2));
 
     certElements.ProductIdsCount = 0;
-    while ((err = reader.Next(AnonymousTag)) == CHIP_NO_ERROR)
+    while ((err = reader.Next(AnonymousTag())) == CHIP_NO_ERROR)
     {
         ReturnErrorOnFailure(reader.Get(certElements.ProductIds[certElements.ProductIdsCount++]));
     }
@@ -187,7 +187,7 @@ CHIP_ERROR DecodeCertificationElements(const ByteSpan & encodedCertElements, Cer
 
     reader.Init(encodedCertElements);
 
-    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag));
+    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag()));
 
     ReturnErrorOnFailure(reader.EnterContainer(outerContainer));
 
@@ -267,7 +267,7 @@ CHIP_ERROR CertificationElementsDecoder::PrepareToReadProductIdList(const ByteSp
     mCertificationDeclarationData = encodedCertElements;
 
     mReader.Init(mCertificationDeclarationData);
-    ReturnErrorOnFailure(mReader.Next(kTLVType_Structure, AnonymousTag));
+    ReturnErrorOnFailure(mReader.Next(kTLVType_Structure, AnonymousTag()));
     ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType1));
 
     // position to ProductId Array
@@ -291,7 +291,7 @@ CHIP_ERROR CertificationElementsDecoder::PrepareToReadProductIdList(const ByteSp
 CHIP_ERROR CertificationElementsDecoder::GetNextProductId(uint16_t & productId)
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(mReader.Next(AnonymousTag));
+    ReturnErrorOnFailure(mReader.Next(AnonymousTag()));
     ReturnErrorOnFailure(mReader.Get(productId));
     return CHIP_NO_ERROR;
 }

--- a/src/credentials/DeviceAttestationConstructor.cpp
+++ b/src/credentials/DeviceAttestationConstructor.cpp
@@ -42,7 +42,7 @@ CHIP_ERROR CountVendorReservedElementsInDA(const ByteSpan & attestationElements,
     TLV::TLVType containerType = TLV::kTLVType_Structure;
 
     tlvReader.Init(attestationElements);
-    ReturnErrorOnFailure(tlvReader.Next(containerType, TLV::AnonymousTag));
+    ReturnErrorOnFailure(tlvReader.Next(containerType, TLV::AnonymousTag()));
     ReturnErrorOnFailure(tlvReader.EnterContainer(containerType));
 
     size_t count = 0;
@@ -77,7 +77,7 @@ CHIP_ERROR DeconstructAttestationElements(const ByteSpan & attestationElements, 
     firmwareInfo = ByteSpan();
 
     tlvReader.Init(attestationElements);
-    ReturnErrorOnFailure(tlvReader.Next(containerType, TLV::AnonymousTag));
+    ReturnErrorOnFailure(tlvReader.Next(containerType, TLV::AnonymousTag()));
     ReturnErrorOnFailure(tlvReader.EnterContainer(containerType));
 
     CHIP_ERROR error;
@@ -156,7 +156,7 @@ CHIP_ERROR ConstructAttestationElements(const ByteSpan & certificationDeclaratio
 
     tlvWriter.Init(attestationElements.data(), static_cast<uint32_t>(attestationElements.size()));
     outerContainerType = TLV::kTLVType_NotSpecified;
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), certificationDeclaration));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), attestationNonce));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(3), timestamp));
@@ -191,7 +191,7 @@ CHIP_ERROR ConstructNOCSRElements(const ByteSpan & csr, const ByteSpan & csrNonc
 
     tlvWriter.Init(nocsrElements.data(), static_cast<uint32_t>(nocsrElements.size()));
     outerContainerType = TLV::kTLVType_NotSpecified;
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), csr));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), csrNonce));
     if (!vendor_reserved1.empty())

--- a/src/credentials/DeviceAttestationConstructor.cpp
+++ b/src/credentials/DeviceAttestationConstructor.cpp
@@ -49,7 +49,7 @@ CHIP_ERROR CountVendorReservedElementsInDA(const ByteSpan & attestationElements,
     CHIP_ERROR error;
     while ((error = tlvReader.Next()) == CHIP_NO_ERROR)
     {
-        uint64_t tag = tlvReader.GetTag();
+        TLV::Tag tag = tlvReader.GetTag();
         if (TLV::IsProfileTag(tag))
         {
             count++;

--- a/src/credentials/DeviceAttestationVendorReserved.h
+++ b/src/credentials/DeviceAttestationVendorReserved.h
@@ -49,7 +49,7 @@ public:
         mAttestationData       = attestationElements;
 
         mTlvReader.Init(mAttestationData);
-        ReturnErrorOnFailure(mTlvReader.Next(containerType, TLV::AnonymousTag));
+        ReturnErrorOnFailure(mTlvReader.Next(containerType, TLV::AnonymousTag()));
         ReturnErrorOnFailure(mTlvReader.EnterContainer(containerType));
 
         // position to first ProfileTag

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -102,12 +102,12 @@ struct LinkedData : public PersistentData<kPersistentBufferMax>
 
 struct FabricData : public PersistentData<kPersistentBufferMax>
 {
-    static const TLV::Tag kTagFirstGroup  = TLV::ContextTag(1);
-    static const TLV::Tag kTagGroupCount  = TLV::ContextTag(2);
-    static const TLV::Tag kTagFirstMap    = TLV::ContextTag(3);
-    static const TLV::Tag kTagMapCount    = TLV::ContextTag(4);
-    static const TLV::Tag kTagFirstKeyset = TLV::ContextTag(5);
-    static const TLV::Tag kTagKeysetCount = TLV::ContextTag(6);
+    static constexpr TLV::Tag TagFirstGroup() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagGroupCount() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagFirstMap() { return TLV::ContextTag(3); }
+    static constexpr TLV::Tag TagMapCount() { return TLV::ContextTag(4); }
+    static constexpr TLV::Tag TagFirstKeyset() { return TLV::ContextTag(5); }
+    static constexpr TLV::Tag TagKeysetCount() { return TLV::ContextTag(6); }
 
     chip::FabricIndex fabric_index = kUndefinedFabricIndex;
     chip::GroupId first_group      = kUndefinedGroupId;
@@ -140,12 +140,12 @@ struct FabricData : public PersistentData<kPersistentBufferMax>
         TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagFirstGroup, static_cast<uint16_t>(first_group)));
-        ReturnErrorOnFailure(writer.Put(kTagGroupCount, static_cast<uint16_t>(group_count)));
-        ReturnErrorOnFailure(writer.Put(kTagFirstMap, static_cast<uint16_t>(first_map)));
-        ReturnErrorOnFailure(writer.Put(kTagMapCount, static_cast<uint16_t>(map_count)));
-        ReturnErrorOnFailure(writer.Put(kTagFirstKeyset, static_cast<uint16_t>(first_keyset)));
-        ReturnErrorOnFailure(writer.Put(kTagKeysetCount, static_cast<uint16_t>(keyset_count)));
+        ReturnErrorOnFailure(writer.Put(TagFirstGroup(), static_cast<uint16_t>(first_group)));
+        ReturnErrorOnFailure(writer.Put(TagGroupCount(), static_cast<uint16_t>(group_count)));
+        ReturnErrorOnFailure(writer.Put(TagFirstMap(), static_cast<uint16_t>(first_map)));
+        ReturnErrorOnFailure(writer.Put(TagMapCount(), static_cast<uint16_t>(map_count)));
+        ReturnErrorOnFailure(writer.Put(TagFirstKeyset(), static_cast<uint16_t>(first_keyset)));
+        ReturnErrorOnFailure(writer.Put(TagKeysetCount(), static_cast<uint16_t>(keyset_count)));
 
         return writer.EndContainer(container);
     }
@@ -158,22 +158,22 @@ struct FabricData : public PersistentData<kPersistentBufferMax>
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // first_group
-        ReturnErrorOnFailure(reader.Next(kTagFirstGroup));
+        ReturnErrorOnFailure(reader.Next(TagFirstGroup()));
         ReturnErrorOnFailure(reader.Get(first_group));
         // group_count
-        ReturnErrorOnFailure(reader.Next(kTagGroupCount));
+        ReturnErrorOnFailure(reader.Next(TagGroupCount()));
         ReturnErrorOnFailure(reader.Get(group_count));
         // first_map
-        ReturnErrorOnFailure(reader.Next(kTagFirstMap));
+        ReturnErrorOnFailure(reader.Next(TagFirstMap()));
         ReturnErrorOnFailure(reader.Get(first_map));
         // map_count
-        ReturnErrorOnFailure(reader.Next(kTagMapCount));
+        ReturnErrorOnFailure(reader.Next(TagMapCount()));
         ReturnErrorOnFailure(reader.Get(map_count));
         // first_keyset
-        ReturnErrorOnFailure(reader.Next(kTagFirstKeyset));
+        ReturnErrorOnFailure(reader.Next(TagFirstKeyset()));
         ReturnErrorOnFailure(reader.Get(first_keyset));
         // keyset_count
-        ReturnErrorOnFailure(reader.Next(kTagKeysetCount));
+        ReturnErrorOnFailure(reader.Next(TagKeysetCount()));
         ReturnErrorOnFailure(reader.Get(keyset_count));
 
         return reader.ExitContainer(container);
@@ -182,11 +182,11 @@ struct FabricData : public PersistentData<kPersistentBufferMax>
 
 struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
 {
-    static const TLV::Tag kTagGroupId       = TLV::ContextTag(1);
-    static const TLV::Tag kTagName          = TLV::ContextTag(2);
-    static const TLV::Tag kTagFirstEndpoint = TLV::ContextTag(3);
-    static const TLV::Tag kTagEndpointCount = TLV::ContextTag(4);
-    static const TLV::Tag kTagNext          = TLV::ContextTag(5);
+    static constexpr TLV::Tag TagGroupId() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagName() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagFirstEndpoint() { return TLV::ContextTag(3); }
+    static constexpr TLV::Tag TagEndpointCount() { return TLV::ContextTag(4); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(5); }
 
     chip::FabricIndex fabric_index  = kUndefinedFabricIndex;
     chip::EndpointId first_endpoint = kInvalidEndpointId;
@@ -218,11 +218,11 @@ struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
         size_t name_size = strnlen(name, GroupDataProvider::GroupInfo::kGroupNameMax);
-        ReturnErrorOnFailure(writer.Put(kTagGroupId, static_cast<uint16_t>(group_id)));
-        ReturnErrorOnFailure(writer.PutString(kTagName, name, static_cast<uint32_t>(name_size)));
-        ReturnErrorOnFailure(writer.Put(kTagFirstEndpoint, static_cast<uint16_t>(first_endpoint)));
-        ReturnErrorOnFailure(writer.Put(kTagEndpointCount, static_cast<uint16_t>(endpoint_count)));
-        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
+        ReturnErrorOnFailure(writer.Put(TagGroupId(), static_cast<uint16_t>(group_id)));
+        ReturnErrorOnFailure(writer.PutString(TagName(), name, static_cast<uint32_t>(name_size)));
+        ReturnErrorOnFailure(writer.Put(TagFirstEndpoint(), static_cast<uint16_t>(first_endpoint)));
+        ReturnErrorOnFailure(writer.Put(TagEndpointCount(), static_cast<uint16_t>(endpoint_count)));
+        ReturnErrorOnFailure(writer.Put(TagNext(), static_cast<uint16_t>(next)));
         return writer.EndContainer(container);
     }
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
@@ -234,21 +234,21 @@ struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // group_id
-        ReturnErrorOnFailure(reader.Next(kTagGroupId));
+        ReturnErrorOnFailure(reader.Next(TagGroupId()));
         ReturnErrorOnFailure(reader.Get(group_id));
         // name
-        ReturnErrorOnFailure(reader.Next(kTagName));
+        ReturnErrorOnFailure(reader.Next(TagName()));
         ReturnErrorOnFailure(reader.GetString(name, sizeof(name)));
         size_t size = strnlen(name, kGroupNameMax);
         name[size]  = 0;
         // first_endpoint
-        ReturnErrorOnFailure(reader.Next(kTagFirstEndpoint));
+        ReturnErrorOnFailure(reader.Next(TagFirstEndpoint()));
         ReturnErrorOnFailure(reader.Get(first_endpoint));
         // endpoint_count
-        ReturnErrorOnFailure(reader.Next(kTagEndpointCount));
+        ReturnErrorOnFailure(reader.Next(TagEndpointCount()));
         ReturnErrorOnFailure(reader.Get(endpoint_count));
         // next
-        ReturnErrorOnFailure(reader.Next(kTagNext));
+        ReturnErrorOnFailure(reader.Next(TagNext()));
         ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);
@@ -317,9 +317,9 @@ struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
 
 struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
 {
-    static const TLV::Tag kTagGroupId  = TLV::ContextTag(1);
-    static const TLV::Tag kTagKeysetId = TLV::ContextTag(2);
-    static const TLV::Tag kTagNext     = TLV::ContextTag(3);
+    static constexpr TLV::Tag TagGroupId() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagKeysetId() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(3); }
 
     chip::FabricIndex fabric_index = kUndefinedFabricIndex;
     chip::GroupId group_id         = kUndefinedGroupId;
@@ -344,9 +344,9 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
         TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagGroupId, static_cast<uint16_t>(group_id)));
-        ReturnErrorOnFailure(writer.Put(kTagKeysetId, static_cast<uint16_t>(keyset_id)));
-        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
+        ReturnErrorOnFailure(writer.Put(TagGroupId(), static_cast<uint16_t>(group_id)));
+        ReturnErrorOnFailure(writer.Put(TagKeysetId(), static_cast<uint16_t>(keyset_id)));
+        ReturnErrorOnFailure(writer.Put(TagNext(), static_cast<uint16_t>(next)));
         return writer.EndContainer(container);
     }
 
@@ -359,13 +359,13 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // first_endpoint
-        ReturnErrorOnFailure(reader.Next(kTagGroupId));
+        ReturnErrorOnFailure(reader.Next(TagGroupId()));
         ReturnErrorOnFailure(reader.Get(group_id));
         // endpoint_count
-        ReturnErrorOnFailure(reader.Next(kTagKeysetId));
+        ReturnErrorOnFailure(reader.Next(TagKeysetId()));
         ReturnErrorOnFailure(reader.Get(keyset_id));
         // next
-        ReturnErrorOnFailure(reader.Next(kTagNext));
+        ReturnErrorOnFailure(reader.Next(TagNext()));
         ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);
@@ -434,8 +434,8 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
 
 struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
 {
-    static const TLV::Tag kTagEndpoint = TLV::ContextTag(1);
-    static const TLV::Tag kTagNext     = TLV::ContextTag(2);
+    static constexpr TLV::Tag TagEndpoint() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(2); }
 
     chip::FabricIndex fabric_index = kUndefinedFabricIndex;
     uint16_t group_link_id         = 0;
@@ -461,8 +461,8 @@ struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
         TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagEndpoint, static_cast<uint16_t>(endpoint_id)));
-        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
+        ReturnErrorOnFailure(writer.Put(TagEndpoint(), static_cast<uint16_t>(endpoint_id)));
+        ReturnErrorOnFailure(writer.Put(TagNext(), static_cast<uint16_t>(next)));
 
         return writer.EndContainer(container);
     }
@@ -475,10 +475,10 @@ struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // endpoint_id
-        ReturnErrorOnFailure(reader.Next(kTagEndpoint));
+        ReturnErrorOnFailure(reader.Next(TagEndpoint()));
         ReturnErrorOnFailure(reader.Get(endpoint_id));
         // next
-        ReturnErrorOnFailure(reader.Next(kTagNext));
+        ReturnErrorOnFailure(reader.Next(TagNext()));
         ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);
@@ -521,13 +521,13 @@ struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
 
 struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistentBufferMax>
 {
-    static const TLV::Tag kTagKeySetId  = TLV::ContextTag(1);
-    static const TLV::Tag kTagPolicy    = TLV::ContextTag(2);
-    static const TLV::Tag kTagNumKeys   = TLV::ContextTag(3);
-    static const TLV::Tag kTagEpochKeys = TLV::ContextTag(4);
-    static const TLV::Tag kTagStartTime = TLV::ContextTag(5);
-    static const TLV::Tag kTagKey       = TLV::ContextTag(6);
-    static const TLV::Tag kTagNext      = TLV::ContextTag(7);
+    static constexpr TLV::Tag TagKeySetId() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagPolicy() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagNumKeys() { return TLV::ContextTag(3); }
+    static constexpr TLV::Tag TagEpochKeys() { return TLV::ContextTag(4); }
+    static constexpr TLV::Tag TagStartTime() { return TLV::ContextTag(5); }
+    static constexpr TLV::Tag TagKey() { return TLV::ContextTag(6); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(7); }
 
     chip::FabricIndex fabric_index = kUndefinedFabricIndex;
     chip::KeysetId next            = 0xffff;
@@ -562,26 +562,26 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
 
         // keyset_id
-        ReturnErrorOnFailure(writer.Put(kTagKeySetId, static_cast<uint16_t>(keyset_id)));
+        ReturnErrorOnFailure(writer.Put(TagKeySetId(), static_cast<uint16_t>(keyset_id)));
         // policy
-        ReturnErrorOnFailure(writer.Put(kTagPolicy, static_cast<uint16_t>(policy)));
+        ReturnErrorOnFailure(writer.Put(TagPolicy(), static_cast<uint16_t>(policy)));
         // num_keys_used
-        ReturnErrorOnFailure(writer.Put(kTagNumKeys, static_cast<uint16_t>(num_keys_used)));
+        ReturnErrorOnFailure(writer.Put(TagNumKeys(), static_cast<uint16_t>(num_keys_used)));
         // epoch_keys
         {
             TLV::TLVType array, item;
-            ReturnErrorOnFailure(writer.StartContainer(kTagEpochKeys, TLV::kTLVType_Array, array));
+            ReturnErrorOnFailure(writer.StartContainer(TagEpochKeys(), TLV::kTLVType_Array, array));
             for (auto & epoch : epoch_keys)
             {
                 ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, item));
-                ReturnErrorOnFailure(writer.Put(kTagStartTime, static_cast<uint64_t>(epoch.start_time)));
-                ReturnErrorOnFailure(writer.Put(kTagKey, ByteSpan(epoch.key, GroupDataProvider::EpochKey::kLengthBytes)));
+                ReturnErrorOnFailure(writer.Put(TagStartTime(), static_cast<uint64_t>(epoch.start_time)));
+                ReturnErrorOnFailure(writer.Put(TagKey(), ByteSpan(epoch.key, GroupDataProvider::EpochKey::kLengthBytes)));
                 ReturnErrorOnFailure(writer.EndContainer(item));
             }
             ReturnErrorOnFailure(writer.EndContainer(array));
         }
         // next keyset
-        ReturnErrorOnFailure(writer.Put(kTagNext, static_cast<uint16_t>(next)));
+        ReturnErrorOnFailure(writer.Put(TagNext(), static_cast<uint16_t>(next)));
 
         return writer.EndContainer(container);
     }
@@ -595,17 +595,17 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // keyset_id
-        ReturnErrorOnFailure(reader.Next(kTagKeySetId));
+        ReturnErrorOnFailure(reader.Next(TagKeySetId()));
         ReturnErrorOnFailure(reader.Get(keyset_id));
         // policy
-        ReturnErrorOnFailure(reader.Next(kTagPolicy));
+        ReturnErrorOnFailure(reader.Next(TagPolicy()));
         ReturnErrorOnFailure(reader.Get(policy));
         // num_keys_used
-        ReturnErrorOnFailure(reader.Next(kTagNumKeys));
+        ReturnErrorOnFailure(reader.Next(TagNumKeys()));
         ReturnErrorOnFailure(reader.Get(num_keys_used));
         {
             // epoch_keys
-            ReturnErrorOnFailure(reader.Next(kTagEpochKeys));
+            ReturnErrorOnFailure(reader.Next(TagEpochKeys()));
             VerifyOrReturnError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_INTERNAL);
 
             TLV::TLVType array, item;
@@ -617,11 +617,11 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
 
                 ReturnErrorOnFailure(reader.EnterContainer(item));
                 // start_time
-                ReturnErrorOnFailure(reader.Next(kTagStartTime));
+                ReturnErrorOnFailure(reader.Next(TagStartTime()));
                 ReturnErrorOnFailure(reader.Get(epoch.start_time));
                 // key
                 ByteSpan key; // epoch.key,
-                ReturnErrorOnFailure(reader.Next(kTagKey));
+                ReturnErrorOnFailure(reader.Next(TagKey()));
                 ReturnErrorOnFailure(reader.Get(key));
                 VerifyOrReturnError(GroupDataProvider::EpochKey::kLengthBytes == key.size(), CHIP_ERROR_INTERNAL);
                 memcpy(epoch.key, key.data(), GroupDataProvider::EpochKey::kLengthBytes);
@@ -630,7 +630,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
             ReturnErrorOnFailure(reader.ExitContainer(array));
         }
         // next keyset
-        ReturnErrorOnFailure(reader.Next(kTagNext));
+        ReturnErrorOnFailure(reader.Next(TagNext()));
         ReturnErrorOnFailure(reader.Get(next));
 
         return reader.ExitContainer(container);

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -138,7 +138,7 @@ struct FabricData : public PersistentData<kPersistentBufferMax>
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
 
         ReturnErrorOnFailure(writer.Put(TagFirstGroup(), static_cast<uint16_t>(first_group)));
         ReturnErrorOnFailure(writer.Put(TagGroupCount(), static_cast<uint16_t>(group_count)));
@@ -151,7 +151,7 @@ struct FabricData : public PersistentData<kPersistentBufferMax>
     }
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
         VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
 
         TLV::TLVType container;
@@ -215,7 +215,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
 
         size_t name_size = strnlen(name, GroupDataProvider::GroupInfo::kGroupNameMax);
         ReturnErrorOnFailure(writer.Put(TagGroupId(), static_cast<uint16_t>(group_id)));
@@ -227,7 +227,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, LinkedData
     }
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
         VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
 
         TLV::TLVType container;
@@ -342,7 +342,7 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
 
         ReturnErrorOnFailure(writer.Put(TagGroupId(), static_cast<uint16_t>(group_id)));
         ReturnErrorOnFailure(writer.Put(TagKeysetId(), static_cast<uint16_t>(keyset_id)));
@@ -352,7 +352,7 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
 
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
         VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
 
         TLV::TLVType container;
@@ -459,7 +459,7 @@ struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
 
         ReturnErrorOnFailure(writer.Put(TagEndpoint(), static_cast<uint16_t>(endpoint_id)));
         ReturnErrorOnFailure(writer.Put(TagNext(), static_cast<uint16_t>(next)));
@@ -468,7 +468,7 @@ struct EndpointData : GroupDataProvider::GroupEndpoint, LinkedData
     }
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
         VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
 
         TLV::TLVType container;
@@ -559,7 +559,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
     {
         TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
 
         // keyset_id
         ReturnErrorOnFailure(writer.Put(TagKeySetId(), static_cast<uint16_t>(keyset_id)));
@@ -573,7 +573,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
             ReturnErrorOnFailure(writer.StartContainer(TagEpochKeys(), TLV::kTLVType_Array, array));
             for (auto & epoch : epoch_keys)
             {
-                ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, item));
+                ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, item));
                 ReturnErrorOnFailure(writer.Put(TagStartTime(), static_cast<uint64_t>(epoch.start_time)));
                 ReturnErrorOnFailure(writer.Put(TagKey(), ByteSpan(epoch.key, GroupDataProvider::EpochKey::kLengthBytes)));
                 ReturnErrorOnFailure(writer.EndContainer(item));
@@ -588,7 +588,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
 
     CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
     {
-        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
         VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
 
         TLV::TLVType container;
@@ -612,7 +612,7 @@ struct KeySetData : public GroupDataProvider::KeySet, PersistentData<kPersistent
             ReturnErrorOnFailure(reader.EnterContainer(array));
             for (auto & epoch : epoch_keys)
             {
-                ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag));
+                ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
                 VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
 
                 ReturnErrorOnFailure(reader.EnterContainer(item));

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -251,7 +251,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::Byte
     }
 
     VerifyOrReturnError(reader.GetType() == kTLVType_Structure, CHIP_ERROR_WRONG_TLV_TYPE);
-    VerifyOrReturnError(reader.GetTag() == AnonymousTag, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrReturnError(reader.GetTag() == AnonymousTag(), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     TLVType containerType;
     ReturnErrorOnFailure(reader.EnterContainer(containerType));

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -384,7 +384,7 @@ static void TestASN1_FromTLVReader(nlTestSuite * inSuite, void * inContext)
     {
         tlvWriter.Init(tlvEncodedData);
 
-        err = tlvWriter.StartContainer(AnonymousTag, kTLVType_Structure, outerContainerType);
+        err = tlvWriter.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = tlvWriter.PutBytes(TLV::ContextTag(1), kTestVal_20_OctetString, sizeof(kTestVal_20_OctetString));
@@ -424,7 +424,7 @@ static void TestASN1_FromTLVReader(nlTestSuite * inSuite, void * inContext)
     writer.Init(asn1EncodedData2);
     ASN1_START_SEQUENCE
     {
-        err = tlvReader.Next(kTLVType_Structure, AnonymousTag);
+        err = tlvReader.Next(kTLVType_Structure, AnonymousTag());
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = tlvReader.EnterContainer(outerContainerType);

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -1159,7 +1159,7 @@ public:
     /**
      * Encodes a TLV signed integer value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1187,7 +1187,7 @@ public:
     /**
      * Encodes a TLV signed integer value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1249,7 +1249,7 @@ public:
     /**
      * Encodes a TLV unsigned integer value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag. Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1277,7 +1277,7 @@ public:
     /**
      * Encodes a TLV unsigned integer value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1339,7 +1339,7 @@ public:
     /**
      * Encodes a TLV floating point value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1372,7 +1372,7 @@ public:
     /**
      * Encodes a TLV byte string value using ByteSpan class.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1419,7 +1419,7 @@ public:
     /**
      * Encodes a TLV boolean value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1459,7 +1459,7 @@ public:
     /**
      * Encodes a TLV byte string value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1488,7 +1488,7 @@ public:
     /**
      * Encodes a TLV UTF8 string value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1516,7 +1516,7 @@ public:
     /**
      * Encodes a TLV UTF8 string value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1545,7 +1545,7 @@ public:
     /**
      * Encodes a TLV UTF8 string value that's passed in as a Span.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1596,7 +1596,7 @@ public:
      * temporary buffer to hold the output, using Platform::MemoryAlloc().
      *
      * @param[in] tag The TLV tag to be encoded with the value, or @p
-     *                AnonymousTag if the value should be encoded without
+     *                AnonymousTag() if the value should be encoded without
      *                a tag.  Tag values should be constructed with one of
      *                the tag definition functions ProfileTag(),
      *                ContextTag() or CommonTag().
@@ -1642,7 +1642,7 @@ public:
      * temporary buffer to hold the output, using Platform::MemoryAlloc().
      *
      * @param[in] tag The TLV tag to be encoded with the value, or @p
-     *                AnonymousTag if the value should be encoded without
+     *                AnonymousTag() if the value should be encoded without
      *                a tag.  Tag values should be constructed with one of
      *                the tag definition functions ProfileTag(),
      *                ContextTag() or CommonTag().
@@ -1665,7 +1665,7 @@ public:
     /**
      * Encodes a TLV null value.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag() if the
      *                              value should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1747,7 +1747,7 @@ public:
      * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
      * other mode has undefined behavior.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag() if
      *                              the container should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1795,7 +1795,7 @@ public:
      * write the elements of the container.  When finish, the application must call the EndContainer()
      * method to finish the encoding of the container.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag() if
      *                              the container should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1883,7 +1883,7 @@ public:
      * @note The StartContainer() method can be used as an alternative to OpenContainer() to write a
      * container element without initializing a new writer object.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag() if
      *                              the container should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -1959,7 +1959,7 @@ public:
      * The method encodes the entirety of the container element in one call.  When PutPreEncodedContainer()
      * returns, the writer object can be used to write additional TLV elements following the container element.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag() if
      *                              the container should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -2050,7 +2050,7 @@ public:
      * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
      * input buffer that contains the entirety of the underlying TLV encoding.
      *
-     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag() if
      *                              the container should be encoded without a tag.  Tag values should be
      *                              constructed with one of the tag definition functions ProfileTag(),
      *                              ContextTag() or CommonTag().
@@ -2099,7 +2099,7 @@ public:
      * When the method returns, the writer object can be used to write additional TLV elements following
      * the container element.
      *
-     * @param[in] tag                   The TLV tag to be encoded with the container, or @p AnonymousTag if
+     * @param[in] tag                   The TLV tag to be encoded with the container, or @p AnonymousTag() if
      *                                  the container should be encoded without a tag.  Tag values should be
      *                                  constructed with one of the tag definition functions ProfileTag(),
      *                                  ContextTag() or CommonTag().

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -576,7 +576,7 @@ CHIP_ERROR TLVReader::Skip()
  */
 void TLVReader::ClearElementState()
 {
-    mElemTag      = AnonymousTag;
+    mElemTag      = AnonymousTag();
     mControlByte  = kTLVControlByte_NotSpecified;
     mElemLenOrVal = 0;
 }
@@ -737,7 +737,7 @@ CHIP_ERROR TLVReader::VerifyElement()
     {
         if (mContainerType == kTLVType_NotSpecified)
             return CHIP_ERROR_INVALID_TLV_ELEMENT;
-        if (mElemTag != AnonymousTag)
+        if (mElemTag != AnonymousTag())
             return CHIP_ERROR_INVALID_TLV_TAG;
     }
     else
@@ -751,11 +751,11 @@ CHIP_ERROR TLVReader::VerifyElement()
                 return CHIP_ERROR_INVALID_TLV_TAG;
             break;
         case kTLVType_Structure:
-            if (mElemTag == AnonymousTag)
+            if (mElemTag == AnonymousTag())
                 return CHIP_ERROR_INVALID_TLV_TAG;
             break;
         case kTLVType_Array:
-            if (mElemTag != AnonymousTag)
+            if (mElemTag != AnonymousTag())
                 return CHIP_ERROR_INVALID_TLV_TAG;
             break;
         case kTLVType_UnknownContainer:
@@ -815,7 +815,7 @@ Tag TLVReader::ReadTag(TLVTagControl tagControl, const uint8_t *& p)
         return ProfileTag(vendorId, profileNum, LittleEndian::Read32(p));
     case TLVTagControl::Anonymous:
     default:
-        return AnonymousTag;
+        return AnonymousTag();
     }
 }
 

--- a/src/lib/core/CHIPTLVTags.h
+++ b/src/lib/core/CHIPTLVTags.h
@@ -29,7 +29,14 @@
 namespace chip {
 namespace TLV {
 
-typedef uint64_t Tag;
+struct Tag
+{
+    explicit constexpr Tag(uint64_t val) : mVal(val) {}
+    Tag() {}
+    constexpr bool operator==(const Tag & other) const { return mVal == other.mVal; }
+    constexpr bool operator!=(const Tag & other) const { return mVal != other.mVal; }
+    uint64_t mVal;
+};
 
 enum TLVCommonProfiles
 {
@@ -94,7 +101,7 @@ enum
  */
 inline constexpr Tag ProfileTag(uint32_t profileId, uint32_t tagNum)
 {
-    return ((static_cast<uint64_t>(profileId)) << kProfileIdShift) | tagNum;
+    return Tag(((static_cast<uint64_t>(profileId)) << kProfileIdShift) | tagNum);
 }
 
 /**
@@ -105,10 +112,10 @@ inline constexpr Tag ProfileTag(uint32_t profileId, uint32_t tagNum)
  * @param[in]   tagNum          The profile-specific tag number assigned to the tag.
  * @return                      A 64-bit integer representing the tag.
  */
-inline Tag ProfileTag(uint16_t vendorId, uint16_t profileNum, uint32_t tagNum)
+inline constexpr Tag ProfileTag(uint16_t vendorId, uint16_t profileNum, uint32_t tagNum)
 {
-    return ((static_cast<uint64_t>(vendorId)) << kVendorIdShift) | ((static_cast<uint64_t>(profileNum)) << kProfileNumShift) |
-        tagNum;
+    return Tag(((static_cast<uint64_t>(vendorId)) << kVendorIdShift) | ((static_cast<uint64_t>(profileNum)) << kProfileNumShift) |
+               tagNum);
 }
 
 /**
@@ -119,7 +126,7 @@ inline Tag ProfileTag(uint16_t vendorId, uint16_t profileNum, uint32_t tagNum)
  */
 inline constexpr Tag ContextTag(uint8_t tagNum)
 {
-    return kSpecialTagMarker | tagNum;
+    return Tag(kSpecialTagMarker | tagNum);
 }
 
 /**
@@ -128,21 +135,17 @@ inline constexpr Tag ContextTag(uint8_t tagNum)
  * @param[in]   tagNum          The common profile tag number assigned to the tag.
  * @return                      A 64-bit integer representing the tag.
  */
-inline Tag CommonTag(uint32_t tagNum)
+inline constexpr Tag CommonTag(uint32_t tagNum)
 {
     return ProfileTag(kCommonProfileId, tagNum);
 }
 
-enum
-{
-    /**
-     * A value signifying a TLV element that has no tag (i.e. an anonymous element).
-     */
-    AnonymousTag = kSpecialTagMarker | 0x00000000FFFFFFFFULL,
-
-    // TODO: Move to private namespace
-    UnknownImplicitTag = kSpecialTagMarker | 0x00000000FFFFFFFEULL
-};
+/**
+ * A value signifying a TLV element that has no tag (i.e. an anonymous element).
+ */
+static constexpr Tag AnonymousTag(kSpecialTagMarker | 0x00000000FFFFFFFFULL);
+// TODO: Move to private namespace
+static constexpr Tag UnknownImplicitTag(kSpecialTagMarker | 0x00000000FFFFFFFEULL);
 
 /**
  * Returns the profile id from a TLV tag
@@ -152,9 +155,9 @@ enum
  * @param[in]   tag             The API representation of a profile-specific TLV tag.
  * @return                      The profile id.
  */
-inline uint32_t ProfileIdFromTag(Tag tag)
+inline constexpr uint32_t ProfileIdFromTag(Tag tag)
 {
-    return static_cast<uint32_t>((tag & kProfileIdMask) >> kProfileIdShift);
+    return static_cast<uint32_t>((tag.mVal & kProfileIdMask) >> kProfileIdShift);
 }
 
 /**
@@ -165,9 +168,9 @@ inline uint32_t ProfileIdFromTag(Tag tag)
  * @param[in]   tag             The API representation of a profile-specific TLV tag.
  * @return                      The associated profile number.
  */
-inline uint16_t ProfileNumFromTag(Tag tag)
+inline constexpr uint16_t ProfileNumFromTag(Tag tag)
 {
-    return static_cast<uint16_t>((tag & kProfileNumMask) >> kProfileNumShift);
+    return static_cast<uint16_t>((tag.mVal & kProfileNumMask) >> kProfileNumShift);
 }
 
 /**
@@ -181,9 +184,9 @@ inline uint16_t ProfileNumFromTag(Tag tag)
  * @param[in]   tag             The API representation of a profile-specific or context-specific TLV tag.
  * @return                      The associated tag number.
  */
-inline uint32_t TagNumFromTag(Tag tag)
+inline constexpr uint32_t TagNumFromTag(Tag tag)
 {
-    return static_cast<uint32_t>(tag & kTagNumMask);
+    return static_cast<uint32_t>(tag.mVal & kTagNumMask);
 }
 
 /**
@@ -194,34 +197,32 @@ inline uint32_t TagNumFromTag(Tag tag)
  * @param[in]   tag             The API representation of a profile-specific TLV tag.
  * @return                      The associated vendor id.
  */
-inline uint16_t VendorIdFromTag(Tag tag)
+inline constexpr uint16_t VendorIdFromTag(Tag tag)
 {
-    return static_cast<uint16_t>((tag & kVendorIdMask) >> kVendorIdShift);
+    return static_cast<uint16_t>((tag.mVal & kVendorIdMask) >> kVendorIdShift);
 }
 
 /**
  * Returns true of the supplied tag is a profile-specific tag.
  */
-inline bool IsProfileTag(Tag tag)
+inline constexpr bool IsProfileTag(Tag tag)
 {
-    return (tag & kProfileIdMask) != kSpecialTagMarker;
+    return (tag.mVal & kProfileIdMask) != kSpecialTagMarker;
 }
 
 /**
  * Returns true if the supplied tag is a context-specific tag.
  */
-inline bool IsContextTag(Tag tag)
+inline constexpr bool IsContextTag(Tag tag)
 {
-    return (tag & kProfileIdMask) == kSpecialTagMarker && TagNumFromTag(tag) <= kContextTagMaxNum;
+    return (tag.mVal & kProfileIdMask) == kSpecialTagMarker && TagNumFromTag(tag) <= kContextTagMaxNum;
 }
 
 // TODO: move to private namespace
-inline bool IsSpecialTag(Tag tag)
+inline constexpr bool IsSpecialTag(Tag tag)
 {
-    return (tag & kProfileIdMask) == kSpecialTagMarker;
+    return (tag.mVal & kProfileIdMask) == kSpecialTagMarker;
 }
-
-constexpr uint8_t kMaxTLVTagLength = 8;
 
 } // namespace TLV
 } // namespace chip

--- a/src/lib/core/CHIPTLVTags.h
+++ b/src/lib/core/CHIPTLVTags.h
@@ -143,7 +143,10 @@ inline constexpr Tag CommonTag(uint32_t tagNum)
 /**
  * A value signifying a TLV element that has no tag (i.e. an anonymous element).
  */
-static constexpr Tag AnonymousTag(kSpecialTagMarker | 0x00000000FFFFFFFFULL);
+inline constexpr Tag AnonymousTag()
+{
+    return Tag(kSpecialTagMarker | 0x00000000FFFFFFFFULL);
+}
 // TODO: Move to private namespace
 static constexpr Tag UnknownImplicitTag(kSpecialTagMarker | 0x00000000FFFFFFFEULL);
 

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     mUpdaterReader.mLenRead       = readDataLen;
     mUpdaterReader.mMaxLen        = aReader.mMaxLen;
     mUpdaterReader.mControlByte   = kTLVControlByte_NotSpecified;
-    mUpdaterReader.mElemTag       = AnonymousTag;
+    mUpdaterReader.mElemTag       = AnonymousTag();
     mUpdaterReader.mElemLenOrVal  = 0;
     mUpdaterReader.mContainerType = aReader.mContainerType;
     mUpdaterReader.SetContainerOpen(false);
@@ -189,7 +189,7 @@ void TLVUpdater::MoveUntilEnd()
     mUpdaterReader.mReadPoint += copyLen;
     mUpdaterReader.mLenRead += copyLen;
     mUpdaterReader.mControlByte   = kTLVControlByte_NotSpecified;
-    mUpdaterReader.mElemTag       = AnonymousTag;
+    mUpdaterReader.mElemTag       = AnonymousTag();
     mUpdaterReader.mElemLenOrVal  = 0;
     mUpdaterReader.mContainerType = kTLVType_NotSpecified;
     mUpdaterReader.SetContainerOpen(false);

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -512,7 +512,7 @@ CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
     // Reset the container writer so that it can't accidentally be used again.
     containerWriter.Init(static_cast<uint8_t *>(nullptr), 0);
 
-    return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag, 0);
+    return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag(), 0);
 }
 
 CHIP_ERROR TLVWriter::StartContainer(Tag tag, TLVType containerType, TLVType & outerContainerType)
@@ -554,7 +554,7 @@ CHIP_ERROR TLVWriter::EndContainer(TLVType outerContainerType)
     if (IsCloseContainerReserved())
         mMaxLen += kEndOfContainerMarkerSize;
 
-    return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag, 0);
+    return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag(), 0);
 }
 
 CHIP_ERROR TLVWriter::PutPreEncodedContainer(Tag tag, TLVType containerType, const uint8_t * data, uint32_t dataLen)

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -364,40 +364,40 @@ static CHIP_ERROR WriteIntMinMax(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
 
-    err = writer.Put(AnonymousTag, static_cast<int8_t>(INT8_MIN));
+    err = writer.Put(AnonymousTag(), static_cast<int8_t>(INT8_MIN));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int8_t>(INT8_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<int8_t>(INT8_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int16_t>(INT16_MIN));
+    err = writer.Put(AnonymousTag(), static_cast<int16_t>(INT16_MIN));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int16_t>(INT16_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<int16_t>(INT16_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int32_t>(INT32_MIN));
+    err = writer.Put(AnonymousTag(), static_cast<int32_t>(INT32_MIN));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int32_t>(INT32_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<int32_t>(INT32_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int64_t>(INT64_MIN));
+    err = writer.Put(AnonymousTag(), static_cast<int64_t>(INT64_MIN));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<int64_t>(INT64_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<int64_t>(INT64_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<uint8_t>(UINT8_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<uint8_t>(UINT8_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<uint16_t>(UINT16_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<uint16_t>(UINT16_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<uint32_t>(UINT32_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<uint32_t>(UINT32_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Put(AnonymousTag, static_cast<uint64_t>(UINT64_MAX));
+    err = writer.Put(AnonymousTag(), static_cast<uint64_t>(UINT64_MAX));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     return err;
@@ -405,159 +405,159 @@ static CHIP_ERROR WriteIntMinMax(nlTestSuite * inSuite, TLVWriter & writer)
 
 static void CheckIntMinMax(nlTestSuite * inSuite, TLVReader & reader)
 {
-    // Writer did Put(AnonymousTag, static_cast<int8_t>(INT8_MIN))
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT8_MIN));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT8_MIN));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT8_MIN));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT8_MIN));
+    // Writer did Put(AnonymousTag(), static_cast<int8_t>(INT8_MIN))
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(INT8_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(INT8_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(INT8_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT8_MIN));
 
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-
-    TestNext<TLVReader>(inSuite, reader);
-
-    // Writer did Put(AnonymousTag, static_cast<int8_t>(INT8_MAX))
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT8_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT8_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT8_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT8_MAX));
-
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
 
     TestNext<TLVReader>(inSuite, reader);
 
-    // Writer did Put(AnonymousTag, static_cast<int16_t>(INT16_MIN))
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT16_MIN));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT16_MIN));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT16_MIN));
+    // Writer did Put(AnonymousTag(), static_cast<int8_t>(INT8_MAX))
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(INT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(INT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(INT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT8_MAX));
 
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-
-    TestNext<TLVReader>(inSuite, reader);
-
-    // Writer did Put(AnonymousTag, static_cast<int16_t>(INT16_MAX))
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT16_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT16_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT16_MAX));
-
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
 
     TestNext<TLVReader>(inSuite, reader);
 
-    // Writer did Put(AnonymousTag, static_cast<int32_t>(INT32_MIN))
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT32_MIN));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT32_MIN));
+    // Writer did Put(AnonymousTag(), static_cast<int16_t>(INT16_MIN))
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(INT16_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(INT16_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT16_MIN));
 
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-
-    TestNext<TLVReader>(inSuite, reader);
-
-    // Writer did Put(AnonymousTag, static_cast<int32_t>(INT32_MAX))
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT32_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT32_MAX));
-
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
 
     TestNext<TLVReader>(inSuite, reader);
 
-    // Writer did Put(AnonymousTag, static_cast<int64_t>(INT64_MIN))
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT64_MIN));
+    // Writer did Put(AnonymousTag(), static_cast<int16_t>(INT16_MAX))
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(INT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(INT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT16_MAX));
 
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-
-    TestNext<TLVReader>(inSuite, reader);
-
-    // Writer did Put(AnonymousTag, static_cast<int64_t>(INT64_MAX))
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT64_MAX));
-
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
 
     TestNext<TLVReader>(inSuite, reader);
 
-    // Writer did Put(AnonymousTag, static_cast<uint8_t>(UINT8_MAX))
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    // Writer did Put(AnonymousTag(), static_cast<int32_t>(INT32_MIN))
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(INT32_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT32_MIN));
 
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(UINT8_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(UINT8_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT8_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT8_MAX));
-
-    TestNext<TLVReader>(inSuite, reader);
-
-    // Writer did Put(AnonymousTag, static_cast<uint16_t>(UINT16_MAX))
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(UINT16_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT16_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT16_MAX));
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
 
     TestNext<TLVReader>(inSuite, reader);
 
-    // Writer did Put(AnonymousTag, static_cast<uint32_t>(UINT32_MAX))
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    // Writer did Put(AnonymousTag(), static_cast<int32_t>(INT32_MAX))
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(INT32_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT32_MAX));
 
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT32_MAX));
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT32_MAX));
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
 
     TestNext<TLVReader>(inSuite, reader);
 
-    // Writer did Put(AnonymousTag, static_cast<uint64_t>(UINT64_MAX))
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    // Writer did Put(AnonymousTag(), static_cast<int64_t>(INT64_MIN))
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT64_MIN));
 
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT64_MAX));
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    // Writer did Put(AnonymousTag(), static_cast<int64_t>(INT64_MAX))
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(INT64_MAX));
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    // Writer did Put(AnonymousTag(), static_cast<uint8_t>(UINT8_MAX))
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint8_t>(UINT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint16_t>(UINT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint32_t>(UINT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint64_t>(UINT8_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    // Writer did Put(AnonymousTag(), static_cast<uint16_t>(UINT16_MAX))
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint16_t>(UINT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint32_t>(UINT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint64_t>(UINT16_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    // Writer did Put(AnonymousTag(), static_cast<uint32_t>(UINT32_MAX))
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint32_t>(UINT32_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint64_t>(UINT32_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    // Writer did Put(AnonymousTag(), static_cast<uint64_t>(UINT64_MAX))
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int8_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int16_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int32_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int64_t>(0), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint8_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint16_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint32_t>(0), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint64_t>(UINT64_MAX));
 }
 
 void WriteEncoding1(nlTestSuite * inSuite, TLVWriter & writer)
@@ -581,22 +581,22 @@ void WriteEncoding1(nlTestSuite * inSuite, TLVWriter & writer)
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         // TODO(#1306): expand coverage of inttype encoding tests.
-        err = writer3.Put(AnonymousTag, static_cast<int32_t>(42));
+        err = writer3.Put(AnonymousTag(), static_cast<int32_t>(42));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int32_t>(-17));
+        err = writer3.Put(AnonymousTag(), static_cast<int32_t>(-17));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int32_t>(-170000));
+        err = writer3.Put(AnonymousTag(), static_cast<int32_t>(-170000));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<uint64_t>(40000000000ULL));
+        err = writer3.Put(AnonymousTag(), static_cast<uint64_t>(40000000000ULL));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         {
             TLVWriter writer4;
 
-            err = writer3.OpenContainer(AnonymousTag, kTLVType_Structure, writer4);
+            err = writer3.OpenContainer(AnonymousTag(), kTLVType_Structure, writer4);
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
             err = writer3.CloseContainer(writer4);
@@ -606,7 +606,7 @@ void WriteEncoding1(nlTestSuite * inSuite, TLVWriter & writer)
         {
             TLVWriter writer5;
 
-            err = writer3.OpenContainer(AnonymousTag, kTLVType_List, writer5);
+            err = writer3.OpenContainer(AnonymousTag(), kTLVType_List, writer5);
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
             err = writer5.PutNull(ProfileTag(TestProfile_1, 17));
@@ -615,7 +615,7 @@ void WriteEncoding1(nlTestSuite * inSuite, TLVWriter & writer)
             err = writer5.PutNull(ProfileTag(TestProfile_2, 900000));
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-            err = writer5.PutNull(AnonymousTag);
+            err = writer5.PutNull(AnonymousTag());
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
             {
@@ -706,40 +706,44 @@ void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(42));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(42));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(42));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(42));
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
-
-            TestNext<TLVReader>(inSuite, reader3);
-
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(-17));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(-17));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-17));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-17));
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(-17), CHIP_ERROR_WRONG_TLV_TYPE);
-
-            TestNext<TLVReader>(inSuite, reader3);
-
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-170000));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-170000));
-
-            TestNext<TLVReader>(inSuite, reader3);
-
-            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL),
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(42));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint8_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint16_t>(42),
                      CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(40000000000ULL));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(42),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(42),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(-17));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(-17),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(-170000));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(-170000));
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int64_t>(40000000000ULL),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint64_t>(40000000000ULL));
 
             TestNext<TLVReader>(inSuite, reader3);
 
             {
                 TLVReader reader4;
 
-                TestAndOpenContainer(inSuite, reader3, kTLVType_Structure, AnonymousTag, reader4);
+                TestAndOpenContainer(inSuite, reader3, kTLVType_Structure, AnonymousTag(), reader4);
 
                 TestEndAndCloseContainer(inSuite, reader3, reader4);
             }
@@ -749,7 +753,7 @@ void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
             {
                 TLVReader reader5;
 
-                TestAndOpenContainer(inSuite, reader3, kTLVType_List, AnonymousTag, reader5);
+                TestAndOpenContainer(inSuite, reader3, kTLVType_List, AnonymousTag(), reader5);
 
                 TestNext<TLVReader>(inSuite, reader5);
 
@@ -761,7 +765,7 @@ void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 
                 TestNext<TLVReader>(inSuite, reader5);
 
-                TestNull(inSuite, reader5, AnonymousTag);
+                TestNull(inSuite, reader5, AnonymousTag());
 
                 TestNext<TLVReader>(inSuite, reader5);
 
@@ -2738,16 +2742,16 @@ void CheckCHIPTLVSkipCircular(nlTestSuite * inSuite, void * inContext)
 
     writer.Init(buffer);
 
-    err = writer.PutString(AnonymousTag, testString);
+    err = writer.PutString(AnonymousTag(), testString);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.PutString(AnonymousTag, testString);
+    err = writer.PutString(AnonymousTag(), testString);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.PutString(AnonymousTag, testString); // This event straddles the boundary
+    err = writer.PutString(AnonymousTag(), testString); // This event straddles the boundary
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.PutString(AnonymousTag, testString); // This one does not.
+    err = writer.PutString(AnonymousTag(), testString); // This one does not.
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = writer.Finalize();
@@ -2909,7 +2913,7 @@ void TestCHIPTLVWriterCopyElement(nlTestSuite * inSuite)
     writer.Init(expectedBuf);
     writer.ImplicitProfileId = TestProfile_2;
 
-    err = writer.StartContainer(AnonymousTag, kTLVType_Structure, outerContainerType);
+    err = writer.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     for (int i = 0; i < kRepeatCount; i++)
@@ -2928,7 +2932,7 @@ void TestCHIPTLVWriterCopyElement(nlTestSuite * inSuite)
     writer.Init(testBuf);
     writer.ImplicitProfileId = TestProfile_2;
 
-    err = writer.StartContainer(AnonymousTag, kTLVType_Structure, outerContainerType);
+    err = writer.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     for (int i = 0; i < kRepeatCount; i++)
@@ -2982,38 +2986,38 @@ void PreserveSizeWrite(nlTestSuite * inSuite, TLVWriter & writer, bool preserveS
         err = writer2.OpenContainer(ContextTag(0), kTLVType_Array, writer3);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<uint8_t>(42), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<uint8_t>(42), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<uint16_t>(42), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<uint16_t>(42), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<uint32_t>(42), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<uint32_t>(42), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<uint64_t>(40000000000ULL), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<uint64_t>(40000000000ULL), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int8_t>(-17), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<int8_t>(-17), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int16_t>(-17), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<int16_t>(-17), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int32_t>(-170000), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<int32_t>(-170000), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int64_t>(-170000), preserveSize);
+        err = writer3.Put(AnonymousTag(), static_cast<int64_t>(-170000), preserveSize);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         // the below cases are for full coverage of PUTs
-        err = writer3.Put(AnonymousTag, static_cast<uint64_t>(65535), false);
+        err = writer3.Put(AnonymousTag(), static_cast<uint64_t>(65535), false);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int64_t>(32767), false);
+        err = writer3.Put(AnonymousTag(), static_cast<int64_t>(32767), false);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer3.Put(AnonymousTag, static_cast<int64_t>(40000000000ULL), false);
+        err = writer3.Put(AnonymousTag(), static_cast<int64_t>(40000000000ULL), false);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = writer2.CloseContainer(writer3);
@@ -3213,37 +3217,39 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(42));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(42));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(42));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(42));
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
-
-            TestNext<TLVReader>(inSuite, reader3);
-
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(-17));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(-17));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-17));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-17));
-
-            TestNext<TLVReader>(inSuite, reader3);
-
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-170000));
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-170000));
-
-            TestNext<TLVReader>(inSuite, reader3);
-
-            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL),
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(42));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint32_t>(42),
                      CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(40000000000ULL));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<uint64_t>(42),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int8_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int16_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(-17));
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int32_t>(-170000));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag(), static_cast<int64_t>(-170000));
+
+            TestNext<TLVReader>(inSuite, reader3);
+
+            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<int64_t>(40000000000ULL),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag(), static_cast<uint64_t>(40000000000ULL));
 
             TestNext<TLVReader>(inSuite, reader3);
 
             {
                 TLVReader reader4;
 
-                TestAndOpenContainer(inSuite, reader3, kTLVType_Structure, AnonymousTag, reader4);
+                TestAndOpenContainer(inSuite, reader3, kTLVType_Structure, AnonymousTag(), reader4);
 
                 TestEndAndCloseContainer(inSuite, reader3, reader4);
             }
@@ -3253,7 +3259,7 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
             {
                 TLVReader reader5;
 
-                TestAndOpenContainer(inSuite, reader3, kTLVType_List, AnonymousTag, reader5);
+                TestAndOpenContainer(inSuite, reader3, kTLVType_List, AnonymousTag(), reader5);
 
                 TestNext<TLVReader>(inSuite, reader5);
 
@@ -3265,7 +3271,7 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 
                 TestNext<TLVReader>(inSuite, reader5);
 
-                TestNull(inSuite, reader5, AnonymousTag);
+                TestNull(inSuite, reader5, AnonymousTag());
 
                 TestNext<TLVReader>(inSuite, reader5);
 
@@ -3393,7 +3399,7 @@ void TestCHIPTLVReaderTruncatedReads(nlTestSuite * inSuite)
     writer.Init(buf);
     writer.ImplicitProfileId = TestProfile_2;
 
-    err = writer.Put(AnonymousTag, double{ 12.5 });
+    err = writer.Put(AnonymousTag(), double{ 12.5 });
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Test reading values from the buffer
@@ -3401,7 +3407,7 @@ void TestCHIPTLVReaderTruncatedReads(nlTestSuite * inSuite)
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_FloatingPointNumber, AnonymousTag, 12.5);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_FloatingPointNumber, AnonymousTag(), 12.5);
 
     err = reader.Get(outF);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_TLV_TYPE);
@@ -3559,70 +3565,70 @@ static void TestItems(nlTestSuite * inSuite, void * inContext)
     writer.Init(sBuffer);
 
     TLVWriter writer2;
-    err = writer.OpenContainer(AnonymousTag, kTLVType_Array, writer2);
+    err = writer.OpenContainer(AnonymousTag(), kTLVType_Array, writer2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     {
-        err = writer2.PutBoolean(AnonymousTag, true);
+        err = writer2.PutBoolean(AnonymousTag(), true);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int8_t>(-1));
+        err = writer2.Put(AnonymousTag(), static_cast<int8_t>(-1));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int16_t>(-2));
+        err = writer2.Put(AnonymousTag(), static_cast<int16_t>(-2));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int32_t>(-3));
+        err = writer2.Put(AnonymousTag(), static_cast<int32_t>(-3));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int64_t>(-4));
+        err = writer2.Put(AnonymousTag(), static_cast<int64_t>(-4));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<float>(-5.5));
+        err = writer2.Put(AnonymousTag(), static_cast<float>(-5.5));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<double>(-3.14159265358979323846));
+        err = writer2.Put(AnonymousTag(), static_cast<double>(-3.14159265358979323846));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     }
 
     err = writer.CloseContainer(writer2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.OpenContainer(AnonymousTag, kTLVType_Array, writer2);
+    err = writer.OpenContainer(AnonymousTag(), kTLVType_Array, writer2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     {
-        err = writer2.PutBoolean(AnonymousTag, false);
+        err = writer2.PutBoolean(AnonymousTag(), false);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int8_t>(1));
+        err = writer2.Put(AnonymousTag(), static_cast<int8_t>(1));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int16_t>(2));
+        err = writer2.Put(AnonymousTag(), static_cast<int16_t>(2));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int32_t>(3));
+        err = writer2.Put(AnonymousTag(), static_cast<int32_t>(3));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<int64_t>(4));
+        err = writer2.Put(AnonymousTag(), static_cast<int64_t>(4));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<uint8_t>(5));
+        err = writer2.Put(AnonymousTag(), static_cast<uint8_t>(5));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<uint16_t>(6));
+        err = writer2.Put(AnonymousTag(), static_cast<uint16_t>(6));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<uint32_t>(7));
+        err = writer2.Put(AnonymousTag(), static_cast<uint32_t>(7));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<uint64_t>(8));
+        err = writer2.Put(AnonymousTag(), static_cast<uint64_t>(8));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<float>(9.9));
+        err = writer2.Put(AnonymousTag(), static_cast<float>(9.9));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = writer2.Put(AnonymousTag, static_cast<double>(3.14159265358979323846));
+        err = writer2.Put(AnonymousTag(), static_cast<double>(3.14159265358979323846));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     }
 
@@ -3645,7 +3651,7 @@ static void TestContainers(nlTestSuite * inSuite, void * inContext)
     writer.Init(sBuffer);
 
     TLVWriter writer2;
-    err = writer.OpenContainer(AnonymousTag, kTLVType_Array, writer2);
+    err = writer.OpenContainer(AnonymousTag(), kTLVType_Array, writer2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     TLVType type = writer2.GetContainerType();
@@ -3654,7 +3660,7 @@ static void TestContainers(nlTestSuite * inSuite, void * inContext)
     err = writer.CloseContainer(writer2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.OpenContainer(AnonymousTag, kTLVType_Structure, writer2);
+    err = writer.OpenContainer(AnonymousTag(), kTLVType_Structure, writer2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     type = writer2.GetContainerType();
@@ -3738,10 +3744,10 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
 
     writer1.Init(buf);
 
-    err = writer1.OpenContainer(AnonymousTag, kTLVType_Array, innerWriter1);
+    err = writer1.OpenContainer(AnonymousTag(), kTLVType_Array, innerWriter1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = innerWriter1.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter2);
+    err = innerWriter1.OpenContainer(AnonymousTag(), kTLVType_Structure, innerWriter2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = innerWriter2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -3755,10 +3761,10 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
 
     writer2.Init(buf, sizeof(buf));
 
-    err = writer2.OpenContainer(AnonymousTag, kTLVType_Array, innerWriter1);
+    err = writer2.OpenContainer(AnonymousTag(), kTLVType_Array, innerWriter1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = innerWriter1.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter2);
+    err = innerWriter1.OpenContainer(AnonymousTag(), kTLVType_Structure, innerWriter2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = innerWriter2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -3774,10 +3780,10 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
 
     writer1.Init(buf);
 
-    err = writer1.StartContainer(AnonymousTag, kTLVType_Array, container1);
+    err = writer1.StartContainer(AnonymousTag(), kTLVType_Array, container1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer1.StartContainer(AnonymousTag, kTLVType_Structure, container2);
+    err = writer1.StartContainer(AnonymousTag(), kTLVType_Structure, container2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -3791,10 +3797,10 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
 
     writer2.Init(buf, sizeof(buf));
 
-    err = writer2.StartContainer(AnonymousTag, kTLVType_Array, container1);
+    err = writer2.StartContainer(AnonymousTag(), kTLVType_Array, container1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer2.StartContainer(AnonymousTag, kTLVType_Structure, container2);
+    err = writer2.StartContainer(AnonymousTag(), kTLVType_Structure, container2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     err = writer2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -3845,7 +3851,7 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
     err = writer1.OpenContainer(ProfileTag(TestProfile_1, 2), kTLVType_Structure, innerWriter1);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    err = writer1.StartContainer(AnonymousTag, kTLVType_Array, container1);
+    err = writer1.StartContainer(AnonymousTag(), kTLVType_Array, container1);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Test again all cases from 0 to the length of buf1
@@ -3856,10 +3862,10 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
 
         writer1.Init(buf, maxLen);
 
-        err = writer1.OpenContainer(AnonymousTag, kTLVType_Array, innerWriter1);
+        err = writer1.OpenContainer(AnonymousTag(), kTLVType_Array, innerWriter1);
 
         if (err == CHIP_NO_ERROR)
-            err = innerWriter1.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter2);
+            err = innerWriter1.OpenContainer(AnonymousTag(), kTLVType_Structure, innerWriter2);
 
         if (err == CHIP_NO_ERROR)
             err = innerWriter2.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -3877,10 +3883,10 @@ static void CheckCloseContainerReserve(nlTestSuite * inSuite, void * inContext)
         writer1.Init(buf, maxLen);
 
         if (err == CHIP_NO_ERROR)
-            err = writer1.StartContainer(AnonymousTag, kTLVType_Array, container1);
+            err = writer1.StartContainer(AnonymousTag(), kTLVType_Array, container1);
 
         if (err == CHIP_NO_ERROR)
-            err = writer1.StartContainer(AnonymousTag, kTLVType_Structure, container2);
+            err = writer1.StartContainer(AnonymousTag(), kTLVType_Structure, container2);
 
         if (err == CHIP_NO_ERROR)
             err = writer1.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -3936,7 +3942,7 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
             TLVType outerContainer2Type;
 
             ReturnErrorOnFailure(reader.EnterContainer(outerContainer2Type));
-            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag));
+            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag()));
 
             FUZZ_CHECK_VAL(int8_t, 42);
             FUZZ_CHECK_VAL(int16_t, 42);
@@ -3947,24 +3953,24 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
             FUZZ_CHECK_VAL(uint32_t, 42);
             FUZZ_CHECK_VAL(uint64_t, 42);
 
-            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag));
+            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag()));
 
             FUZZ_CHECK_VAL(int8_t, -17);
             FUZZ_CHECK_VAL(int16_t, -17);
             FUZZ_CHECK_VAL(int32_t, -17);
             FUZZ_CHECK_VAL(int64_t, -17);
 
-            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag));
+            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag()));
 
             FUZZ_CHECK_VAL(int32_t, -170000);
             FUZZ_CHECK_VAL(int64_t, -170000);
 
-            ReturnErrorOnFailure(reader.Next(kTLVType_UnsignedInteger, AnonymousTag));
+            ReturnErrorOnFailure(reader.Next(kTLVType_UnsignedInteger, AnonymousTag()));
 
             FUZZ_CHECK_VAL(int64_t, 40000000000ULL);
             FUZZ_CHECK_VAL(uint64_t, 40000000000ULL);
 
-            ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag));
+            ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag()));
 
             {
                 TLVType outerContainer3Type;
@@ -3973,7 +3979,7 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
                 ReturnErrorOnFailure(reader.ExitContainer(outerContainer3Type));
             }
 
-            ReturnErrorOnFailure(reader.Next(kTLVType_List, AnonymousTag));
+            ReturnErrorOnFailure(reader.Next(kTLVType_List, AnonymousTag()));
 
             {
                 TLVType outerContainer3Type;
@@ -3981,7 +3987,7 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
                 ReturnErrorOnFailure(reader.EnterContainer(outerContainer3Type));
                 ReturnErrorOnFailure(reader.Next(kTLVType_Null, ProfileTag(TestProfile_1, 17)));
                 ReturnErrorOnFailure(reader.Next(kTLVType_Null, ProfileTag(TestProfile_2, 900000)));
-                ReturnErrorOnFailure(reader.Next(kTLVType_Null, AnonymousTag));
+                ReturnErrorOnFailure(reader.Next(kTLVType_Null, AnonymousTag()));
                 ReturnErrorOnFailure(reader.Next(kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL)));
 
                 {
@@ -4307,14 +4313,14 @@ static void CheckCHIPTLVScopedBuffer(nlTestSuite * inSuite, void * inContext)
 
         NL_TEST_ASSERT(inSuite, buf.Get() == nullptr);
 
-        err = writer.Put(TLV::AnonymousTag, (uint8_t) 33);
+        err = writer.Put(TLV::AnonymousTag(), (uint8_t) 33);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = writer.Finalize(buf);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, buf.Get() != nullptr);
 
-        err = writer.Put(TLV::AnonymousTag, (uint8_t) 33);
+        err = writer.Put(TLV::AnonymousTag(), (uint8_t) 33);
         NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
     }
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -313,7 +313,7 @@ CHIP_ERROR CASESession::SendSigma1()
     VerifyOrReturnError(!msg_R1.IsNull(), CHIP_ERROR_NO_MEMORY);
 
     tlvWriter.Init(std::move(msg_R1));
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), ByteSpan(mInitiatorRandom)));
     // Retrieve Session Identifier
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalSessionId()));
@@ -471,7 +471,7 @@ CHIP_ERROR CASESession::SendSigma2Resume(const ByteSpan & initiatorRandom)
     // Generate a new resumption ID
     ReturnErrorOnFailure(DRBG_get_bytes(mResumptionId, sizeof(mResumptionId)));
 
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), ByteSpan(mResumptionId)));
 
     uint8_t sigma2ResumeMIC[CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES];
@@ -569,7 +569,7 @@ CHIP_ERROR CASESession::SendSigma2()
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
     tlvWriter.Init(msg_R2_Encrypted.Get(), msg_r2_signed_enc_len);
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(kTag_TBEData_SenderNOC), nocCert));
     if (!icaCert.empty())
     {
@@ -605,7 +605,7 @@ CHIP_ERROR CASESession::SendSigma2()
     outerContainerType = TLV::kTLVType_NotSpecified;
 
     tlvWriterMsg2.Init(std::move(msg_R2));
-    ReturnErrorOnFailure(tlvWriterMsg2.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriterMsg2.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriterMsg2.PutBytes(TLV::ContextTag(1), &msg_rand[0], sizeof(msg_rand)));
     ReturnErrorOnFailure(tlvWriterMsg2.Put(TLV::ContextTag(2), GetLocalSessionId()));
     ReturnErrorOnFailure(
@@ -648,7 +648,7 @@ CHIP_ERROR CASESession::HandleSigma2Resume(System::PacketBufferHandle && msg)
     uint8_t sigma2ResumeMIC[CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES];
 
     tlvReader.Init(std::move(msg));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = tlvReader.Next());
@@ -743,7 +743,7 @@ CHIP_ERROR CASESession::HandleSigma2(System::PacketBufferHandle && msg)
     ChipLogDetail(SecureChannel, "Received Sigma2 msg");
 
     tlvReader.Init(std::move(msg));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     // Retrieve Responder's Random value
@@ -797,7 +797,7 @@ CHIP_ERROR CASESession::HandleSigma2(System::PacketBufferHandle && msg)
 
     decryptedDataTlvReader.Init(msg_R2_Encrypted.Get(), msg_r2_encrypted_len);
     containerType = TLV::kTLVType_Structure;
-    SuccessOrExit(err = decryptedDataTlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = decryptedDataTlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = decryptedDataTlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = decryptedDataTlvReader.Next(TLV::kTLVType_ByteString, TLV::ContextTag(kTag_TBEData_SenderNOC)));
@@ -914,7 +914,7 @@ CHIP_ERROR CASESession::SendSigma3()
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
         tlvWriter.Init(msg_R3_Encrypted.Get(), msg_r3_encrypted_len);
-        SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+        SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kTag_TBEData_SenderNOC), nocCert));
         if (!icaCert.empty())
         {
@@ -956,7 +956,7 @@ CHIP_ERROR CASESession::SendSigma3()
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
         tlvWriter.Init(std::move(msg_R3));
-        err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType);
+        err = tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType);
         SuccessOrExit(err);
         err = tlvWriter.PutBytes(TLV::ContextTag(1), msg_R3_Encrypted.Get(),
                                  static_cast<uint32_t>(msg_r3_encrypted_len + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES));
@@ -1025,7 +1025,7 @@ CHIP_ERROR CASESession::HandleSigma3(System::PacketBufferHandle && msg)
     ChipLogDetail(SecureChannel, "Received Sigma3 msg");
 
     tlvReader.Init(std::move(msg));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     // Fetch encrypted data
@@ -1059,7 +1059,7 @@ CHIP_ERROR CASESession::HandleSigma3(System::PacketBufferHandle && msg)
 
     decryptedDataTlvReader.Init(msg_R3_Encrypted.Get(), msg_r3_encrypted_len);
     containerType = TLV::kTLVType_Structure;
-    SuccessOrExit(err = decryptedDataTlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = decryptedDataTlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = decryptedDataTlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = decryptedDataTlvReader.Next(TLV::kTLVType_ByteString, TLV::ContextTag(kTag_TBEData_SenderNOC)));
@@ -1259,7 +1259,7 @@ CHIP_ERROR CASESession::ConstructTBSData(const ByteSpan & senderNOC, const ByteS
     };
 
     tlvWriter.Init(tbsData, tbsDataLen);
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(kTag_TBSData_SenderNOC), senderNOC));
     if (!senderICAC.empty())
     {
@@ -1350,7 +1350,7 @@ CHIP_ERROR CASESession::ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, 
     constexpr uint8_t kResume1MICTag         = 7;
 
     TLVType containerType = kTLVType_Structure;
-    ReturnErrorOnFailure(tlvReader.Next(containerType, AnonymousTag));
+    ReturnErrorOnFailure(tlvReader.Next(containerType, AnonymousTag()));
     ReturnErrorOnFailure(tlvReader.EnterContainer(containerType));
 
     ReturnErrorOnFailure(tlvReader.Next(ContextTag(kInitiatorRandomTag)));

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -376,7 +376,7 @@ CHIP_ERROR PASESession::SendPBKDFParamRequest()
     tlvWriter.Init(std::move(req));
 
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(1), mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalSessionId()));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(3), mPasscodeID));
@@ -420,7 +420,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamRequest(System::PacketBufferHandle && ms
     SuccessOrExit(err = mCommissioningHash.AddData(ByteSpan{ msg->Start(), msg->DataLength() }));
 
     tlvReader.Init(std::move(msg));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = tlvReader.Next());
@@ -481,7 +481,7 @@ CHIP_ERROR PASESession::SendPBKDFParamResponse(ByteSpan initiatorRandom, bool in
     tlvWriter.Init(std::move(resp));
 
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
     // The initiator random value is being sent back in the response as required by the specifications
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), initiatorRandom));
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(2), mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
@@ -542,7 +542,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     SuccessOrExit(err = mCommissioningHash.AddData(ByteSpan{ msg->Start(), msg->DataLength() }));
 
     tlvReader.Init(std::move(msg));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = tlvReader.Next());
@@ -621,7 +621,7 @@ CHIP_ERROR PASESession::SendMsg1()
     tlvWriter.Init(std::move(msg));
 
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+    ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
 
     uint8_t X[kMAX_Point_Length];
     size_t X_len = sizeof(X);
@@ -664,7 +664,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
     size_t X_len = 0;
 
     tlvReader.Init(std::move(msg1));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = tlvReader.Next());
@@ -691,7 +691,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
         tlvWriter.Init(std::move(msg2));
 
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-        SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+        SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kPake2_pB), ByteSpan(Y)));
         SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kPake2_cB), ByteSpan(verifier, verifier_len)));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
@@ -737,7 +737,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
     uint32_t decodeTagIdSeq = 0;
 
     tlvReader.Init(std::move(msg2));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = tlvReader.Next());
@@ -767,7 +767,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
         tlvWriter.Init(std::move(msg3));
 
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-        SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
+        SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kPake3_cB), ByteSpan(verifier, verifier_len)));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize(&msg3));
@@ -805,7 +805,7 @@ CHIP_ERROR PASESession::HandleMsg3(System::PacketBufferHandle && msg)
     size_t peer_verifier_len = 0;
 
     tlvReader.Init(std::move(msg));
-    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
+    SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag()));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));
 
     SuccessOrExit(err = tlvReader.Next());

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -427,7 +427,7 @@ static CHIP_ERROR EncodeSigma1(MutableByteSpan & buf)
     writer.Init(buf);
 
     TLVType containerType;
-    ReturnErrorOnFailure(writer.StartContainer(AnonymousTag, kTLVType_Structure, containerType));
+    ReturnErrorOnFailure(writer.StartContainer(AnonymousTag(), kTLVType_Structure, containerType));
     uint8_t initiatorRandom[Params::initiatorRandomLen] = { 1 };
     ReturnErrorOnFailure(writer.Put(Params::NumToTag(Params::initiatorRandomTag), ByteSpan(initiatorRandom)));
 

--- a/src/setup_payload/AdditionalDataPayloadGenerator.cpp
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.cpp
@@ -55,7 +55,7 @@ AdditionalDataPayloadGenerator::generateAdditionalDataPayload(uint16_t lifetimeC
     // Initialize TLVWriter
     writer.Init(chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize));
 
-    ReturnErrorOnFailure(writer.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter));
+    ReturnErrorOnFailure(writer.OpenContainer(AnonymousTag(), kTLVType_Structure, innerWriter));
 
     if (additionalDataFields.Has(AdditionalDataFields::RotatingDeviceId))
     {

--- a/src/setup_payload/AdditionalDataPayloadParser.cpp
+++ b/src/setup_payload/AdditionalDataPayloadParser.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR AdditionalDataPayloadParser::populatePayload(SetupPayloadData::Additi
     TLV::ContiguousBufferTLVReader innerReader;
 
     reader.Init(mPayloadBufferData, mPayloadBufferLength);
-    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag));
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
 
     // Open the container
     ReturnErrorOnFailure(reader.OpenContainer(innerReader));

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::generateTLVFromOptionalData(SetupPayload
 
     TLV::TLVWriter innerStructureWriter;
 
-    ReturnErrorOnFailure(rootWriter.OpenContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, innerStructureWriter));
+    ReturnErrorOnFailure(rootWriter.OpenContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, innerStructureWriter));
 
     for (OptionalQRCodeInfo info : optionalData)
     {

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -251,7 +251,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::parseTLVFields(SetupPayload & outPayload, u
     }
 
     TLV::ContiguousBufferTLVReader innerStructureReader;
-    ReturnErrorOnFailure(openTLVContainer(rootReader, TLV::kTLVType_Structure, TLV::AnonymousTag, innerStructureReader));
+    ReturnErrorOnFailure(openTLVContainer(rootReader, TLV::kTLVType_Structure, TLV::AnonymousTag(), innerStructureReader));
     ReturnErrorOnFailure(innerStructureReader.Next());
     err = retrieveOptionalInfos(outPayload, innerStructureReader);
 

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -60,7 +60,8 @@ void PairingSessionEncodeDecodeMRPParams(nlTestSuite * inSuite, void * inContext
     writer.Init(buf.Retain());
 
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    NL_TEST_ASSERT(inSuite, writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, PairingSession::EncodeMRPParameters(TLV::ContextTag(1), config, writer) == CHIP_NO_ERROR);
 
@@ -71,7 +72,7 @@ void PairingSessionEncodeDecodeMRPParams(nlTestSuite * inSuite, void * inContext
     TLV::TLVType containerType = TLV::kTLVType_Structure;
 
     reader.Init(std::move(buf));
-    NL_TEST_ASSERT(inSuite, reader.Next(containerType, TLV::AnonymousTag) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, reader.Next(containerType, TLV::AnonymousTag()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, reader.EnterContainer(containerType) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_NO_ERROR);
@@ -90,7 +91,8 @@ void PairingSessionTryDecodeMissingMRPParams(nlTestSuite * inSuite, void * inCon
     writer.Init(buf.Retain());
 
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    NL_TEST_ASSERT(inSuite, writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, writer.Put(TLV::ContextTag(1), static_cast<uint16_t>(0x1234)) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, writer.Finalize(&buf) == CHIP_NO_ERROR);
@@ -99,7 +101,7 @@ void PairingSessionTryDecodeMissingMRPParams(nlTestSuite * inSuite, void * inCon
     TLV::TLVType containerType = TLV::kTLVType_Structure;
 
     reader.Init(std::move(buf));
-    NL_TEST_ASSERT(inSuite, reader.Next(containerType, TLV::AnonymousTag) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, reader.Next(containerType, TLV::AnonymousTag()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, reader.EnterContainer(containerType) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, session.DecodeMRPParametersIfPresent(TLV::ContextTag(2), reader) == CHIP_NO_ERROR);


### PR DESCRIPTION
#### Problem
People keep mixing up tags and tag numbers.

#### Change overview
Make Tag a struct with constexpr constructor.

There are some changes to replace const static members with constexpr functions (which are smaller codesize-wise than static constexpr members), and to replace AnonymousTag with a constexpr function, also because this reduces codesize compared to it being a static constexpr variable.

Without those various changes the codesize increase was close to 1KB instead of ~200 bytes.

I've left the methods that operate on Tag instances as free functions for now, but as a followup we can make them be class members.

#### Testing
Tree compiles.  No behavior changes intended.