### PR TITLE
[YAML] Automatically add simulated clusters from the clusters directo…

### DIFF
--- a/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
+++ b/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
@@ -16,13 +16,17 @@
  */
 
 const { ensureClusters } = require('../ClustersHelper.js');
-const { DelayCommands }  = require('./TestDelayCommands.js');
-const { LogCommands }    = require('./TestLogCommands.js');
 
-const SimulatedClusters = [
-  DelayCommands,
-  LogCommands,
-];
+const fs   = require('fs');
+const path = require('path');
+
+let SimulatedClusters = [];
+(async () => {
+  const simulatedClustersPath  = path.join(__dirname, 'clusters');
+  const simulatedClustersFiles = await fs.promises.readdir(simulatedClustersPath);
+  SimulatedClusters = simulatedClustersFiles.map(filename => (require(path.join(simulatedClustersPath, filename))).cluster);
+  return SimulatedClusters;
+})();
 
 function getSimulatedCluster(clusterName)
 {

--- a/src/app/zap-templates/common/simulated-clusters/clusters/DelayCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/DelayCommands.js
@@ -16,32 +16,41 @@
  */
 
 /*
- * This file declares test suite utility methods for logging.
+ * This file declare test suites utilities methods for delayed commands.
  *
  * Each method declared in this file needs to be implemented on a per-language
- * basis and allows exposing  methods to the test suites that are not part
+ * basis and permits to exposes methods to the test suites that are not part
  * of the regular cluster set of APIs.
  *
  */
 
-const Log = {
-  name : 'Log',
-  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
+const WaitForMs = {
+  name : 'WaitForMs',
+  arguments : [ { type : 'INT32U', name : 'ms' } ],
   response : { arguments : [] }
 };
 
-const UserPrompt = {
-  name : 'UserPrompt',
-  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
+const WaitForCommissioning = {
+  name : 'WaitForCommissioning',
+  arguments : [],
   response : { arguments : [] }
 };
 
-const LogCommands = {
-  name : 'LogCommands',
-  commands : [ Log, UserPrompt ],
+const WaitForCommissionee = {
+  name : 'WaitForCommissionee',
+  arguments : [],
+  response : { arguments : [] }
+};
+
+const name     = 'DelayCommands';
+const commands = [ WaitForMs, WaitForCommissioning, WaitForCommissionee ];
+
+const DelayCommands = {
+  name,
+  commands
 };
 
 //
 // Module exports
 //
-exports.LogCommands = LogCommands;
+exports.cluster = DelayCommands;

--- a/src/app/zap-templates/common/simulated-clusters/clusters/LogCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/LogCommands.js
@@ -16,41 +16,32 @@
  */
 
 /*
- * This file declare test suites utilities methods for delayed commands.
+ * This file declares test suite utility methods for logging.
  *
  * Each method declared in this file needs to be implemented on a per-language
- * basis and permits to exposes methods to the test suites that are not part
+ * basis and allows exposing  methods to the test suites that are not part
  * of the regular cluster set of APIs.
  *
  */
 
-const WaitForMs = {
-  name : 'WaitForMs',
-  arguments : [ { type : 'INT32U', name : 'ms' } ],
+const Log = {
+  name : 'Log',
+  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
   response : { arguments : [] }
 };
 
-const WaitForCommissioning = {
-  name : 'WaitForCommissioning',
-  arguments : [],
+const UserPrompt = {
+  name : 'UserPrompt',
+  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
   response : { arguments : [] }
 };
 
-const WaitForCommissionee = {
-  name : 'WaitForCommissionee',
-  arguments : [],
-  response : { arguments : [] }
-};
-
-const name     = 'DelayCommands';
-const commands = [ WaitForMs, WaitForCommissioning, WaitForCommissionee ];
-
-const DelayCommands = {
-  name,
-  commands
+const LogCommands = {
+  name : 'LogCommands',
+  commands : [ Log, UserPrompt ],
 };
 
 //
 // Module exports
 //
-exports.DelayCommands = DelayCommands;
+exports.cluster = LogCommands;


### PR DESCRIPTION
…ry into the list of clusters used for test generation instead of manually adding them one by one at the top of SimulatedClusters.js

#### Problem

"Simulated" clusters needs to be added manually to `SimulatedClusters.js`. It can be done automatically.

#### Change overview
 * Get the list automatically from the files into the `clusters` subfolder.

#### Testing
I did regenerate tests to validate that it works and observe no difference in the generated code.
