### PR TITLE
Fix Doxygen errors

### DIFF
--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -251,6 +251,7 @@ public:
      * be called inside ScanNetworks.
      *
      * @param ssid    The interested SSID, the scanning MAY be restricted to to the given SSID.
+     * @param callback    Callback that will be invoked upon finishing the scan
      */
     virtual void ScanNetworks(ByteSpan ssid, ScanCallback * callback) = 0;
 

--- a/src/lib/support/TypeTraits.h
+++ b/src/lib/support/TypeTraits.h
@@ -41,6 +41,7 @@ constexpr std::underlying_type_t<T> to_underlying(T e)
 /**
  * @brief This template is not designed to be used directly. A common pattern to check the presence of a member of a class is:
  *
+ * \cond
  * template <typename T>
  * class IsMagic
  * {
@@ -54,6 +55,7 @@ constexpr std::underlying_type_t<T> to_underlying(T e)
  * public:
  *     static constexpr bool value = decltype(TestHasMagic<std::decay_t<T>>(0))::value;
  * };
+ * \endcond
  *
  *   The compiler will try to match TestHasMagicFunction(int) first, if MagicFunction is a member function of T, the match succeed
  * and HasMagicFunction is an alias of std::true_type. If MagicFunction is not a member function of T, the match of


### PR DESCRIPTION
#### Problem
Fixed Doxygen errors

Re-enabling the "Doxygen workflow" for all PRs should prevent such issues from being introduced. Unless there's a different reason for disabling the Doxygen workflow that I am not aware of... :-)

#### Change overview
Updated comments that were causing Doxygen generation from succeeding.

#### Testing
Tested by successfully generating Doxygen HTML docs on my local machine, i.e. the following commands now work.
```
doxygen docs/Doxyfile
```

```
./scripts/helpers/doxygen.sh 
```
