### PR TITLE
[OTA] Support multiple sequential BDX transfers

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -121,6 +121,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         blockData.IsEof  = (blockData.Length < blockSize) ||
             (mNumBytesSent + static_cast<uint64_t>(blockData.Length) == mTransfer.GetTransferLength() || (otaFile.peek() == EOF));
         mNumBytesSent = static_cast<uint32_t>(mNumBytesSent + blockData.Length);
+        otaFile.close();
 
         VerifyOrReturn(CHIP_NO_ERROR == mTransfer.PrepareBlock(blockData),
                        ChipLogError(BDX, "%s: PrepareBlock failed: %s", __FUNCTION__, chip::ErrorStr(err)));

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -20,6 +20,7 @@
 
 #include <app/CommandHandler.h>
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
+#include <ota-provider-common/BdxOtaSender.h>
 
 /**
  * A reference implementation for an OTA Provider. Includes a method for providing a path to a local OTA file to serve.
@@ -30,6 +31,7 @@ public:
     OTAProviderExample();
 
     void SetOTAFilePath(const char * path);
+    BdxOtaSender * GetBdxOtaSender() { return &mBdxOtaSender; }
 
     // Inherited from OTAProviderDelegate
     EmberAfStatus HandleQueryImage(
@@ -52,6 +54,7 @@ public:
     void SetDelayedActionTimeSec(uint32_t time) { mDelayedActionTimeSec = time; }
 
 private:
+    BdxOtaSender mBdxOtaSender;
     static constexpr size_t kFilepathBufLen = 256;
     char mOTAFilePath[kFilepathBufLen]; // null-terminated
     queryImageBehaviorType mQueryImageBehavior;

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -49,6 +49,9 @@ void BDXDownloader::OnMessageReceived(const chip::PayloadHeader & payloadHeader,
 
 CHIP_ERROR BDXDownloader::SetBDXParams(const chip::bdx::TransferSession::TransferInitData & bdxInitData)
 {
+    mState = State::kIdle;
+    mBdxTransfer.Reset();
+
     VerifyOrReturnError(mState == State::kIdle, CHIP_ERROR_INCORRECT_STATE);
 
     // Must call StartTransfer() here to store the the pointer data contained in bdxInitData in the TransferSession object.


### PR DESCRIPTION
#### Problem
Once an initial BDX transfer occurs for OTA, a sequential transfer fails. The initialization of the BDX transfer session was being done when the OTA Provider is first started. Any sequential transfers are in a bad state and cannot proceed.
Fixes: https://github.com/project-chip/connectedhomeip/issues/9737

#### Change overview
- `PrepareForTransfer` should be called for every new OTA download after QueryImage request is received
- An instance of `BdxOtaSender` has been moved into `OTAProviderExample` class so that each new transfer can be properly initialized
- The filed to be transferred is now closed after each block is processed
- Some states within the `BDXDownloader` class are reset after transfer complete

#### Testing
The basic Linux OTA requestor/provider transfer completes successfully. Any subsequent transfers also complete successfully.
