### PR TITLE
[NetworkCommissioning] WiFiScanResults and ThreadScanResults should be optional fields

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
@@ -100,8 +100,8 @@ limitations under the License.
             <description>TODO</description>
             <arg name="NetworkingStatus" type="NetworkCommissioningStatus"/>
             <arg name="DebugText" type="CHAR_STRING"/>
-            <arg name="WiFiScanResults" type="WiFiInterfaceScanResult" array="true"/>
-            <arg name="ThreadScanResults" type="ThreadInterfaceScanResult" array="true"/>
+            <arg name="WiFiScanResults" type="WiFiInterfaceScanResult" array="true" optional="true"/>
+            <arg name="ThreadScanResults" type="ThreadInterfaceScanResult" array="true" optional="true"/>
         </command>
         <command source="client" code="0x02" name="AddOrUpdateWiFiNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatewifinetwork">
             <description>TODO</description>

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -1606,11 +1606,27 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
     chip::UtfString DebugTextUtfString(env, dataResponse.debugText);
     DebugText = DebugTextUtfString.jniValue();
     jobject WiFiScanResults;
+    if (!dataResponse.wiFiScanResults.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, WiFiScanResults);
+    }
+    else
+    {
 
-    WiFiScanResults = nullptr; /* Array - Conversion from this type to Java is not properly implemented yet */
+        WiFiScanResults = nullptr; /* Array - Conversion from this type to Java is not properly implemented yet */
+        chip::JniReferences::GetInstance().CreateOptional(WiFiScanResults, WiFiScanResults);
+    }
     jobject ThreadScanResults;
+    if (!dataResponse.threadScanResults.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, ThreadScanResults);
+    }
+    else
+    {
 
-    ThreadScanResults = nullptr; /* Array - Conversion from this type to Java is not properly implemented yet */
+        ThreadScanResults = nullptr; /* Array - Conversion from this type to Java is not properly implemented yet */
+        chip::JniReferences::GetInstance().CreateOptional(ThreadScanResults, ThreadScanResults);
+    }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, NetworkingStatus, DebugText, WiFiScanResults, ThreadScanResults);
 }

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -8334,14 +8334,14 @@ class NetworkCommissioning(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="networkingStatus", Tag=0, Type=NetworkCommissioning.Enums.NetworkCommissioningStatus),
                             ClusterObjectFieldDescriptor(Label="debugText", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="wiFiScanResults", Tag=2, Type=typing.List[NetworkCommissioning.Structs.WiFiInterfaceScanResult]),
-                            ClusterObjectFieldDescriptor(Label="threadScanResults", Tag=3, Type=typing.List[NetworkCommissioning.Structs.ThreadInterfaceScanResult]),
+                            ClusterObjectFieldDescriptor(Label="wiFiScanResults", Tag=2, Type=typing.Optional[typing.List[NetworkCommissioning.Structs.WiFiInterfaceScanResult]]),
+                            ClusterObjectFieldDescriptor(Label="threadScanResults", Tag=3, Type=typing.Optional[typing.List[NetworkCommissioning.Structs.ThreadInterfaceScanResult]]),
                     ])
 
             networkingStatus: 'NetworkCommissioning.Enums.NetworkCommissioningStatus' = 0
             debugText: 'str' = ""
