### PR TITLE
Add avahi-utils to the raspi deps in building guide doc

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -91,7 +91,7 @@ Boot the SD card, login with the default user account "ubuntu" and password
 Finally, install some Raspberry Pi specific dependencies:
 
 ```
-sudo apt-get install pi-bluetooth
+sudo apt-get install pi-bluetooth avahi-utils
 ```
 
 You need to reboot your RPi after install `pi-bluetooth`.


### PR DESCRIPTION
#### Problem
Update the build doc on Raspberry Pi  pre-requisites.
Fixes: https://github.com/project-chip/connectedhomeip/issues/13336

#### Change overview
Added avahi-utils dep 

#### Testing
Tested with Raspi running ubuntu 21.04 and 21.10, chip-tool unable to commission with M5 stack when avahi-utils not installed, and chip-tool successfully commissions with M5 stack after avahi-utils is installed 


