### PR TITLE
Fix 'Failed to get extended timeout configuration' error

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -56,6 +57,7 @@ namespace {
 
 constexpr int kFactoryResetTriggerTimeout      = 3000;
 constexpr int kFactoryResetCancelWindowTimeout = 3000;
+constexpr int kExtDiscoveryTimeoutSecs         = 20;
 constexpr int kAppEventQueueSize               = 10;
 constexpr int kExampleVendorID                 = 0xabcd;
 constexpr uint8_t kButtonPushEvent             = 1;
@@ -125,6 +127,10 @@ int AppTask::Init()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+#if defined(CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY)
+    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(kExtDiscoveryTimeoutSecs);
+#endif
 
 #if defined(CONFIG_CHIP_NFC_COMMISSIONING)
     PlatformMgr().AddEventHandler(ChipEventHandler, 0);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #13281

#### Change overview
Add SetExtendedDiscoveryTimeoutSecs (20 seconds, referencing [other example app](https://github.com/project-chip/connectedhomeip/blob/8a3095971900a9daa2ae0561706fc935ce29ff47/examples/lock-app/qpg/src/AppTask.cpp#L77)) to nrf light example

#### Testing

Log observed on nRF52840dongle
 
```
[00:15:00.475,311] <dbg> chip.LogV: [DIS]GetExtendedDiscoveryTimeoutSecs 20
[00:15:00.475,402] <dbg> chip.LogV: [DIS]Scheduling Extended Discovery timeout in secs=20
[00:15:00.529,022] <dbg> chip.LogV: [DL]CHIPoBLE advertising set to off
[00:15:00.529,144] <inf> chip: [DL]CHIPoBLE advertising disabled because of timeout expired
[00:15:00.529,571] <inf> chip: [DL]CHIPoBLE advertising stopped
[00:15:00.529,754] <inf> chip: [DL]NFC Tag emulation stopped
[00:15:20.476,074] <dbg> chip.LogV: [DIS]OnExpiration - valid time out
[00:15:20.476,165] <dbg> chip.LogV: [DL]Using Thread extended MAC for hostname.
```
