### PR TITLE
fix parameter error in 32 bits system

### DIFF
--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -155,7 +155,7 @@ Commands::PlaybackResponse::Type MediaPlaybackManager::HandleMediaRequest(MediaP
     VerifyOrExit(env != NULL, err = CHIP_JNI_ERROR_NO_ENV);
 
     env->ExceptionClear();
-    ret = env->CallIntMethod(mMediaPlaybackManagerObject, mRequestMethod, static_cast<jlong>(mediaPlaybackRequest),
+    ret = env->CallIntMethod(mMediaPlaybackManagerObject, mRequestMethod, static_cast<jint>(mediaPlaybackRequest),
                              static_cast<jlong>(deltaPositionMilliseconds));
     if (env->ExceptionCheck())
     {


### PR DESCRIPTION
#### Problem
* MediaPlaybackManager::Request get error mediaPlaybackRequest id in 32 bits system

#### Change overview
* The jni parameter should be a jint (32 bits) but set to long (64 bits)

#### Testing
* chip-tool mediaplayback media-seek