-            wiFiScanResults: 'typing.List[NetworkCommissioning.Structs.WiFiInterfaceScanResult]' = field(default_factory=lambda: [])
-            threadScanResults: 'typing.List[NetworkCommissioning.Structs.ThreadInterfaceScanResult]' = field(default_factory=lambda: [])
+            wiFiScanResults: 'typing.Optional[typing.List[NetworkCommissioning.Structs.WiFiInterfaceScanResult]]' = None
+            threadScanResults: 'typing.Optional[typing.List[NetworkCommissioning.Structs.ThreadInterfaceScanResult]]' = None
 
         @dataclass
         class AddOrUpdateWiFiNetwork(ClusterCommand):

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -5523,56 +5523,64 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
                                                     encoding:NSUTF8StringEncoding];
     }
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.wiFiScanResults.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            CHIPNetworkCommissioningClusterWiFiInterfaceScanResult * newElement_0;
-            newElement_0 = [CHIPNetworkCommissioningClusterWiFiInterfaceScanResult new];
-            newElement_0.security = [NSNumber numberWithUnsignedChar:entry_0.security];
-            newElement_0.ssid = [NSData dataWithBytes:entry_0.ssid.data() length:entry_0.ssid.size()];
-            newElement_0.bssid = [NSData dataWithBytes:entry_0.bssid.data() length:entry_0.bssid.size()];
-            newElement_0.channel = [NSNumber numberWithUnsignedShort:entry_0.channel];
-            newElement_0.wiFiBand = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.wiFiBand)];
-            newElement_0.rssi = [NSNumber numberWithChar:entry_0.rssi];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
-            CHIP_ERROR err = iter_0.GetStatus();
-            if (err != CHIP_NO_ERROR) {
-                OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
-                return;
+        if (data.wiFiScanResults.HasValue()) {
+            auto * array_1 = [NSMutableArray new];
+            auto iter_1 = data.wiFiScanResults.Value().begin();
+            while (iter_1.Next()) {
+                auto & entry_1 = iter_1.GetValue();
+                CHIPNetworkCommissioningClusterWiFiInterfaceScanResult * newElement_1;
+                newElement_1 = [CHIPNetworkCommissioningClusterWiFiInterfaceScanResult new];
+                newElement_1.security = [NSNumber numberWithUnsignedChar:entry_1.security];
+                newElement_1.ssid = [NSData dataWithBytes:entry_1.ssid.data() length:entry_1.ssid.size()];
+                newElement_1.bssid = [NSData dataWithBytes:entry_1.bssid.data() length:entry_1.bssid.size()];
+                newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
+                newElement_1.wiFiBand = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_1.wiFiBand)];
+                newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
+                [array_1 addObject:newElement_1];
             }
+            { // Scope for the error so we will know what it's named
+                CHIP_ERROR err = iter_1.GetStatus();
+                if (err != CHIP_NO_ERROR) {
+                    OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
+                    return;
+                }
+            }
+            response.wiFiScanResults = array_1;
+        } else {
+            response.wiFiScanResults = nil;
         }
