### PR TITLE
Add check for failed allocation in ResolverProxy::Init

### DIFF
--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -68,7 +68,7 @@ public:
         ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(udpEndPoint));
         VerifyOrReturnError(mDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
         mDelegate = chip::Platform::New<ResolverDelegateProxy>();
-        return CHIP_NO_ERROR;
+        return mDelegate != nullptr ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
     }
 
     void SetResolverDelegate(ResolverDelegate * delegate) override


### PR DESCRIPTION
Fixes #12943

#### Problem

ResolverProxy::Init allocates memory with Platform::New, but returns success even if this fails.

#### Change overview

Add check for allocation failure and return appropriate error status for this case.

#### Testing

* Integration tests reliant upon successful resolve pass.