### PR TITLE
Add optimization options for CC13x2x7 platform

### DIFF
--- a/examples/lock-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/lock-app/cc13x2x7_26x2x7/args.gni
@@ -21,8 +21,14 @@ ti_simplelink_sysconfig_target =
 
 ti_simplelink_board = "LP_CC2652R7"
 
-# use -Os instead of -Og
+# Size Optimizations
+# use -Os instead of -Og, LWIP release build
 #is_debug = false
+
+# Disable CHIP Logging
+#chip_progress_logging = false
+#chip_detail_logging = false
+#chip_automation_logging = false
 
 # BLE options
 chip_config_network_layer_ble = true

--- a/examples/lock-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
@@ -29,8 +29,8 @@
 #define CHIP_PROJECT_CONFIG_H
 
 #if BUILD_RELEASE // release build
-
-#else // development build
+// Note: Default Pairing/PIN/Serial Numbers being used. These should not be enabled for production builds
+#endif // BUILD_RELEASE
 
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
@@ -46,8 +46,6 @@
  * is found in CHIP NV storage.
  */
 #define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
-
-#endif // BUILD_RELEASE
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID

--- a/examples/pump-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/pump-app/cc13x2x7_26x2x7/args.gni
@@ -21,8 +21,14 @@ ti_simplelink_sysconfig_target =
 
 ti_simplelink_board = "LP_CC2652R7"
 
-# use -Os instead of -Og
+# Size Optimizations
+# use -Os instead of -Og, LWIP release build
 #is_debug = false
+
+# Disable CHIP Logging
+#chip_progress_logging = false
+#chip_detail_logging = false
+#chip_automation_logging = false
 
 # BLE options
 chip_config_network_layer_ble = true

--- a/examples/pump-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
@@ -33,8 +33,8 @@
 #define CHIP_CONFIG_REQUIRE_AUTH 1
 
 #if BUILD_RELEASE // release build
-
-#else // development build
+// Note: Default Pairing/PIN/Serial Numbers being used. These should not be enabled for production builds
+#endif // BUILD_RELEASE
 
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
@@ -50,8 +50,6 @@
  * is found in CHIP NV storage.
  */
 #define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
-
-#endif // BUILD_RELEASE
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/args.gni
@@ -21,8 +21,14 @@ ti_simplelink_sysconfig_target =
 
 ti_simplelink_board = "LP_CC2652R7"
 
-# use -Os instead of -Og
+# Size Optimizations
+# use -Os instead of -Og, LWIP release build
 #is_debug = false
+
+# Disable CHIP Logging
+#chip_progress_logging = false
+#chip_detail_logging = false
+#chip_automation_logging = false
 
 # BLE options
 chip_config_network_layer_ble = true

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
@@ -33,8 +33,8 @@
 #define CHIP_CONFIG_REQUIRE_AUTH 1
 
 #if BUILD_RELEASE // release build
-
-#else // development build
+// Note: Default Pairing/PIN/Serial Numbers being used. These should not be enabled for production builds
+#endif // BUILD_RELEASE
 
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
@@ -50,8 +50,6 @@
  * is found in CHIP NV storage.
  */
 #define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
-
-#endif // BUILD_RELEASE
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID


### PR DESCRIPTION
#### Problem
Added optimization options to reduce CHIP application build size

#### Change overview
Updated local args.gni files for lock-app, pump-controller, pump-controller-app to highlight optimization options.

#### Testing
*Built lock-app, pump-controller, pump-controller-app for CC13x2x7 platform using -Os/-Og.