### PR TITLE
Fix ResolverProxy use-after-free in HandleNodeBrowse

### DIFF
--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -51,6 +51,10 @@ public:
     /** Adds one to the usage count of this class */
     Subclass * Retain()
     {
+        if (kInitRefCount && mRefCount == 0)
+        {
+            abort();
+        }
         if (mRefCount == std::numeric_limits<count_type>::max())
         {
             abort();

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -129,7 +129,6 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
 static void HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)
 {
     ResolverDelegateProxy * proxy = static_cast<ResolverDelegateProxy *>(context);
-    proxy->Release();
 
     for (size_t i = 0; i < servicesSize; ++i)
     {
@@ -144,6 +143,7 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
             HandleNodeResolve(context, &services[i], error);
         }
     }
+    proxy->Release();
 }
 
 CHIP_ERROR AddPtrRecord(DiscoveryFilter filter, const char ** entries, size_t & entriesCount, char * buffer, size_t bufferLen)


### PR DESCRIPTION
#### Problem

HandleNodeBrowse decrements the ResolverProxy reference count, which will cause the object to be destructed if the counter reaches 0.  But then it increments the counter and accesses the object, which can be a use-after-free.

Fixes #13289

#### Change overview

This fixes the problem by ordering Release to occur after Retain. This also adds an abort to ReferenceCounted::Retain to check for cases like this when kInitRefCount is non-zero.  For objects that are initialized with a non-zero reference count, we don't ever expect to call Retain when the count has already decremented to 0 because this indicates the object has been deleted.

#### Testing

Tested locally with a modified chip-tool that dynamically creates and initializes ResolverProxy objects for resolve calls, and calls their Shutdown method from within the OnNodeDiscoveryComplete callback.  This reliably caused segfault without the fix and did not after.  Additional instrumentation was added to log reference counts during testing and it was verified that these were now as expected.

The abort that has been added for ReferenceCounted::Retain should also provide significant coverage.