-        response.wiFiScanResults = array_0;
     }
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.threadScanResults.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            CHIPNetworkCommissioningClusterThreadInterfaceScanResult * newElement_0;
-            newElement_0 = [CHIPNetworkCommissioningClusterThreadInterfaceScanResult new];
-            newElement_0.panId = [NSNumber numberWithUnsignedLongLong:entry_0.panId];
-            newElement_0.extendedPanId = [NSNumber numberWithUnsignedLongLong:entry_0.extendedPanId];
-            newElement_0.networkName = [[NSString alloc] initWithBytes:entry_0.networkName.data()
-                                                                length:entry_0.networkName.size()
-                                                              encoding:NSUTF8StringEncoding];
-            newElement_0.channel = [NSNumber numberWithUnsignedShort:entry_0.channel];
-            newElement_0.version = [NSNumber numberWithUnsignedChar:entry_0.version];
-            newElement_0.extendedAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extendedAddress];
-            newElement_0.rssi = [NSNumber numberWithChar:entry_0.rssi];
-            newElement_0.lqi = [NSNumber numberWithUnsignedChar:entry_0.lqi];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
-            CHIP_ERROR err = iter_0.GetStatus();
-            if (err != CHIP_NO_ERROR) {
-                OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
-                return;
+        if (data.threadScanResults.HasValue()) {
+            auto * array_1 = [NSMutableArray new];
+            auto iter_1 = data.threadScanResults.Value().begin();
+            while (iter_1.Next()) {
+                auto & entry_1 = iter_1.GetValue();
+                CHIPNetworkCommissioningClusterThreadInterfaceScanResult * newElement_1;
+                newElement_1 = [CHIPNetworkCommissioningClusterThreadInterfaceScanResult new];
+                newElement_1.panId = [NSNumber numberWithUnsignedLongLong:entry_1.panId];
+                newElement_1.extendedPanId = [NSNumber numberWithUnsignedLongLong:entry_1.extendedPanId];
+                newElement_1.networkName = [[NSString alloc] initWithBytes:entry_1.networkName.data()
+                                                                    length:entry_1.networkName.size()
+                                                                  encoding:NSUTF8StringEncoding];
+                newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
+                newElement_1.version = [NSNumber numberWithUnsignedChar:entry_1.version];
+                newElement_1.extendedAddress = [NSNumber numberWithUnsignedLongLong:entry_1.extendedAddress];
+                newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
+                newElement_1.lqi = [NSNumber numberWithUnsignedChar:entry_1.lqi];
+                [array_1 addObject:newElement_1];
             }
+            { // Scope for the error so we will know what it's named
+                CHIP_ERROR err = iter_1.GetStatus();
+                if (err != CHIP_NO_ERROR) {
+                    OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
+                    return;
+                }
+            }
+            response.threadScanResults = array_1;
+        } else {
+            response.threadScanResults = nil;
         }
-        response.threadScanResults = array_0;
     }
     DispatchSuccess(context, response);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -672,8 +672,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPNetworkCommissioningClusterScanNetworksResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull networkingStatus;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
-@property (strong, nonatomic) NSArray * _Nonnull wiFiScanResults;
-@property (strong, nonatomic) NSArray * _Nonnull threadScanResults;
+@property (strong, nonatomic) NSArray * _Nullable wiFiScanResults;
+@property (strong, nonatomic) NSArray * _Nullable threadScanResults;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -1414,9 +1414,9 @@ NS_ASSUME_NONNULL_BEGIN
 
         _debugText = @"";
 
-        _wiFiScanResults = [NSArray array];
+        _wiFiScanResults = nil;
 
-        _threadScanResults = [NSArray array];
+        _threadScanResults = nil;
     }
     return self;
 }

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -10156,8 +10156,8 @@ public:
 
     NetworkCommissioningStatus networkingStatus;
     chip::CharSpan debugText;
-    DataModel::List<const Structs::WiFiInterfaceScanResult::Type> wiFiScanResults;
-    DataModel::List<const Structs::ThreadInterfaceScanResult::Type> threadScanResults;
+    Optional<DataModel::List<const Structs::WiFiInterfaceScanResult::Type>> wiFiScanResults;
+    Optional<DataModel::List<const Structs::ThreadInterfaceScanResult::Type>> threadScanResults;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10174,8 +10174,8 @@ public:
 
     NetworkCommissioningStatus networkingStatus;
     chip::CharSpan debugText;
-    DataModel::DecodableList<Structs::WiFiInterfaceScanResult::DecodableType> wiFiScanResults;
-    DataModel::DecodableList<Structs::ThreadInterfaceScanResult::DecodableType> threadScanResults;
+    Optional<DataModel::DecodableList<Structs::WiFiInterfaceScanResult::DecodableType>> wiFiScanResults;
+    Optional<DataModel::DecodableList<Structs::ThreadInterfaceScanResult::DecodableType>> threadScanResults;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ScanNetworksResponse


### PR DESCRIPTION
#### Problem
- WiFiScanResults and ThreadScanResults fields are not marked as optional fields, and it will break some apps when decoding the response.

#### Change overview
- From the spec, the WiFiScanResults should only exist on WiFi interface, and ThreadScanResults should only exist on Thread interfaces, so mark them as optional fields.

#### Testing

Manually tested.