### PR TITLE
Remove extra length constraint from Ethernet diagnostic xml definition

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
@@ -35,7 +35,7 @@ limitations under the License.
     <code>0x0037</code>
     <define>ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER</define>
     <description>The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
-    <attribute side="server" code="0x00" define="PHY_RATE" type="ENUM8" length="6" writable="false" optional="true">PHYRate</attribute>
+    <attribute side="server" code="0x00" define="PHY_RATE" type="ENUM8" writable="false" optional="true">PHYRate</attribute>
     <attribute side="server" code="0x01" define="FULL_DUPLEX" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="true">FullDuplex</attribute>
     <attribute side="server" code="0x02" define="PACKET_RX_COUNT" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="false">PacketRxCount</attribute>
     <attribute side="server" code="0x03" define="PACKET_TX_COUNT" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="false">PacketTxCount</attribute>


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* 'length' constraint is meaningless in attribute with type of ENUM


#### Change overview
Remove extra length constraint from Ethernet diagnostic xml definition

#### Testing
How was this tested? (at least one bullet point required)
* No source code update