### PR TITLE
Fix app name for door lock app build

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -73,8 +73,8 @@ class HostApp(Enum):
             yield 'chip-tv-app'
             yield 'chip-tv-app.map'
         elif self == HostApp.LOCK:
-            yield 'chip-lock-app'
-            yield 'chip-lock-app.map'
+            yield 'chip-door-lock-app'
+            yield 'chip-door-lock-app.map'
         elif self == HostApp.TESTS:
             pass
         else:


### PR DESCRIPTION
#### Problem

Running `./scripts/build/build_examples.py --target linux-arm64-door-lock --enable-flashbundle build --copy-artifacts-to out/archives` fails with:

```
Step #4 - "Linux": Traceback (most recent call last):
Step #4 - "Linux":   File "/workspace/./scripts/build/build_examples.py", line 220, in <module>
Step #4 - "Linux":     main()
Step #4 - "Linux":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
Step #4 - "Linux":     return self.main(*args, **kwargs)
Step #4 - "Linux":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 782, in main
Step #4 - "Linux":     rv = self.invoke(ctx)
Step #4 - "Linux":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1289, in invoke
Step #4 - "Linux":     rv.append(sub_ctx.command.invoke(sub_ctx))
Step #4 - "Linux":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
Step #4 - "Linux":     return ctx.invoke(self.callback, **ctx.params)
Step #4 - "Linux":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
Step #4 - "Linux":     return callback(*args, **kwargs)
Step #4 - "Linux":   File "/pwenv/pigweed-venv/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
Step #4 - "Linux":     return f(get_current_context(), *args, **kwargs)
Step #4 - "Linux":   File "/workspace/./scripts/build/build_examples.py", line 216, in cmd_build
Step #4 - "Linux":     context.obj.CreateArtifactArchives(create_archives)
Step #4 - "Linux":   File "/workspace/scripts/build/build/__init__.py", line 75, in CreateArtifactArchives
Step #4 - "Linux":     builder.CompressArtifacts(os.path.join(
Step #4 - "Linux":   File "/workspace/scripts/build/builders/builder.py", line 101, in CompressArtifacts
Step #4 - "Linux":     tar.add(source_name, target_name)
Step #4 - "Linux":   File "/usr/lib/python3.9/tarfile.py", line 1963, in add
Step #4 - "Linux":     tarinfo = self.gettarinfo(name, arcname)
Step #4 - "Linux":   File "/usr/lib/python3.9/tarfile.py", line 1842, in gettarinfo
Step #4 - "Linux":     statres = os.lstat(name)
Step #4 - "Linux": FileNotFoundError: [Errno 2] No such file or directory: '/workspace/out/linux-arm64-door-lock/chip-lock-app'
Finished Step #4 - "Linux"
```

#### Change overview
Updated path for lock app

#### Testing
Ran the build locally