### PR TITLE
Bump some test timeouts.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
     darwin:
         name: Build Darwin
-        timeout-minutes: 60
+        timeout-minutes: 75
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: macos-latest

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     qemu:
         name: ESP32
-        timeout-minutes: 70
+        timeout-minutes: 85
 
         env:
             BUILD_TYPE: esp32-qemu
@@ -63,7 +63,7 @@ jobs:
                       build                             \
                   "
             - name: Run all tests
-              timeout-minutes: 30
+              timeout-minutes: 40
               run: |
                   src/test_driver/esp32/run_qemu_image.py \
                     --verbose                             \


### PR DESCRIPTION
On Darwin, we hit the 60-minute timeout if bootstrap takes more than
about 6 minutes, which it often does.

QEMU is hitting the 30-minute timeout on the "Run all tests" step.

#### Problem
Tests timing out.

#### Change overview
Increase timeouts.

#### Testing
Tests will hopefully not time out.