### PR TITLE
Add update nrf cli doc to reflect latest command

### DIFF
--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -111,8 +111,8 @@ Performing factory reset ...
 
 Handles a group of commands that are used to view information about device
 onboarding codes. The `onboardingcodes` command takes one required parameter for
-the rendezvous type, then an optional parameter for printing a specific type
-of onboarding code.
+the rendezvous type, then an optional parameter for printing a specific type of
+onboarding code.
 
 The full format of the command is:
 
@@ -121,7 +121,6 @@ onboardingcodes none|softap|ble|onnetwork [qrcode|qrcodeurl|manualpairingcode]
 ```
 
 To print all the onboardingcodes:
-
 
 ```shell
 uart:~$ matter onboardingcodes none

--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -103,24 +103,34 @@ Performs device factory reset that is hardware reset preceded by erasing of the
 whole Matter settings stored in a non-volatile memory.
 
 ```shell
-uart:~$ matter factoryreset
+uart:~$ matter device factoryreset
 Performing factory reset ...
 ```
 
 ### onboardingcodes
 
 Handles a group of commands that are used to view information about device
-onboarding codes. You can use this command without any subcommand to print all
-available onboarding codes or to add a specific subcommand.
+onboarding codes. The `onboardingcodes` command takes one required parameter for
+the rendezvous type, then an optional parameter for printing a specific type
+of onboarding code.
+
+The full format of the command is:
+
+```
+onboardingcodes none|softap|ble|onnetwork [qrcode|qrcodeurl|manualpairingcode]
+```
+
+To print all the onboardingcodes:
+
 
 ```shell
-uart:~$ matter onboardingcodes
+uart:~$ matter onboardingcodes none
 QRCode:             MT:W0GU2OTB00KA0648G00
 QRCodeUrl:          https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
 ManualPairingCode:  34970112332
 ```
 
-The `onboardingcodes` command can also take the subcommands listed below.
+To print a specific type of onboarding code:
 
 #### qrcode
 
@@ -129,7 +139,7 @@ Prints the device
 Takes no arguments.
 
 ```shell
-uart:~$ matter onboardingcodes qrcode
+uart:~$ matter onboardingcodes none qrcode
 MT:W0GU2OTB00KA0648G00
 ```
 
@@ -140,7 +150,7 @@ Prints the URL to view the
 in a web browser. Takes no arguments.
 
 ```shell
-uart:~$ matter onboardingcodes qrcodeurl
+uart:~$ matter onboardingcodes none qrcodeurl
 https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
 ```
 
@@ -150,7 +160,7 @@ Prints the pairing code for the manual onboarding of a device. Takes no
 arguments.
 
 ```shell
-uart:~$ matter onboardingcodes manualpairingcode
+uart:~$ matter onboardingcodes none manualpairingcode
 34970112332
 ```
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #13270, the doc has an incorrect example and some outdated examples
- `matter factoryreset` is incorrect, it should be `matter device factoryreset`
- `matter onboardingcodes` now requires a rendezvous flag due to PR #12963

#### Change overview
Doc updates only

#### Testing
How was this tested? (at least one bullet point required)
* Tested all the relevant commands on nrf52840 boards
