### PR TITLE
[EFR32] fix BLE not advertising at boot while device is not provisionned

### DIFF
--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -287,6 +287,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
+#if CHIP_KVS_AVAILABLE
+    PersistedStorage::KeyValueStoreMgrImpl().ErasePartition();
+#endif // CHIP_KVS_AVAILABLE
+
     // Restart the system.
     ChipLogProgress(DeviceLayer, "System restarting");
     NVIC_SystemReset();

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -95,12 +95,11 @@ public:
     static constexpr Key kConfigKey_CountryCode        = EFR32ConfigKey(kChipConfig_KeyBase, 0x0A);
     static constexpr Key kConfigKey_Breadcrumb         = EFR32ConfigKey(kChipConfig_KeyBase, 0x0B);
     static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_GroupKeyMax        = EFR32ConfigKey(kChipConfig_KeyBase, 0x1B); // Allows 16 Group Keys to be created.
+    static constexpr Key kConfigKey_GroupKeyMax = EFR32ConfigKey(kChipConfig_KeyBase, 0x1B); // Allows 16 Group Keys to be created.
 
     // CHIP Counter Keys
     static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x00);
     static constexpr Key kConfigKey_TotalOperationalHours = EFR32ConfigKey(kChipCounter_KeyBase, 0x01);
-
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = EFR32ConfigKey(kChipFactory_KeyBase, 0x00);

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -94,12 +94,13 @@ public:
     static constexpr Key kConfigKey_RegulatoryLocation = EFR32ConfigKey(kChipConfig_KeyBase, 0x09);
     static constexpr Key kConfigKey_CountryCode        = EFR32ConfigKey(kChipConfig_KeyBase, 0x0A);
     static constexpr Key kConfigKey_Breadcrumb         = EFR32ConfigKey(kChipConfig_KeyBase, 0x0B);
+    static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0C);
+    static constexpr Key kConfigKey_GroupKeyMax        = EFR32ConfigKey(kChipConfig_KeyBase, 0x1B); // Allows 16 Group Keys to be created.
 
-    static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_TotalOperationalHours = EFR32ConfigKey(kChipCounter_KeyBase, 0x0D);
+    // CHIP Counter Keys
+    static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x00);
+    static constexpr Key kConfigKey_TotalOperationalHours = EFR32ConfigKey(kChipCounter_KeyBase, 0x01);
 
-    static constexpr Key kConfigKey_GroupKeyBase = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
-    static constexpr Key kConfigKey_GroupKeyMax  = EFR32ConfigKey(kChipConfig_KeyBase, 0x1D); // Allows 16 Group Keys to be created.
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = EFR32ConfigKey(kChipFactory_KeyBase, 0x00);


### PR DESCRIPTION
#### Problem
The recent merge of PR #13181 exposed an issue where factory reset didn't clear the last fabric ID. With the change in condition, The BLE advertissement was stopped during init regardless of the device provision state. 

#### Change overview
Erase Kvs partition on Factory Reset. This is were the fabric ID and info are stored.

nit : noticed an error for the ChipCounter Key placement in NVM. It is not the same section as  kChipConfig, we should start at the begining of kChipCounter_KeyBase.

#### Testing
Factory reset the device. BLE advertises after reboot. Chip-tool can establish the connexion and provide the thread info
