### PR TITLE
app/ReadPrepareParams: store session in SessionHolder instead of SessionHandle

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR ReadClient::SendReadRequest(ReadPrepareParams & aReadPrepareParams)
         ReturnErrorOnFailure(writer.Finalize(&msgBuf));
     }
 
-    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHandle, this);
+    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHolder.Get(), this);
     VerifyOrReturnError(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     mpExchangeCtx->SetResponseTimeout(aReadPrepareParams.mTimeout);
@@ -190,8 +190,8 @@ CHIP_ERROR ReadClient::SendReadRequest(ReadPrepareParams & aReadPrepareParams)
     ReturnErrorOnFailure(mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
                                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
-    mPeerNodeId  = aReadPrepareParams.mSessionHandle.GetPeerNodeId();
-    mFabricIndex = aReadPrepareParams.mSessionHandle.GetFabricIndex();
+    mPeerNodeId  = aReadPrepareParams.mSessionHolder.Get().GetPeerNodeId();
+    mFabricIndex = aReadPrepareParams.mSessionHolder.Get().GetFabricIndex();
 
     MoveToState(ClientState::AwaitingInitialReport);
 
@@ -699,7 +699,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
 
     ReturnErrorOnFailure(writer.Finalize(&msgBuf));
 
-    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHandle, this);
+    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHolder.Get(), this);
     VerifyOrReturnError(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeout);
@@ -712,8 +712,8 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
     ReturnErrorOnFailure(mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::SubscribeRequest, std::move(msgBuf),
                                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
-    mPeerNodeId  = aReadPrepareParams.mSessionHandle.GetPeerNodeId();
-    mFabricIndex = aReadPrepareParams.mSessionHandle.GetFabricIndex();
+    mPeerNodeId  = aReadPrepareParams.mSessionHolder.Get().GetPeerNodeId();
+    mFabricIndex = aReadPrepareParams.mSessionHolder.Get().GetFabricIndex();
 
     MoveToState(ClientState::AwaitingInitialReport);
 

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -29,7 +29,7 @@ namespace chip {
 namespace app {
 struct ReadPrepareParams
 {
-    SessionHandle mSessionHandle;
+    SessionHolder mSessionHolder;
     EventPathParams * mpEventPathParamsList         = nullptr;
     size_t mEventPathParamsListSize                 = 0;
     AttributePathParams * mpAttributePathParamsList = nullptr;
@@ -40,8 +40,8 @@ struct ReadPrepareParams
     uint16_t mMaxIntervalCeilingSeconds             = 0;
     bool mKeepSubscriptions                         = true;
 
-    ReadPrepareParams(const SessionHandle & sessionHandle) : mSessionHandle(sessionHandle) {}
-    ReadPrepareParams(ReadPrepareParams && other) : mSessionHandle(other.mSessionHandle)
+    ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }
+    ReadPrepareParams(ReadPrepareParams && other) : mSessionHolder(other.mSessionHolder)
     {
         mKeepSubscriptions                 = other.mKeepSubscriptions;
         mpEventPathParamsList              = other.mpEventPathParamsList;
@@ -64,7 +64,7 @@ struct ReadPrepareParams
             return *this;
 
         mKeepSubscriptions                 = other.mKeepSubscriptions;
-        mSessionHandle                     = other.mSessionHandle;
+        mSessionHolder                     = other.mSessionHolder;
         mpEventPathParamsList              = other.mpEventPathParamsList;
         mEventPathParamsListSize           = other.mEventPathParamsListSize;
         mpAttributePathParamsList          = other.mpAttributePathParamsList;

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1319,7 +1319,7 @@ void TestReadInteraction::TestSubscribeInvalidAttributePathRoundtrip(nlTestSuite
 
     readPrepareParams.mAttributePathParamsListSize = 1;
 
-    readPrepareParams.mSessionHandle             = ctx.GetSessionBobToAlice();
+    readPrepareParams.mSessionHolder.Grab(ctx.GetSessionBobToAlice());
     readPrepareParams.mMinIntervalFloorSeconds   = 2;
     readPrepareParams.mMaxIntervalCeilingSeconds = 5;
     printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
@@ -1406,7 +1406,7 @@ void TestReadInteraction::TestSubscribeInvalidIterval(nlTestSuite * apSuite, voi
 
     readPrepareParams.mAttributePathParamsListSize = 1;
 
-    readPrepareParams.mSessionHandle             = ctx.GetSessionBobToAlice();
+    readPrepareParams.mSessionHolder.Grab(ctx.GetSessionBobToAlice());
     readPrepareParams.mMinIntervalFloorSeconds   = 6;
     readPrepareParams.mMaxIntervalCeilingSeconds = 5;
 

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -41,12 +41,7 @@ public:
     SessionHolder(SessionHolder && that);
     SessionHolder operator=(SessionHolder && that);
 
-    void Grab(const SessionHandle & sessionHandle)
-    {
-        Release();
-        mSession.SetValue(sessionHandle);
-    }
-
+    void Grab(const SessionHandle & sessionHandle) { mSession.SetValue(sessionHandle); }
     void Release() { mSession.ClearValue(); }
 
     // TODO: call this function when the underlying session is released


### PR DESCRIPTION
#### Problem
`SessionHandle` should not be used to store a session

#### Change overview
Replace `SessionHandle` with `SessionHolder` in `app/ReadPrepareParams`

#### Testing
Refactor. Verified using unit-tests.