### PR TITLE
Update misplaced removal of an event handler. 

### DIFF
--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -74,11 +74,11 @@ public:
         {
         case chip::DeviceLayer::DeviceEventType::kCommissioningComplete:
             ChipLogProgress(chipTool, "Commissioning complete");
-            chip::DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, arg);
 
             TestCommand * command = reinterpret_cast<TestCommand *>(arg);
             command->isRunning    = true;
             command->NextTest();
+            chip::DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, arg);
             break;
         }
     }


### PR DESCRIPTION
#### Problem
In simulated devices immediately after pairing, the simulated device crashes. This is due to the even being removed during the call of the event.

#### Change overview
Deleted line the removes the even handler.

#### Testing
Reproduced crasher and commissioned the simulated device successfully after change. 