### PR TITLE
bump binaries generation timeout to 30min for cirque

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -94,7 +94,7 @@ jobs:
                   if_true: "${{ github.sha }}"
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Build Binaries
-              timeout-minutes: 15
+              timeout-minutes: 30
               run: |
                   integrations/docker/images/chip-build-cirque/run.sh \
                     --env GITHUB_ACTION_RUN=1 \


### PR DESCRIPTION
#### Problem
bump binaries generation timeout to 30min for cirque
#### Change overview
bump binaries generation timeout to 30min for cirque

#### Testing
presubmit run
