### PR TITLE
[Android] Support timed invoke and write

### DIFF
--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -44,7 +44,7 @@ JNI_METHOD(jlong, {{asUpperCamelCase name}}Cluster, initWithDevice)(JNIEnv * env
 }
 
 {{#chip_cluster_commands}}
-JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJniBasicType type true}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}})
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJniBasicType type true}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}}, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -70,12 +70,15 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})
     auto successFn = chip::Callback::Callback<CHIP{{>callbackName}}CallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall
     {{#if mustUseTimedInvoke}}
-      {{!TODO Fix Java API to pass in this information.  For now, 10 seconds.}}
-      , 10000
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall, chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    {{else}}
+    if (timedInvokeTimeoutMs == nullptr) {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    } else {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall, chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     {{/if}}
-    );
     VerifyOrReturn(err == CHIP_NO_ERROR, AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command", CHIP_ERROR_INCORRECT_STATE));
 
     onSuccess.release();
@@ -88,7 +91,7 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})
 {{! TODO: Lists not supported in attribute writes yet. }}
 {{#unless isList}}
 
-JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase name}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{asJniBasicType type true}} value)
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase name}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{asJniBasicType type true}} value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
@@ -108,12 +111,16 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase na
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall
+
     {{#if mustUseTimedWrite}}
-      {{!TODO Fix Java API to pass in this information.  For now, 10 seconds.}}
-      , 10000
+    err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall, chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    {{else}}
+    if (timedWriteTimeoutMs == nullptr) {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    } else {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall, chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     {{/if}}
-    );
     VerifyOrReturn(err == CHIP_NO_ERROR, chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
 
     onSuccess.release();

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -95,13 +95,12 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
   {{#chip_cluster_commands}}
 
-    {{#if mustUseTimedInvoke}}
-    {{else}}
+    {{#unless mustUseTimedInvoke}}
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
       {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}) {
       {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}, null);
     }
-    {{/if}}
+    {{/unless}}
 
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
       {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}, int timedInvokeTimeoutMs) {
@@ -250,12 +249,11 @@ public class ChipClusters {
   {{#if isWritableAttribute}}
   {{! TODO: Lists not supported in attribute writes yet. }}
   {{#unless isList}}
-    {{#if mustUseTimedWrite}}
-    {{else}}
+    {{#unless mustUseTimedWrite}}
     public void write{{asUpperCamelCase name}}Attribute(DefaultClusterCallback callback{{>java_type_for_argument}} value) {
       write{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback, value, null);
     }
-    {{/if}}
+    {{/unless}}
 
     public void write{{asUpperCamelCase name}}Attribute(DefaultClusterCallback callback{{>java_type_for_argument}} value, int timedWriteTimeoutMs) {
       write{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -95,15 +95,23 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
   {{#chip_cluster_commands}}
 
+    {{#if mustUseTimedInvoke}}
+    {{else}}
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
       {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}) {
-      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}, null);
     }
+    {{/if}}
 
+    public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
+      {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}, int timedInvokeTimeoutMs) {
+      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}, timedInvokeTimeoutMs);
+    }
   {{/chip_cluster_commands}}
   {{#chip_cluster_commands}}
     private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} Callback
-      {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+      {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}
+      , @Nullable Integer timedInvokeTimeoutMs);
   {{/chip_cluster_commands}}
   {{#chip_cluster_responses}}
     public interface {{asUpperCamelCase name}}Callback {
@@ -242,9 +250,15 @@ public class ChipClusters {
   {{#if isWritableAttribute}}
   {{! TODO: Lists not supported in attribute writes yet. }}
   {{#unless isList}}
-
+    {{#if mustUseTimedWrite}}
+    {{else}}
     public void write{{asUpperCamelCase name}}Attribute(DefaultClusterCallback callback{{>java_type_for_argument}} value) {
-      write{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback, value);
+      write{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback, value, null);
+    }
+    {{/if}}
+
+    public void write{{asUpperCamelCase name}}Attribute(DefaultClusterCallback callback{{>java_type_for_argument}} value, int timedWriteTimeoutMs) {
+      write{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
   {{/unless}}
   {{/if}}
@@ -278,7 +292,7 @@ public class ChipClusters {
   {{! TODO: Lists not supported in attribute writes yet. }}
   {{#unless isList}}
 
-    private native void write{{asUpperCamelCase name}}Attribute(long chipClusterPtr, DefaultClusterCallback callback{{>java_type_for_argument}} value);
+    private native void write{{asUpperCamelCase name}}Attribute(long chipClusterPtr, DefaultClusterCallback callback{{>java_type_for_argument}} value, @Nullable Integer timedWriteTimeoutMs);
   {{/unless}}
   {{/if}}
   {{#if isReportableAttribute}}

--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -336,6 +336,8 @@ public class ClusterInfoMapping {
            commandArguments.get("{{asLowerCamelCase label}}")
            {{/if_is_struct}}
            {{/chip_cluster_command_arguments_with_structs_expanded}}
+           {{! TODO: Allow timeout to be passed from client for this and timed write. }}
+           {{#if mustUseTimedInvoke}}, 10000{{/if}}
            );
          },
          () -> new Delegated{{asUpperCamelCase responseName}}Callback(),
@@ -350,6 +352,7 @@ public class ClusterInfoMapping {
            ({{#if isOptional}}Optional<{{/if}}{{asJavaBoxedType type}}{{#if isOptional}}>{{/if}})
            commandArguments.get("{{asLowerCamelCase label}}")
            {{/chip_cluster_command_arguments_with_structs_expanded}}
+           {{#if mustUseTimedInvoke}}, 10000{{/if}}
            );
          },
          () -> new DelegatedDefaultClusterCallback(),

--- a/src/controller/java/templates/ClusterInfo-write-interaction.zapt
+++ b/src/controller/java/templates/ClusterInfo-write-interaction.zapt
@@ -29,6 +29,7 @@ public class ClusterWriteMapping {
               (DefaultClusterCallback) callback,
               ({{asJavaBoxedType type}})
               commandArguments.get("value")
+              {{#if mustUseTimedWrite}}, 10000{{/if}}
             );
           },
           () -> new ClusterInfoMapping.DelegatedDefaultClusterCallback(),

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -69,7 +69,7 @@ JNI_METHOD(jlong, AccountLoginCluster, initWithDevice)(JNIEnv * env, jobject sel
 }
 
 JNI_METHOD(void, AccountLoginCluster, getSetupPINRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring tempAccountIdentifier)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring tempAccountIdentifier, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -101,7 +101,8 @@ JNI_METHOD(void, AccountLoginCluster, getSetupPINRequest)
         chip::Callback::Callback<CHIPAccountLoginClusterGetSetupPINResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall, 10000);
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                    chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -110,7 +111,8 @@ JNI_METHOD(void, AccountLoginCluster, getSetupPINRequest)
     onFailure.release();
 }
 JNI_METHOD(void, AccountLoginCluster, loginRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring tempAccountIdentifier, jstring setupPIN)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring tempAccountIdentifier, jstring setupPIN,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -140,7 +142,15 @@ JNI_METHOD(void, AccountLoginCluster, loginRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -148,7 +158,8 @@ JNI_METHOD(void, AccountLoginCluster, loginRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, AccountLoginCluster, logoutRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, AccountLoginCluster, logoutRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -175,7 +186,8 @@ JNI_METHOD(void, AccountLoginCluster, logoutRequest)(JNIEnv * env, jobject self,
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall, 10000);
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                    chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -230,7 +242,7 @@ JNI_METHOD(jlong, AdministratorCommissioningCluster, initWithDevice)(JNIEnv * en
 }
 
 JNI_METHOD(void, AdministratorCommissioningCluster, openBasicCommissioningWindow)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject commissioningTimeout)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject commissioningTimeout, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -260,7 +272,15 @@ JNI_METHOD(void, AdministratorCommissioningCluster, openBasicCommissioningWindow
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -270,7 +290,7 @@ JNI_METHOD(void, AdministratorCommissioningCluster, openBasicCommissioningWindow
 }
 JNI_METHOD(void, AdministratorCommissioningCluster, openCommissioningWindow)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject commissioningTimeout, jbyteArray PAKEVerifier,
- jobject discriminator, jobject iterations, jbyteArray salt, jobject passcodeID)
+ jobject discriminator, jobject iterations, jbyteArray salt, jobject passcodeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -307,7 +327,15 @@ JNI_METHOD(void, AdministratorCommissioningCluster, openCommissioningWindow)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -316,7 +344,7 @@ JNI_METHOD(void, AdministratorCommissioningCluster, openCommissioningWindow)
     onFailure.release();
 }
 JNI_METHOD(void, AdministratorCommissioningCluster, revokeCommissioning)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -343,7 +371,15 @@ JNI_METHOD(void, AdministratorCommissioningCluster, revokeCommissioning)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -667,7 +703,8 @@ JNI_METHOD(jlong, ApplicationLauncherCluster, initWithDevice)(JNIEnv * env, jobj
 }
 
 JNI_METHOD(void, ApplicationLauncherCluster, hideAppRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject catalogVendorId, jstring applicationId)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject catalogVendorId, jstring applicationId,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -699,7 +736,15 @@ JNI_METHOD(void, ApplicationLauncherCluster, hideAppRequest)
         chip::Callback::Callback<CHIPApplicationLauncherClusterLauncherResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -708,7 +753,8 @@ JNI_METHOD(void, ApplicationLauncherCluster, hideAppRequest)
     onFailure.release();
 }
 JNI_METHOD(void, ApplicationLauncherCluster, launchAppRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring data, jobject catalogVendorId, jstring applicationId)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring data, jobject catalogVendorId, jstring applicationId,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -741,7 +787,15 @@ JNI_METHOD(void, ApplicationLauncherCluster, launchAppRequest)
         chip::Callback::Callback<CHIPApplicationLauncherClusterLauncherResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -750,7 +804,8 @@ JNI_METHOD(void, ApplicationLauncherCluster, launchAppRequest)
     onFailure.release();
 }
 JNI_METHOD(void, ApplicationLauncherCluster, stopAppRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject catalogVendorId, jstring applicationId)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject catalogVendorId, jstring applicationId,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -782,7 +837,15 @@ JNI_METHOD(void, ApplicationLauncherCluster, stopAppRequest)
         chip::Callback::Callback<CHIPApplicationLauncherClusterLauncherResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -837,7 +900,7 @@ JNI_METHOD(jlong, AudioOutputCluster, initWithDevice)(JNIEnv * env, jobject self
 }
 
 JNI_METHOD(void, AudioOutputCluster, renameOutputRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index, jstring name)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index, jstring name, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -867,7 +930,15 @@ JNI_METHOD(void, AudioOutputCluster, renameOutputRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -876,7 +947,7 @@ JNI_METHOD(void, AudioOutputCluster, renameOutputRequest)
     onFailure.release();
 }
 JNI_METHOD(void, AudioOutputCluster, selectOutputRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -905,7 +976,15 @@ JNI_METHOD(void, AudioOutputCluster, selectOutputRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -997,7 +1076,7 @@ JNI_METHOD(jlong, BarrierControlCluster, initWithDevice)(JNIEnv * env, jobject s
 }
 
 JNI_METHOD(void, BarrierControlCluster, barrierControlGoToPercent)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject percentOpen)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject percentOpen, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1027,7 +1106,15 @@ JNI_METHOD(void, BarrierControlCluster, barrierControlGoToPercent)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -1035,7 +1122,8 @@ JNI_METHOD(void, BarrierControlCluster, barrierControlGoToPercent)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, BarrierControlCluster, barrierControlStop)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, BarrierControlCluster, barrierControlStop)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1062,7 +1150,15 @@ JNI_METHOD(void, BarrierControlCluster, barrierControlStop)(JNIEnv * env, jobjec
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -1264,7 +1360,8 @@ JNI_METHOD(jlong, BasicCluster, initWithDevice)(JNIEnv * env, jobject self, jlon
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, BasicCluster, mfgSpecificPing)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, BasicCluster, mfgSpecificPing)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1291,7 +1388,15 @@ JNI_METHOD(void, BasicCluster, mfgSpecificPing)(JNIEnv * env, jobject self, jlon
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -1484,7 +1589,7 @@ JNI_METHOD(void, BasicCluster, subscribeProductIDAttribute)
 }
 
 JNI_METHOD(void, BasicCluster, writeNodeLabelAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Basic::Attributes::NodeLabel::TypeInfo;
@@ -1512,7 +1617,16 @@ JNI_METHOD(void, BasicCluster, writeNodeLabelAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -1558,7 +1672,7 @@ JNI_METHOD(void, BasicCluster, subscribeNodeLabelAttribute)
 }
 
 JNI_METHOD(void, BasicCluster, writeLocationAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Basic::Attributes::Location::TypeInfo;
@@ -1586,7 +1700,16 @@ JNI_METHOD(void, BasicCluster, writeLocationAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -1963,7 +2086,7 @@ JNI_METHOD(void, BasicCluster, subscribeSerialNumberAttribute)
 }
 
 JNI_METHOD(void, BasicCluster, writeLocalConfigDisabledAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Basic::Attributes::LocalConfigDisabled::TypeInfo;
@@ -1991,7 +2114,16 @@ JNI_METHOD(void, BasicCluster, writeLocalConfigDisabledAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -2119,7 +2251,7 @@ JNI_METHOD(jlong, BinaryInputBasicCluster, initWithDevice)(JNIEnv * env, jobject
 }
 
 JNI_METHOD(void, BinaryInputBasicCluster, writeOutOfServiceAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo;
@@ -2147,7 +2279,16 @@ JNI_METHOD(void, BinaryInputBasicCluster, writeOutOfServiceAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -2194,7 +2335,7 @@ JNI_METHOD(void, BinaryInputBasicCluster, subscribeOutOfServiceAttribute)
 }
 
 JNI_METHOD(void, BinaryInputBasicCluster, writePresentValueAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo;
@@ -2222,7 +2363,16 @@ JNI_METHOD(void, BinaryInputBasicCluster, writePresentValueAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -2352,7 +2502,7 @@ JNI_METHOD(jlong, BindingCluster, initWithDevice)(JNIEnv * env, jobject self, jl
 
 JNI_METHOD(void, BindingCluster, bind)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject nodeId, jobject groupId, jobject endpointId,
- jobject clusterId)
+ jobject clusterId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2385,7 +2535,15 @@ JNI_METHOD(void, BindingCluster, bind)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2395,7 +2553,7 @@ JNI_METHOD(void, BindingCluster, bind)
 }
 JNI_METHOD(void, BindingCluster, unbind)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject nodeId, jobject groupId, jobject endpointId,
- jobject clusterId)
+ jobject clusterId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2428,7 +2586,15 @@ JNI_METHOD(void, BindingCluster, unbind)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2566,7 +2732,7 @@ JNI_METHOD(jlong, BridgedActionsCluster, initWithDevice)(JNIEnv * env, jobject s
 }
 
 JNI_METHOD(void, BridgedActionsCluster, disableAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2598,7 +2764,15 @@ JNI_METHOD(void, BridgedActionsCluster, disableAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2607,7 +2781,8 @@ JNI_METHOD(void, BridgedActionsCluster, disableAction)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, disableActionWithDuration)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2640,7 +2815,15 @@ JNI_METHOD(void, BridgedActionsCluster, disableActionWithDuration)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2649,7 +2832,7 @@ JNI_METHOD(void, BridgedActionsCluster, disableActionWithDuration)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, enableAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2681,7 +2864,15 @@ JNI_METHOD(void, BridgedActionsCluster, enableAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2690,7 +2881,8 @@ JNI_METHOD(void, BridgedActionsCluster, enableAction)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, enableActionWithDuration)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2723,7 +2915,15 @@ JNI_METHOD(void, BridgedActionsCluster, enableActionWithDuration)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2732,7 +2932,7 @@ JNI_METHOD(void, BridgedActionsCluster, enableActionWithDuration)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, instantAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2764,7 +2964,15 @@ JNI_METHOD(void, BridgedActionsCluster, instantAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2773,7 +2981,8 @@ JNI_METHOD(void, BridgedActionsCluster, instantAction)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, instantActionWithTransition)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject transitionTime)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject transitionTime,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2807,7 +3016,15 @@ JNI_METHOD(void, BridgedActionsCluster, instantActionWithTransition)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2816,7 +3033,7 @@ JNI_METHOD(void, BridgedActionsCluster, instantActionWithTransition)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, pauseAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2848,7 +3065,15 @@ JNI_METHOD(void, BridgedActionsCluster, pauseAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2857,7 +3082,8 @@ JNI_METHOD(void, BridgedActionsCluster, pauseAction)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, pauseActionWithDuration)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2890,7 +3116,15 @@ JNI_METHOD(void, BridgedActionsCluster, pauseActionWithDuration)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2899,7 +3133,7 @@ JNI_METHOD(void, BridgedActionsCluster, pauseActionWithDuration)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, resumeAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2931,7 +3165,15 @@ JNI_METHOD(void, BridgedActionsCluster, resumeAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2940,7 +3182,7 @@ JNI_METHOD(void, BridgedActionsCluster, resumeAction)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, startAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2972,7 +3214,15 @@ JNI_METHOD(void, BridgedActionsCluster, startAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -2981,7 +3231,8 @@ JNI_METHOD(void, BridgedActionsCluster, startAction)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, startActionWithDuration)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject duration,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3014,7 +3265,15 @@ JNI_METHOD(void, BridgedActionsCluster, startActionWithDuration)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3023,7 +3282,7 @@ JNI_METHOD(void, BridgedActionsCluster, startActionWithDuration)
     onFailure.release();
 }
 JNI_METHOD(void, BridgedActionsCluster, stopAction)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject actionID, jobject invokeID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3055,7 +3314,15 @@ JNI_METHOD(void, BridgedActionsCluster, stopAction)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3193,7 +3460,8 @@ JNI_METHOD(jlong, ChannelCluster, initWithDevice)(JNIEnv * env, jobject self, jl
 }
 
 JNI_METHOD(void, ChannelCluster, changeChannelByNumberRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject majorNumber, jobject minorNumber)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject majorNumber, jobject minorNumber,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3225,7 +3493,15 @@ JNI_METHOD(void, ChannelCluster, changeChannelByNumberRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3234,7 +3510,7 @@ JNI_METHOD(void, ChannelCluster, changeChannelByNumberRequest)
     onFailure.release();
 }
 JNI_METHOD(void, ChannelCluster, changeChannelRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring match)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring match, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3265,7 +3541,15 @@ JNI_METHOD(void, ChannelCluster, changeChannelRequest)
         chip::Callback::Callback<CHIPChannelClusterChangeChannelResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3273,7 +3557,8 @@ JNI_METHOD(void, ChannelCluster, changeChannelRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, ChannelCluster, skipChannelRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject count)
+JNI_METHOD(void, ChannelCluster, skipChannelRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject count, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3302,7 +3587,15 @@ JNI_METHOD(void, ChannelCluster, skipChannelRequest)(JNIEnv * env, jobject self,
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3358,7 +3651,7 @@ JNI_METHOD(jlong, ColorControlCluster, initWithDevice)(JNIEnv * env, jobject sel
 
 JNI_METHOD(void, ColorControlCluster, colorLoopSet)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject updateFlags, jobject action, jobject direction,
- jobject time, jobject startHue, jobject optionsMask, jobject optionsOverride)
+ jobject time, jobject startHue, jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3396,7 +3689,15 @@ JNI_METHOD(void, ColorControlCluster, colorLoopSet)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3406,7 +3707,7 @@ JNI_METHOD(void, ColorControlCluster, colorLoopSet)
 }
 JNI_METHOD(void, ColorControlCluster, enhancedMoveHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate, jobject optionsMask,
- jobject optionsOverride)
+ jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3440,7 +3741,15 @@ JNI_METHOD(void, ColorControlCluster, enhancedMoveHue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3450,7 +3759,7 @@ JNI_METHOD(void, ColorControlCluster, enhancedMoveHue)
 }
 JNI_METHOD(void, ColorControlCluster, enhancedMoveToHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject enhancedHue, jobject direction, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3487,7 +3796,15 @@ JNI_METHOD(void, ColorControlCluster, enhancedMoveToHue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3497,7 +3814,7 @@ JNI_METHOD(void, ColorControlCluster, enhancedMoveToHue)
 }
 JNI_METHOD(void, ColorControlCluster, enhancedMoveToHueAndSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject enhancedHue, jobject saturation, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3535,7 +3852,15 @@ JNI_METHOD(void, ColorControlCluster, enhancedMoveToHueAndSaturation)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3545,7 +3870,7 @@ JNI_METHOD(void, ColorControlCluster, enhancedMoveToHueAndSaturation)
 }
 JNI_METHOD(void, ColorControlCluster, enhancedStepHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3581,7 +3906,15 @@ JNI_METHOD(void, ColorControlCluster, enhancedStepHue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3591,7 +3924,7 @@ JNI_METHOD(void, ColorControlCluster, enhancedStepHue)
 }
 JNI_METHOD(void, ColorControlCluster, moveColor)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject rateX, jobject rateY, jobject optionsMask,
- jobject optionsOverride)
+ jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3625,7 +3958,15 @@ JNI_METHOD(void, ColorControlCluster, moveColor)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3635,7 +3976,7 @@ JNI_METHOD(void, ColorControlCluster, moveColor)
 }
 JNI_METHOD(void, ColorControlCluster, moveColorTemperature)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate, jobject colorTemperatureMinimum,
- jobject colorTemperatureMaximum, jobject optionsMask, jobject optionsOverride)
+ jobject colorTemperatureMaximum, jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3673,7 +4014,15 @@ JNI_METHOD(void, ColorControlCluster, moveColorTemperature)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3683,7 +4032,7 @@ JNI_METHOD(void, ColorControlCluster, moveColorTemperature)
 }
 JNI_METHOD(void, ColorControlCluster, moveHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate, jobject optionsMask,
- jobject optionsOverride)
+ jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3717,7 +4066,15 @@ JNI_METHOD(void, ColorControlCluster, moveHue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3727,7 +4084,7 @@ JNI_METHOD(void, ColorControlCluster, moveHue)
 }
 JNI_METHOD(void, ColorControlCluster, moveSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate, jobject optionsMask,
- jobject optionsOverride)
+ jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3761,7 +4118,15 @@ JNI_METHOD(void, ColorControlCluster, moveSaturation)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3771,7 +4136,7 @@ JNI_METHOD(void, ColorControlCluster, moveSaturation)
 }
 JNI_METHOD(void, ColorControlCluster, moveToColor)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject colorX, jobject colorY, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3807,7 +4172,15 @@ JNI_METHOD(void, ColorControlCluster, moveToColor)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3817,7 +4190,7 @@ JNI_METHOD(void, ColorControlCluster, moveToColor)
 }
 JNI_METHOD(void, ColorControlCluster, moveToColorTemperature)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject colorTemperature, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3853,7 +4226,15 @@ JNI_METHOD(void, ColorControlCluster, moveToColorTemperature)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3863,7 +4244,7 @@ JNI_METHOD(void, ColorControlCluster, moveToColorTemperature)
 }
 JNI_METHOD(void, ColorControlCluster, moveToHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject hue, jobject direction, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3899,7 +4280,15 @@ JNI_METHOD(void, ColorControlCluster, moveToHue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3909,7 +4298,7 @@ JNI_METHOD(void, ColorControlCluster, moveToHue)
 }
 JNI_METHOD(void, ColorControlCluster, moveToHueAndSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject hue, jobject saturation, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3946,7 +4335,15 @@ JNI_METHOD(void, ColorControlCluster, moveToHueAndSaturation)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -3956,7 +4353,7 @@ JNI_METHOD(void, ColorControlCluster, moveToHueAndSaturation)
 }
 JNI_METHOD(void, ColorControlCluster, moveToSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject saturation, jobject transitionTime, jobject optionsMask,
- jobject optionsOverride)
+ jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3992,7 +4389,15 @@ JNI_METHOD(void, ColorControlCluster, moveToSaturation)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -4002,7 +4407,7 @@ JNI_METHOD(void, ColorControlCluster, moveToSaturation)
 }
 JNI_METHOD(void, ColorControlCluster, stepColor)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepX, jobject stepY, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4038,7 +4443,15 @@ JNI_METHOD(void, ColorControlCluster, stepColor)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -4048,7 +4461,8 @@ JNI_METHOD(void, ColorControlCluster, stepColor)
 }
 JNI_METHOD(void, ColorControlCluster, stepColorTemperature)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime,
- jobject colorTemperatureMinimum, jobject colorTemperatureMaximum, jobject optionsMask, jobject optionsOverride)
+ jobject colorTemperatureMinimum, jobject colorTemperatureMaximum, jobject optionsMask, jobject optionsOverride,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4088,7 +4502,15 @@ JNI_METHOD(void, ColorControlCluster, stepColorTemperature)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -4098,7 +4520,7 @@ JNI_METHOD(void, ColorControlCluster, stepColorTemperature)
 }
 JNI_METHOD(void, ColorControlCluster, stepHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4134,7 +4556,15 @@ JNI_METHOD(void, ColorControlCluster, stepHue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -4144,7 +4574,7 @@ JNI_METHOD(void, ColorControlCluster, stepHue)
 }
 JNI_METHOD(void, ColorControlCluster, stepSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime,
- jobject optionsMask, jobject optionsOverride)
+ jobject optionsMask, jobject optionsOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4180,7 +4610,15 @@ JNI_METHOD(void, ColorControlCluster, stepSaturation)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -4189,7 +4627,8 @@ JNI_METHOD(void, ColorControlCluster, stepSaturation)
     onFailure.release();
 }
 JNI_METHOD(void, ColorControlCluster, stopMoveStep)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject optionsMask, jobject optionsOverride)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject optionsMask, jobject optionsOverride,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4221,7 +4660,15 @@ JNI_METHOD(void, ColorControlCluster, stopMoveStep)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -4564,7 +5011,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorModeAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorControlOptionsAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo;
@@ -4592,7 +5039,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorControlOptionsAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5342,7 +5798,7 @@ JNI_METHOD(void, ColorControlCluster, subscribePrimary6IntensityAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeWhitePointXAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::WhitePointX::TypeInfo;
@@ -5370,7 +5826,16 @@ JNI_METHOD(void, ColorControlCluster, writeWhitePointXAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5417,7 +5882,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeWhitePointXAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeWhitePointYAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::WhitePointY::TypeInfo;
@@ -5445,7 +5910,16 @@ JNI_METHOD(void, ColorControlCluster, writeWhitePointYAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5492,7 +5966,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeWhitePointYAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointRXAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointRX::TypeInfo;
@@ -5520,7 +5994,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointRXAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5567,7 +6050,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointRXAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointRYAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointRY::TypeInfo;
@@ -5595,7 +6078,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointRYAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5642,7 +6134,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointRYAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointRIntensityAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointRIntensity::TypeInfo;
@@ -5670,7 +6162,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointRIntensityAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5717,7 +6218,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointRIntensityAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointGXAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointGX::TypeInfo;
@@ -5745,7 +6246,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointGXAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5792,7 +6302,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointGXAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointGYAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointGY::TypeInfo;
@@ -5820,7 +6330,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointGYAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5867,7 +6386,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointGYAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointGIntensityAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointGIntensity::TypeInfo;
@@ -5895,7 +6414,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointGIntensityAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -5942,7 +6470,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointGIntensityAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointBXAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointBX::TypeInfo;
@@ -5970,7 +6498,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointBXAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -6017,7 +6554,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointBXAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointBYAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointBY::TypeInfo;
@@ -6045,7 +6582,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointBYAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -6092,7 +6638,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeColorPointBYAttribute)
 }
 
 JNI_METHOD(void, ColorControlCluster, writeColorPointBIntensityAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::ColorPointBIntensity::TypeInfo;
@@ -6120,7 +6666,16 @@ JNI_METHOD(void, ColorControlCluster, writeColorPointBIntensityAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -6577,7 +7132,7 @@ JNI_METHOD(void, ColorControlCluster, subscribeCoupleColorTempToLevelMinMiredsAt
 }
 
 JNI_METHOD(void, ColorControlCluster, writeStartUpColorTemperatureMiredsAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo;
@@ -6605,7 +7160,16 @@ JNI_METHOD(void, ColorControlCluster, writeStartUpColorTemperatureMiredsAttribut
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -6698,7 +7262,8 @@ JNI_METHOD(jlong, ContentLauncherCluster, initWithDevice)(JNIEnv * env, jobject 
 }
 
 JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject autoPlay, jstring data, jobject parameterList)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject autoPlay, jstring data, jobject parameterList,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -6731,7 +7296,15 @@ JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
         chip::Callback::Callback<CHIPContentLauncherClusterLaunchResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -6741,7 +7314,7 @@ JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
 }
 JNI_METHOD(void, ContentLauncherCluster, launchURLRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring contentURL, jstring displayString, jstring providerName,
- jobject background, jobject logo, jobject progressBar, jobject splash, jobject waterMark)
+ jobject background, jobject logo, jobject progressBar, jobject splash, jobject waterMark, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -6774,7 +7347,15 @@ JNI_METHOD(void, ContentLauncherCluster, launchURLRequest)
         chip::Callback::Callback<CHIPContentLauncherClusterLaunchResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -6784,7 +7365,7 @@ JNI_METHOD(void, ContentLauncherCluster, launchURLRequest)
 }
 
 JNI_METHOD(void, ContentLauncherCluster, writeSupportedStreamingProtocolsAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::TypeInfo;
@@ -6812,7 +7393,16 @@ JNI_METHOD(void, ContentLauncherCluster, writeSupportedStreamingProtocolsAttribu
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -6952,7 +7542,7 @@ JNI_METHOD(jlong, DiagnosticLogsCluster, initWithDevice)(JNIEnv * env, jobject s
 
 JNI_METHOD(void, DiagnosticLogsCluster, retrieveLogsRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject intent, jobject requestedProtocol,
- jbyteArray transferFileDesignator)
+ jbyteArray transferFileDesignator, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -6987,7 +7577,15 @@ JNI_METHOD(void, DiagnosticLogsCluster, retrieveLogsRequest)
         chip::Callback::Callback<CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7005,7 +7603,8 @@ JNI_METHOD(jlong, DoorLockCluster, initWithDevice)(JNIEnv * env, jobject self, j
 }
 
 JNI_METHOD(void, DoorLockCluster, clearCredential)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject credentialType, jobject credentialIndex)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject credentialType, jobject credentialIndex,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7034,7 +7633,15 @@ JNI_METHOD(void, DoorLockCluster, clearCredential)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7042,7 +7649,8 @@ JNI_METHOD(void, DoorLockCluster, clearCredential)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, DoorLockCluster, clearUser)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject userIndex)
+JNI_METHOD(void, DoorLockCluster, clearUser)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject userIndex, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7071,7 +7679,15 @@ JNI_METHOD(void, DoorLockCluster, clearUser)(JNIEnv * env, jobject self, jlong c
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7080,7 +7696,8 @@ JNI_METHOD(void, DoorLockCluster, clearUser)(JNIEnv * env, jobject self, jlong c
     onFailure.release();
 }
 JNI_METHOD(void, DoorLockCluster, getCredentialStatus)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject credentialType, jobject credentialIndex)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject credentialType, jobject credentialIndex,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7112,7 +7729,15 @@ JNI_METHOD(void, DoorLockCluster, getCredentialStatus)
         chip::Callback::Callback<CHIPDoorLockClusterGetCredentialStatusResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7120,7 +7745,8 @@ JNI_METHOD(void, DoorLockCluster, getCredentialStatus)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, DoorLockCluster, getUser)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject userIndex)
+JNI_METHOD(void, DoorLockCluster, getUser)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject userIndex, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7150,7 +7776,15 @@ JNI_METHOD(void, DoorLockCluster, getUser)(JNIEnv * env, jobject self, jlong clu
     auto successFn = chip::Callback::Callback<CHIPDoorLockClusterGetUserResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7158,7 +7792,8 @@ JNI_METHOD(void, DoorLockCluster, getUser)(JNIEnv * env, jobject self, jlong clu
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject pinCode)
+JNI_METHOD(void, DoorLockCluster, lockDoor)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject pinCode, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7188,7 +7823,15 @@ JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong cl
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7198,7 +7841,7 @@ JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong cl
 }
 JNI_METHOD(void, DoorLockCluster, setCredential)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject operationType, jobject credentialType,
- jobject credentialIndex, jbyteArray credentialData, jobject userIndex, jobject userStatus)
+ jobject credentialIndex, jbyteArray credentialData, jobject userIndex, jobject userStatus, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7235,7 +7878,15 @@ JNI_METHOD(void, DoorLockCluster, setCredential)
         chip::Callback::Callback<CHIPDoorLockClusterSetCredentialResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7245,7 +7896,7 @@ JNI_METHOD(void, DoorLockCluster, setCredential)
 }
 JNI_METHOD(void, DoorLockCluster, setUser)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject operationType, jobject userIndex, jstring userName,
- jobject userUniqueId, jobject userStatus, jobject userType, jobject credentialRule)
+ jobject userUniqueId, jobject userStatus, jobject userType, jobject credentialRule, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7295,7 +7946,15 @@ JNI_METHOD(void, DoorLockCluster, setUser)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7303,7 +7962,8 @@ JNI_METHOD(void, DoorLockCluster, setUser)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, DoorLockCluster, unlockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject pinCode)
+JNI_METHOD(void, DoorLockCluster, unlockDoor)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject pinCode, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -7333,7 +7993,15 @@ JNI_METHOD(void, DoorLockCluster, unlockDoor)(JNIEnv * env, jobject self, jlong 
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -7493,7 +8161,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeDoorStateAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeLanguageAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::Language::TypeInfo;
@@ -7521,7 +8189,16 @@ JNI_METHOD(void, DoorLockCluster, writeLanguageAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -7568,7 +8245,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeLanguageAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeAutoRelockTimeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::AutoRelockTime::TypeInfo;
@@ -7596,7 +8273,16 @@ JNI_METHOD(void, DoorLockCluster, writeAutoRelockTimeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -7643,7 +8329,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeAutoRelockTimeAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeSoundVolumeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::SoundVolume::TypeInfo;
@@ -7671,7 +8357,16 @@ JNI_METHOD(void, DoorLockCluster, writeSoundVolumeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -7718,7 +8413,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeSoundVolumeAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeOperatingModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::OperatingMode::TypeInfo;
@@ -7746,7 +8441,16 @@ JNI_METHOD(void, DoorLockCluster, writeOperatingModeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -7793,7 +8497,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeOperatingModeAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeEnableOneTouchLockingAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::EnableOneTouchLocking::TypeInfo;
@@ -7821,7 +8525,16 @@ JNI_METHOD(void, DoorLockCluster, writeEnableOneTouchLockingAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -7868,7 +8581,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeEnableOneTouchLockingAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeEnablePrivacyModeButtonAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::EnablePrivacyModeButton::TypeInfo;
@@ -7896,7 +8609,16 @@ JNI_METHOD(void, DoorLockCluster, writeEnablePrivacyModeButtonAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -7943,7 +8665,7 @@ JNI_METHOD(void, DoorLockCluster, subscribeEnablePrivacyModeButtonAttribute)
 }
 
 JNI_METHOD(void, DoorLockCluster, writeWrongCodeEntryLimitAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::DoorLock::Attributes::WrongCodeEntryLimit::TypeInfo;
@@ -7971,7 +8693,16 @@ JNI_METHOD(void, DoorLockCluster, writeWrongCodeEntryLimitAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -8516,7 +9247,8 @@ JNI_METHOD(jlong, EthernetNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * en
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, EthernetNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, EthernetNetworkDiagnosticsCluster, resetCounts)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -8543,7 +9275,15 @@ JNI_METHOD(void, EthernetNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, j
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9178,7 +9918,8 @@ JNI_METHOD(jlong, GeneralCommissioningCluster, initWithDevice)(JNIEnv * env, job
 }
 
 JNI_METHOD(void, GeneralCommissioningCluster, armFailSafe)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject expiryLengthSeconds, jobject breadcrumb, jobject timeoutMs)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject expiryLengthSeconds, jobject breadcrumb, jobject timeoutMs,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9213,7 +9954,15 @@ JNI_METHOD(void, GeneralCommissioningCluster, armFailSafe)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9221,7 +9970,8 @@ JNI_METHOD(void, GeneralCommissioningCluster, armFailSafe)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, GeneralCommissioningCluster, commissioningComplete)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, GeneralCommissioningCluster, commissioningComplete)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9252,7 +10002,15 @@ JNI_METHOD(void, GeneralCommissioningCluster, commissioningComplete)(JNIEnv * en
             onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9262,7 +10020,7 @@ JNI_METHOD(void, GeneralCommissioningCluster, commissioningComplete)(JNIEnv * en
 }
 JNI_METHOD(void, GeneralCommissioningCluster, setRegulatoryConfig)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject location, jstring countryCode, jobject breadcrumb,
- jobject timeoutMs)
+ jobject timeoutMs, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9298,7 +10056,15 @@ JNI_METHOD(void, GeneralCommissioningCluster, setRegulatoryConfig)
             onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9308,7 +10074,7 @@ JNI_METHOD(void, GeneralCommissioningCluster, setRegulatoryConfig)
 }
 
 JNI_METHOD(void, GeneralCommissioningCluster, writeBreadcrumbAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::GeneralCommissioning::Attributes::Breadcrumb::TypeInfo;
@@ -9336,7 +10102,16 @@ JNI_METHOD(void, GeneralCommissioningCluster, writeBreadcrumbAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -9623,7 +10398,7 @@ JNI_METHOD(jlong, GroupKeyManagementCluster, initWithDevice)(JNIEnv * env, jobje
 }
 
 JNI_METHOD(void, GroupKeyManagementCluster, keySetRead)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9656,7 +10431,15 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetRead)
         chip::Callback::Callback<CHIPGroupKeyManagementClusterKeySetReadResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9665,7 +10448,7 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetRead)
     onFailure.release();
 }
 JNI_METHOD(void, GroupKeyManagementCluster, keySetReadAllIndices)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetIDs)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetIDs, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9698,7 +10481,15 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetReadAllIndices)
             onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9707,7 +10498,7 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetReadAllIndices)
     onFailure.release();
 }
 JNI_METHOD(void, GroupKeyManagementCluster, keySetRemove)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetID)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetID, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9737,7 +10528,15 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetRemove)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9748,7 +10547,7 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetRemove)
 JNI_METHOD(void, GroupKeyManagementCluster, keySetWrite)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupKeySetID, jobject securityPolicy,
  jbyteArray epochKey0, jobject epochStartTime0, jbyteArray epochKey1, jobject epochStartTime1, jbyteArray epochKey2,
- jobject epochStartTime2)
+ jobject epochStartTime2, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9777,7 +10576,15 @@ JNI_METHOD(void, GroupKeyManagementCluster, keySetWrite)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9832,7 +10639,7 @@ JNI_METHOD(jlong, GroupsCluster, initWithDevice)(JNIEnv * env, jobject self, jlo
 }
 
 JNI_METHOD(void, GroupsCluster, addGroup)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jstring groupName)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jstring groupName, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9863,7 +10670,15 @@ JNI_METHOD(void, GroupsCluster, addGroup)
     auto successFn = chip::Callback::Callback<CHIPGroupsClusterAddGroupResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9872,7 +10687,7 @@ JNI_METHOD(void, GroupsCluster, addGroup)
     onFailure.release();
 }
 JNI_METHOD(void, GroupsCluster, addGroupIfIdentifying)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jstring groupName)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jstring groupName, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9902,7 +10717,15 @@ JNI_METHOD(void, GroupsCluster, addGroupIfIdentifying)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9911,7 +10734,7 @@ JNI_METHOD(void, GroupsCluster, addGroupIfIdentifying)
     onFailure.release();
 }
 JNI_METHOD(void, GroupsCluster, getGroupMembership)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupList)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupList, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9943,7 +10766,15 @@ JNI_METHOD(void, GroupsCluster, getGroupMembership)
         chip::Callback::Callback<CHIPGroupsClusterGetGroupMembershipResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9951,7 +10782,8 @@ JNI_METHOD(void, GroupsCluster, getGroupMembership)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, GroupsCluster, removeAllGroups)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, GroupsCluster, removeAllGroups)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -9978,7 +10810,15 @@ JNI_METHOD(void, GroupsCluster, removeAllGroups)(JNIEnv * env, jobject self, jlo
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -9986,7 +10826,8 @@ JNI_METHOD(void, GroupsCluster, removeAllGroups)(JNIEnv * env, jobject self, jlo
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, GroupsCluster, removeGroup)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId)
+JNI_METHOD(void, GroupsCluster, removeGroup)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10017,7 +10858,15 @@ JNI_METHOD(void, GroupsCluster, removeGroup)(JNIEnv * env, jobject self, jlong c
         chip::Callback::Callback<CHIPGroupsClusterRemoveGroupResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10025,7 +10874,8 @@ JNI_METHOD(void, GroupsCluster, removeGroup)(JNIEnv * env, jobject self, jlong c
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, GroupsCluster, viewGroup)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId)
+JNI_METHOD(void, GroupsCluster, viewGroup)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10055,7 +10905,15 @@ JNI_METHOD(void, GroupsCluster, viewGroup)(JNIEnv * env, jobject self, jlong clu
     auto successFn = chip::Callback::Callback<CHIPGroupsClusterViewGroupResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10146,7 +11004,8 @@ JNI_METHOD(jlong, IdentifyCluster, initWithDevice)(JNIEnv * env, jobject self, j
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, IdentifyCluster, identify)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject identifyTime)
+JNI_METHOD(void, IdentifyCluster, identify)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject identifyTime, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10176,7 +11035,15 @@ JNI_METHOD(void, IdentifyCluster, identify)(JNIEnv * env, jobject self, jlong cl
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10184,7 +11051,8 @@ JNI_METHOD(void, IdentifyCluster, identify)(JNIEnv * env, jobject self, jlong cl
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, IdentifyCluster, identifyQuery)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, IdentifyCluster, identifyQuery)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10213,7 +11081,15 @@ JNI_METHOD(void, IdentifyCluster, identifyQuery)(JNIEnv * env, jobject self, jlo
         chip::Callback::Callback<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10222,7 +11098,8 @@ JNI_METHOD(void, IdentifyCluster, identifyQuery)(JNIEnv * env, jobject self, jlo
     onFailure.release();
 }
 JNI_METHOD(void, IdentifyCluster, triggerEffect)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject effectIdentifier, jobject effectVariant)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject effectIdentifier, jobject effectVariant,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10254,7 +11131,15 @@ JNI_METHOD(void, IdentifyCluster, triggerEffect)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10264,7 +11149,7 @@ JNI_METHOD(void, IdentifyCluster, triggerEffect)
 }
 
 JNI_METHOD(void, IdentifyCluster, writeIdentifyTimeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Identify::Attributes::IdentifyTime::TypeInfo;
@@ -10292,7 +11177,16 @@ JNI_METHOD(void, IdentifyCluster, writeIdentifyTimeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -10664,7 +11558,7 @@ JNI_METHOD(jlong, KeypadInputCluster, initWithDevice)(JNIEnv * env, jobject self
 }
 
 JNI_METHOD(void, KeypadInputCluster, sendKeyRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject keyCode)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject keyCode, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10695,7 +11589,15 @@ JNI_METHOD(void, KeypadInputCluster, sendKeyRequest)
         chip::Callback::Callback<CHIPKeypadInputClusterSendKeyResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10751,7 +11653,7 @@ JNI_METHOD(jlong, LevelControlCluster, initWithDevice)(JNIEnv * env, jobject sel
 
 JNI_METHOD(void, LevelControlCluster, move)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate, jobject optionMask,
- jobject optionOverride)
+ jobject optionOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10785,7 +11687,15 @@ JNI_METHOD(void, LevelControlCluster, move)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10795,7 +11705,7 @@ JNI_METHOD(void, LevelControlCluster, move)
 }
 JNI_METHOD(void, LevelControlCluster, moveToLevel)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject level, jobject transitionTime, jobject optionMask,
- jobject optionOverride)
+ jobject optionOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10830,7 +11740,15 @@ JNI_METHOD(void, LevelControlCluster, moveToLevel)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10839,7 +11757,8 @@ JNI_METHOD(void, LevelControlCluster, moveToLevel)
     onFailure.release();
 }
 JNI_METHOD(void, LevelControlCluster, moveToLevelWithOnOff)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject level, jobject transitionTime)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject level, jobject transitionTime,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10870,7 +11789,15 @@ JNI_METHOD(void, LevelControlCluster, moveToLevelWithOnOff)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10879,7 +11806,7 @@ JNI_METHOD(void, LevelControlCluster, moveToLevelWithOnOff)
     onFailure.release();
 }
 JNI_METHOD(void, LevelControlCluster, moveWithOnOff)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject moveMode, jobject rate, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10909,7 +11836,15 @@ JNI_METHOD(void, LevelControlCluster, moveWithOnOff)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10919,7 +11854,7 @@ JNI_METHOD(void, LevelControlCluster, moveWithOnOff)
 }
 JNI_METHOD(void, LevelControlCluster, step)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime,
- jobject optionMask, jobject optionOverride)
+ jobject optionMask, jobject optionOverride, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10955,7 +11890,15 @@ JNI_METHOD(void, LevelControlCluster, step)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -10964,7 +11907,8 @@ JNI_METHOD(void, LevelControlCluster, step)
     onFailure.release();
 }
 JNI_METHOD(void, LevelControlCluster, stepWithOnOff)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject stepMode, jobject stepSize, jobject transitionTime,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -10996,7 +11940,15 @@ JNI_METHOD(void, LevelControlCluster, stepWithOnOff)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -11005,7 +11957,8 @@ JNI_METHOD(void, LevelControlCluster, stepWithOnOff)
     onFailure.release();
 }
 JNI_METHOD(void, LevelControlCluster, stop)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject optionMask, jobject optionOverride)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject optionMask, jobject optionOverride,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -11037,7 +11990,15 @@ JNI_METHOD(void, LevelControlCluster, stop)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -11045,7 +12006,8 @@ JNI_METHOD(void, LevelControlCluster, stop)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, LevelControlCluster, stopWithOnOff)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, LevelControlCluster, stopWithOnOff)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -11072,7 +12034,15 @@ JNI_METHOD(void, LevelControlCluster, stopWithOnOff)(JNIEnv * env, jobject self,
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -11341,7 +12311,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeMaxFrequencyAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeOptionsAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::Options::TypeInfo;
@@ -11369,7 +12339,16 @@ JNI_METHOD(void, LevelControlCluster, writeOptionsAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11416,7 +12395,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeOptionsAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeOnOffTransitionTimeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo;
@@ -11444,7 +12423,16 @@ JNI_METHOD(void, LevelControlCluster, writeOnOffTransitionTimeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11491,7 +12479,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeOnOffTransitionTimeAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeOnLevelAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::OnLevel::TypeInfo;
@@ -11524,7 +12512,16 @@ JNI_METHOD(void, LevelControlCluster, writeOnLevelAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11572,7 +12569,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeOnLevelAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeOnTransitionTimeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::OnTransitionTime::TypeInfo;
@@ -11605,7 +12602,16 @@ JNI_METHOD(void, LevelControlCluster, writeOnTransitionTimeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11654,7 +12660,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeOnTransitionTimeAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeOffTransitionTimeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::OffTransitionTime::TypeInfo;
@@ -11687,7 +12693,16 @@ JNI_METHOD(void, LevelControlCluster, writeOffTransitionTimeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11736,7 +12751,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeOffTransitionTimeAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeDefaultMoveRateAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo;
@@ -11769,7 +12784,16 @@ JNI_METHOD(void, LevelControlCluster, writeDefaultMoveRateAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11817,7 +12841,7 @@ JNI_METHOD(void, LevelControlCluster, subscribeDefaultMoveRateAttribute)
 }
 
 JNI_METHOD(void, LevelControlCluster, writeStartUpCurrentLevelAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LevelControl::Attributes::StartUpCurrentLevel::TypeInfo;
@@ -11845,7 +12869,16 @@ JNI_METHOD(void, LevelControlCluster, writeStartUpCurrentLevelAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -11982,7 +13015,8 @@ JNI_METHOD(jlong, LowPowerCluster, initWithDevice)(JNIEnv * env, jobject self, j
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, LowPowerCluster, sleep)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, LowPowerCluster, sleep)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12009,7 +13043,15 @@ JNI_METHOD(void, LowPowerCluster, sleep)(JNIEnv * env, jobject self, jlong clust
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12063,7 +13105,8 @@ JNI_METHOD(jlong, MediaInputCluster, initWithDevice)(JNIEnv * env, jobject self,
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, MediaInputCluster, hideInputStatusRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaInputCluster, hideInputStatusRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12090,7 +13133,15 @@ JNI_METHOD(void, MediaInputCluster, hideInputStatusRequest)(JNIEnv * env, jobjec
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12099,7 +13150,7 @@ JNI_METHOD(void, MediaInputCluster, hideInputStatusRequest)(JNIEnv * env, jobjec
     onFailure.release();
 }
 JNI_METHOD(void, MediaInputCluster, renameInputRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index, jstring name)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index, jstring name, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12129,7 +13180,15 @@ JNI_METHOD(void, MediaInputCluster, renameInputRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12138,7 +13197,7 @@ JNI_METHOD(void, MediaInputCluster, renameInputRequest)
     onFailure.release();
 }
 JNI_METHOD(void, MediaInputCluster, selectInputRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject index, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12167,7 +13226,15 @@ JNI_METHOD(void, MediaInputCluster, selectInputRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12175,7 +13242,8 @@ JNI_METHOD(void, MediaInputCluster, selectInputRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaInputCluster, showInputStatusRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaInputCluster, showInputStatusRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12202,7 +13270,15 @@ JNI_METHOD(void, MediaInputCluster, showInputStatusRequest)(JNIEnv * env, jobjec
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12293,7 +13369,8 @@ JNI_METHOD(jlong, MediaPlaybackCluster, initWithDevice)(JNIEnv * env, jobject se
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, MediaPlaybackCluster, fastForwardRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, fastForwardRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12322,7 +13399,15 @@ JNI_METHOD(void, MediaPlaybackCluster, fastForwardRequest)(JNIEnv * env, jobject
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12330,7 +13415,8 @@ JNI_METHOD(void, MediaPlaybackCluster, fastForwardRequest)(JNIEnv * env, jobject
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, nextRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, nextRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12359,7 +13445,15 @@ JNI_METHOD(void, MediaPlaybackCluster, nextRequest)(JNIEnv * env, jobject self, 
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12367,7 +13461,8 @@ JNI_METHOD(void, MediaPlaybackCluster, nextRequest)(JNIEnv * env, jobject self, 
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, pauseRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, pauseRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12396,7 +13491,15 @@ JNI_METHOD(void, MediaPlaybackCluster, pauseRequest)(JNIEnv * env, jobject self,
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12404,7 +13507,8 @@ JNI_METHOD(void, MediaPlaybackCluster, pauseRequest)(JNIEnv * env, jobject self,
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, playRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, playRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12433,7 +13537,15 @@ JNI_METHOD(void, MediaPlaybackCluster, playRequest)(JNIEnv * env, jobject self, 
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12441,7 +13553,8 @@ JNI_METHOD(void, MediaPlaybackCluster, playRequest)(JNIEnv * env, jobject self, 
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, previousRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, previousRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12470,7 +13583,15 @@ JNI_METHOD(void, MediaPlaybackCluster, previousRequest)(JNIEnv * env, jobject se
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12478,7 +13599,8 @@ JNI_METHOD(void, MediaPlaybackCluster, previousRequest)(JNIEnv * env, jobject se
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, rewindRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, rewindRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12507,7 +13629,15 @@ JNI_METHOD(void, MediaPlaybackCluster, rewindRequest)(JNIEnv * env, jobject self
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12516,7 +13646,7 @@ JNI_METHOD(void, MediaPlaybackCluster, rewindRequest)(JNIEnv * env, jobject self
     onFailure.release();
 }
 JNI_METHOD(void, MediaPlaybackCluster, seekRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject position)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject position, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12547,7 +13677,15 @@ JNI_METHOD(void, MediaPlaybackCluster, seekRequest)
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12556,7 +13694,7 @@ JNI_METHOD(void, MediaPlaybackCluster, seekRequest)
     onFailure.release();
 }
 JNI_METHOD(void, MediaPlaybackCluster, skipBackwardRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject deltaPositionMilliseconds)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject deltaPositionMilliseconds, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12588,7 +13726,15 @@ JNI_METHOD(void, MediaPlaybackCluster, skipBackwardRequest)
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12597,7 +13743,7 @@ JNI_METHOD(void, MediaPlaybackCluster, skipBackwardRequest)
     onFailure.release();
 }
 JNI_METHOD(void, MediaPlaybackCluster, skipForwardRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject deltaPositionMilliseconds)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject deltaPositionMilliseconds, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12629,7 +13775,15 @@ JNI_METHOD(void, MediaPlaybackCluster, skipForwardRequest)
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12637,7 +13791,8 @@ JNI_METHOD(void, MediaPlaybackCluster, skipForwardRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, startOverRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, startOverRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12666,7 +13821,15 @@ JNI_METHOD(void, MediaPlaybackCluster, startOverRequest)(JNIEnv * env, jobject s
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12674,7 +13837,8 @@ JNI_METHOD(void, MediaPlaybackCluster, startOverRequest)(JNIEnv * env, jobject s
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, MediaPlaybackCluster, stopRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, MediaPlaybackCluster, stopRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12703,7 +13867,15 @@ JNI_METHOD(void, MediaPlaybackCluster, stopRequest)(JNIEnv * env, jobject self, 
         chip::Callback::Callback<CHIPMediaPlaybackClusterPlaybackResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -12942,7 +14114,8 @@ JNI_METHOD(jlong, ModeSelectCluster, initWithDevice)(JNIEnv * env, jobject self,
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, ModeSelectCluster, changeToMode)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject newMode)
+JNI_METHOD(void, ModeSelectCluster, changeToMode)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject newMode, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -12971,7 +14144,15 @@ JNI_METHOD(void, ModeSelectCluster, changeToMode)(JNIEnv * env, jobject self, jl
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13018,7 +14199,7 @@ JNI_METHOD(void, ModeSelectCluster, subscribeCurrentModeAttribute)
 }
 
 JNI_METHOD(void, ModeSelectCluster, writeOnModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ModeSelect::Attributes::OnMode::TypeInfo;
@@ -13046,7 +14227,16 @@ JNI_METHOD(void, ModeSelectCluster, writeOnModeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -13212,7 +14402,8 @@ JNI_METHOD(jlong, NetworkCommissioningCluster, initWithDevice)(JNIEnv * env, job
 }
 
 JNI_METHOD(void, NetworkCommissioningCluster, addOrUpdateThreadNetwork)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray operationalDataset, jobject breadcrumb)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray operationalDataset, jobject breadcrumb,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13245,7 +14436,15 @@ JNI_METHOD(void, NetworkCommissioningCluster, addOrUpdateThreadNetwork)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13254,7 +14453,8 @@ JNI_METHOD(void, NetworkCommissioningCluster, addOrUpdateThreadNetwork)
     onFailure.release();
 }
 JNI_METHOD(void, NetworkCommissioningCluster, addOrUpdateWiFiNetwork)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jbyteArray credentials, jobject breadcrumb)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jbyteArray credentials, jobject breadcrumb,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13288,7 +14488,15 @@ JNI_METHOD(void, NetworkCommissioningCluster, addOrUpdateWiFiNetwork)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13297,7 +14505,8 @@ JNI_METHOD(void, NetworkCommissioningCluster, addOrUpdateWiFiNetwork)
     onFailure.release();
 }
 JNI_METHOD(void, NetworkCommissioningCluster, connectNetwork)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jobject breadcrumb)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jobject breadcrumb,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13330,7 +14539,15 @@ JNI_METHOD(void, NetworkCommissioningCluster, connectNetwork)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13339,7 +14556,8 @@ JNI_METHOD(void, NetworkCommissioningCluster, connectNetwork)
     onFailure.release();
 }
 JNI_METHOD(void, NetworkCommissioningCluster, removeNetwork)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jobject breadcrumb)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jobject breadcrumb,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13372,7 +14590,15 @@ JNI_METHOD(void, NetworkCommissioningCluster, removeNetwork)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13381,7 +14607,8 @@ JNI_METHOD(void, NetworkCommissioningCluster, removeNetwork)
     onFailure.release();
 }
 JNI_METHOD(void, NetworkCommissioningCluster, reorderNetwork)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jobject networkIndex, jobject breadcrumb)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jobject networkIndex, jobject breadcrumb,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13416,7 +14643,15 @@ JNI_METHOD(void, NetworkCommissioningCluster, reorderNetwork)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13425,7 +14660,7 @@ JNI_METHOD(void, NetworkCommissioningCluster, reorderNetwork)
     onFailure.release();
 }
 JNI_METHOD(void, NetworkCommissioningCluster, scanNetworks)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jobject breadcrumb)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jobject breadcrumb, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13458,7 +14693,15 @@ JNI_METHOD(void, NetworkCommissioningCluster, scanNetworks)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13468,7 +14711,7 @@ JNI_METHOD(void, NetworkCommissioningCluster, scanNetworks)
 }
 
 JNI_METHOD(void, NetworkCommissioningCluster, writeInterfaceEnabledAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::NetworkCommissioning::Attributes::InterfaceEnabled::TypeInfo;
@@ -13496,7 +14739,16 @@ JNI_METHOD(void, NetworkCommissioningCluster, writeInterfaceEnabledAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -13588,7 +14840,8 @@ JNI_METHOD(jlong, OtaSoftwareUpdateProviderCluster, initWithDevice)(JNIEnv * env
 }
 
 JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, applyUpdateRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray updateToken, jobject newVersion)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray updateToken, jobject newVersion,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13621,7 +14874,15 @@ JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, applyUpdateRequest)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13630,7 +14891,8 @@ JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, applyUpdateRequest)
     onFailure.release();
 }
 JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, notifyUpdateApplied)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray updateToken, jobject softwareVersion)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray updateToken, jobject softwareVersion,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13661,7 +14923,15 @@ JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, notifyUpdateApplied)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13671,7 +14941,8 @@ JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, notifyUpdateApplied)
 }
 JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, queryImage)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject vendorId, jobject productId, jobject softwareVersion,
- jobject protocolsSupported, jobject hardwareVersion, jobject location, jobject requestorCanConsent, jobject metadataForProvider)
+ jobject protocolsSupported, jobject hardwareVersion, jobject location, jobject requestorCanConsent, jobject metadataForProvider,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13719,7 +14990,15 @@ JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, queryImage)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -13776,7 +15055,7 @@ JNI_METHOD(jlong, OtaSoftwareUpdateRequestorCluster, initWithDevice)(JNIEnv * en
 
 JNI_METHOD(void, OtaSoftwareUpdateRequestorCluster, announceOtaProvider)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject providerNodeId, jobject vendorId,
- jobject announcementReason, jobject metadataForNode, jobject endpoint)
+ jobject announcementReason, jobject metadataForNode, jobject endpoint, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -13813,7 +15092,15 @@ JNI_METHOD(void, OtaSoftwareUpdateRequestorCluster, announceOtaProvider)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14143,7 +15430,7 @@ JNI_METHOD(jlong, OnOffCluster, initWithDevice)(JNIEnv * env, jobject self, jlon
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, OnOffCluster, off)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, OnOffCluster, off)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14170,7 +15457,15 @@ JNI_METHOD(void, OnOffCluster, off)(JNIEnv * env, jobject self, jlong clusterPtr
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14179,7 +15474,8 @@ JNI_METHOD(void, OnOffCluster, off)(JNIEnv * env, jobject self, jlong clusterPtr
     onFailure.release();
 }
 JNI_METHOD(void, OnOffCluster, offWithEffect)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject effectId, jobject effectVariant)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject effectId, jobject effectVariant,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14210,7 +15506,15 @@ JNI_METHOD(void, OnOffCluster, offWithEffect)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14218,7 +15522,7 @@ JNI_METHOD(void, OnOffCluster, offWithEffect)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14245,7 +15549,15 @@ JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr,
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14253,7 +15565,8 @@ JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr,
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, OnOffCluster, onWithRecallGlobalScene)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, OnOffCluster, onWithRecallGlobalScene)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14280,7 +15593,15 @@ JNI_METHOD(void, OnOffCluster, onWithRecallGlobalScene)(JNIEnv * env, jobject se
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14289,7 +15610,8 @@ JNI_METHOD(void, OnOffCluster, onWithRecallGlobalScene)(JNIEnv * env, jobject se
     onFailure.release();
 }
 JNI_METHOD(void, OnOffCluster, onWithTimedOff)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject onOffControl, jobject onTime, jobject offWaitTime)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject onOffControl, jobject onTime, jobject offWaitTime,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14322,7 +15644,15 @@ JNI_METHOD(void, OnOffCluster, onWithTimedOff)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14330,7 +15660,7 @@ JNI_METHOD(void, OnOffCluster, onWithTimedOff)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, OnOffCluster, toggle)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, OnOffCluster, toggle)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14357,7 +15687,15 @@ JNI_METHOD(void, OnOffCluster, toggle)(JNIEnv * env, jobject self, jlong cluster
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14439,7 +15777,8 @@ JNI_METHOD(void, OnOffCluster, subscribeGlobalSceneControlAttribute)
     onFailure.release();
 }
 
-JNI_METHOD(void, OnOffCluster, writeOnTimeAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+JNI_METHOD(void, OnOffCluster, writeOnTimeAttribute)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo;
@@ -14467,7 +15806,16 @@ JNI_METHOD(void, OnOffCluster, writeOnTimeAttribute)(JNIEnv * env, jobject self,
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -14513,7 +15861,7 @@ JNI_METHOD(void, OnOffCluster, subscribeOnTimeAttribute)
 }
 
 JNI_METHOD(void, OnOffCluster, writeOffWaitTimeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo;
@@ -14541,7 +15889,16 @@ JNI_METHOD(void, OnOffCluster, writeOffWaitTimeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -14588,7 +15945,7 @@ JNI_METHOD(void, OnOffCluster, subscribeOffWaitTimeAttribute)
 }
 
 JNI_METHOD(void, OnOffCluster, writeStartUpOnOffAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo;
@@ -14616,7 +15973,16 @@ JNI_METHOD(void, OnOffCluster, writeStartUpOnOffAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -14782,7 +16148,7 @@ JNI_METHOD(void, OnOffSwitchConfigurationCluster, subscribeSwitchTypeAttribute)
 }
 
 JNI_METHOD(void, OnOffSwitchConfigurationCluster, writeSwitchActionsAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::OnOffSwitchConfiguration::Attributes::SwitchActions::TypeInfo;
@@ -14810,7 +16176,16 @@ JNI_METHOD(void, OnOffSwitchConfigurationCluster, writeSwitchActionsAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -14905,7 +16280,7 @@ JNI_METHOD(jlong, OperationalCredentialsCluster, initWithDevice)(JNIEnv * env, j
 
 JNI_METHOD(void, OperationalCredentialsCluster, addNOC)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray NOCValue, jobject ICACValue, jbyteArray IPKValue,
- jobject caseAdminNode, jobject adminVendorId)
+ jobject caseAdminNode, jobject adminVendorId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14944,7 +16319,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, addNOC)
         chip::Callback::Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14953,7 +16336,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, addNOC)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, addTrustedRootCertificate)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray rootCertificate)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray rootCertificate, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -14982,7 +16365,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, addTrustedRootCertificate)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -14991,7 +16382,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, addTrustedRootCertificate)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, attestationRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray attestationNonce)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray attestationNonce, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15023,7 +16414,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, attestationRequest)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -15032,7 +16431,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, attestationRequest)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, certificateChainRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject certificateType)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject certificateType, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15066,7 +16465,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, certificateChainRequest)
             onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -15075,7 +16482,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, certificateChainRequest)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, opCSRRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray CSRNonce)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray CSRNonce, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15107,7 +16514,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, opCSRRequest)
         chip::Callback::Callback<CHIPOperationalCredentialsClusterOpCSRResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -15116,7 +16531,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, opCSRRequest)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, removeFabric)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject fabricIndex)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject fabricIndex, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15149,7 +16564,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, removeFabric)
         chip::Callback::Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -15158,7 +16581,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, removeFabric)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, removeTrustedRootCertificate)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray trustedRootIdentifier)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray trustedRootIdentifier, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15187,7 +16610,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, removeTrustedRootCertificate)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -15196,7 +16627,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, removeTrustedRootCertificate)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, updateFabricLabel)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring label)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring label, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15228,7 +16659,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, updateFabricLabel)
         chip::Callback::Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -15237,7 +16676,8 @@ JNI_METHOD(void, OperationalCredentialsCluster, updateFabricLabel)
     onFailure.release();
 }
 JNI_METHOD(void, OperationalCredentialsCluster, updateNOC)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray NOCValue, jobject ICACValue)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray NOCValue, jobject ICACValue,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -15271,7 +16711,15 @@ JNI_METHOD(void, OperationalCredentialsCluster, updateNOC)
         chip::Callback::Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -16670,7 +18118,7 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, subscribeSpeedAttribute)
 }
 
 JNI_METHOD(void, PumpConfigurationAndControlCluster, writeLifetimeRunningHoursAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo;
@@ -16703,7 +18151,16 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, writeLifetimeRunningHoursAt
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -16791,7 +18248,7 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, subscribePowerAttribute)
 }
 
 JNI_METHOD(void, PumpConfigurationAndControlCluster, writeLifetimeEnergyConsumedAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo;
@@ -16824,7 +18281,16 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, writeLifetimeEnergyConsumed
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -16875,7 +18341,7 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, subscribeLifetimeEnergyCons
 }
 
 JNI_METHOD(void, PumpConfigurationAndControlCluster, writeOperationModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::PumpConfigurationAndControl::Attributes::OperationMode::TypeInfo;
@@ -16903,7 +18369,16 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, writeOperationModeAttribute
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -16951,7 +18426,7 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, subscribeOperationModeAttri
 }
 
 JNI_METHOD(void, PumpConfigurationAndControlCluster, writeControlModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo;
@@ -16979,7 +18454,16 @@ JNI_METHOD(void, PumpConfigurationAndControlCluster, writeControlModeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -17347,7 +18831,7 @@ JNI_METHOD(jlong, ScenesCluster, initWithDevice)(JNIEnv * env, jobject self, jlo
 
 JNI_METHOD(void, ScenesCluster, addScene)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId, jobject transitionTime,
- jstring sceneName, jobject clusterId, jobject length, jobject value)
+ jstring sceneName, jobject clusterId, jobject length, jobject value, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17383,7 +18867,15 @@ JNI_METHOD(void, ScenesCluster, addScene)
     auto successFn = chip::Callback::Callback<CHIPScenesClusterAddSceneResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17391,7 +18883,8 @@ JNI_METHOD(void, ScenesCluster, addScene)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, ScenesCluster, getSceneMembership)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId)
+JNI_METHOD(void, ScenesCluster, getSceneMembership)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17423,7 +18916,15 @@ JNI_METHOD(void, ScenesCluster, getSceneMembership)(JNIEnv * env, jobject self, 
         chip::Callback::Callback<CHIPScenesClusterGetSceneMembershipResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17432,7 +18933,8 @@ JNI_METHOD(void, ScenesCluster, getSceneMembership)(JNIEnv * env, jobject self, 
     onFailure.release();
 }
 JNI_METHOD(void, ScenesCluster, recallScene)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId, jobject transitionTime)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId, jobject transitionTime,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17464,7 +18966,15 @@ JNI_METHOD(void, ScenesCluster, recallScene)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17472,7 +18982,8 @@ JNI_METHOD(void, ScenesCluster, recallScene)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, ScenesCluster, removeAllScenes)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId)
+JNI_METHOD(void, ScenesCluster, removeAllScenes)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17503,7 +19014,15 @@ JNI_METHOD(void, ScenesCluster, removeAllScenes)(JNIEnv * env, jobject self, jlo
         chip::Callback::Callback<CHIPScenesClusterRemoveAllScenesResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17512,7 +19031,7 @@ JNI_METHOD(void, ScenesCluster, removeAllScenes)(JNIEnv * env, jobject self, jlo
     onFailure.release();
 }
 JNI_METHOD(void, ScenesCluster, removeScene)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17544,7 +19063,15 @@ JNI_METHOD(void, ScenesCluster, removeScene)
         chip::Callback::Callback<CHIPScenesClusterRemoveSceneResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17553,7 +19080,7 @@ JNI_METHOD(void, ScenesCluster, removeScene)
     onFailure.release();
 }
 JNI_METHOD(void, ScenesCluster, storeScene)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17584,7 +19111,15 @@ JNI_METHOD(void, ScenesCluster, storeScene)
     auto successFn = chip::Callback::Callback<CHIPScenesClusterStoreSceneResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17593,7 +19128,7 @@ JNI_METHOD(void, ScenesCluster, storeScene)
     onFailure.release();
 }
 JNI_METHOD(void, ScenesCluster, viewScene)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject groupId, jobject sceneId, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17624,7 +19159,15 @@ JNI_METHOD(void, ScenesCluster, viewScene)
     auto successFn = chip::Callback::Callback<CHIPScenesClusterViewSceneResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -17863,7 +19406,8 @@ JNI_METHOD(jlong, SoftwareDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobj
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, SoftwareDiagnosticsCluster, resetWatermarks)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, SoftwareDiagnosticsCluster, resetWatermarks)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -17890,7 +19434,15 @@ JNI_METHOD(void, SoftwareDiagnosticsCluster, resetWatermarks)(JNIEnv * env, jobj
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18251,7 +19803,7 @@ JNI_METHOD(jlong, TargetNavigatorCluster, initWithDevice)(JNIEnv * env, jobject 
 }
 
 JNI_METHOD(void, TargetNavigatorCluster, navigateTargetRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject target, jstring data)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject target, jstring data, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18284,7 +19836,15 @@ JNI_METHOD(void, TargetNavigatorCluster, navigateTargetRequest)
         chip::Callback::Callback<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18575,7 +20135,7 @@ JNI_METHOD(jlong, TestClusterCluster, initWithDevice)(JNIEnv * env, jobject self
 
 JNI_METHOD(void, TestClusterCluster, simpleStructEchoRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jbyteArray d, jstring e,
- jobject f, jobject g, jobject h)
+ jobject f, jobject g, jobject h, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18607,7 +20167,15 @@ JNI_METHOD(void, TestClusterCluster, simpleStructEchoRequest)
         chip::Callback::Callback<CHIPTestClusterClusterSimpleStructResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18615,7 +20183,8 @@ JNI_METHOD(void, TestClusterCluster, simpleStructEchoRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, TestClusterCluster, test)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, TestClusterCluster, test)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18642,7 +20211,15 @@ JNI_METHOD(void, TestClusterCluster, test)(JNIEnv * env, jobject self, jlong clu
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18651,7 +20228,7 @@ JNI_METHOD(void, TestClusterCluster, test)(JNIEnv * env, jobject self, jlong clu
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testAddArguments)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject arg2)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject arg2, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18684,7 +20261,15 @@ JNI_METHOD(void, TestClusterCluster, testAddArguments)
         chip::Callback::Callback<CHIPTestClusterClusterTestAddArgumentsResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18693,7 +20278,7 @@ JNI_METHOD(void, TestClusterCluster, testAddArguments)
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testEnumsRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject arg2)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject arg2, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18725,7 +20310,15 @@ JNI_METHOD(void, TestClusterCluster, testEnumsRequest)
         chip::Callback::Callback<CHIPTestClusterClusterTestEnumsResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18734,7 +20327,7 @@ JNI_METHOD(void, TestClusterCluster, testEnumsRequest)
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testListInt8UArgumentRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18765,7 +20358,15 @@ JNI_METHOD(void, TestClusterCluster, testListInt8UArgumentRequest)
         chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18774,7 +20375,7 @@ JNI_METHOD(void, TestClusterCluster, testListInt8UArgumentRequest)
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testListInt8UReverseRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18806,7 +20407,15 @@ JNI_METHOD(void, TestClusterCluster, testListInt8UReverseRequest)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18816,7 +20425,7 @@ JNI_METHOD(void, TestClusterCluster, testListInt8UReverseRequest)
 }
 JNI_METHOD(void, TestClusterCluster, testListNestedStructListArgumentRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jobject d, jobject e,
- jbyteArray f, jobject g)
+ jbyteArray f, jobject g, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18847,7 +20456,15 @@ JNI_METHOD(void, TestClusterCluster, testListNestedStructListArgumentRequest)
         chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18857,7 +20474,7 @@ JNI_METHOD(void, TestClusterCluster, testListNestedStructListArgumentRequest)
 }
 JNI_METHOD(void, TestClusterCluster, testListStructArgumentRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jbyteArray d, jstring e,
- jobject f, jobject g, jobject h)
+ jobject f, jobject g, jobject h, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18888,7 +20505,15 @@ JNI_METHOD(void, TestClusterCluster, testListStructArgumentRequest)
         chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18897,7 +20522,7 @@ JNI_METHOD(void, TestClusterCluster, testListStructArgumentRequest)
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testNestedStructArgumentRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18928,7 +20553,15 @@ JNI_METHOD(void, TestClusterCluster, testNestedStructArgumentRequest)
         chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18938,7 +20571,7 @@ JNI_METHOD(void, TestClusterCluster, testNestedStructArgumentRequest)
 }
 JNI_METHOD(void, TestClusterCluster, testNestedStructListArgumentRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jobject d, jobject e,
- jbyteArray f, jobject g)
+ jbyteArray f, jobject g, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -18969,7 +20602,15 @@ JNI_METHOD(void, TestClusterCluster, testNestedStructListArgumentRequest)
         chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -18977,7 +20618,8 @@ JNI_METHOD(void, TestClusterCluster, testNestedStructListArgumentRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, TestClusterCluster, testNotHandled)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, TestClusterCluster, testNotHandled)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19004,7 +20646,15 @@ JNI_METHOD(void, TestClusterCluster, testNotHandled)(JNIEnv * env, jobject self,
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19013,7 +20663,7 @@ JNI_METHOD(void, TestClusterCluster, testNotHandled)(JNIEnv * env, jobject self,
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testNullableOptionalRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19052,7 +20702,15 @@ JNI_METHOD(void, TestClusterCluster, testNullableOptionalRequest)
         onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19061,7 +20719,7 @@ JNI_METHOD(void, TestClusterCluster, testNullableOptionalRequest)
     onFailure.release();
 }
 JNI_METHOD(void, TestClusterCluster, testSimpleOptionalArgumentRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject arg1, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19092,7 +20750,15 @@ JNI_METHOD(void, TestClusterCluster, testSimpleOptionalArgumentRequest)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19100,7 +20766,8 @@ JNI_METHOD(void, TestClusterCluster, testSimpleOptionalArgumentRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, TestClusterCluster, testSpecific)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, TestClusterCluster, testSpecific)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19130,7 +20797,15 @@ JNI_METHOD(void, TestClusterCluster, testSpecific)(JNIEnv * env, jobject self, j
         chip::Callback::Callback<CHIPTestClusterClusterTestSpecificResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19140,7 +20815,7 @@ JNI_METHOD(void, TestClusterCluster, testSpecific)(JNIEnv * env, jobject self, j
 }
 JNI_METHOD(void, TestClusterCluster, testStructArgumentRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jbyteArray d, jstring e,
- jobject f, jobject g, jobject h)
+ jobject f, jobject g, jobject h, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19171,7 +20846,15 @@ JNI_METHOD(void, TestClusterCluster, testStructArgumentRequest)
         chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19179,7 +20862,8 @@ JNI_METHOD(void, TestClusterCluster, testStructArgumentRequest)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, TestClusterCluster, testUnknownCommand)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, TestClusterCluster, testUnknownCommand)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19206,7 +20890,15 @@ JNI_METHOD(void, TestClusterCluster, testUnknownCommand)(JNIEnv * env, jobject s
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19214,7 +20906,8 @@ JNI_METHOD(void, TestClusterCluster, testUnknownCommand)(JNIEnv * env, jobject s
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, TestClusterCluster, timedInvokeRequest)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, TestClusterCluster, timedInvokeRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -19241,7 +20934,8 @@ JNI_METHOD(void, TestClusterCluster, timedInvokeRequest)(JNIEnv * env, jobject s
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall, 10000);
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                    chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -19251,7 +20945,7 @@ JNI_METHOD(void, TestClusterCluster, timedInvokeRequest)(JNIEnv * env, jobject s
 }
 
 JNI_METHOD(void, TestClusterCluster, writeBooleanAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo;
@@ -19279,7 +20973,16 @@ JNI_METHOD(void, TestClusterCluster, writeBooleanAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19326,7 +21029,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeBooleanAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeBitmap8Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo;
@@ -19354,7 +21057,16 @@ JNI_METHOD(void, TestClusterCluster, writeBitmap8Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19401,7 +21113,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeBitmap8Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeBitmap16Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo;
@@ -19429,7 +21141,16 @@ JNI_METHOD(void, TestClusterCluster, writeBitmap16Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19476,7 +21197,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeBitmap16Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeBitmap32Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo;
@@ -19504,7 +21225,16 @@ JNI_METHOD(void, TestClusterCluster, writeBitmap32Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19551,7 +21281,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeBitmap32Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeBitmap64Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo;
@@ -19579,7 +21309,16 @@ JNI_METHOD(void, TestClusterCluster, writeBitmap64Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19626,7 +21365,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeBitmap64Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt8uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo;
@@ -19654,7 +21393,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt8uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19701,7 +21449,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt8uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt16uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo;
@@ -19729,7 +21477,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt16uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19776,7 +21533,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt16uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt24uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int24u::TypeInfo;
@@ -19804,7 +21561,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt24uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19851,7 +21617,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt24uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt32uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo;
@@ -19879,7 +21645,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt32uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -19926,7 +21701,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt32uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt40uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int40u::TypeInfo;
@@ -19954,7 +21729,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt40uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20001,7 +21785,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt40uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt48uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int48u::TypeInfo;
@@ -20029,7 +21813,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt48uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20076,7 +21869,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt48uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt56uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int56u::TypeInfo;
@@ -20104,7 +21897,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt56uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20151,7 +21953,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt56uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt64uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo;
@@ -20179,7 +21981,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt64uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20226,7 +22037,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt64uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt8sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo;
@@ -20254,7 +22065,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt8sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20301,7 +22121,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt8sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt16sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo;
@@ -20329,7 +22149,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt16sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20376,7 +22205,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt16sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt24sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int24s::TypeInfo;
@@ -20404,7 +22233,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt24sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20451,7 +22289,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt24sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt32sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo;
@@ -20479,7 +22317,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt32sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20526,7 +22373,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt32sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt40sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int40s::TypeInfo;
@@ -20554,7 +22401,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt40sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20601,7 +22457,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt40sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt48sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int48s::TypeInfo;
@@ -20629,7 +22485,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt48sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20676,7 +22541,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt48sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt56sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int56s::TypeInfo;
@@ -20704,7 +22569,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt56sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20751,7 +22625,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt56sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeInt64sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo;
@@ -20779,7 +22653,16 @@ JNI_METHOD(void, TestClusterCluster, writeInt64sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20826,7 +22709,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeInt64sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeEnum8Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo;
@@ -20854,7 +22737,16 @@ JNI_METHOD(void, TestClusterCluster, writeEnum8Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20901,7 +22793,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeEnum8Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeEnum16Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo;
@@ -20929,7 +22821,16 @@ JNI_METHOD(void, TestClusterCluster, writeEnum16Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -20976,7 +22877,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeEnum16Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeFloatSingleAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo;
@@ -21004,7 +22905,16 @@ JNI_METHOD(void, TestClusterCluster, writeFloatSingleAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21051,7 +22961,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeFloatSingleAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeFloatDoubleAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo;
@@ -21079,7 +22989,16 @@ JNI_METHOD(void, TestClusterCluster, writeFloatDoubleAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21126,7 +23045,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeFloatDoubleAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeOctetStringAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo;
@@ -21154,7 +23073,16 @@ JNI_METHOD(void, TestClusterCluster, writeOctetStringAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21201,7 +23129,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeOctetStringAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeLongOctetStringAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo;
@@ -21229,7 +23157,16 @@ JNI_METHOD(void, TestClusterCluster, writeLongOctetStringAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21276,7 +23213,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeLongOctetStringAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeCharStringAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo;
@@ -21304,7 +23241,16 @@ JNI_METHOD(void, TestClusterCluster, writeCharStringAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21351,7 +23297,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeCharStringAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeLongCharStringAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo;
@@ -21379,7 +23325,16 @@ JNI_METHOD(void, TestClusterCluster, writeLongCharStringAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21426,7 +23381,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeLongCharStringAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeEpochUsAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo;
@@ -21454,7 +23409,16 @@ JNI_METHOD(void, TestClusterCluster, writeEpochUsAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21501,7 +23465,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeEpochUsAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeEpochSAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo;
@@ -21529,7 +23493,16 @@ JNI_METHOD(void, TestClusterCluster, writeEpochSAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21576,7 +23549,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeEpochSAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeVendorIdAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo;
@@ -21604,7 +23577,16 @@ JNI_METHOD(void, TestClusterCluster, writeVendorIdAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21652,7 +23634,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeVendorIdAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeEnumAttrAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::EnumAttr::TypeInfo;
@@ -21680,7 +23662,16 @@ JNI_METHOD(void, TestClusterCluster, writeEnumAttrAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21727,7 +23718,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeEnumAttrAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt8uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo;
@@ -21755,7 +23746,16 @@ JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt8uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21802,7 +23802,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeRangeRestrictedInt8uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt8sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo;
@@ -21830,7 +23830,16 @@ JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt8sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21877,7 +23886,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeRangeRestrictedInt8sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt16uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo;
@@ -21905,7 +23914,16 @@ JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt16uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -21952,7 +23970,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeRangeRestrictedInt16uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt16sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo;
@@ -21980,7 +23998,16 @@ JNI_METHOD(void, TestClusterCluster, writeRangeRestrictedInt16sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22027,7 +24054,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeRangeRestrictedInt16sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeTimedWriteBooleanAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo;
@@ -22055,7 +24082,9 @@ JNI_METHOD(void, TestClusterCluster, writeTimedWriteBooleanAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall, 10000);
+
+    err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                               chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22065,7 +24094,7 @@ JNI_METHOD(void, TestClusterCluster, writeTimedWriteBooleanAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeUnsupportedAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::Unsupported::TypeInfo;
@@ -22093,7 +24122,16 @@ JNI_METHOD(void, TestClusterCluster, writeUnsupportedAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22140,7 +24178,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeUnsupportedAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableBooleanAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo;
@@ -22173,7 +24211,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableBooleanAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22221,7 +24268,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableBooleanAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableBitmap8Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo;
@@ -22254,7 +24301,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableBitmap8Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22302,7 +24358,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableBitmap8Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableBitmap16Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo;
@@ -22335,7 +24391,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableBitmap16Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22383,7 +24448,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableBitmap16Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableBitmap32Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo;
@@ -22416,7 +24481,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableBitmap32Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22464,7 +24538,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableBitmap32Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableBitmap64Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo;
@@ -22497,7 +24571,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableBitmap64Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22545,7 +24628,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableBitmap64Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt8uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo;
@@ -22578,7 +24661,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt8uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22626,7 +24718,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt8uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt16uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo;
@@ -22659,7 +24751,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt16uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22707,7 +24808,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt16uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt24uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt24u::TypeInfo;
@@ -22740,7 +24841,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt24uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22788,7 +24898,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt24uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt32uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo;
@@ -22821,7 +24931,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt32uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22869,7 +24988,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt32uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt40uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt40u::TypeInfo;
@@ -22902,7 +25021,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt40uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -22950,7 +25078,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt40uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt48uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt48u::TypeInfo;
@@ -22983,7 +25111,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt48uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23031,7 +25168,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt48uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt56uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt56u::TypeInfo;
@@ -23064,7 +25201,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt56uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23112,7 +25258,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt56uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt64uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo;
@@ -23145,7 +25291,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt64uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23193,7 +25348,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt64uAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt8sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo;
@@ -23226,7 +25381,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt8sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23274,7 +25438,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt8sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt16sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo;
@@ -23307,7 +25471,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt16sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23355,7 +25528,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt16sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt24sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt24s::TypeInfo;
@@ -23388,7 +25561,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt24sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23436,7 +25618,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt24sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt32sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo;
@@ -23469,7 +25651,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt32sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23517,7 +25708,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt32sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt40sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt40s::TypeInfo;
@@ -23550,7 +25741,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt40sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23598,7 +25798,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt40sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt48sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt48s::TypeInfo;
@@ -23631,7 +25831,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt48sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23679,7 +25888,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt48sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt56sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt56s::TypeInfo;
@@ -23712,7 +25921,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt56sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23760,7 +25978,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt56sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableInt64sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo;
@@ -23793,7 +26011,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableInt64sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23841,7 +26068,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableInt64sAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableEnum8Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo;
@@ -23874,7 +26101,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableEnum8Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -23922,7 +26158,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableEnum8Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableEnum16Attribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo;
@@ -23955,7 +26191,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableEnum16Attribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24003,7 +26248,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableEnum16Attribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableFloatSingleAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo;
@@ -24036,7 +26281,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableFloatSingleAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24085,7 +26339,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableFloatSingleAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableFloatDoubleAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo;
@@ -24118,7 +26372,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableFloatDoubleAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24167,7 +26430,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableFloatDoubleAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableOctetStringAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo;
@@ -24201,7 +26464,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableOctetStringAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24250,7 +26522,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableOctetStringAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableCharStringAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo;
@@ -24284,7 +26556,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableCharStringAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24333,7 +26614,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableCharStringAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableEnumAttrAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableEnumAttr::TypeInfo;
@@ -24367,7 +26648,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableEnumAttrAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24415,7 +26705,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableEnumAttrAttribute)
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt8uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo;
@@ -24448,7 +26738,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt8uAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24499,7 +26798,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableRangeRestrictedInt8uAttrib
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt8sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo;
@@ -24532,7 +26831,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt8sAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24583,7 +26891,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableRangeRestrictedInt8sAttrib
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt16uAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo;
@@ -24616,7 +26924,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt16uAttribute
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24667,7 +26984,7 @@ JNI_METHOD(void, TestClusterCluster, subscribeNullableRangeRestrictedInt16uAttri
 }
 
 JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt16sAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo;
@@ -24700,7 +27017,16 @@ JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt16sAttribute
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -24795,7 +27121,8 @@ JNI_METHOD(jlong, ThermostatCluster, initWithDevice)(JNIEnv * env, jobject self,
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, ThermostatCluster, clearWeeklySchedule)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, ThermostatCluster, clearWeeklySchedule)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -24822,7 +27149,15 @@ JNI_METHOD(void, ThermostatCluster, clearWeeklySchedule)(JNIEnv * env, jobject s
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -24830,7 +27165,8 @@ JNI_METHOD(void, ThermostatCluster, clearWeeklySchedule)(JNIEnv * env, jobject s
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, ThermostatCluster, getRelayStatusLog)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, ThermostatCluster, getRelayStatusLog)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -24860,7 +27196,15 @@ JNI_METHOD(void, ThermostatCluster, getRelayStatusLog)(JNIEnv * env, jobject sel
         chip::Callback::Callback<CHIPThermostatClusterGetRelayStatusLogResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -24869,7 +27213,8 @@ JNI_METHOD(void, ThermostatCluster, getRelayStatusLog)(JNIEnv * env, jobject sel
     onFailure.release();
 }
 JNI_METHOD(void, ThermostatCluster, getWeeklySchedule)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject daysToReturn, jobject modeToReturn)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject daysToReturn, jobject modeToReturn,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -24904,7 +27249,15 @@ JNI_METHOD(void, ThermostatCluster, getWeeklySchedule)
         chip::Callback::Callback<CHIPThermostatClusterGetWeeklyScheduleResponseCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -24914,7 +27267,7 @@ JNI_METHOD(void, ThermostatCluster, getWeeklySchedule)
 }
 JNI_METHOD(void, ThermostatCluster, setWeeklySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject numberOfTransitionsForSequence,
- jobject dayOfWeekForSequence, jobject modeForSequence, jobject payload)
+ jobject dayOfWeekForSequence, jobject modeForSequence, jobject payload, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -24949,7 +27302,15 @@ JNI_METHOD(void, ThermostatCluster, setWeeklySchedule)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -24958,7 +27319,7 @@ JNI_METHOD(void, ThermostatCluster, setWeeklySchedule)
     onFailure.release();
 }
 JNI_METHOD(void, ThermostatCluster, setpointRaiseLower)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject mode, jobject amount)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject mode, jobject amount, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -24988,7 +27349,15 @@ JNI_METHOD(void, ThermostatCluster, setpointRaiseLower)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -25183,7 +27552,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeAbsMaxCoolSetpointLimitAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeOccupiedCoolingSetpointAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo;
@@ -25211,7 +27580,16 @@ JNI_METHOD(void, ThermostatCluster, writeOccupiedCoolingSetpointAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25258,7 +27636,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeOccupiedCoolingSetpointAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeOccupiedHeatingSetpointAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo;
@@ -25286,7 +27664,16 @@ JNI_METHOD(void, ThermostatCluster, writeOccupiedHeatingSetpointAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25333,7 +27720,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeOccupiedHeatingSetpointAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeMinHeatSetpointLimitAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo;
@@ -25361,7 +27748,16 @@ JNI_METHOD(void, ThermostatCluster, writeMinHeatSetpointLimitAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25408,7 +27804,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeMinHeatSetpointLimitAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeMaxHeatSetpointLimitAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo;
@@ -25436,7 +27832,16 @@ JNI_METHOD(void, ThermostatCluster, writeMaxHeatSetpointLimitAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25483,7 +27888,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeMaxHeatSetpointLimitAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeMinCoolSetpointLimitAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo;
@@ -25511,7 +27916,16 @@ JNI_METHOD(void, ThermostatCluster, writeMinCoolSetpointLimitAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25558,7 +27972,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeMinCoolSetpointLimitAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeMaxCoolSetpointLimitAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo;
@@ -25586,7 +28000,16 @@ JNI_METHOD(void, ThermostatCluster, writeMaxCoolSetpointLimitAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25633,7 +28056,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeMaxCoolSetpointLimitAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeMinSetpointDeadBandAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::MinSetpointDeadBand::TypeInfo;
@@ -25661,7 +28084,16 @@ JNI_METHOD(void, ThermostatCluster, writeMinSetpointDeadBandAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25708,7 +28140,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeMinSetpointDeadBandAttribute)
 }
 
 JNI_METHOD(void, ThermostatCluster, writeControlSequenceOfOperationAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo;
@@ -25736,7 +28168,16 @@ JNI_METHOD(void, ThermostatCluster, writeControlSequenceOfOperationAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -25783,7 +28224,7 @@ JNI_METHOD(void, ThermostatCluster, subscribeControlSequenceOfOperationAttribute
 }
 
 JNI_METHOD(void, ThermostatCluster, writeSystemModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::Thermostat::Attributes::SystemMode::TypeInfo;
@@ -25811,7 +28252,16 @@ JNI_METHOD(void, ThermostatCluster, writeSystemModeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -26052,7 +28502,7 @@ JNI_METHOD(jlong, ThermostatUserInterfaceConfigurationCluster, initWithDevice)
 }
 
 JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, writeTemperatureDisplayModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo;
@@ -26081,7 +28531,16 @@ JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, writeTemperatureDi
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -26130,7 +28589,7 @@ JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, subscribeTemperatu
 }
 
 JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, writeKeypadLockoutAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo;
@@ -26159,7 +28618,16 @@ JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, writeKeypadLockout
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -26208,7 +28676,7 @@ JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, subscribeKeypadLoc
 }
 
 JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, writeScheduleProgrammingVisibilityAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo;
@@ -26237,7 +28705,16 @@ JNI_METHOD(void, ThermostatUserInterfaceConfigurationCluster, writeScheduleProgr
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
@@ -26331,7 +28808,8 @@ JNI_METHOD(jlong, ThreadNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * env,
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, ThreadNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, ThreadNetworkDiagnosticsCluster, resetCounts)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -26358,7 +28836,15 @@ JNI_METHOD(void, ThreadNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, job
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -28689,7 +31175,8 @@ JNI_METHOD(jlong, WiFiNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * env, j
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, WiFiNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, WiFiNetworkDiagnosticsCluster, resetCounts)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -28716,7 +31203,15 @@ JNI_METHOD(void, WiFiNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, jobje
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29257,7 +31752,8 @@ JNI_METHOD(jlong, WindowCoveringCluster, initWithDevice)(JNIEnv * env, jobject s
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-JNI_METHOD(void, WindowCoveringCluster, downOrClose)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, WindowCoveringCluster, downOrClose)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29284,7 +31780,15 @@ JNI_METHOD(void, WindowCoveringCluster, downOrClose)(JNIEnv * env, jobject self,
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29293,7 +31797,8 @@ JNI_METHOD(void, WindowCoveringCluster, downOrClose)(JNIEnv * env, jobject self,
     onFailure.release();
 }
 JNI_METHOD(void, WindowCoveringCluster, goToLiftPercentage)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject liftPercentageValue, jobject liftPercent100thsValue)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject liftPercentageValue, jobject liftPercent100thsValue,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29325,7 +31830,15 @@ JNI_METHOD(void, WindowCoveringCluster, goToLiftPercentage)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29334,7 +31847,7 @@ JNI_METHOD(void, WindowCoveringCluster, goToLiftPercentage)
     onFailure.release();
 }
 JNI_METHOD(void, WindowCoveringCluster, goToLiftValue)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject liftValue)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject liftValue, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29363,7 +31876,15 @@ JNI_METHOD(void, WindowCoveringCluster, goToLiftValue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29372,7 +31893,8 @@ JNI_METHOD(void, WindowCoveringCluster, goToLiftValue)
     onFailure.release();
 }
 JNI_METHOD(void, WindowCoveringCluster, goToTiltPercentage)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject tiltPercentageValue, jobject tiltPercent100thsValue)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject tiltPercentageValue, jobject tiltPercent100thsValue,
+ jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29404,7 +31926,15 @@ JNI_METHOD(void, WindowCoveringCluster, goToTiltPercentage)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29413,7 +31943,7 @@ JNI_METHOD(void, WindowCoveringCluster, goToTiltPercentage)
     onFailure.release();
 }
 JNI_METHOD(void, WindowCoveringCluster, goToTiltValue)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject tiltValue)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject tiltValue, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29442,7 +31972,15 @@ JNI_METHOD(void, WindowCoveringCluster, goToTiltValue)
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29450,7 +31988,8 @@ JNI_METHOD(void, WindowCoveringCluster, goToTiltValue)
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, WindowCoveringCluster, stopMotion)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, WindowCoveringCluster, stopMotion)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29477,7 +32016,15 @@ JNI_METHOD(void, WindowCoveringCluster, stopMotion)(JNIEnv * env, jobject self, 
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -29485,7 +32032,8 @@ JNI_METHOD(void, WindowCoveringCluster, stopMotion)(JNIEnv * env, jobject self, 
     onSuccess.release();
     onFailure.release();
 }
-JNI_METHOD(void, WindowCoveringCluster, upOrOpen)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, WindowCoveringCluster, upOrOpen)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -29512,7 +32060,15 @@ JNI_METHOD(void, WindowCoveringCluster, upOrOpen)(JNIEnv * env, jobject self, jl
     auto successFn = chip::Callback::Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
 
-    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    if (timedInvokeTimeoutMs == nullptr)
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                        chip::JniReferences::GetInstance().IntegerToPrimitive(timedInvokeTimeoutMs));
+    }
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
                                                                                        CHIP_ERROR_INCORRECT_STATE));
@@ -30144,7 +32700,7 @@ JNI_METHOD(void, WindowCoveringCluster, subscribeInstalledClosedLimitTiltAttribu
 }
 
 JNI_METHOD(void, WindowCoveringCluster, writeModeAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::WindowCovering::Attributes::Mode::TypeInfo;
@@ -30172,7 +32728,16 @@ JNI_METHOD(void, WindowCoveringCluster, writeModeAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -12970,7 +12970,7 @@ JNI_METHOD(jlong, LocalizationConfigurationCluster, initWithDevice)(JNIEnv * env
 }
 
 JNI_METHOD(void, LocalizationConfigurationCluster, writeActiveLocaleAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring value, jobject timedWriteTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     using TypeInfo = chip::app::Clusters::LocalizationConfiguration::Attributes::ActiveLocale::TypeInfo;
@@ -12998,7 +12998,16 @@ JNI_METHOD(void, LocalizationConfigurationCluster, writeActiveLocaleAttribute)
 
     auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
     auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
-    err            = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
         chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -7658,7 +7658,12 @@ public class ChipClusters {
     }
 
     public void writeActiveLocaleAttribute(DefaultClusterCallback callback, String value) {
-      writeActiveLocaleAttribute(chipClusterPtr, callback, value);
+      writeActiveLocaleAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeActiveLocaleAttribute(
+        DefaultClusterCallback callback, String value, int timedWriteTimeoutMs) {
+      writeActiveLocaleAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void readSupportedLocalesAttribute(SupportedLocalesAttributeCallback callback) {
@@ -7669,7 +7674,10 @@ public class ChipClusters {
         long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void writeActiveLocaleAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void readSupportedLocalesAttribute(
         long chipClusterPtr, SupportedLocalesAttributeCallback callback);

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -243,29 +243,46 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void getSetupPINRequest(
-        GetSetupPINResponseCallback callback, String tempAccountIdentifier) {
-      getSetupPINRequest(chipClusterPtr, callback, tempAccountIdentifier);
+        GetSetupPINResponseCallback callback,
+        String tempAccountIdentifier,
+        int timedInvokeTimeoutMs) {
+      getSetupPINRequest(chipClusterPtr, callback, tempAccountIdentifier, timedInvokeTimeoutMs);
     }
 
     public void loginRequest(
         DefaultClusterCallback callback, String tempAccountIdentifier, String setupPIN) {
-      loginRequest(chipClusterPtr, callback, tempAccountIdentifier, setupPIN);
+      loginRequest(chipClusterPtr, callback, tempAccountIdentifier, setupPIN, null);
     }
 
-    public void logoutRequest(DefaultClusterCallback callback) {
-      logoutRequest(chipClusterPtr, callback);
+    public void loginRequest(
+        DefaultClusterCallback callback,
+        String tempAccountIdentifier,
+        String setupPIN,
+        int timedInvokeTimeoutMs) {
+      loginRequest(chipClusterPtr, callback, tempAccountIdentifier, setupPIN, timedInvokeTimeoutMs);
+    }
+
+    public void logoutRequest(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      logoutRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     private native void getSetupPINRequest(
-        long chipClusterPtr, GetSetupPINResponseCallback Callback, String tempAccountIdentifier);
+        long chipClusterPtr,
+        GetSetupPINResponseCallback Callback,
+        String tempAccountIdentifier,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void loginRequest(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         String tempAccountIdentifier,
-        String setupPIN);
+        String setupPIN,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void logoutRequest(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void logoutRequest(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface GetSetupPINResponseCallback {
       void onSuccess(String setupPIN);
@@ -318,7 +335,13 @@ public class ChipClusters {
 
     public void openBasicCommissioningWindow(
         DefaultClusterCallback callback, Integer commissioningTimeout) {
-      openBasicCommissioningWindow(chipClusterPtr, callback, commissioningTimeout);
+      openBasicCommissioningWindow(chipClusterPtr, callback, commissioningTimeout, null);
+    }
+
+    public void openBasicCommissioningWindow(
+        DefaultClusterCallback callback, Integer commissioningTimeout, int timedInvokeTimeoutMs) {
+      openBasicCommissioningWindow(
+          chipClusterPtr, callback, commissioningTimeout, timedInvokeTimeoutMs);
     }
 
     public void openCommissioningWindow(
@@ -337,15 +360,44 @@ public class ChipClusters {
           discriminator,
           iterations,
           salt,
-          passcodeID);
+          passcodeID,
+          null);
+    }
+
+    public void openCommissioningWindow(
+        DefaultClusterCallback callback,
+        Integer commissioningTimeout,
+        byte[] PAKEVerifier,
+        Integer discriminator,
+        Long iterations,
+        byte[] salt,
+        Integer passcodeID,
+        int timedInvokeTimeoutMs) {
+      openCommissioningWindow(
+          chipClusterPtr,
+          callback,
+          commissioningTimeout,
+          PAKEVerifier,
+          discriminator,
+          iterations,
+          salt,
+          passcodeID,
+          timedInvokeTimeoutMs);
     }
 
     public void revokeCommissioning(DefaultClusterCallback callback) {
-      revokeCommissioning(chipClusterPtr, callback);
+      revokeCommissioning(chipClusterPtr, callback, null);
+    }
+
+    public void revokeCommissioning(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      revokeCommissioning(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     private native void openBasicCommissioningWindow(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer commissioningTimeout);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer commissioningTimeout,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void openCommissioningWindow(
         long chipClusterPtr,
@@ -355,9 +407,13 @@ public class ChipClusters {
         Integer discriminator,
         Long iterations,
         byte[] salt,
-        Integer passcodeID);
+        Integer passcodeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void revokeCommissioning(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void revokeCommissioning(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AdminFabricIndexAttributeCallback {
       void onSuccess(Integer value);
@@ -590,7 +646,16 @@ public class ChipClusters {
 
     public void hideAppRequest(
         LauncherResponseCallback callback, Integer catalogVendorId, String applicationId) {
-      hideAppRequest(chipClusterPtr, callback, catalogVendorId, applicationId);
+      hideAppRequest(chipClusterPtr, callback, catalogVendorId, applicationId, null);
+    }
+
+    public void hideAppRequest(
+        LauncherResponseCallback callback,
+        Integer catalogVendorId,
+        String applicationId,
+        int timedInvokeTimeoutMs) {
+      hideAppRequest(
+          chipClusterPtr, callback, catalogVendorId, applicationId, timedInvokeTimeoutMs);
     }
 
     public void launchAppRequest(
@@ -598,32 +663,54 @@ public class ChipClusters {
         String data,
         Integer catalogVendorId,
         String applicationId) {
-      launchAppRequest(chipClusterPtr, callback, data, catalogVendorId, applicationId);
+      launchAppRequest(chipClusterPtr, callback, data, catalogVendorId, applicationId, null);
+    }
+
+    public void launchAppRequest(
+        LauncherResponseCallback callback,
+        String data,
+        Integer catalogVendorId,
+        String applicationId,
+        int timedInvokeTimeoutMs) {
+      launchAppRequest(
+          chipClusterPtr, callback, data, catalogVendorId, applicationId, timedInvokeTimeoutMs);
     }
 
     public void stopAppRequest(
         LauncherResponseCallback callback, Integer catalogVendorId, String applicationId) {
-      stopAppRequest(chipClusterPtr, callback, catalogVendorId, applicationId);
+      stopAppRequest(chipClusterPtr, callback, catalogVendorId, applicationId, null);
+    }
+
+    public void stopAppRequest(
+        LauncherResponseCallback callback,
+        Integer catalogVendorId,
+        String applicationId,
+        int timedInvokeTimeoutMs) {
+      stopAppRequest(
+          chipClusterPtr, callback, catalogVendorId, applicationId, timedInvokeTimeoutMs);
     }
 
     private native void hideAppRequest(
         long chipClusterPtr,
         LauncherResponseCallback Callback,
         Integer catalogVendorId,
-        String applicationId);
+        String applicationId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void launchAppRequest(
         long chipClusterPtr,
         LauncherResponseCallback Callback,
         String data,
         Integer catalogVendorId,
-        String applicationId);
+        String applicationId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stopAppRequest(
         long chipClusterPtr,
         LauncherResponseCallback Callback,
         Integer catalogVendorId,
-        String applicationId);
+        String applicationId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface LauncherResponseCallback {
       void onSuccess(Integer status, String data);
@@ -691,18 +778,35 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void renameOutputRequest(DefaultClusterCallback callback, Integer index, String name) {
-      renameOutputRequest(chipClusterPtr, callback, index, name);
+      renameOutputRequest(chipClusterPtr, callback, index, name, null);
+    }
+
+    public void renameOutputRequest(
+        DefaultClusterCallback callback, Integer index, String name, int timedInvokeTimeoutMs) {
+      renameOutputRequest(chipClusterPtr, callback, index, name, timedInvokeTimeoutMs);
     }
 
     public void selectOutputRequest(DefaultClusterCallback callback, Integer index) {
-      selectOutputRequest(chipClusterPtr, callback, index);
+      selectOutputRequest(chipClusterPtr, callback, index, null);
+    }
+
+    public void selectOutputRequest(
+        DefaultClusterCallback callback, Integer index, int timedInvokeTimeoutMs) {
+      selectOutputRequest(chipClusterPtr, callback, index, timedInvokeTimeoutMs);
     }
 
     private native void renameOutputRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer index, String name);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer index,
+        String name,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void selectOutputRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer index);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer index,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class AudioOutputListAttribute {
       public Integer index;
@@ -808,17 +912,32 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void barrierControlGoToPercent(DefaultClusterCallback callback, Integer percentOpen) {
-      barrierControlGoToPercent(chipClusterPtr, callback, percentOpen);
+      barrierControlGoToPercent(chipClusterPtr, callback, percentOpen, null);
+    }
+
+    public void barrierControlGoToPercent(
+        DefaultClusterCallback callback, Integer percentOpen, int timedInvokeTimeoutMs) {
+      barrierControlGoToPercent(chipClusterPtr, callback, percentOpen, timedInvokeTimeoutMs);
     }
 
     public void barrierControlStop(DefaultClusterCallback callback) {
-      barrierControlStop(chipClusterPtr, callback);
+      barrierControlStop(chipClusterPtr, callback, null);
+    }
+
+    public void barrierControlStop(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      barrierControlStop(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     private native void barrierControlGoToPercent(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer percentOpen);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer percentOpen,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void barrierControlStop(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void barrierControlStop(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -924,10 +1043,17 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void mfgSpecificPing(DefaultClusterCallback callback) {
-      mfgSpecificPing(chipClusterPtr, callback);
+      mfgSpecificPing(chipClusterPtr, callback, null);
     }
 
-    private native void mfgSpecificPing(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void mfgSpecificPing(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      mfgSpecificPing(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void mfgSpecificPing(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface VendorIDAttributeCallback {
       void onSuccess(Integer value);
@@ -995,7 +1121,12 @@ public class ChipClusters {
     }
 
     public void writeNodeLabelAttribute(DefaultClusterCallback callback, String value) {
-      writeNodeLabelAttribute(chipClusterPtr, callback, value);
+      writeNodeLabelAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNodeLabelAttribute(
+        DefaultClusterCallback callback, String value, int timedWriteTimeoutMs) {
+      writeNodeLabelAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNodeLabelAttribute(
@@ -1008,7 +1139,12 @@ public class ChipClusters {
     }
 
     public void writeLocationAttribute(DefaultClusterCallback callback, String value) {
-      writeLocationAttribute(chipClusterPtr, callback, value);
+      writeLocationAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLocationAttribute(
+        DefaultClusterCallback callback, String value, int timedWriteTimeoutMs) {
+      writeLocationAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLocationAttribute(
@@ -1102,7 +1238,12 @@ public class ChipClusters {
     }
 
     public void writeLocalConfigDisabledAttribute(DefaultClusterCallback callback, Boolean value) {
-      writeLocalConfigDisabledAttribute(chipClusterPtr, callback, value);
+      writeLocalConfigDisabledAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLocalConfigDisabledAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeLocalConfigDisabledAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLocalConfigDisabledAttribute(
@@ -1176,7 +1317,10 @@ public class ChipClusters {
         long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void writeNodeLabelAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNodeLabelAttribute(
         long chipClusterPtr,
@@ -1188,7 +1332,10 @@ public class ChipClusters {
         long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void writeLocationAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLocationAttribute(
         long chipClusterPtr,
@@ -1275,7 +1422,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeLocalConfigDisabledAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLocalConfigDisabledAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -1324,7 +1474,12 @@ public class ChipClusters {
     }
 
     public void writeOutOfServiceAttribute(DefaultClusterCallback callback, Boolean value) {
-      writeOutOfServiceAttribute(chipClusterPtr, callback, value);
+      writeOutOfServiceAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOutOfServiceAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeOutOfServiceAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOutOfServiceAttribute(
@@ -1337,7 +1492,12 @@ public class ChipClusters {
     }
 
     public void writePresentValueAttribute(DefaultClusterCallback callback, Boolean value) {
-      writePresentValueAttribute(chipClusterPtr, callback, value);
+      writePresentValueAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writePresentValueAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writePresentValueAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribePresentValueAttribute(
@@ -1371,7 +1531,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeOutOfServiceAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOutOfServiceAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -1380,7 +1543,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writePresentValueAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribePresentValueAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -1419,7 +1585,17 @@ public class ChipClusters {
         Integer groupId,
         Integer endpointId,
         Long clusterId) {
-      bind(chipClusterPtr, callback, nodeId, groupId, endpointId, clusterId);
+      bind(chipClusterPtr, callback, nodeId, groupId, endpointId, clusterId, null);
+    }
+
+    public void bind(
+        DefaultClusterCallback callback,
+        Long nodeId,
+        Integer groupId,
+        Integer endpointId,
+        Long clusterId,
+        int timedInvokeTimeoutMs) {
+      bind(chipClusterPtr, callback, nodeId, groupId, endpointId, clusterId, timedInvokeTimeoutMs);
     }
 
     public void unbind(
@@ -1428,7 +1604,18 @@ public class ChipClusters {
         Integer groupId,
         Integer endpointId,
         Long clusterId) {
-      unbind(chipClusterPtr, callback, nodeId, groupId, endpointId, clusterId);
+      unbind(chipClusterPtr, callback, nodeId, groupId, endpointId, clusterId, null);
+    }
+
+    public void unbind(
+        DefaultClusterCallback callback,
+        Long nodeId,
+        Integer groupId,
+        Integer endpointId,
+        Long clusterId,
+        int timedInvokeTimeoutMs) {
+      unbind(
+          chipClusterPtr, callback, nodeId, groupId, endpointId, clusterId, timedInvokeTimeoutMs);
     }
 
     private native void bind(
@@ -1437,7 +1624,8 @@ public class ChipClusters {
         Long nodeId,
         Integer groupId,
         Integer endpointId,
-        Long clusterId);
+        Long clusterId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void unbind(
         long chipClusterPtr,
@@ -1445,7 +1633,8 @@ public class ChipClusters {
         Long nodeId,
         Integer groupId,
         Integer endpointId,
-        Long clusterId);
+        Long clusterId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -1550,27 +1739,71 @@ public class ChipClusters {
 
     public void disableAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      disableAction(chipClusterPtr, callback, actionID, invokeID);
+      disableAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void disableAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      disableAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     public void disableActionWithDuration(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID, Long duration) {
-      disableActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration);
+      disableActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration, null);
+    }
+
+    public void disableActionWithDuration(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        Long duration,
+        int timedInvokeTimeoutMs) {
+      disableActionWithDuration(
+          chipClusterPtr, callback, actionID, invokeID, duration, timedInvokeTimeoutMs);
     }
 
     public void enableAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      enableAction(chipClusterPtr, callback, actionID, invokeID);
+      enableAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void enableAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      enableAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     public void enableActionWithDuration(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID, Long duration) {
-      enableActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration);
+      enableActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration, null);
+    }
+
+    public void enableActionWithDuration(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        Long duration,
+        int timedInvokeTimeoutMs) {
+      enableActionWithDuration(
+          chipClusterPtr, callback, actionID, invokeID, duration, timedInvokeTimeoutMs);
     }
 
     public void instantAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      instantAction(chipClusterPtr, callback, actionID, invokeID);
+      instantAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void instantAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      instantAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     public void instantActionWithTransition(
@@ -1578,115 +1811,190 @@ public class ChipClusters {
         Integer actionID,
         Optional<Long> invokeID,
         Integer transitionTime) {
-      instantActionWithTransition(chipClusterPtr, callback, actionID, invokeID, transitionTime);
+      instantActionWithTransition(
+          chipClusterPtr, callback, actionID, invokeID, transitionTime, null);
+    }
+
+    public void instantActionWithTransition(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        Integer transitionTime,
+        int timedInvokeTimeoutMs) {
+      instantActionWithTransition(
+          chipClusterPtr, callback, actionID, invokeID, transitionTime, timedInvokeTimeoutMs);
     }
 
     public void pauseAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      pauseAction(chipClusterPtr, callback, actionID, invokeID);
+      pauseAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void pauseAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      pauseAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     public void pauseActionWithDuration(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID, Long duration) {
-      pauseActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration);
+      pauseActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration, null);
+    }
+
+    public void pauseActionWithDuration(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        Long duration,
+        int timedInvokeTimeoutMs) {
+      pauseActionWithDuration(
+          chipClusterPtr, callback, actionID, invokeID, duration, timedInvokeTimeoutMs);
     }
 
     public void resumeAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      resumeAction(chipClusterPtr, callback, actionID, invokeID);
+      resumeAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void resumeAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      resumeAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     public void startAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      startAction(chipClusterPtr, callback, actionID, invokeID);
+      startAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void startAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      startAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     public void startActionWithDuration(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID, Long duration) {
-      startActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration);
+      startActionWithDuration(chipClusterPtr, callback, actionID, invokeID, duration, null);
+    }
+
+    public void startActionWithDuration(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        Long duration,
+        int timedInvokeTimeoutMs) {
+      startActionWithDuration(
+          chipClusterPtr, callback, actionID, invokeID, duration, timedInvokeTimeoutMs);
     }
 
     public void stopAction(
         DefaultClusterCallback callback, Integer actionID, Optional<Long> invokeID) {
-      stopAction(chipClusterPtr, callback, actionID, invokeID);
+      stopAction(chipClusterPtr, callback, actionID, invokeID, null);
+    }
+
+    public void stopAction(
+        DefaultClusterCallback callback,
+        Integer actionID,
+        Optional<Long> invokeID,
+        int timedInvokeTimeoutMs) {
+      stopAction(chipClusterPtr, callback, actionID, invokeID, timedInvokeTimeoutMs);
     }
 
     private native void disableAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void disableActionWithDuration(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
         Optional<Long> invokeID,
-        Long duration);
+        Long duration,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void enableAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void enableActionWithDuration(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
         Optional<Long> invokeID,
-        Long duration);
+        Long duration,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void instantAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void instantActionWithTransition(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
         Optional<Long> invokeID,
-        Integer transitionTime);
+        Integer transitionTime,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void pauseAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void pauseActionWithDuration(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
         Optional<Long> invokeID,
-        Long duration);
+        Long duration,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void resumeAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void startAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void startActionWithDuration(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
         Optional<Long> invokeID,
-        Long duration);
+        Long duration,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stopAction(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer actionID,
-        Optional<Long> invokeID);
+        Optional<Long> invokeID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class ActionListAttribute {
       public Integer actionID;
@@ -1908,28 +2216,54 @@ public class ChipClusters {
 
     public void changeChannelByNumberRequest(
         DefaultClusterCallback callback, Integer majorNumber, Integer minorNumber) {
-      changeChannelByNumberRequest(chipClusterPtr, callback, majorNumber, minorNumber);
+      changeChannelByNumberRequest(chipClusterPtr, callback, majorNumber, minorNumber, null);
+    }
+
+    public void changeChannelByNumberRequest(
+        DefaultClusterCallback callback,
+        Integer majorNumber,
+        Integer minorNumber,
+        int timedInvokeTimeoutMs) {
+      changeChannelByNumberRequest(
+          chipClusterPtr, callback, majorNumber, minorNumber, timedInvokeTimeoutMs);
     }
 
     public void changeChannelRequest(ChangeChannelResponseCallback callback, String match) {
-      changeChannelRequest(chipClusterPtr, callback, match);
+      changeChannelRequest(chipClusterPtr, callback, match, null);
+    }
+
+    public void changeChannelRequest(
+        ChangeChannelResponseCallback callback, String match, int timedInvokeTimeoutMs) {
+      changeChannelRequest(chipClusterPtr, callback, match, timedInvokeTimeoutMs);
     }
 
     public void skipChannelRequest(DefaultClusterCallback callback, Integer count) {
-      skipChannelRequest(chipClusterPtr, callback, count);
+      skipChannelRequest(chipClusterPtr, callback, count, null);
+    }
+
+    public void skipChannelRequest(
+        DefaultClusterCallback callback, Integer count, int timedInvokeTimeoutMs) {
+      skipChannelRequest(chipClusterPtr, callback, count, timedInvokeTimeoutMs);
     }
 
     private native void changeChannelByNumberRequest(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer majorNumber,
-        Integer minorNumber);
+        Integer minorNumber,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void changeChannelRequest(
-        long chipClusterPtr, ChangeChannelResponseCallback Callback, String match);
+        long chipClusterPtr,
+        ChangeChannelResponseCallback Callback,
+        String match,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void skipChannelRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer count);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer count,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ChangeChannelResponseCallback {
       void onSuccess( // channelMatch: Struct ChannelInfo
@@ -2062,7 +2396,31 @@ public class ChipClusters {
           time,
           startHue,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void colorLoopSet(
+        DefaultClusterCallback callback,
+        Integer updateFlags,
+        Integer action,
+        Integer direction,
+        Integer time,
+        Integer startHue,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      colorLoopSet(
+          chipClusterPtr,
+          callback,
+          updateFlags,
+          action,
+          direction,
+          time,
+          startHue,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void enhancedMoveHue(
@@ -2071,7 +2429,24 @@ public class ChipClusters {
         Integer rate,
         Integer optionsMask,
         Integer optionsOverride) {
-      enhancedMoveHue(chipClusterPtr, callback, moveMode, rate, optionsMask, optionsOverride);
+      enhancedMoveHue(chipClusterPtr, callback, moveMode, rate, optionsMask, optionsOverride, null);
+    }
+
+    public void enhancedMoveHue(
+        DefaultClusterCallback callback,
+        Integer moveMode,
+        Integer rate,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      enhancedMoveHue(
+          chipClusterPtr,
+          callback,
+          moveMode,
+          rate,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void enhancedMoveToHue(
@@ -2088,7 +2463,27 @@ public class ChipClusters {
           direction,
           transitionTime,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void enhancedMoveToHue(
+        DefaultClusterCallback callback,
+        Integer enhancedHue,
+        Integer direction,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      enhancedMoveToHue(
+          chipClusterPtr,
+          callback,
+          enhancedHue,
+          direction,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void enhancedMoveToHueAndSaturation(
@@ -2105,7 +2500,27 @@ public class ChipClusters {
           saturation,
           transitionTime,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void enhancedMoveToHueAndSaturation(
+        DefaultClusterCallback callback,
+        Integer enhancedHue,
+        Integer saturation,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      enhancedMoveToHueAndSaturation(
+          chipClusterPtr,
+          callback,
+          enhancedHue,
+          saturation,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void enhancedStepHue(
@@ -2122,7 +2537,27 @@ public class ChipClusters {
           stepSize,
           transitionTime,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void enhancedStepHue(
+        DefaultClusterCallback callback,
+        Integer stepMode,
+        Integer stepSize,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      enhancedStepHue(
+          chipClusterPtr,
+          callback,
+          stepMode,
+          stepSize,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveColor(
@@ -2131,7 +2566,24 @@ public class ChipClusters {
         Integer rateY,
         Integer optionsMask,
         Integer optionsOverride) {
-      moveColor(chipClusterPtr, callback, rateX, rateY, optionsMask, optionsOverride);
+      moveColor(chipClusterPtr, callback, rateX, rateY, optionsMask, optionsOverride, null);
+    }
+
+    public void moveColor(
+        DefaultClusterCallback callback,
+        Integer rateX,
+        Integer rateY,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveColor(
+          chipClusterPtr,
+          callback,
+          rateX,
+          rateY,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveColorTemperature(
@@ -2150,7 +2602,29 @@ public class ChipClusters {
           colorTemperatureMinimum,
           colorTemperatureMaximum,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void moveColorTemperature(
+        DefaultClusterCallback callback,
+        Integer moveMode,
+        Integer rate,
+        Integer colorTemperatureMinimum,
+        Integer colorTemperatureMaximum,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveColorTemperature(
+          chipClusterPtr,
+          callback,
+          moveMode,
+          rate,
+          colorTemperatureMinimum,
+          colorTemperatureMaximum,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveHue(
@@ -2159,7 +2633,24 @@ public class ChipClusters {
         Integer rate,
         Integer optionsMask,
         Integer optionsOverride) {
-      moveHue(chipClusterPtr, callback, moveMode, rate, optionsMask, optionsOverride);
+      moveHue(chipClusterPtr, callback, moveMode, rate, optionsMask, optionsOverride, null);
+    }
+
+    public void moveHue(
+        DefaultClusterCallback callback,
+        Integer moveMode,
+        Integer rate,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveHue(
+          chipClusterPtr,
+          callback,
+          moveMode,
+          rate,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveSaturation(
@@ -2168,7 +2659,24 @@ public class ChipClusters {
         Integer rate,
         Integer optionsMask,
         Integer optionsOverride) {
-      moveSaturation(chipClusterPtr, callback, moveMode, rate, optionsMask, optionsOverride);
+      moveSaturation(chipClusterPtr, callback, moveMode, rate, optionsMask, optionsOverride, null);
+    }
+
+    public void moveSaturation(
+        DefaultClusterCallback callback,
+        Integer moveMode,
+        Integer rate,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveSaturation(
+          chipClusterPtr,
+          callback,
+          moveMode,
+          rate,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToColor(
@@ -2179,7 +2687,33 @@ public class ChipClusters {
         Integer optionsMask,
         Integer optionsOverride) {
       moveToColor(
-          chipClusterPtr, callback, colorX, colorY, transitionTime, optionsMask, optionsOverride);
+          chipClusterPtr,
+          callback,
+          colorX,
+          colorY,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          null);
+    }
+
+    public void moveToColor(
+        DefaultClusterCallback callback,
+        Integer colorX,
+        Integer colorY,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveToColor(
+          chipClusterPtr,
+          callback,
+          colorX,
+          colorY,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToColorTemperature(
@@ -2189,7 +2723,30 @@ public class ChipClusters {
         Integer optionsMask,
         Integer optionsOverride) {
       moveToColorTemperature(
-          chipClusterPtr, callback, colorTemperature, transitionTime, optionsMask, optionsOverride);
+          chipClusterPtr,
+          callback,
+          colorTemperature,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          null);
+    }
+
+    public void moveToColorTemperature(
+        DefaultClusterCallback callback,
+        Integer colorTemperature,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveToColorTemperature(
+          chipClusterPtr,
+          callback,
+          colorTemperature,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToHue(
@@ -2200,7 +2757,33 @@ public class ChipClusters {
         Integer optionsMask,
         Integer optionsOverride) {
       moveToHue(
-          chipClusterPtr, callback, hue, direction, transitionTime, optionsMask, optionsOverride);
+          chipClusterPtr,
+          callback,
+          hue,
+          direction,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          null);
+    }
+
+    public void moveToHue(
+        DefaultClusterCallback callback,
+        Integer hue,
+        Integer direction,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveToHue(
+          chipClusterPtr,
+          callback,
+          hue,
+          direction,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToHueAndSaturation(
@@ -2211,7 +2794,33 @@ public class ChipClusters {
         Integer optionsMask,
         Integer optionsOverride) {
       moveToHueAndSaturation(
-          chipClusterPtr, callback, hue, saturation, transitionTime, optionsMask, optionsOverride);
+          chipClusterPtr,
+          callback,
+          hue,
+          saturation,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          null);
+    }
+
+    public void moveToHueAndSaturation(
+        DefaultClusterCallback callback,
+        Integer hue,
+        Integer saturation,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveToHueAndSaturation(
+          chipClusterPtr,
+          callback,
+          hue,
+          saturation,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToSaturation(
@@ -2221,7 +2830,24 @@ public class ChipClusters {
         Integer optionsMask,
         Integer optionsOverride) {
       moveToSaturation(
-          chipClusterPtr, callback, saturation, transitionTime, optionsMask, optionsOverride);
+          chipClusterPtr, callback, saturation, transitionTime, optionsMask, optionsOverride, null);
+    }
+
+    public void moveToSaturation(
+        DefaultClusterCallback callback,
+        Integer saturation,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      moveToSaturation(
+          chipClusterPtr,
+          callback,
+          saturation,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void stepColor(
@@ -2232,7 +2858,33 @@ public class ChipClusters {
         Integer optionsMask,
         Integer optionsOverride) {
       stepColor(
-          chipClusterPtr, callback, stepX, stepY, transitionTime, optionsMask, optionsOverride);
+          chipClusterPtr,
+          callback,
+          stepX,
+          stepY,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          null);
+    }
+
+    public void stepColor(
+        DefaultClusterCallback callback,
+        Integer stepX,
+        Integer stepY,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      stepColor(
+          chipClusterPtr,
+          callback,
+          stepX,
+          stepY,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void stepColorTemperature(
@@ -2253,7 +2905,31 @@ public class ChipClusters {
           colorTemperatureMinimum,
           colorTemperatureMaximum,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void stepColorTemperature(
+        DefaultClusterCallback callback,
+        Integer stepMode,
+        Integer stepSize,
+        Integer transitionTime,
+        Integer colorTemperatureMinimum,
+        Integer colorTemperatureMaximum,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      stepColorTemperature(
+          chipClusterPtr,
+          callback,
+          stepMode,
+          stepSize,
+          transitionTime,
+          colorTemperatureMinimum,
+          colorTemperatureMaximum,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void stepHue(
@@ -2270,7 +2946,27 @@ public class ChipClusters {
           stepSize,
           transitionTime,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void stepHue(
+        DefaultClusterCallback callback,
+        Integer stepMode,
+        Integer stepSize,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      stepHue(
+          chipClusterPtr,
+          callback,
+          stepMode,
+          stepSize,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void stepSaturation(
@@ -2287,12 +2983,40 @@ public class ChipClusters {
           stepSize,
           transitionTime,
           optionsMask,
-          optionsOverride);
+          optionsOverride,
+          null);
+    }
+
+    public void stepSaturation(
+        DefaultClusterCallback callback,
+        Integer stepMode,
+        Integer stepSize,
+        Integer transitionTime,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      stepSaturation(
+          chipClusterPtr,
+          callback,
+          stepMode,
+          stepSize,
+          transitionTime,
+          optionsMask,
+          optionsOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void stopMoveStep(
         DefaultClusterCallback callback, Integer optionsMask, Integer optionsOverride) {
-      stopMoveStep(chipClusterPtr, callback, optionsMask, optionsOverride);
+      stopMoveStep(chipClusterPtr, callback, optionsMask, optionsOverride, null);
+    }
+
+    public void stopMoveStep(
+        DefaultClusterCallback callback,
+        Integer optionsMask,
+        Integer optionsOverride,
+        int timedInvokeTimeoutMs) {
+      stopMoveStep(chipClusterPtr, callback, optionsMask, optionsOverride, timedInvokeTimeoutMs);
     }
 
     private native void colorLoopSet(
@@ -2304,7 +3028,8 @@ public class ChipClusters {
         Integer time,
         Integer startHue,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void enhancedMoveHue(
         long chipClusterPtr,
@@ -2312,7 +3037,8 @@ public class ChipClusters {
         Integer moveMode,
         Integer rate,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void enhancedMoveToHue(
         long chipClusterPtr,
@@ -2321,7 +3047,8 @@ public class ChipClusters {
         Integer direction,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void enhancedMoveToHueAndSaturation(
         long chipClusterPtr,
@@ -2330,7 +3057,8 @@ public class ChipClusters {
         Integer saturation,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void enhancedStepHue(
         long chipClusterPtr,
@@ -2339,7 +3067,8 @@ public class ChipClusters {
         Integer stepSize,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveColor(
         long chipClusterPtr,
@@ -2347,7 +3076,8 @@ public class ChipClusters {
         Integer rateX,
         Integer rateY,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveColorTemperature(
         long chipClusterPtr,
@@ -2357,7 +3087,8 @@ public class ChipClusters {
         Integer colorTemperatureMinimum,
         Integer colorTemperatureMaximum,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveHue(
         long chipClusterPtr,
@@ -2365,7 +3096,8 @@ public class ChipClusters {
         Integer moveMode,
         Integer rate,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveSaturation(
         long chipClusterPtr,
@@ -2373,7 +3105,8 @@ public class ChipClusters {
         Integer moveMode,
         Integer rate,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToColor(
         long chipClusterPtr,
@@ -2382,7 +3115,8 @@ public class ChipClusters {
         Integer colorY,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToColorTemperature(
         long chipClusterPtr,
@@ -2390,7 +3124,8 @@ public class ChipClusters {
         Integer colorTemperature,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToHue(
         long chipClusterPtr,
@@ -2399,7 +3134,8 @@ public class ChipClusters {
         Integer direction,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToHueAndSaturation(
         long chipClusterPtr,
@@ -2408,7 +3144,8 @@ public class ChipClusters {
         Integer saturation,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToSaturation(
         long chipClusterPtr,
@@ -2416,7 +3153,8 @@ public class ChipClusters {
         Integer saturation,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stepColor(
         long chipClusterPtr,
@@ -2425,7 +3163,8 @@ public class ChipClusters {
         Integer stepY,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stepColorTemperature(
         long chipClusterPtr,
@@ -2436,7 +3175,8 @@ public class ChipClusters {
         Integer colorTemperatureMinimum,
         Integer colorTemperatureMaximum,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stepHue(
         long chipClusterPtr,
@@ -2445,7 +3185,8 @@ public class ChipClusters {
         Integer stepSize,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stepSaturation(
         long chipClusterPtr,
@@ -2454,13 +3195,15 @@ public class ChipClusters {
         Integer stepSize,
         Integer transitionTime,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stopMoveStep(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer optionsMask,
-        Integer optionsOverride);
+        Integer optionsOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -2556,7 +3299,12 @@ public class ChipClusters {
     }
 
     public void writeColorControlOptionsAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorControlOptionsAttribute(chipClusterPtr, callback, value);
+      writeColorControlOptionsAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorControlOptionsAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorControlOptionsAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorControlOptionsAttribute(
@@ -2740,7 +3488,12 @@ public class ChipClusters {
     }
 
     public void writeWhitePointXAttribute(DefaultClusterCallback callback, Integer value) {
-      writeWhitePointXAttribute(chipClusterPtr, callback, value);
+      writeWhitePointXAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeWhitePointXAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeWhitePointXAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeWhitePointXAttribute(
@@ -2753,7 +3506,12 @@ public class ChipClusters {
     }
 
     public void writeWhitePointYAttribute(DefaultClusterCallback callback, Integer value) {
-      writeWhitePointYAttribute(chipClusterPtr, callback, value);
+      writeWhitePointYAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeWhitePointYAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeWhitePointYAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeWhitePointYAttribute(
@@ -2766,7 +3524,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointRXAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointRXAttribute(chipClusterPtr, callback, value);
+      writeColorPointRXAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointRXAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointRXAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointRXAttribute(
@@ -2779,7 +3542,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointRYAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointRYAttribute(chipClusterPtr, callback, value);
+      writeColorPointRYAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointRYAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointRYAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointRYAttribute(
@@ -2792,7 +3560,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointRIntensityAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointRIntensityAttribute(chipClusterPtr, callback, value);
+      writeColorPointRIntensityAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointRIntensityAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointRIntensityAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointRIntensityAttribute(
@@ -2805,7 +3578,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointGXAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointGXAttribute(chipClusterPtr, callback, value);
+      writeColorPointGXAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointGXAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointGXAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointGXAttribute(
@@ -2818,7 +3596,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointGYAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointGYAttribute(chipClusterPtr, callback, value);
+      writeColorPointGYAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointGYAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointGYAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointGYAttribute(
@@ -2831,7 +3614,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointGIntensityAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointGIntensityAttribute(chipClusterPtr, callback, value);
+      writeColorPointGIntensityAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointGIntensityAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointGIntensityAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointGIntensityAttribute(
@@ -2844,7 +3632,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointBXAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointBXAttribute(chipClusterPtr, callback, value);
+      writeColorPointBXAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointBXAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointBXAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointBXAttribute(
@@ -2857,7 +3650,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointBYAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointBYAttribute(chipClusterPtr, callback, value);
+      writeColorPointBYAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointBYAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointBYAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointBYAttribute(
@@ -2870,7 +3668,12 @@ public class ChipClusters {
     }
 
     public void writeColorPointBIntensityAttribute(DefaultClusterCallback callback, Integer value) {
-      writeColorPointBIntensityAttribute(chipClusterPtr, callback, value);
+      writeColorPointBIntensityAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeColorPointBIntensityAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeColorPointBIntensityAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeColorPointBIntensityAttribute(
@@ -2986,7 +3789,13 @@ public class ChipClusters {
 
     public void writeStartUpColorTemperatureMiredsAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeStartUpColorTemperatureMiredsAttribute(chipClusterPtr, callback, value);
+      writeStartUpColorTemperatureMiredsAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeStartUpColorTemperatureMiredsAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeStartUpColorTemperatureMiredsAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeStartUpColorTemperatureMiredsAttribute(
@@ -3069,7 +3878,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorControlOptionsAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorControlOptionsAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3192,7 +4004,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeWhitePointXAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeWhitePointXAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3201,7 +4016,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeWhitePointYAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeWhitePointYAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3210,7 +4028,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointRXAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointRXAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3219,7 +4040,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointRYAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointRYAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3228,7 +4052,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointRIntensityAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointRIntensityAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3237,7 +4064,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointGXAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointGXAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3246,7 +4076,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointGYAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointGYAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3255,7 +4088,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointGIntensityAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointGIntensityAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3264,7 +4100,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointBXAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointBXAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3273,7 +4112,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointBYAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointBYAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3282,7 +4124,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeColorPointBIntensityAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeColorPointBIntensityAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3357,7 +4202,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeStartUpColorTemperatureMiredsAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeStartUpColorTemperatureMiredsAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -3386,7 +4234,12 @@ public class ChipClusters {
 
     public void launchContentRequest(
         LaunchResponseCallback callback, Boolean autoPlay, String data) {
-      launchContentRequest(chipClusterPtr, callback, autoPlay, data);
+      launchContentRequest(chipClusterPtr, callback, autoPlay, data, null);
+    }
+
+    public void launchContentRequest(
+        LaunchResponseCallback callback, Boolean autoPlay, String data, int timedInvokeTimeoutMs) {
+      launchContentRequest(chipClusterPtr, callback, autoPlay, data, timedInvokeTimeoutMs);
     }
 
     public void launchURLRequest(
@@ -3394,18 +4247,33 @@ public class ChipClusters {
         String contentURL,
         String displayString,
         String providerName) {
-      launchURLRequest(chipClusterPtr, callback, contentURL, displayString, providerName);
+      launchURLRequest(chipClusterPtr, callback, contentURL, displayString, providerName, null);
+    }
+
+    public void launchURLRequest(
+        LaunchResponseCallback callback,
+        String contentURL,
+        String displayString,
+        String providerName,
+        int timedInvokeTimeoutMs) {
+      launchURLRequest(
+          chipClusterPtr, callback, contentURL, displayString, providerName, timedInvokeTimeoutMs);
     }
 
     private native void launchContentRequest(
-        long chipClusterPtr, LaunchResponseCallback Callback, Boolean autoPlay, String data);
+        long chipClusterPtr,
+        LaunchResponseCallback Callback,
+        Boolean autoPlay,
+        String data,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void launchURLRequest(
         long chipClusterPtr,
         LaunchResponseCallback Callback,
         String contentURL,
         String displayString,
-        String providerName);
+        String providerName,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface LaunchResponseCallback {
       void onSuccess(Integer status, String data);
@@ -3439,7 +4307,13 @@ public class ChipClusters {
 
     public void writeSupportedStreamingProtocolsAttribute(
         DefaultClusterCallback callback, Long value) {
-      writeSupportedStreamingProtocolsAttribute(chipClusterPtr, callback, value);
+      writeSupportedStreamingProtocolsAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeSupportedStreamingProtocolsAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeSupportedStreamingProtocolsAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeSupportedStreamingProtocolsAttribute(
@@ -3468,7 +4342,10 @@ public class ChipClusters {
         long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeSupportedStreamingProtocolsAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeSupportedStreamingProtocolsAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -3628,7 +4505,22 @@ public class ChipClusters {
         Integer requestedProtocol,
         byte[] transferFileDesignator) {
       retrieveLogsRequest(
-          chipClusterPtr, callback, intent, requestedProtocol, transferFileDesignator);
+          chipClusterPtr, callback, intent, requestedProtocol, transferFileDesignator, null);
+    }
+
+    public void retrieveLogsRequest(
+        RetrieveLogsResponseCallback callback,
+        Integer intent,
+        Integer requestedProtocol,
+        byte[] transferFileDesignator,
+        int timedInvokeTimeoutMs) {
+      retrieveLogsRequest(
+          chipClusterPtr,
+          callback,
+          intent,
+          requestedProtocol,
+          transferFileDesignator,
+          timedInvokeTimeoutMs);
     }
 
     private native void retrieveLogsRequest(
@@ -3636,7 +4528,8 @@ public class ChipClusters {
         RetrieveLogsResponseCallback Callback,
         Integer intent,
         Integer requestedProtocol,
-        byte[] transferFileDesignator);
+        byte[] transferFileDesignator,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface RetrieveLogsResponseCallback {
       void onSuccess(Integer status, byte[] content, Long timeStamp, Long timeSinceBoot);
@@ -3674,26 +4567,59 @@ public class ChipClusters {
 
     public void clearCredential(
         DefaultClusterCallback callback, Integer credentialType, Integer credentialIndex) {
-      clearCredential(chipClusterPtr, callback, credentialType, credentialIndex);
+      clearCredential(chipClusterPtr, callback, credentialType, credentialIndex, null);
+    }
+
+    public void clearCredential(
+        DefaultClusterCallback callback,
+        Integer credentialType,
+        Integer credentialIndex,
+        int timedInvokeTimeoutMs) {
+      clearCredential(
+          chipClusterPtr, callback, credentialType, credentialIndex, timedInvokeTimeoutMs);
     }
 
     public void clearUser(DefaultClusterCallback callback, Integer userIndex) {
-      clearUser(chipClusterPtr, callback, userIndex);
+      clearUser(chipClusterPtr, callback, userIndex, null);
+    }
+
+    public void clearUser(
+        DefaultClusterCallback callback, Integer userIndex, int timedInvokeTimeoutMs) {
+      clearUser(chipClusterPtr, callback, userIndex, timedInvokeTimeoutMs);
     }
 
     public void getCredentialStatus(
         GetCredentialStatusResponseCallback callback,
         Integer credentialType,
         Integer credentialIndex) {
-      getCredentialStatus(chipClusterPtr, callback, credentialType, credentialIndex);
+      getCredentialStatus(chipClusterPtr, callback, credentialType, credentialIndex, null);
+    }
+
+    public void getCredentialStatus(
+        GetCredentialStatusResponseCallback callback,
+        Integer credentialType,
+        Integer credentialIndex,
+        int timedInvokeTimeoutMs) {
+      getCredentialStatus(
+          chipClusterPtr, callback, credentialType, credentialIndex, timedInvokeTimeoutMs);
     }
 
     public void getUser(GetUserResponseCallback callback, Integer userIndex) {
-      getUser(chipClusterPtr, callback, userIndex);
+      getUser(chipClusterPtr, callback, userIndex, null);
+    }
+
+    public void getUser(
+        GetUserResponseCallback callback, Integer userIndex, int timedInvokeTimeoutMs) {
+      getUser(chipClusterPtr, callback, userIndex, timedInvokeTimeoutMs);
     }
 
     public void lockDoor(DefaultClusterCallback callback, Optional<byte[]> pinCode) {
-      lockDoor(chipClusterPtr, callback, pinCode);
+      lockDoor(chipClusterPtr, callback, pinCode, null);
+    }
+
+    public void lockDoor(
+        DefaultClusterCallback callback, Optional<byte[]> pinCode, int timedInvokeTimeoutMs) {
+      lockDoor(chipClusterPtr, callback, pinCode, timedInvokeTimeoutMs);
     }
 
     public void setCredential(
@@ -3712,7 +4638,29 @@ public class ChipClusters {
           credentialIndex,
           credentialData,
           userIndex,
-          userStatus);
+          userStatus,
+          null);
+    }
+
+    public void setCredential(
+        SetCredentialResponseCallback callback,
+        Integer operationType,
+        Integer credentialType,
+        Integer credentialIndex,
+        byte[] credentialData,
+        Integer userIndex,
+        Integer userStatus,
+        int timedInvokeTimeoutMs) {
+      setCredential(
+          chipClusterPtr,
+          callback,
+          operationType,
+          credentialType,
+          credentialIndex,
+          credentialData,
+          userIndex,
+          userStatus,
+          timedInvokeTimeoutMs);
     }
 
     public void setUser(
@@ -3733,33 +4681,73 @@ public class ChipClusters {
           userUniqueId,
           userStatus,
           userType,
-          credentialRule);
+          credentialRule,
+          null);
+    }
+
+    public void setUser(
+        DefaultClusterCallback callback,
+        Integer operationType,
+        Integer userIndex,
+        @Nullable String userName,
+        @Nullable Long userUniqueId,
+        Integer userStatus,
+        Integer userType,
+        Integer credentialRule,
+        int timedInvokeTimeoutMs) {
+      setUser(
+          chipClusterPtr,
+          callback,
+          operationType,
+          userIndex,
+          userName,
+          userUniqueId,
+          userStatus,
+          userType,
+          credentialRule,
+          timedInvokeTimeoutMs);
     }
 
     public void unlockDoor(DefaultClusterCallback callback, Optional<byte[]> pinCode) {
-      unlockDoor(chipClusterPtr, callback, pinCode);
+      unlockDoor(chipClusterPtr, callback, pinCode, null);
+    }
+
+    public void unlockDoor(
+        DefaultClusterCallback callback, Optional<byte[]> pinCode, int timedInvokeTimeoutMs) {
+      unlockDoor(chipClusterPtr, callback, pinCode, timedInvokeTimeoutMs);
     }
 
     private native void clearCredential(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer credentialType,
-        Integer credentialIndex);
+        Integer credentialIndex,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void clearUser(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer userIndex);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer userIndex,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void getCredentialStatus(
         long chipClusterPtr,
         GetCredentialStatusResponseCallback Callback,
         Integer credentialType,
-        Integer credentialIndex);
+        Integer credentialIndex,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void getUser(
-        long chipClusterPtr, GetUserResponseCallback Callback, Integer userIndex);
+        long chipClusterPtr,
+        GetUserResponseCallback Callback,
+        Integer userIndex,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void lockDoor(
-        long chipClusterPtr, DefaultClusterCallback Callback, Optional<byte[]> pinCode);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Optional<byte[]> pinCode,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void setCredential(
         long chipClusterPtr,
@@ -3769,7 +4757,8 @@ public class ChipClusters {
         Integer credentialIndex,
         byte[] credentialData,
         Integer userIndex,
-        Integer userStatus);
+        Integer userStatus,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void setUser(
         long chipClusterPtr,
@@ -3780,10 +4769,14 @@ public class ChipClusters {
         @Nullable Long userUniqueId,
         Integer userStatus,
         Integer userType,
-        Integer credentialRule);
+        Integer credentialRule,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void unlockDoor(
-        long chipClusterPtr, DefaultClusterCallback Callback, Optional<byte[]> pinCode);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Optional<byte[]> pinCode,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface GetCredentialStatusResponseCallback {
       void onSuccess(
@@ -3899,7 +4892,12 @@ public class ChipClusters {
     }
 
     public void writeLanguageAttribute(DefaultClusterCallback callback, String value) {
-      writeLanguageAttribute(chipClusterPtr, callback, value);
+      writeLanguageAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLanguageAttribute(
+        DefaultClusterCallback callback, String value, int timedWriteTimeoutMs) {
+      writeLanguageAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLanguageAttribute(
@@ -3912,7 +4910,12 @@ public class ChipClusters {
     }
 
     public void writeAutoRelockTimeAttribute(DefaultClusterCallback callback, Long value) {
-      writeAutoRelockTimeAttribute(chipClusterPtr, callback, value);
+      writeAutoRelockTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeAutoRelockTimeAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeAutoRelockTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeAutoRelockTimeAttribute(
@@ -3925,7 +4928,12 @@ public class ChipClusters {
     }
 
     public void writeSoundVolumeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeSoundVolumeAttribute(chipClusterPtr, callback, value);
+      writeSoundVolumeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeSoundVolumeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeSoundVolumeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeSoundVolumeAttribute(
@@ -3938,7 +4946,12 @@ public class ChipClusters {
     }
 
     public void writeOperatingModeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOperatingModeAttribute(chipClusterPtr, callback, value);
+      writeOperatingModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOperatingModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOperatingModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOperatingModeAttribute(
@@ -3956,7 +4969,12 @@ public class ChipClusters {
 
     public void writeEnableOneTouchLockingAttribute(
         DefaultClusterCallback callback, Boolean value) {
-      writeEnableOneTouchLockingAttribute(chipClusterPtr, callback, value);
+      writeEnableOneTouchLockingAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEnableOneTouchLockingAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeEnableOneTouchLockingAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEnableOneTouchLockingAttribute(
@@ -3970,7 +4988,12 @@ public class ChipClusters {
 
     public void writeEnablePrivacyModeButtonAttribute(
         DefaultClusterCallback callback, Boolean value) {
-      writeEnablePrivacyModeButtonAttribute(chipClusterPtr, callback, value);
+      writeEnablePrivacyModeButtonAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEnablePrivacyModeButtonAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeEnablePrivacyModeButtonAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEnablePrivacyModeButtonAttribute(
@@ -3983,7 +5006,12 @@ public class ChipClusters {
     }
 
     public void writeWrongCodeEntryLimitAttribute(DefaultClusterCallback callback, Integer value) {
-      writeWrongCodeEntryLimitAttribute(chipClusterPtr, callback, value);
+      writeWrongCodeEntryLimitAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeWrongCodeEntryLimitAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeWrongCodeEntryLimitAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeWrongCodeEntryLimitAttribute(
@@ -4044,7 +5072,10 @@ public class ChipClusters {
         long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void writeLanguageAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLanguageAttribute(
         long chipClusterPtr,
@@ -4056,7 +5087,10 @@ public class ChipClusters {
         long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeAutoRelockTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeAutoRelockTimeAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -4065,7 +5099,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeSoundVolumeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeSoundVolumeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -4074,7 +5111,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOperatingModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOperatingModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -4086,7 +5126,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeEnableOneTouchLockingAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEnableOneTouchLockingAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -4095,7 +5138,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeEnablePrivacyModeButtonAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEnablePrivacyModeButtonAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -4104,7 +5150,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeWrongCodeEntryLimitAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeWrongCodeEntryLimitAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -4340,10 +5389,17 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void resetCounts(DefaultClusterCallback callback) {
-      resetCounts(chipClusterPtr, callback);
+      resetCounts(chipClusterPtr, callback, null);
     }
 
-    private native void resetCounts(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void resetCounts(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      resetCounts(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void resetCounts(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -4720,11 +5776,31 @@ public class ChipClusters {
         Integer expiryLengthSeconds,
         Long breadcrumb,
         Long timeoutMs) {
-      armFailSafe(chipClusterPtr, callback, expiryLengthSeconds, breadcrumb, timeoutMs);
+      armFailSafe(chipClusterPtr, callback, expiryLengthSeconds, breadcrumb, timeoutMs, null);
+    }
+
+    public void armFailSafe(
+        ArmFailSafeResponseCallback callback,
+        Integer expiryLengthSeconds,
+        Long breadcrumb,
+        Long timeoutMs,
+        int timedInvokeTimeoutMs) {
+      armFailSafe(
+          chipClusterPtr,
+          callback,
+          expiryLengthSeconds,
+          breadcrumb,
+          timeoutMs,
+          timedInvokeTimeoutMs);
     }
 
     public void commissioningComplete(CommissioningCompleteResponseCallback callback) {
-      commissioningComplete(chipClusterPtr, callback);
+      commissioningComplete(chipClusterPtr, callback, null);
+    }
+
+    public void commissioningComplete(
+        CommissioningCompleteResponseCallback callback, int timedInvokeTimeoutMs) {
+      commissioningComplete(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void setRegulatoryConfig(
@@ -4733,7 +5809,25 @@ public class ChipClusters {
         String countryCode,
         Long breadcrumb,
         Long timeoutMs) {
-      setRegulatoryConfig(chipClusterPtr, callback, location, countryCode, breadcrumb, timeoutMs);
+      setRegulatoryConfig(
+          chipClusterPtr, callback, location, countryCode, breadcrumb, timeoutMs, null);
+    }
+
+    public void setRegulatoryConfig(
+        SetRegulatoryConfigResponseCallback callback,
+        Integer location,
+        String countryCode,
+        Long breadcrumb,
+        Long timeoutMs,
+        int timedInvokeTimeoutMs) {
+      setRegulatoryConfig(
+          chipClusterPtr,
+          callback,
+          location,
+          countryCode,
+          breadcrumb,
+          timeoutMs,
+          timedInvokeTimeoutMs);
     }
 
     private native void armFailSafe(
@@ -4741,10 +5835,13 @@ public class ChipClusters {
         ArmFailSafeResponseCallback Callback,
         Integer expiryLengthSeconds,
         Long breadcrumb,
-        Long timeoutMs);
+        Long timeoutMs,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void commissioningComplete(
-        long chipClusterPtr, CommissioningCompleteResponseCallback Callback);
+        long chipClusterPtr,
+        CommissioningCompleteResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void setRegulatoryConfig(
         long chipClusterPtr,
@@ -4752,7 +5849,8 @@ public class ChipClusters {
         Integer location,
         String countryCode,
         Long breadcrumb,
-        Long timeoutMs);
+        Long timeoutMs,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ArmFailSafeResponseCallback {
       void onSuccess(Integer errorCode, String debugText);
@@ -4811,7 +5909,12 @@ public class ChipClusters {
     }
 
     public void writeBreadcrumbAttribute(DefaultClusterCallback callback, Long value) {
-      writeBreadcrumbAttribute(chipClusterPtr, callback, value);
+      writeBreadcrumbAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeBreadcrumbAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeBreadcrumbAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeBreadcrumbAttribute(
@@ -4849,7 +5952,10 @@ public class ChipClusters {
         long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeBreadcrumbAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeBreadcrumbAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -5102,16 +6208,33 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void keySetRead(KeySetReadResponseCallback callback, Integer groupKeySetID) {
-      keySetRead(chipClusterPtr, callback, groupKeySetID);
+      keySetRead(chipClusterPtr, callback, groupKeySetID, null);
+    }
+
+    public void keySetRead(
+        KeySetReadResponseCallback callback, Integer groupKeySetID, int timedInvokeTimeoutMs) {
+      keySetRead(chipClusterPtr, callback, groupKeySetID, timedInvokeTimeoutMs);
     }
 
     public void keySetReadAllIndices(
         KeySetReadAllIndicesResponseCallback callback, Integer groupKeySetIDs) {
-      keySetReadAllIndices(chipClusterPtr, callback, groupKeySetIDs);
+      keySetReadAllIndices(chipClusterPtr, callback, groupKeySetIDs, null);
+    }
+
+    public void keySetReadAllIndices(
+        KeySetReadAllIndicesResponseCallback callback,
+        Integer groupKeySetIDs,
+        int timedInvokeTimeoutMs) {
+      keySetReadAllIndices(chipClusterPtr, callback, groupKeySetIDs, timedInvokeTimeoutMs);
     }
 
     public void keySetRemove(DefaultClusterCallback callback, Integer groupKeySetID) {
-      keySetRemove(chipClusterPtr, callback, groupKeySetID);
+      keySetRemove(chipClusterPtr, callback, groupKeySetID, null);
+    }
+
+    public void keySetRemove(
+        DefaultClusterCallback callback, Integer groupKeySetID, int timedInvokeTimeoutMs) {
+      keySetRemove(chipClusterPtr, callback, groupKeySetID, timedInvokeTimeoutMs);
     }
 
     public void keySetWrite(
@@ -5134,17 +6257,52 @@ public class ChipClusters {
           epochKey1,
           epochStartTime1,
           epochKey2,
-          epochStartTime2);
+          epochStartTime2,
+          null);
+    }
+
+    public void keySetWrite(
+        DefaultClusterCallback callback,
+        Integer groupKeySetID,
+        Integer securityPolicy,
+        byte[] epochKey0,
+        Long epochStartTime0,
+        byte[] epochKey1,
+        Long epochStartTime1,
+        byte[] epochKey2,
+        Long epochStartTime2,
+        int timedInvokeTimeoutMs) {
+      keySetWrite(
+          chipClusterPtr,
+          callback,
+          groupKeySetID,
+          securityPolicy,
+          epochKey0,
+          epochStartTime0,
+          epochKey1,
+          epochStartTime1,
+          epochKey2,
+          epochStartTime2,
+          timedInvokeTimeoutMs);
     }
 
     private native void keySetRead(
-        long chipClusterPtr, KeySetReadResponseCallback Callback, Integer groupKeySetID);
+        long chipClusterPtr,
+        KeySetReadResponseCallback Callback,
+        Integer groupKeySetID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void keySetReadAllIndices(
-        long chipClusterPtr, KeySetReadAllIndicesResponseCallback Callback, Integer groupKeySetIDs);
+        long chipClusterPtr,
+        KeySetReadAllIndicesResponseCallback Callback,
+        Integer groupKeySetIDs,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void keySetRemove(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer groupKeySetID);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer groupKeySetID,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void keySetWrite(
         long chipClusterPtr,
@@ -5156,7 +6314,8 @@ public class ChipClusters {
         byte[] epochKey1,
         Long epochStartTime1,
         byte[] epochKey2,
-        Long epochStartTime2);
+        Long epochStartTime2,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface KeySetReadAllIndicesResponseCallback {
       void onSuccess( // groupKeySetIDs: /* TYPE WARNING: array array defaults to */ uint8_t *
@@ -5322,46 +6481,101 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void addGroup(AddGroupResponseCallback callback, Integer groupId, String groupName) {
-      addGroup(chipClusterPtr, callback, groupId, groupName);
+      addGroup(chipClusterPtr, callback, groupId, groupName, null);
+    }
+
+    public void addGroup(
+        AddGroupResponseCallback callback,
+        Integer groupId,
+        String groupName,
+        int timedInvokeTimeoutMs) {
+      addGroup(chipClusterPtr, callback, groupId, groupName, timedInvokeTimeoutMs);
     }
 
     public void addGroupIfIdentifying(
         DefaultClusterCallback callback, Integer groupId, String groupName) {
-      addGroupIfIdentifying(chipClusterPtr, callback, groupId, groupName);
+      addGroupIfIdentifying(chipClusterPtr, callback, groupId, groupName, null);
+    }
+
+    public void addGroupIfIdentifying(
+        DefaultClusterCallback callback,
+        Integer groupId,
+        String groupName,
+        int timedInvokeTimeoutMs) {
+      addGroupIfIdentifying(chipClusterPtr, callback, groupId, groupName, timedInvokeTimeoutMs);
     }
 
     public void getGroupMembership(GetGroupMembershipResponseCallback callback, Integer groupList) {
-      getGroupMembership(chipClusterPtr, callback, groupList);
+      getGroupMembership(chipClusterPtr, callback, groupList, null);
+    }
+
+    public void getGroupMembership(
+        GetGroupMembershipResponseCallback callback, Integer groupList, int timedInvokeTimeoutMs) {
+      getGroupMembership(chipClusterPtr, callback, groupList, timedInvokeTimeoutMs);
     }
 
     public void removeAllGroups(DefaultClusterCallback callback) {
-      removeAllGroups(chipClusterPtr, callback);
+      removeAllGroups(chipClusterPtr, callback, null);
+    }
+
+    public void removeAllGroups(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      removeAllGroups(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void removeGroup(RemoveGroupResponseCallback callback, Integer groupId) {
-      removeGroup(chipClusterPtr, callback, groupId);
+      removeGroup(chipClusterPtr, callback, groupId, null);
+    }
+
+    public void removeGroup(
+        RemoveGroupResponseCallback callback, Integer groupId, int timedInvokeTimeoutMs) {
+      removeGroup(chipClusterPtr, callback, groupId, timedInvokeTimeoutMs);
     }
 
     public void viewGroup(ViewGroupResponseCallback callback, Integer groupId) {
-      viewGroup(chipClusterPtr, callback, groupId);
+      viewGroup(chipClusterPtr, callback, groupId, null);
+    }
+
+    public void viewGroup(
+        ViewGroupResponseCallback callback, Integer groupId, int timedInvokeTimeoutMs) {
+      viewGroup(chipClusterPtr, callback, groupId, timedInvokeTimeoutMs);
     }
 
     private native void addGroup(
-        long chipClusterPtr, AddGroupResponseCallback Callback, Integer groupId, String groupName);
+        long chipClusterPtr,
+        AddGroupResponseCallback Callback,
+        Integer groupId,
+        String groupName,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void addGroupIfIdentifying(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer groupId, String groupName);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer groupId,
+        String groupName,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void getGroupMembership(
-        long chipClusterPtr, GetGroupMembershipResponseCallback Callback, Integer groupList);
+        long chipClusterPtr,
+        GetGroupMembershipResponseCallback Callback,
+        Integer groupList,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void removeAllGroups(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void removeAllGroups(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeGroup(
-        long chipClusterPtr, RemoveGroupResponseCallback Callback, Integer groupId);
+        long chipClusterPtr,
+        RemoveGroupResponseCallback Callback,
+        Integer groupId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void viewGroup(
-        long chipClusterPtr, ViewGroupResponseCallback Callback, Integer groupId);
+        long chipClusterPtr,
+        ViewGroupResponseCallback Callback,
+        Integer groupId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AddGroupResponseCallback {
       void onSuccess(Integer status, Integer groupId);
@@ -5449,28 +6663,53 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void identify(DefaultClusterCallback callback, Integer identifyTime) {
-      identify(chipClusterPtr, callback, identifyTime);
+      identify(chipClusterPtr, callback, identifyTime, null);
+    }
+
+    public void identify(
+        DefaultClusterCallback callback, Integer identifyTime, int timedInvokeTimeoutMs) {
+      identify(chipClusterPtr, callback, identifyTime, timedInvokeTimeoutMs);
     }
 
     public void identifyQuery(IdentifyQueryResponseCallback callback) {
-      identifyQuery(chipClusterPtr, callback);
+      identifyQuery(chipClusterPtr, callback, null);
+    }
+
+    public void identifyQuery(IdentifyQueryResponseCallback callback, int timedInvokeTimeoutMs) {
+      identifyQuery(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void triggerEffect(
         DefaultClusterCallback callback, Integer effectIdentifier, Integer effectVariant) {
-      triggerEffect(chipClusterPtr, callback, effectIdentifier, effectVariant);
+      triggerEffect(chipClusterPtr, callback, effectIdentifier, effectVariant, null);
+    }
+
+    public void triggerEffect(
+        DefaultClusterCallback callback,
+        Integer effectIdentifier,
+        Integer effectVariant,
+        int timedInvokeTimeoutMs) {
+      triggerEffect(
+          chipClusterPtr, callback, effectIdentifier, effectVariant, timedInvokeTimeoutMs);
     }
 
     private native void identify(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer identifyTime);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer identifyTime,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void identifyQuery(long chipClusterPtr, IdentifyQueryResponseCallback Callback);
+    private native void identifyQuery(
+        long chipClusterPtr,
+        IdentifyQueryResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void triggerEffect(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer effectIdentifier,
-        Integer effectVariant);
+        Integer effectVariant,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface IdentifyQueryResponseCallback {
       void onSuccess(Integer timeout);
@@ -5491,7 +6730,12 @@ public class ChipClusters {
     }
 
     public void writeIdentifyTimeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeIdentifyTimeAttribute(chipClusterPtr, callback, value);
+      writeIdentifyTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeIdentifyTimeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeIdentifyTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeIdentifyTimeAttribute(
@@ -5525,7 +6769,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeIdentifyTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeIdentifyTimeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -5721,11 +6968,19 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void sendKeyRequest(SendKeyResponseCallback callback, Integer keyCode) {
-      sendKeyRequest(chipClusterPtr, callback, keyCode);
+      sendKeyRequest(chipClusterPtr, callback, keyCode, null);
+    }
+
+    public void sendKeyRequest(
+        SendKeyResponseCallback callback, Integer keyCode, int timedInvokeTimeoutMs) {
+      sendKeyRequest(chipClusterPtr, callback, keyCode, timedInvokeTimeoutMs);
     }
 
     private native void sendKeyRequest(
-        long chipClusterPtr, SendKeyResponseCallback Callback, Integer keyCode);
+        long chipClusterPtr,
+        SendKeyResponseCallback Callback,
+        Integer keyCode,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface SendKeyResponseCallback {
       void onSuccess(Integer status);
@@ -5782,7 +7037,24 @@ public class ChipClusters {
         Integer rate,
         Integer optionMask,
         Integer optionOverride) {
-      move(chipClusterPtr, callback, moveMode, rate, optionMask, optionOverride);
+      move(chipClusterPtr, callback, moveMode, rate, optionMask, optionOverride, null);
+    }
+
+    public void move(
+        DefaultClusterCallback callback,
+        Integer moveMode,
+        Integer rate,
+        Integer optionMask,
+        Integer optionOverride,
+        int timedInvokeTimeoutMs) {
+      move(
+          chipClusterPtr,
+          callback,
+          moveMode,
+          rate,
+          optionMask,
+          optionOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToLevel(
@@ -5791,16 +7063,47 @@ public class ChipClusters {
         Integer transitionTime,
         Integer optionMask,
         Integer optionOverride) {
-      moveToLevel(chipClusterPtr, callback, level, transitionTime, optionMask, optionOverride);
+      moveToLevel(
+          chipClusterPtr, callback, level, transitionTime, optionMask, optionOverride, null);
+    }
+
+    public void moveToLevel(
+        DefaultClusterCallback callback,
+        Integer level,
+        Integer transitionTime,
+        Integer optionMask,
+        Integer optionOverride,
+        int timedInvokeTimeoutMs) {
+      moveToLevel(
+          chipClusterPtr,
+          callback,
+          level,
+          transitionTime,
+          optionMask,
+          optionOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void moveToLevelWithOnOff(
         DefaultClusterCallback callback, Integer level, Integer transitionTime) {
-      moveToLevelWithOnOff(chipClusterPtr, callback, level, transitionTime);
+      moveToLevelWithOnOff(chipClusterPtr, callback, level, transitionTime, null);
+    }
+
+    public void moveToLevelWithOnOff(
+        DefaultClusterCallback callback,
+        Integer level,
+        Integer transitionTime,
+        int timedInvokeTimeoutMs) {
+      moveToLevelWithOnOff(chipClusterPtr, callback, level, transitionTime, timedInvokeTimeoutMs);
     }
 
     public void moveWithOnOff(DefaultClusterCallback callback, Integer moveMode, Integer rate) {
-      moveWithOnOff(chipClusterPtr, callback, moveMode, rate);
+      moveWithOnOff(chipClusterPtr, callback, moveMode, rate, null);
+    }
+
+    public void moveWithOnOff(
+        DefaultClusterCallback callback, Integer moveMode, Integer rate, int timedInvokeTimeoutMs) {
+      moveWithOnOff(chipClusterPtr, callback, moveMode, rate, timedInvokeTimeoutMs);
     }
 
     public void step(
@@ -5811,7 +7114,33 @@ public class ChipClusters {
         Integer optionMask,
         Integer optionOverride) {
       step(
-          chipClusterPtr, callback, stepMode, stepSize, transitionTime, optionMask, optionOverride);
+          chipClusterPtr,
+          callback,
+          stepMode,
+          stepSize,
+          transitionTime,
+          optionMask,
+          optionOverride,
+          null);
+    }
+
+    public void step(
+        DefaultClusterCallback callback,
+        Integer stepMode,
+        Integer stepSize,
+        Integer transitionTime,
+        Integer optionMask,
+        Integer optionOverride,
+        int timedInvokeTimeoutMs) {
+      step(
+          chipClusterPtr,
+          callback,
+          stepMode,
+          stepSize,
+          transitionTime,
+          optionMask,
+          optionOverride,
+          timedInvokeTimeoutMs);
     }
 
     public void stepWithOnOff(
@@ -5819,15 +7148,37 @@ public class ChipClusters {
         Integer stepMode,
         Integer stepSize,
         Integer transitionTime) {
-      stepWithOnOff(chipClusterPtr, callback, stepMode, stepSize, transitionTime);
+      stepWithOnOff(chipClusterPtr, callback, stepMode, stepSize, transitionTime, null);
+    }
+
+    public void stepWithOnOff(
+        DefaultClusterCallback callback,
+        Integer stepMode,
+        Integer stepSize,
+        Integer transitionTime,
+        int timedInvokeTimeoutMs) {
+      stepWithOnOff(
+          chipClusterPtr, callback, stepMode, stepSize, transitionTime, timedInvokeTimeoutMs);
     }
 
     public void stop(DefaultClusterCallback callback, Integer optionMask, Integer optionOverride) {
-      stop(chipClusterPtr, callback, optionMask, optionOverride);
+      stop(chipClusterPtr, callback, optionMask, optionOverride, null);
+    }
+
+    public void stop(
+        DefaultClusterCallback callback,
+        Integer optionMask,
+        Integer optionOverride,
+        int timedInvokeTimeoutMs) {
+      stop(chipClusterPtr, callback, optionMask, optionOverride, timedInvokeTimeoutMs);
     }
 
     public void stopWithOnOff(DefaultClusterCallback callback) {
-      stopWithOnOff(chipClusterPtr, callback);
+      stopWithOnOff(chipClusterPtr, callback, null);
+    }
+
+    public void stopWithOnOff(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      stopWithOnOff(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     private native void move(
@@ -5836,7 +7187,8 @@ public class ChipClusters {
         Integer moveMode,
         Integer rate,
         Integer optionMask,
-        Integer optionOverride);
+        Integer optionOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToLevel(
         long chipClusterPtr,
@@ -5844,16 +7196,22 @@ public class ChipClusters {
         Integer level,
         Integer transitionTime,
         Integer optionMask,
-        Integer optionOverride);
+        Integer optionOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveToLevelWithOnOff(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer level,
-        Integer transitionTime);
+        Integer transitionTime,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void moveWithOnOff(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer moveMode, Integer rate);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer moveMode,
+        Integer rate,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void step(
         long chipClusterPtr,
@@ -5862,22 +7220,28 @@ public class ChipClusters {
         Integer stepSize,
         Integer transitionTime,
         Integer optionMask,
-        Integer optionOverride);
+        Integer optionOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stepWithOnOff(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer stepMode,
         Integer stepSize,
-        Integer transitionTime);
+        Integer transitionTime,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stop(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer optionMask,
-        Integer optionOverride);
+        Integer optionOverride,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void stopWithOnOff(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void stopWithOnOff(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface OnLevelAttributeCallback {
       void onSuccess(@Nullable Integer value);
@@ -5987,7 +7351,12 @@ public class ChipClusters {
     }
 
     public void writeOptionsAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOptionsAttribute(chipClusterPtr, callback, value);
+      writeOptionsAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOptionsAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOptionsAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOptionsAttribute(
@@ -6000,7 +7369,12 @@ public class ChipClusters {
     }
 
     public void writeOnOffTransitionTimeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOnOffTransitionTimeAttribute(chipClusterPtr, callback, value);
+      writeOnOffTransitionTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOnOffTransitionTimeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOnOffTransitionTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOnOffTransitionTimeAttribute(
@@ -6013,7 +7387,12 @@ public class ChipClusters {
     }
 
     public void writeOnLevelAttribute(DefaultClusterCallback callback, @Nullable Integer value) {
-      writeOnLevelAttribute(chipClusterPtr, callback, value);
+      writeOnLevelAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOnLevelAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeOnLevelAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOnLevelAttribute(
@@ -6027,7 +7406,12 @@ public class ChipClusters {
 
     public void writeOnTransitionTimeAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeOnTransitionTimeAttribute(chipClusterPtr, callback, value);
+      writeOnTransitionTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOnTransitionTimeAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeOnTransitionTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOnTransitionTimeAttribute(
@@ -6041,7 +7425,12 @@ public class ChipClusters {
 
     public void writeOffTransitionTimeAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeOffTransitionTimeAttribute(chipClusterPtr, callback, value);
+      writeOffTransitionTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOffTransitionTimeAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeOffTransitionTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOffTransitionTimeAttribute(
@@ -6055,7 +7444,12 @@ public class ChipClusters {
 
     public void writeDefaultMoveRateAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeDefaultMoveRateAttribute(chipClusterPtr, callback, value);
+      writeDefaultMoveRateAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeDefaultMoveRateAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeDefaultMoveRateAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeDefaultMoveRateAttribute(
@@ -6068,7 +7462,12 @@ public class ChipClusters {
     }
 
     public void writeStartUpCurrentLevelAttribute(DefaultClusterCallback callback, Integer value) {
-      writeStartUpCurrentLevelAttribute(chipClusterPtr, callback, value);
+      writeStartUpCurrentLevelAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeStartUpCurrentLevelAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeStartUpCurrentLevelAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeStartUpCurrentLevelAttribute(
@@ -6135,7 +7534,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOptionsAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOptionsAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -6144,7 +7546,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOnOffTransitionTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOnOffTransitionTimeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -6153,7 +7558,10 @@ public class ChipClusters {
         long chipClusterPtr, OnLevelAttributeCallback callback);
 
     private native void writeOnLevelAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOnLevelAttribute(
         long chipClusterPtr, OnLevelAttributeCallback callback, int minInterval, int maxInterval);
@@ -6162,7 +7570,10 @@ public class ChipClusters {
         long chipClusterPtr, OnTransitionTimeAttributeCallback callback);
 
     private native void writeOnTransitionTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOnTransitionTimeAttribute(
         long chipClusterPtr,
@@ -6174,7 +7585,10 @@ public class ChipClusters {
         long chipClusterPtr, OffTransitionTimeAttributeCallback callback);
 
     private native void writeOffTransitionTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOffTransitionTimeAttribute(
         long chipClusterPtr,
@@ -6186,7 +7600,10 @@ public class ChipClusters {
         long chipClusterPtr, DefaultMoveRateAttributeCallback callback);
 
     private native void writeDefaultMoveRateAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeDefaultMoveRateAttribute(
         long chipClusterPtr,
@@ -6198,7 +7615,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeStartUpCurrentLevelAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeStartUpCurrentLevelAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -6268,10 +7688,17 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void sleep(DefaultClusterCallback callback) {
-      sleep(chipClusterPtr, callback);
+      sleep(chipClusterPtr, callback, null);
     }
 
-    private native void sleep(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void sleep(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      sleep(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void sleep(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -6317,32 +7744,61 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void hideInputStatusRequest(DefaultClusterCallback callback) {
-      hideInputStatusRequest(chipClusterPtr, callback);
+      hideInputStatusRequest(chipClusterPtr, callback, null);
+    }
+
+    public void hideInputStatusRequest(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      hideInputStatusRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void renameInputRequest(DefaultClusterCallback callback, Integer index, String name) {
-      renameInputRequest(chipClusterPtr, callback, index, name);
+      renameInputRequest(chipClusterPtr, callback, index, name, null);
+    }
+
+    public void renameInputRequest(
+        DefaultClusterCallback callback, Integer index, String name, int timedInvokeTimeoutMs) {
+      renameInputRequest(chipClusterPtr, callback, index, name, timedInvokeTimeoutMs);
     }
 
     public void selectInputRequest(DefaultClusterCallback callback, Integer index) {
-      selectInputRequest(chipClusterPtr, callback, index);
+      selectInputRequest(chipClusterPtr, callback, index, null);
+    }
+
+    public void selectInputRequest(
+        DefaultClusterCallback callback, Integer index, int timedInvokeTimeoutMs) {
+      selectInputRequest(chipClusterPtr, callback, index, timedInvokeTimeoutMs);
     }
 
     public void showInputStatusRequest(DefaultClusterCallback callback) {
-      showInputStatusRequest(chipClusterPtr, callback);
+      showInputStatusRequest(chipClusterPtr, callback, null);
+    }
+
+    public void showInputStatusRequest(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      showInputStatusRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     private native void hideInputStatusRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void renameInputRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer index, String name);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer index,
+        String name,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void selectInputRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer index);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer index,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void showInputStatusRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class MediaInputListAttribute {
       public Integer index;
@@ -6455,75 +7911,160 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void fastForwardRequest(PlaybackResponseCallback callback) {
-      fastForwardRequest(chipClusterPtr, callback);
+      fastForwardRequest(chipClusterPtr, callback, null);
+    }
+
+    public void fastForwardRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      fastForwardRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void nextRequest(PlaybackResponseCallback callback) {
-      nextRequest(chipClusterPtr, callback);
+      nextRequest(chipClusterPtr, callback, null);
+    }
+
+    public void nextRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      nextRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void pauseRequest(PlaybackResponseCallback callback) {
-      pauseRequest(chipClusterPtr, callback);
+      pauseRequest(chipClusterPtr, callback, null);
+    }
+
+    public void pauseRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      pauseRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void playRequest(PlaybackResponseCallback callback) {
-      playRequest(chipClusterPtr, callback);
+      playRequest(chipClusterPtr, callback, null);
+    }
+
+    public void playRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      playRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void previousRequest(PlaybackResponseCallback callback) {
-      previousRequest(chipClusterPtr, callback);
+      previousRequest(chipClusterPtr, callback, null);
+    }
+
+    public void previousRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      previousRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void rewindRequest(PlaybackResponseCallback callback) {
-      rewindRequest(chipClusterPtr, callback);
+      rewindRequest(chipClusterPtr, callback, null);
+    }
+
+    public void rewindRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      rewindRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void seekRequest(PlaybackResponseCallback callback, Long position) {
-      seekRequest(chipClusterPtr, callback, position);
+      seekRequest(chipClusterPtr, callback, position, null);
+    }
+
+    public void seekRequest(
+        PlaybackResponseCallback callback, Long position, int timedInvokeTimeoutMs) {
+      seekRequest(chipClusterPtr, callback, position, timedInvokeTimeoutMs);
     }
 
     public void skipBackwardRequest(
         PlaybackResponseCallback callback, Long deltaPositionMilliseconds) {
-      skipBackwardRequest(chipClusterPtr, callback, deltaPositionMilliseconds);
+      skipBackwardRequest(chipClusterPtr, callback, deltaPositionMilliseconds, null);
+    }
+
+    public void skipBackwardRequest(
+        PlaybackResponseCallback callback,
+        Long deltaPositionMilliseconds,
+        int timedInvokeTimeoutMs) {
+      skipBackwardRequest(
+          chipClusterPtr, callback, deltaPositionMilliseconds, timedInvokeTimeoutMs);
     }
 
     public void skipForwardRequest(
         PlaybackResponseCallback callback, Long deltaPositionMilliseconds) {
-      skipForwardRequest(chipClusterPtr, callback, deltaPositionMilliseconds);
+      skipForwardRequest(chipClusterPtr, callback, deltaPositionMilliseconds, null);
+    }
+
+    public void skipForwardRequest(
+        PlaybackResponseCallback callback,
+        Long deltaPositionMilliseconds,
+        int timedInvokeTimeoutMs) {
+      skipForwardRequest(chipClusterPtr, callback, deltaPositionMilliseconds, timedInvokeTimeoutMs);
     }
 
     public void startOverRequest(PlaybackResponseCallback callback) {
-      startOverRequest(chipClusterPtr, callback);
+      startOverRequest(chipClusterPtr, callback, null);
+    }
+
+    public void startOverRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      startOverRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void stopRequest(PlaybackResponseCallback callback) {
-      stopRequest(chipClusterPtr, callback);
+      stopRequest(chipClusterPtr, callback, null);
     }
 
-    private native void fastForwardRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    public void stopRequest(PlaybackResponseCallback callback, int timedInvokeTimeoutMs) {
+      stopRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
 
-    private native void nextRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void fastForwardRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void pauseRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void nextRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void playRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void pauseRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void previousRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void playRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void rewindRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void previousRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
+
+    private native void rewindRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void seekRequest(
-        long chipClusterPtr, PlaybackResponseCallback Callback, Long position);
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        Long position,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void skipBackwardRequest(
-        long chipClusterPtr, PlaybackResponseCallback Callback, Long deltaPositionMilliseconds);
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        Long deltaPositionMilliseconds,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void skipForwardRequest(
-        long chipClusterPtr, PlaybackResponseCallback Callback, Long deltaPositionMilliseconds);
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        Long deltaPositionMilliseconds,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void startOverRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void startOverRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void stopRequest(long chipClusterPtr, PlaybackResponseCallback Callback);
+    private native void stopRequest(
+        long chipClusterPtr,
+        PlaybackResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface PlaybackResponseCallback {
       void onSuccess(Integer status);
@@ -6655,11 +8196,19 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void changeToMode(DefaultClusterCallback callback, Integer newMode) {
-      changeToMode(chipClusterPtr, callback, newMode);
+      changeToMode(chipClusterPtr, callback, newMode, null);
+    }
+
+    public void changeToMode(
+        DefaultClusterCallback callback, Integer newMode, int timedInvokeTimeoutMs) {
+      changeToMode(chipClusterPtr, callback, newMode, timedInvokeTimeoutMs);
     }
 
     private native void changeToMode(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer newMode);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer newMode,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class SupportedModesAttribute {
       public String label;
@@ -6725,7 +8274,12 @@ public class ChipClusters {
     }
 
     public void writeOnModeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOnModeAttribute(chipClusterPtr, callback, value);
+      writeOnModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOnModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOnModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOnModeAttribute(
@@ -6776,7 +8330,10 @@ public class ChipClusters {
     private native void readOnModeAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOnModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOnModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -6820,22 +8377,57 @@ public class ChipClusters {
 
     public void addOrUpdateThreadNetwork(
         NetworkConfigResponseCallback callback, byte[] operationalDataset, Long breadcrumb) {
-      addOrUpdateThreadNetwork(chipClusterPtr, callback, operationalDataset, breadcrumb);
+      addOrUpdateThreadNetwork(chipClusterPtr, callback, operationalDataset, breadcrumb, null);
+    }
+
+    public void addOrUpdateThreadNetwork(
+        NetworkConfigResponseCallback callback,
+        byte[] operationalDataset,
+        Long breadcrumb,
+        int timedInvokeTimeoutMs) {
+      addOrUpdateThreadNetwork(
+          chipClusterPtr, callback, operationalDataset, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void addOrUpdateWiFiNetwork(
         NetworkConfigResponseCallback callback, byte[] ssid, byte[] credentials, Long breadcrumb) {
-      addOrUpdateWiFiNetwork(chipClusterPtr, callback, ssid, credentials, breadcrumb);
+      addOrUpdateWiFiNetwork(chipClusterPtr, callback, ssid, credentials, breadcrumb, null);
+    }
+
+    public void addOrUpdateWiFiNetwork(
+        NetworkConfigResponseCallback callback,
+        byte[] ssid,
+        byte[] credentials,
+        Long breadcrumb,
+        int timedInvokeTimeoutMs) {
+      addOrUpdateWiFiNetwork(
+          chipClusterPtr, callback, ssid, credentials, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void connectNetwork(
         ConnectNetworkResponseCallback callback, byte[] networkID, Long breadcrumb) {
-      connectNetwork(chipClusterPtr, callback, networkID, breadcrumb);
+      connectNetwork(chipClusterPtr, callback, networkID, breadcrumb, null);
+    }
+
+    public void connectNetwork(
+        ConnectNetworkResponseCallback callback,
+        byte[] networkID,
+        Long breadcrumb,
+        int timedInvokeTimeoutMs) {
+      connectNetwork(chipClusterPtr, callback, networkID, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void removeNetwork(
         NetworkConfigResponseCallback callback, byte[] networkID, Long breadcrumb) {
-      removeNetwork(chipClusterPtr, callback, networkID, breadcrumb);
+      removeNetwork(chipClusterPtr, callback, networkID, breadcrumb, null);
+    }
+
+    public void removeNetwork(
+        NetworkConfigResponseCallback callback,
+        byte[] networkID,
+        Long breadcrumb,
+        int timedInvokeTimeoutMs) {
+      removeNetwork(chipClusterPtr, callback, networkID, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void reorderNetwork(
@@ -6843,47 +8435,74 @@ public class ChipClusters {
         byte[] networkID,
         Integer networkIndex,
         Long breadcrumb) {
-      reorderNetwork(chipClusterPtr, callback, networkID, networkIndex, breadcrumb);
+      reorderNetwork(chipClusterPtr, callback, networkID, networkIndex, breadcrumb, null);
+    }
+
+    public void reorderNetwork(
+        NetworkConfigResponseCallback callback,
+        byte[] networkID,
+        Integer networkIndex,
+        Long breadcrumb,
+        int timedInvokeTimeoutMs) {
+      reorderNetwork(
+          chipClusterPtr, callback, networkID, networkIndex, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void scanNetworks(ScanNetworksResponseCallback callback, byte[] ssid, Long breadcrumb) {
-      scanNetworks(chipClusterPtr, callback, ssid, breadcrumb);
+      scanNetworks(chipClusterPtr, callback, ssid, breadcrumb, null);
+    }
+
+    public void scanNetworks(
+        ScanNetworksResponseCallback callback,
+        byte[] ssid,
+        Long breadcrumb,
+        int timedInvokeTimeoutMs) {
+      scanNetworks(chipClusterPtr, callback, ssid, breadcrumb, timedInvokeTimeoutMs);
     }
 
     private native void addOrUpdateThreadNetwork(
         long chipClusterPtr,
         NetworkConfigResponseCallback Callback,
         byte[] operationalDataset,
-        Long breadcrumb);
+        Long breadcrumb,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void addOrUpdateWiFiNetwork(
         long chipClusterPtr,
         NetworkConfigResponseCallback Callback,
         byte[] ssid,
         byte[] credentials,
-        Long breadcrumb);
+        Long breadcrumb,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void connectNetwork(
         long chipClusterPtr,
         ConnectNetworkResponseCallback Callback,
         byte[] networkID,
-        Long breadcrumb);
+        Long breadcrumb,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeNetwork(
         long chipClusterPtr,
         NetworkConfigResponseCallback Callback,
         byte[] networkID,
-        Long breadcrumb);
+        Long breadcrumb,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void reorderNetwork(
         long chipClusterPtr,
         NetworkConfigResponseCallback Callback,
         byte[] networkID,
         Integer networkIndex,
-        Long breadcrumb);
+        Long breadcrumb,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void scanNetworks(
-        long chipClusterPtr, ScanNetworksResponseCallback Callback, byte[] ssid, Long breadcrumb);
+        long chipClusterPtr,
+        ScanNetworksResponseCallback Callback,
+        byte[] ssid,
+        Long breadcrumb,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ConnectNetworkResponseCallback {
       void onSuccess(Integer NetworkingStatus, String DebugText, Long ErrorValue);
@@ -6961,7 +8580,12 @@ public class ChipClusters {
     }
 
     public void writeInterfaceEnabledAttribute(DefaultClusterCallback callback, Boolean value) {
-      writeInterfaceEnabledAttribute(chipClusterPtr, callback, value);
+      writeInterfaceEnabledAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInterfaceEnabledAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeInterfaceEnabledAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void readLastNetworkingStatusAttribute(IntegerAttributeCallback callback) {
@@ -7010,7 +8634,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeInterfaceEnabledAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void readLastNetworkingStatusAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback);
@@ -7048,12 +8675,29 @@ public class ChipClusters {
 
     public void applyUpdateRequest(
         ApplyUpdateResponseCallback callback, byte[] updateToken, Long newVersion) {
-      applyUpdateRequest(chipClusterPtr, callback, updateToken, newVersion);
+      applyUpdateRequest(chipClusterPtr, callback, updateToken, newVersion, null);
+    }
+
+    public void applyUpdateRequest(
+        ApplyUpdateResponseCallback callback,
+        byte[] updateToken,
+        Long newVersion,
+        int timedInvokeTimeoutMs) {
+      applyUpdateRequest(chipClusterPtr, callback, updateToken, newVersion, timedInvokeTimeoutMs);
     }
 
     public void notifyUpdateApplied(
         DefaultClusterCallback callback, byte[] updateToken, Long softwareVersion) {
-      notifyUpdateApplied(chipClusterPtr, callback, updateToken, softwareVersion);
+      notifyUpdateApplied(chipClusterPtr, callback, updateToken, softwareVersion, null);
+    }
+
+    public void notifyUpdateApplied(
+        DefaultClusterCallback callback,
+        byte[] updateToken,
+        Long softwareVersion,
+        int timedInvokeTimeoutMs) {
+      notifyUpdateApplied(
+          chipClusterPtr, callback, updateToken, softwareVersion, timedInvokeTimeoutMs);
     }
 
     public void queryImage(
@@ -7076,20 +8720,48 @@ public class ChipClusters {
           hardwareVersion,
           location,
           requestorCanConsent,
-          metadataForProvider);
+          metadataForProvider,
+          null);
+    }
+
+    public void queryImage(
+        QueryImageResponseCallback callback,
+        Integer vendorId,
+        Integer productId,
+        Long softwareVersion,
+        Integer protocolsSupported,
+        Optional<Integer> hardwareVersion,
+        Optional<String> location,
+        Optional<Boolean> requestorCanConsent,
+        Optional<byte[]> metadataForProvider,
+        int timedInvokeTimeoutMs) {
+      queryImage(
+          chipClusterPtr,
+          callback,
+          vendorId,
+          productId,
+          softwareVersion,
+          protocolsSupported,
+          hardwareVersion,
+          location,
+          requestorCanConsent,
+          metadataForProvider,
+          timedInvokeTimeoutMs);
     }
 
     private native void applyUpdateRequest(
         long chipClusterPtr,
         ApplyUpdateResponseCallback Callback,
         byte[] updateToken,
-        Long newVersion);
+        Long newVersion,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void notifyUpdateApplied(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         byte[] updateToken,
-        Long softwareVersion);
+        Long softwareVersion,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void queryImage(
         long chipClusterPtr,
@@ -7101,7 +8773,8 @@ public class ChipClusters {
         Optional<Integer> hardwareVersion,
         Optional<String> location,
         Optional<Boolean> requestorCanConsent,
-        Optional<byte[]> metadataForProvider);
+        Optional<byte[]> metadataForProvider,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ApplyUpdateResponseCallback {
       void onSuccess(Integer action, Long delayedActionTime);
@@ -7180,7 +8853,27 @@ public class ChipClusters {
           vendorId,
           announcementReason,
           metadataForNode,
-          endpoint);
+          endpoint,
+          null);
+    }
+
+    public void announceOtaProvider(
+        DefaultClusterCallback callback,
+        Long providerNodeId,
+        Integer vendorId,
+        Integer announcementReason,
+        Optional<byte[]> metadataForNode,
+        Integer endpoint,
+        int timedInvokeTimeoutMs) {
+      announceOtaProvider(
+          chipClusterPtr,
+          callback,
+          providerNodeId,
+          vendorId,
+          announcementReason,
+          metadataForNode,
+          endpoint,
+          timedInvokeTimeoutMs);
     }
 
     private native void announceOtaProvider(
@@ -7190,7 +8883,8 @@ public class ChipClusters {
         Integer vendorId,
         Integer announcementReason,
         Optional<byte[]> metadataForNode,
-        Integer endpoint);
+        Integer endpoint,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class DefaultOtaProvidersAttribute {
       public Integer fabricIndex;
@@ -7427,20 +9121,40 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void off(DefaultClusterCallback callback) {
-      off(chipClusterPtr, callback);
+      off(chipClusterPtr, callback, null);
+    }
+
+    public void off(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      off(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void offWithEffect(
         DefaultClusterCallback callback, Integer effectId, Integer effectVariant) {
-      offWithEffect(chipClusterPtr, callback, effectId, effectVariant);
+      offWithEffect(chipClusterPtr, callback, effectId, effectVariant, null);
+    }
+
+    public void offWithEffect(
+        DefaultClusterCallback callback,
+        Integer effectId,
+        Integer effectVariant,
+        int timedInvokeTimeoutMs) {
+      offWithEffect(chipClusterPtr, callback, effectId, effectVariant, timedInvokeTimeoutMs);
     }
 
     public void on(DefaultClusterCallback callback) {
-      on(chipClusterPtr, callback);
+      on(chipClusterPtr, callback, null);
+    }
+
+    public void on(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      on(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void onWithRecallGlobalScene(DefaultClusterCallback callback) {
-      onWithRecallGlobalScene(chipClusterPtr, callback);
+      onWithRecallGlobalScene(chipClusterPtr, callback, null);
+    }
+
+    public void onWithRecallGlobalScene(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      onWithRecallGlobalScene(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void onWithTimedOff(
@@ -7448,34 +9162,61 @@ public class ChipClusters {
         Integer onOffControl,
         Integer onTime,
         Integer offWaitTime) {
-      onWithTimedOff(chipClusterPtr, callback, onOffControl, onTime, offWaitTime);
+      onWithTimedOff(chipClusterPtr, callback, onOffControl, onTime, offWaitTime, null);
+    }
+
+    public void onWithTimedOff(
+        DefaultClusterCallback callback,
+        Integer onOffControl,
+        Integer onTime,
+        Integer offWaitTime,
+        int timedInvokeTimeoutMs) {
+      onWithTimedOff(
+          chipClusterPtr, callback, onOffControl, onTime, offWaitTime, timedInvokeTimeoutMs);
     }
 
     public void toggle(DefaultClusterCallback callback) {
-      toggle(chipClusterPtr, callback);
+      toggle(chipClusterPtr, callback, null);
     }
 
-    private native void off(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void toggle(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      toggle(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void off(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void offWithEffect(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer effectId,
-        Integer effectVariant);
+        Integer effectVariant,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void on(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void on(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void onWithRecallGlobalScene(
-        long chipClusterPtr, DefaultClusterCallback Callback);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void onWithTimedOff(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer onOffControl,
         Integer onTime,
-        Integer offWaitTime);
+        Integer offWaitTime,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void toggle(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void toggle(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -7508,7 +9249,12 @@ public class ChipClusters {
     }
 
     public void writeOnTimeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOnTimeAttribute(chipClusterPtr, callback, value);
+      writeOnTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOnTimeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOnTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOnTimeAttribute(
@@ -7521,7 +9267,12 @@ public class ChipClusters {
     }
 
     public void writeOffWaitTimeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOffWaitTimeAttribute(chipClusterPtr, callback, value);
+      writeOffWaitTimeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOffWaitTimeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOffWaitTimeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOffWaitTimeAttribute(
@@ -7534,7 +9285,12 @@ public class ChipClusters {
     }
 
     public void writeStartUpOnOffAttribute(DefaultClusterCallback callback, Integer value) {
-      writeStartUpOnOffAttribute(chipClusterPtr, callback, value);
+      writeStartUpOnOffAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeStartUpOnOffAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeStartUpOnOffAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeStartUpOnOffAttribute(
@@ -7578,7 +9334,10 @@ public class ChipClusters {
     private native void readOnTimeAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOnTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOnTimeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -7587,7 +9346,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOffWaitTimeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOffWaitTimeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -7596,7 +9358,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeStartUpOnOffAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeStartUpOnOffAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -7651,7 +9416,12 @@ public class ChipClusters {
     }
 
     public void writeSwitchActionsAttribute(DefaultClusterCallback callback, Integer value) {
-      writeSwitchActionsAttribute(chipClusterPtr, callback, value);
+      writeSwitchActionsAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeSwitchActionsAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeSwitchActionsAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeSwitchActionsAttribute(
@@ -7682,7 +9452,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeSwitchActionsAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeSwitchActionsAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -7716,42 +9489,115 @@ public class ChipClusters {
         byte[] IPKValue,
         Long caseAdminNode,
         Integer adminVendorId) {
-      addNOC(chipClusterPtr, callback, NOCValue, ICACValue, IPKValue, caseAdminNode, adminVendorId);
+      addNOC(
+          chipClusterPtr,
+          callback,
+          NOCValue,
+          ICACValue,
+          IPKValue,
+          caseAdminNode,
+          adminVendorId,
+          null);
+    }
+
+    public void addNOC(
+        NOCResponseCallback callback,
+        byte[] NOCValue,
+        Optional<byte[]> ICACValue,
+        byte[] IPKValue,
+        Long caseAdminNode,
+        Integer adminVendorId,
+        int timedInvokeTimeoutMs) {
+      addNOC(
+          chipClusterPtr,
+          callback,
+          NOCValue,
+          ICACValue,
+          IPKValue,
+          caseAdminNode,
+          adminVendorId,
+          timedInvokeTimeoutMs);
     }
 
     public void addTrustedRootCertificate(DefaultClusterCallback callback, byte[] rootCertificate) {
-      addTrustedRootCertificate(chipClusterPtr, callback, rootCertificate);
+      addTrustedRootCertificate(chipClusterPtr, callback, rootCertificate, null);
+    }
+
+    public void addTrustedRootCertificate(
+        DefaultClusterCallback callback, byte[] rootCertificate, int timedInvokeTimeoutMs) {
+      addTrustedRootCertificate(chipClusterPtr, callback, rootCertificate, timedInvokeTimeoutMs);
     }
 
     public void attestationRequest(AttestationResponseCallback callback, byte[] attestationNonce) {
-      attestationRequest(chipClusterPtr, callback, attestationNonce);
+      attestationRequest(chipClusterPtr, callback, attestationNonce, null);
+    }
+
+    public void attestationRequest(
+        AttestationResponseCallback callback, byte[] attestationNonce, int timedInvokeTimeoutMs) {
+      attestationRequest(chipClusterPtr, callback, attestationNonce, timedInvokeTimeoutMs);
     }
 
     public void certificateChainRequest(
         CertificateChainResponseCallback callback, Integer certificateType) {
-      certificateChainRequest(chipClusterPtr, callback, certificateType);
+      certificateChainRequest(chipClusterPtr, callback, certificateType, null);
+    }
+
+    public void certificateChainRequest(
+        CertificateChainResponseCallback callback,
+        Integer certificateType,
+        int timedInvokeTimeoutMs) {
+      certificateChainRequest(chipClusterPtr, callback, certificateType, timedInvokeTimeoutMs);
     }
 
     public void opCSRRequest(OpCSRResponseCallback callback, byte[] CSRNonce) {
-      opCSRRequest(chipClusterPtr, callback, CSRNonce);
+      opCSRRequest(chipClusterPtr, callback, CSRNonce, null);
+    }
+
+    public void opCSRRequest(
+        OpCSRResponseCallback callback, byte[] CSRNonce, int timedInvokeTimeoutMs) {
+      opCSRRequest(chipClusterPtr, callback, CSRNonce, timedInvokeTimeoutMs);
     }
 
     public void removeFabric(NOCResponseCallback callback, Integer fabricIndex) {
-      removeFabric(chipClusterPtr, callback, fabricIndex);
+      removeFabric(chipClusterPtr, callback, fabricIndex, null);
+    }
+
+    public void removeFabric(
+        NOCResponseCallback callback, Integer fabricIndex, int timedInvokeTimeoutMs) {
+      removeFabric(chipClusterPtr, callback, fabricIndex, timedInvokeTimeoutMs);
     }
 
     public void removeTrustedRootCertificate(
         DefaultClusterCallback callback, byte[] trustedRootIdentifier) {
-      removeTrustedRootCertificate(chipClusterPtr, callback, trustedRootIdentifier);
+      removeTrustedRootCertificate(chipClusterPtr, callback, trustedRootIdentifier, null);
+    }
+
+    public void removeTrustedRootCertificate(
+        DefaultClusterCallback callback, byte[] trustedRootIdentifier, int timedInvokeTimeoutMs) {
+      removeTrustedRootCertificate(
+          chipClusterPtr, callback, trustedRootIdentifier, timedInvokeTimeoutMs);
     }
 
     public void updateFabricLabel(NOCResponseCallback callback, String label) {
-      updateFabricLabel(chipClusterPtr, callback, label);
+      updateFabricLabel(chipClusterPtr, callback, label, null);
+    }
+
+    public void updateFabricLabel(
+        NOCResponseCallback callback, String label, int timedInvokeTimeoutMs) {
+      updateFabricLabel(chipClusterPtr, callback, label, timedInvokeTimeoutMs);
     }
 
     public void updateNOC(
         NOCResponseCallback callback, byte[] NOCValue, Optional<byte[]> ICACValue) {
-      updateNOC(chipClusterPtr, callback, NOCValue, ICACValue);
+      updateNOC(chipClusterPtr, callback, NOCValue, ICACValue, null);
+    }
+
+    public void updateNOC(
+        NOCResponseCallback callback,
+        byte[] NOCValue,
+        Optional<byte[]> ICACValue,
+        int timedInvokeTimeoutMs) {
+      updateNOC(chipClusterPtr, callback, NOCValue, ICACValue, timedInvokeTimeoutMs);
     }
 
     private native void addNOC(
@@ -7761,34 +9607,57 @@ public class ChipClusters {
         Optional<byte[]> ICACValue,
         byte[] IPKValue,
         Long caseAdminNode,
-        Integer adminVendorId);
+        Integer adminVendorId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void addTrustedRootCertificate(
-        long chipClusterPtr, DefaultClusterCallback Callback, byte[] rootCertificate);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        byte[] rootCertificate,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void attestationRequest(
-        long chipClusterPtr, AttestationResponseCallback Callback, byte[] attestationNonce);
+        long chipClusterPtr,
+        AttestationResponseCallback Callback,
+        byte[] attestationNonce,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void certificateChainRequest(
-        long chipClusterPtr, CertificateChainResponseCallback Callback, Integer certificateType);
+        long chipClusterPtr,
+        CertificateChainResponseCallback Callback,
+        Integer certificateType,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void opCSRRequest(
-        long chipClusterPtr, OpCSRResponseCallback Callback, byte[] CSRNonce);
+        long chipClusterPtr,
+        OpCSRResponseCallback Callback,
+        byte[] CSRNonce,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeFabric(
-        long chipClusterPtr, NOCResponseCallback Callback, Integer fabricIndex);
+        long chipClusterPtr,
+        NOCResponseCallback Callback,
+        Integer fabricIndex,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeTrustedRootCertificate(
-        long chipClusterPtr, DefaultClusterCallback Callback, byte[] trustedRootIdentifier);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        byte[] trustedRootIdentifier,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void updateFabricLabel(
-        long chipClusterPtr, NOCResponseCallback Callback, String label);
+        long chipClusterPtr,
+        NOCResponseCallback Callback,
+        String label,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void updateNOC(
         long chipClusterPtr,
         NOCResponseCallback Callback,
         byte[] NOCValue,
-        Optional<byte[]> ICACValue);
+        Optional<byte[]> ICACValue,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttestationResponseCallback {
       void onSuccess(byte[] AttestationElements, byte[] Signature);
@@ -8522,7 +10391,12 @@ public class ChipClusters {
 
     public void writeLifetimeRunningHoursAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeLifetimeRunningHoursAttribute(chipClusterPtr, callback, value);
+      writeLifetimeRunningHoursAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLifetimeRunningHoursAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeLifetimeRunningHoursAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLifetimeRunningHoursAttribute(
@@ -8546,7 +10420,12 @@ public class ChipClusters {
 
     public void writeLifetimeEnergyConsumedAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeLifetimeEnergyConsumedAttribute(chipClusterPtr, callback, value);
+      writeLifetimeEnergyConsumedAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLifetimeEnergyConsumedAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeLifetimeEnergyConsumedAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLifetimeEnergyConsumedAttribute(
@@ -8559,7 +10438,12 @@ public class ChipClusters {
     }
 
     public void writeOperationModeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeOperationModeAttribute(chipClusterPtr, callback, value);
+      writeOperationModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOperationModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOperationModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOperationModeAttribute(
@@ -8572,7 +10456,12 @@ public class ChipClusters {
     }
 
     public void writeControlModeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeControlModeAttribute(chipClusterPtr, callback, value);
+      writeControlModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeControlModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeControlModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeControlModeAttribute(
@@ -8722,7 +10611,10 @@ public class ChipClusters {
         long chipClusterPtr, LifetimeRunningHoursAttributeCallback callback);
 
     private native void writeLifetimeRunningHoursAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLifetimeRunningHoursAttribute(
         long chipClusterPtr,
@@ -8739,7 +10631,10 @@ public class ChipClusters {
         long chipClusterPtr, LifetimeEnergyConsumedAttributeCallback callback);
 
     private native void writeLifetimeEnergyConsumedAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLifetimeEnergyConsumedAttribute(
         long chipClusterPtr,
@@ -8751,7 +10646,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOperationModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOperationModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -8760,7 +10658,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeControlModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeControlModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -8920,33 +10821,100 @@ public class ChipClusters {
           sceneName,
           clusterId,
           length,
-          value);
+          value,
+          null);
+    }
+
+    public void addScene(
+        AddSceneResponseCallback callback,
+        Integer groupId,
+        Integer sceneId,
+        Integer transitionTime,
+        String sceneName,
+        Long clusterId,
+        Integer length,
+        Integer value,
+        int timedInvokeTimeoutMs) {
+      addScene(
+          chipClusterPtr,
+          callback,
+          groupId,
+          sceneId,
+          transitionTime,
+          sceneName,
+          clusterId,
+          length,
+          value,
+          timedInvokeTimeoutMs);
     }
 
     public void getSceneMembership(GetSceneMembershipResponseCallback callback, Integer groupId) {
-      getSceneMembership(chipClusterPtr, callback, groupId);
+      getSceneMembership(chipClusterPtr, callback, groupId, null);
+    }
+
+    public void getSceneMembership(
+        GetSceneMembershipResponseCallback callback, Integer groupId, int timedInvokeTimeoutMs) {
+      getSceneMembership(chipClusterPtr, callback, groupId, timedInvokeTimeoutMs);
     }
 
     public void recallScene(
         DefaultClusterCallback callback, Integer groupId, Integer sceneId, Integer transitionTime) {
-      recallScene(chipClusterPtr, callback, groupId, sceneId, transitionTime);
+      recallScene(chipClusterPtr, callback, groupId, sceneId, transitionTime, null);
+    }
+
+    public void recallScene(
+        DefaultClusterCallback callback,
+        Integer groupId,
+        Integer sceneId,
+        Integer transitionTime,
+        int timedInvokeTimeoutMs) {
+      recallScene(chipClusterPtr, callback, groupId, sceneId, transitionTime, timedInvokeTimeoutMs);
     }
 
     public void removeAllScenes(RemoveAllScenesResponseCallback callback, Integer groupId) {
-      removeAllScenes(chipClusterPtr, callback, groupId);
+      removeAllScenes(chipClusterPtr, callback, groupId, null);
+    }
+
+    public void removeAllScenes(
+        RemoveAllScenesResponseCallback callback, Integer groupId, int timedInvokeTimeoutMs) {
+      removeAllScenes(chipClusterPtr, callback, groupId, timedInvokeTimeoutMs);
     }
 
     public void removeScene(
         RemoveSceneResponseCallback callback, Integer groupId, Integer sceneId) {
-      removeScene(chipClusterPtr, callback, groupId, sceneId);
+      removeScene(chipClusterPtr, callback, groupId, sceneId, null);
+    }
+
+    public void removeScene(
+        RemoveSceneResponseCallback callback,
+        Integer groupId,
+        Integer sceneId,
+        int timedInvokeTimeoutMs) {
+      removeScene(chipClusterPtr, callback, groupId, sceneId, timedInvokeTimeoutMs);
     }
 
     public void storeScene(StoreSceneResponseCallback callback, Integer groupId, Integer sceneId) {
-      storeScene(chipClusterPtr, callback, groupId, sceneId);
+      storeScene(chipClusterPtr, callback, groupId, sceneId, null);
+    }
+
+    public void storeScene(
+        StoreSceneResponseCallback callback,
+        Integer groupId,
+        Integer sceneId,
+        int timedInvokeTimeoutMs) {
+      storeScene(chipClusterPtr, callback, groupId, sceneId, timedInvokeTimeoutMs);
     }
 
     public void viewScene(ViewSceneResponseCallback callback, Integer groupId, Integer sceneId) {
-      viewScene(chipClusterPtr, callback, groupId, sceneId);
+      viewScene(chipClusterPtr, callback, groupId, sceneId, null);
+    }
+
+    public void viewScene(
+        ViewSceneResponseCallback callback,
+        Integer groupId,
+        Integer sceneId,
+        int timedInvokeTimeoutMs) {
+      viewScene(chipClusterPtr, callback, groupId, sceneId, timedInvokeTimeoutMs);
     }
 
     private native void addScene(
@@ -8958,32 +10926,49 @@ public class ChipClusters {
         String sceneName,
         Long clusterId,
         Integer length,
-        Integer value);
+        Integer value,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void getSceneMembership(
-        long chipClusterPtr, GetSceneMembershipResponseCallback Callback, Integer groupId);
+        long chipClusterPtr,
+        GetSceneMembershipResponseCallback Callback,
+        Integer groupId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void recallScene(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer groupId,
         Integer sceneId,
-        Integer transitionTime);
+        Integer transitionTime,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeAllScenes(
-        long chipClusterPtr, RemoveAllScenesResponseCallback Callback, Integer groupId);
+        long chipClusterPtr,
+        RemoveAllScenesResponseCallback Callback,
+        Integer groupId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeScene(
         long chipClusterPtr,
         RemoveSceneResponseCallback Callback,
         Integer groupId,
-        Integer sceneId);
+        Integer sceneId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void storeScene(
-        long chipClusterPtr, StoreSceneResponseCallback Callback, Integer groupId, Integer sceneId);
+        long chipClusterPtr,
+        StoreSceneResponseCallback Callback,
+        Integer groupId,
+        Integer sceneId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void viewScene(
-        long chipClusterPtr, ViewSceneResponseCallback Callback, Integer groupId, Integer sceneId);
+        long chipClusterPtr,
+        ViewSceneResponseCallback Callback,
+        Integer groupId,
+        Integer sceneId,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AddSceneResponseCallback {
       void onSuccess(Integer status, Integer groupId, Integer sceneId);
@@ -9147,10 +11132,17 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void resetWatermarks(DefaultClusterCallback callback) {
-      resetWatermarks(chipClusterPtr, callback);
+      resetWatermarks(chipClusterPtr, callback, null);
     }
 
-    private native void resetWatermarks(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void resetWatermarks(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      resetWatermarks(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void resetWatermarks(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class ThreadMetricsAttribute {
       public Long id;
@@ -9411,11 +11403,23 @@ public class ChipClusters {
 
     public void navigateTargetRequest(
         NavigateTargetResponseCallback callback, Integer target, String data) {
-      navigateTargetRequest(chipClusterPtr, callback, target, data);
+      navigateTargetRequest(chipClusterPtr, callback, target, data, null);
+    }
+
+    public void navigateTargetRequest(
+        NavigateTargetResponseCallback callback,
+        Integer target,
+        String data,
+        int timedInvokeTimeoutMs) {
+      navigateTargetRequest(chipClusterPtr, callback, target, data, timedInvokeTimeoutMs);
     }
 
     private native void navigateTargetRequest(
-        long chipClusterPtr, NavigateTargetResponseCallback Callback, Integer target, String data);
+        long chipClusterPtr,
+        NavigateTargetResponseCallback Callback,
+        Integer target,
+        String data,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface NavigateTargetResponseCallback {
       void onSuccess(Integer status, String data);
@@ -9633,34 +11637,88 @@ public class ChipClusters {
         Integer f,
         Float g,
         Double h) {
-      simpleStructEchoRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h);
+      simpleStructEchoRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h, null);
+    }
+
+    public void simpleStructEchoRequest(
+        SimpleStructResponseCallback callback,
+        Integer a,
+        Boolean b,
+        Integer c,
+        byte[] d,
+        String e,
+        Integer f,
+        Float g,
+        Double h,
+        int timedInvokeTimeoutMs) {
+      simpleStructEchoRequest(
+          chipClusterPtr, callback, a, b, c, d, e, f, g, h, timedInvokeTimeoutMs);
     }
 
     public void test(DefaultClusterCallback callback) {
-      test(chipClusterPtr, callback);
+      test(chipClusterPtr, callback, null);
+    }
+
+    public void test(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      test(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void testAddArguments(
         TestAddArgumentsResponseCallback callback, Integer arg1, Integer arg2) {
-      testAddArguments(chipClusterPtr, callback, arg1, arg2);
+      testAddArguments(chipClusterPtr, callback, arg1, arg2, null);
+    }
+
+    public void testAddArguments(
+        TestAddArgumentsResponseCallback callback,
+        Integer arg1,
+        Integer arg2,
+        int timedInvokeTimeoutMs) {
+      testAddArguments(chipClusterPtr, callback, arg1, arg2, timedInvokeTimeoutMs);
     }
 
     public void testEnumsRequest(TestEnumsResponseCallback callback, Integer arg1, Integer arg2) {
-      testEnumsRequest(chipClusterPtr, callback, arg1, arg2);
+      testEnumsRequest(chipClusterPtr, callback, arg1, arg2, null);
+    }
+
+    public void testEnumsRequest(
+        TestEnumsResponseCallback callback, Integer arg1, Integer arg2, int timedInvokeTimeoutMs) {
+      testEnumsRequest(chipClusterPtr, callback, arg1, arg2, timedInvokeTimeoutMs);
     }
 
     public void testListInt8UArgumentRequest(BooleanResponseCallback callback, Integer arg1) {
-      testListInt8UArgumentRequest(chipClusterPtr, callback, arg1);
+      testListInt8UArgumentRequest(chipClusterPtr, callback, arg1, null);
+    }
+
+    public void testListInt8UArgumentRequest(
+        BooleanResponseCallback callback, Integer arg1, int timedInvokeTimeoutMs) {
+      testListInt8UArgumentRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
     }
 
     public void testListInt8UReverseRequest(
         TestListInt8UReverseResponseCallback callback, Integer arg1) {
-      testListInt8UReverseRequest(chipClusterPtr, callback, arg1);
+      testListInt8UReverseRequest(chipClusterPtr, callback, arg1, null);
+    }
+
+    public void testListInt8UReverseRequest(
+        TestListInt8UReverseResponseCallback callback, Integer arg1, int timedInvokeTimeoutMs) {
+      testListInt8UReverseRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
     }
 
     public void testListNestedStructListArgumentRequest(
         BooleanResponseCallback callback, Integer a, Boolean b, Long e, byte[] f, Integer g) {
-      testListNestedStructListArgumentRequest(chipClusterPtr, callback, a, b, e, f, g);
+      testListNestedStructListArgumentRequest(chipClusterPtr, callback, a, b, e, f, g, null);
+    }
+
+    public void testListNestedStructListArgumentRequest(
+        BooleanResponseCallback callback,
+        Integer a,
+        Boolean b,
+        Long e,
+        byte[] f,
+        Integer g,
+        int timedInvokeTimeoutMs) {
+      testListNestedStructListArgumentRequest(
+          chipClusterPtr, callback, a, b, e, f, g, timedInvokeTimeoutMs);
     }
 
     public void testListStructArgumentRequest(
@@ -9673,35 +11731,87 @@ public class ChipClusters {
         Integer f,
         Float g,
         Double h) {
-      testListStructArgumentRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h);
+      testListStructArgumentRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h, null);
+    }
+
+    public void testListStructArgumentRequest(
+        BooleanResponseCallback callback,
+        Integer a,
+        Boolean b,
+        Integer c,
+        byte[] d,
+        String e,
+        Integer f,
+        Float g,
+        Double h,
+        int timedInvokeTimeoutMs) {
+      testListStructArgumentRequest(
+          chipClusterPtr, callback, a, b, c, d, e, f, g, h, timedInvokeTimeoutMs);
     }
 
     public void testNestedStructArgumentRequest(
         BooleanResponseCallback callback, Integer a, Boolean b) {
-      testNestedStructArgumentRequest(chipClusterPtr, callback, a, b);
+      testNestedStructArgumentRequest(chipClusterPtr, callback, a, b, null);
+    }
+
+    public void testNestedStructArgumentRequest(
+        BooleanResponseCallback callback, Integer a, Boolean b, int timedInvokeTimeoutMs) {
+      testNestedStructArgumentRequest(chipClusterPtr, callback, a, b, timedInvokeTimeoutMs);
     }
 
     public void testNestedStructListArgumentRequest(
         BooleanResponseCallback callback, Integer a, Boolean b, Long e, byte[] f, Integer g) {
-      testNestedStructListArgumentRequest(chipClusterPtr, callback, a, b, e, f, g);
+      testNestedStructListArgumentRequest(chipClusterPtr, callback, a, b, e, f, g, null);
+    }
+
+    public void testNestedStructListArgumentRequest(
+        BooleanResponseCallback callback,
+        Integer a,
+        Boolean b,
+        Long e,
+        byte[] f,
+        Integer g,
+        int timedInvokeTimeoutMs) {
+      testNestedStructListArgumentRequest(
+          chipClusterPtr, callback, a, b, e, f, g, timedInvokeTimeoutMs);
     }
 
     public void testNotHandled(DefaultClusterCallback callback) {
-      testNotHandled(chipClusterPtr, callback);
+      testNotHandled(chipClusterPtr, callback, null);
+    }
+
+    public void testNotHandled(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      testNotHandled(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void testNullableOptionalRequest(
         TestNullableOptionalResponseCallback callback, Optional<Integer> arg1) {
-      testNullableOptionalRequest(chipClusterPtr, callback, arg1);
+      testNullableOptionalRequest(chipClusterPtr, callback, arg1, null);
+    }
+
+    public void testNullableOptionalRequest(
+        TestNullableOptionalResponseCallback callback,
+        Optional<Integer> arg1,
+        int timedInvokeTimeoutMs) {
+      testNullableOptionalRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
     }
 
     public void testSimpleOptionalArgumentRequest(
         DefaultClusterCallback callback, Optional<Boolean> arg1) {
-      testSimpleOptionalArgumentRequest(chipClusterPtr, callback, arg1);
+      testSimpleOptionalArgumentRequest(chipClusterPtr, callback, arg1, null);
+    }
+
+    public void testSimpleOptionalArgumentRequest(
+        DefaultClusterCallback callback, Optional<Boolean> arg1, int timedInvokeTimeoutMs) {
+      testSimpleOptionalArgumentRequest(chipClusterPtr, callback, arg1, timedInvokeTimeoutMs);
     }
 
     public void testSpecific(TestSpecificResponseCallback callback) {
-      testSpecific(chipClusterPtr, callback);
+      testSpecific(chipClusterPtr, callback, null);
+    }
+
+    public void testSpecific(TestSpecificResponseCallback callback, int timedInvokeTimeoutMs) {
+      testSpecific(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void testStructArgumentRequest(
@@ -9714,15 +11824,34 @@ public class ChipClusters {
         Integer f,
         Float g,
         Double h) {
-      testStructArgumentRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h);
+      testStructArgumentRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h, null);
+    }
+
+    public void testStructArgumentRequest(
+        BooleanResponseCallback callback,
+        Integer a,
+        Boolean b,
+        Integer c,
+        byte[] d,
+        String e,
+        Integer f,
+        Float g,
+        Double h,
+        int timedInvokeTimeoutMs) {
+      testStructArgumentRequest(
+          chipClusterPtr, callback, a, b, c, d, e, f, g, h, timedInvokeTimeoutMs);
     }
 
     public void testUnknownCommand(DefaultClusterCallback callback) {
-      testUnknownCommand(chipClusterPtr, callback);
+      testUnknownCommand(chipClusterPtr, callback, null);
     }
 
-    public void timedInvokeRequest(DefaultClusterCallback callback) {
-      timedInvokeRequest(chipClusterPtr, callback);
+    public void testUnknownCommand(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      testUnknownCommand(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    public void timedInvokeRequest(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      timedInvokeRequest(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     private native void simpleStructEchoRequest(
@@ -9735,21 +11864,39 @@ public class ChipClusters {
         String e,
         Integer f,
         Float g,
-        Double h);
+        Double h,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void test(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void test(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testAddArguments(
-        long chipClusterPtr, TestAddArgumentsResponseCallback Callback, Integer arg1, Integer arg2);
+        long chipClusterPtr,
+        TestAddArgumentsResponseCallback Callback,
+        Integer arg1,
+        Integer arg2,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testEnumsRequest(
-        long chipClusterPtr, TestEnumsResponseCallback Callback, Integer arg1, Integer arg2);
+        long chipClusterPtr,
+        TestEnumsResponseCallback Callback,
+        Integer arg1,
+        Integer arg2,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testListInt8UArgumentRequest(
-        long chipClusterPtr, BooleanResponseCallback Callback, Integer arg1);
+        long chipClusterPtr,
+        BooleanResponseCallback Callback,
+        Integer arg1,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testListInt8UReverseRequest(
-        long chipClusterPtr, TestListInt8UReverseResponseCallback Callback, Integer arg1);
+        long chipClusterPtr,
+        TestListInt8UReverseResponseCallback Callback,
+        Integer arg1,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testListNestedStructListArgumentRequest(
         long chipClusterPtr,
@@ -9758,7 +11905,8 @@ public class ChipClusters {
         Boolean b,
         Long e,
         byte[] f,
-        Integer g);
+        Integer g,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testListStructArgumentRequest(
         long chipClusterPtr,
@@ -9770,10 +11918,15 @@ public class ChipClusters {
         String e,
         Integer f,
         Float g,
-        Double h);
+        Double h,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testNestedStructArgumentRequest(
-        long chipClusterPtr, BooleanResponseCallback Callback, Integer a, Boolean b);
+        long chipClusterPtr,
+        BooleanResponseCallback Callback,
+        Integer a,
+        Boolean b,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testNestedStructListArgumentRequest(
         long chipClusterPtr,
@@ -9782,17 +11935,30 @@ public class ChipClusters {
         Boolean b,
         Long e,
         byte[] f,
-        Integer g);
+        Integer g,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void testNotHandled(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void testNotHandled(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testNullableOptionalRequest(
-        long chipClusterPtr, TestNullableOptionalResponseCallback Callback, Optional<Integer> arg1);
+        long chipClusterPtr,
+        TestNullableOptionalResponseCallback Callback,
+        Optional<Integer> arg1,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testSimpleOptionalArgumentRequest(
-        long chipClusterPtr, DefaultClusterCallback Callback, Optional<Boolean> arg1);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Optional<Boolean> arg1,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void testSpecific(long chipClusterPtr, TestSpecificResponseCallback Callback);
+    private native void testSpecific(
+        long chipClusterPtr,
+        TestSpecificResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void testStructArgumentRequest(
         long chipClusterPtr,
@@ -9804,11 +11970,18 @@ public class ChipClusters {
         String e,
         Integer f,
         Float g,
-        Double h);
+        Double h,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void testUnknownCommand(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void testUnknownCommand(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void timedInvokeRequest(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void timedInvokeRequest(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface BooleanResponseCallback {
       void onSuccess(Boolean value);
@@ -10232,7 +12405,12 @@ public class ChipClusters {
     }
 
     public void writeBooleanAttribute(DefaultClusterCallback callback, Boolean value) {
-      writeBooleanAttribute(chipClusterPtr, callback, value);
+      writeBooleanAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeBooleanAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeBooleanAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeBooleanAttribute(
@@ -10245,7 +12423,12 @@ public class ChipClusters {
     }
 
     public void writeBitmap8Attribute(DefaultClusterCallback callback, Integer value) {
-      writeBitmap8Attribute(chipClusterPtr, callback, value);
+      writeBitmap8Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeBitmap8Attribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeBitmap8Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeBitmap8Attribute(
@@ -10258,7 +12441,12 @@ public class ChipClusters {
     }
 
     public void writeBitmap16Attribute(DefaultClusterCallback callback, Integer value) {
-      writeBitmap16Attribute(chipClusterPtr, callback, value);
+      writeBitmap16Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeBitmap16Attribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeBitmap16Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeBitmap16Attribute(
@@ -10271,7 +12459,12 @@ public class ChipClusters {
     }
 
     public void writeBitmap32Attribute(DefaultClusterCallback callback, Long value) {
-      writeBitmap32Attribute(chipClusterPtr, callback, value);
+      writeBitmap32Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeBitmap32Attribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeBitmap32Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeBitmap32Attribute(
@@ -10284,7 +12477,12 @@ public class ChipClusters {
     }
 
     public void writeBitmap64Attribute(DefaultClusterCallback callback, Long value) {
-      writeBitmap64Attribute(chipClusterPtr, callback, value);
+      writeBitmap64Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeBitmap64Attribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeBitmap64Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeBitmap64Attribute(
@@ -10297,7 +12495,12 @@ public class ChipClusters {
     }
 
     public void writeInt8uAttribute(DefaultClusterCallback callback, Integer value) {
-      writeInt8uAttribute(chipClusterPtr, callback, value);
+      writeInt8uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt8uAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeInt8uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt8uAttribute(
@@ -10310,7 +12513,12 @@ public class ChipClusters {
     }
 
     public void writeInt16uAttribute(DefaultClusterCallback callback, Integer value) {
-      writeInt16uAttribute(chipClusterPtr, callback, value);
+      writeInt16uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt16uAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeInt16uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt16uAttribute(
@@ -10323,7 +12531,12 @@ public class ChipClusters {
     }
 
     public void writeInt24uAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt24uAttribute(chipClusterPtr, callback, value);
+      writeInt24uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt24uAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt24uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt24uAttribute(
@@ -10336,7 +12549,12 @@ public class ChipClusters {
     }
 
     public void writeInt32uAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt32uAttribute(chipClusterPtr, callback, value);
+      writeInt32uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt32uAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt32uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt32uAttribute(
@@ -10349,7 +12567,12 @@ public class ChipClusters {
     }
 
     public void writeInt40uAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt40uAttribute(chipClusterPtr, callback, value);
+      writeInt40uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt40uAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt40uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt40uAttribute(
@@ -10362,7 +12585,12 @@ public class ChipClusters {
     }
 
     public void writeInt48uAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt48uAttribute(chipClusterPtr, callback, value);
+      writeInt48uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt48uAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt48uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt48uAttribute(
@@ -10375,7 +12603,12 @@ public class ChipClusters {
     }
 
     public void writeInt56uAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt56uAttribute(chipClusterPtr, callback, value);
+      writeInt56uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt56uAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt56uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt56uAttribute(
@@ -10388,7 +12621,12 @@ public class ChipClusters {
     }
 
     public void writeInt64uAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt64uAttribute(chipClusterPtr, callback, value);
+      writeInt64uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt64uAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt64uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt64uAttribute(
@@ -10401,7 +12639,12 @@ public class ChipClusters {
     }
 
     public void writeInt8sAttribute(DefaultClusterCallback callback, Integer value) {
-      writeInt8sAttribute(chipClusterPtr, callback, value);
+      writeInt8sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt8sAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeInt8sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt8sAttribute(
@@ -10414,7 +12657,12 @@ public class ChipClusters {
     }
 
     public void writeInt16sAttribute(DefaultClusterCallback callback, Integer value) {
-      writeInt16sAttribute(chipClusterPtr, callback, value);
+      writeInt16sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt16sAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeInt16sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt16sAttribute(
@@ -10427,7 +12675,12 @@ public class ChipClusters {
     }
 
     public void writeInt24sAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt24sAttribute(chipClusterPtr, callback, value);
+      writeInt24sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt24sAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt24sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt24sAttribute(
@@ -10440,7 +12693,12 @@ public class ChipClusters {
     }
 
     public void writeInt32sAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt32sAttribute(chipClusterPtr, callback, value);
+      writeInt32sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt32sAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt32sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt32sAttribute(
@@ -10453,7 +12711,12 @@ public class ChipClusters {
     }
 
     public void writeInt40sAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt40sAttribute(chipClusterPtr, callback, value);
+      writeInt40sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt40sAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt40sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt40sAttribute(
@@ -10466,7 +12729,12 @@ public class ChipClusters {
     }
 
     public void writeInt48sAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt48sAttribute(chipClusterPtr, callback, value);
+      writeInt48sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt48sAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt48sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt48sAttribute(
@@ -10479,7 +12747,12 @@ public class ChipClusters {
     }
 
     public void writeInt56sAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt56sAttribute(chipClusterPtr, callback, value);
+      writeInt56sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt56sAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt56sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt56sAttribute(
@@ -10492,7 +12765,12 @@ public class ChipClusters {
     }
 
     public void writeInt64sAttribute(DefaultClusterCallback callback, Long value) {
-      writeInt64sAttribute(chipClusterPtr, callback, value);
+      writeInt64sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeInt64sAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeInt64sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeInt64sAttribute(
@@ -10505,7 +12783,12 @@ public class ChipClusters {
     }
 
     public void writeEnum8Attribute(DefaultClusterCallback callback, Integer value) {
-      writeEnum8Attribute(chipClusterPtr, callback, value);
+      writeEnum8Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEnum8Attribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeEnum8Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEnum8Attribute(
@@ -10518,7 +12801,12 @@ public class ChipClusters {
     }
 
     public void writeEnum16Attribute(DefaultClusterCallback callback, Integer value) {
-      writeEnum16Attribute(chipClusterPtr, callback, value);
+      writeEnum16Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEnum16Attribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeEnum16Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEnum16Attribute(
@@ -10531,7 +12819,12 @@ public class ChipClusters {
     }
 
     public void writeFloatSingleAttribute(DefaultClusterCallback callback, Float value) {
-      writeFloatSingleAttribute(chipClusterPtr, callback, value);
+      writeFloatSingleAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeFloatSingleAttribute(
+        DefaultClusterCallback callback, Float value, int timedWriteTimeoutMs) {
+      writeFloatSingleAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeFloatSingleAttribute(
@@ -10544,7 +12837,12 @@ public class ChipClusters {
     }
 
     public void writeFloatDoubleAttribute(DefaultClusterCallback callback, Double value) {
-      writeFloatDoubleAttribute(chipClusterPtr, callback, value);
+      writeFloatDoubleAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeFloatDoubleAttribute(
+        DefaultClusterCallback callback, Double value, int timedWriteTimeoutMs) {
+      writeFloatDoubleAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeFloatDoubleAttribute(
@@ -10557,7 +12855,12 @@ public class ChipClusters {
     }
 
     public void writeOctetStringAttribute(DefaultClusterCallback callback, byte[] value) {
-      writeOctetStringAttribute(chipClusterPtr, callback, value);
+      writeOctetStringAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOctetStringAttribute(
+        DefaultClusterCallback callback, byte[] value, int timedWriteTimeoutMs) {
+      writeOctetStringAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOctetStringAttribute(
@@ -10583,7 +12886,12 @@ public class ChipClusters {
     }
 
     public void writeLongOctetStringAttribute(DefaultClusterCallback callback, byte[] value) {
-      writeLongOctetStringAttribute(chipClusterPtr, callback, value);
+      writeLongOctetStringAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLongOctetStringAttribute(
+        DefaultClusterCallback callback, byte[] value, int timedWriteTimeoutMs) {
+      writeLongOctetStringAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLongOctetStringAttribute(
@@ -10596,7 +12904,12 @@ public class ChipClusters {
     }
 
     public void writeCharStringAttribute(DefaultClusterCallback callback, String value) {
-      writeCharStringAttribute(chipClusterPtr, callback, value);
+      writeCharStringAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeCharStringAttribute(
+        DefaultClusterCallback callback, String value, int timedWriteTimeoutMs) {
+      writeCharStringAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeCharStringAttribute(
@@ -10609,7 +12922,12 @@ public class ChipClusters {
     }
 
     public void writeLongCharStringAttribute(DefaultClusterCallback callback, String value) {
-      writeLongCharStringAttribute(chipClusterPtr, callback, value);
+      writeLongCharStringAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeLongCharStringAttribute(
+        DefaultClusterCallback callback, String value, int timedWriteTimeoutMs) {
+      writeLongCharStringAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeLongCharStringAttribute(
@@ -10622,7 +12940,12 @@ public class ChipClusters {
     }
 
     public void writeEpochUsAttribute(DefaultClusterCallback callback, Long value) {
-      writeEpochUsAttribute(chipClusterPtr, callback, value);
+      writeEpochUsAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEpochUsAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeEpochUsAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEpochUsAttribute(
@@ -10635,7 +12958,12 @@ public class ChipClusters {
     }
 
     public void writeEpochSAttribute(DefaultClusterCallback callback, Long value) {
-      writeEpochSAttribute(chipClusterPtr, callback, value);
+      writeEpochSAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEpochSAttribute(
+        DefaultClusterCallback callback, Long value, int timedWriteTimeoutMs) {
+      writeEpochSAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEpochSAttribute(
@@ -10648,7 +12976,12 @@ public class ChipClusters {
     }
 
     public void writeVendorIdAttribute(DefaultClusterCallback callback, Integer value) {
-      writeVendorIdAttribute(chipClusterPtr, callback, value);
+      writeVendorIdAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeVendorIdAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeVendorIdAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeVendorIdAttribute(
@@ -10666,7 +12999,12 @@ public class ChipClusters {
     }
 
     public void writeEnumAttrAttribute(DefaultClusterCallback callback, Integer value) {
-      writeEnumAttrAttribute(chipClusterPtr, callback, value);
+      writeEnumAttrAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeEnumAttrAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeEnumAttrAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeEnumAttrAttribute(
@@ -10679,7 +13017,12 @@ public class ChipClusters {
     }
 
     public void writeRangeRestrictedInt8uAttribute(DefaultClusterCallback callback, Integer value) {
-      writeRangeRestrictedInt8uAttribute(chipClusterPtr, callback, value);
+      writeRangeRestrictedInt8uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeRangeRestrictedInt8uAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeRangeRestrictedInt8uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeRangeRestrictedInt8uAttribute(
@@ -10692,7 +13035,12 @@ public class ChipClusters {
     }
 
     public void writeRangeRestrictedInt8sAttribute(DefaultClusterCallback callback, Integer value) {
-      writeRangeRestrictedInt8sAttribute(chipClusterPtr, callback, value);
+      writeRangeRestrictedInt8sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeRangeRestrictedInt8sAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeRangeRestrictedInt8sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeRangeRestrictedInt8sAttribute(
@@ -10706,7 +13054,12 @@ public class ChipClusters {
 
     public void writeRangeRestrictedInt16uAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeRangeRestrictedInt16uAttribute(chipClusterPtr, callback, value);
+      writeRangeRestrictedInt16uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeRangeRestrictedInt16uAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeRangeRestrictedInt16uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeRangeRestrictedInt16uAttribute(
@@ -10720,7 +13073,12 @@ public class ChipClusters {
 
     public void writeRangeRestrictedInt16sAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeRangeRestrictedInt16sAttribute(chipClusterPtr, callback, value);
+      writeRangeRestrictedInt16sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeRangeRestrictedInt16sAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeRangeRestrictedInt16sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeRangeRestrictedInt16sAttribute(
@@ -10736,8 +13094,9 @@ public class ChipClusters {
       readTimedWriteBooleanAttribute(chipClusterPtr, callback);
     }
 
-    public void writeTimedWriteBooleanAttribute(DefaultClusterCallback callback, Boolean value) {
-      writeTimedWriteBooleanAttribute(chipClusterPtr, callback, value);
+    public void writeTimedWriteBooleanAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeTimedWriteBooleanAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void readUnsupportedAttribute(BooleanAttributeCallback callback) {
@@ -10745,7 +13104,12 @@ public class ChipClusters {
     }
 
     public void writeUnsupportedAttribute(DefaultClusterCallback callback, Boolean value) {
-      writeUnsupportedAttribute(chipClusterPtr, callback, value);
+      writeUnsupportedAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeUnsupportedAttribute(
+        DefaultClusterCallback callback, Boolean value, int timedWriteTimeoutMs) {
+      writeUnsupportedAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeUnsupportedAttribute(
@@ -10759,7 +13123,12 @@ public class ChipClusters {
 
     public void writeNullableBooleanAttribute(
         DefaultClusterCallback callback, @Nullable Boolean value) {
-      writeNullableBooleanAttribute(chipClusterPtr, callback, value);
+      writeNullableBooleanAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableBooleanAttribute(
+        DefaultClusterCallback callback, @Nullable Boolean value, int timedWriteTimeoutMs) {
+      writeNullableBooleanAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableBooleanAttribute(
@@ -10773,7 +13142,12 @@ public class ChipClusters {
 
     public void writeNullableBitmap8Attribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableBitmap8Attribute(chipClusterPtr, callback, value);
+      writeNullableBitmap8Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableBitmap8Attribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableBitmap8Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableBitmap8Attribute(
@@ -10787,7 +13161,12 @@ public class ChipClusters {
 
     public void writeNullableBitmap16Attribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableBitmap16Attribute(chipClusterPtr, callback, value);
+      writeNullableBitmap16Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableBitmap16Attribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableBitmap16Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableBitmap16Attribute(
@@ -10801,7 +13180,12 @@ public class ChipClusters {
 
     public void writeNullableBitmap32Attribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableBitmap32Attribute(chipClusterPtr, callback, value);
+      writeNullableBitmap32Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableBitmap32Attribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableBitmap32Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableBitmap32Attribute(
@@ -10815,7 +13199,12 @@ public class ChipClusters {
 
     public void writeNullableBitmap64Attribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableBitmap64Attribute(chipClusterPtr, callback, value);
+      writeNullableBitmap64Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableBitmap64Attribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableBitmap64Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableBitmap64Attribute(
@@ -10829,7 +13218,12 @@ public class ChipClusters {
 
     public void writeNullableInt8uAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableInt8uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt8uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt8uAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableInt8uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt8uAttribute(
@@ -10843,7 +13237,12 @@ public class ChipClusters {
 
     public void writeNullableInt16uAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableInt16uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt16uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt16uAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableInt16uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt16uAttribute(
@@ -10857,7 +13256,12 @@ public class ChipClusters {
 
     public void writeNullableInt24uAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt24uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt24uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt24uAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt24uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt24uAttribute(
@@ -10871,7 +13275,12 @@ public class ChipClusters {
 
     public void writeNullableInt32uAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt32uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt32uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt32uAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt32uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt32uAttribute(
@@ -10885,7 +13294,12 @@ public class ChipClusters {
 
     public void writeNullableInt40uAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt40uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt40uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt40uAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt40uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt40uAttribute(
@@ -10899,7 +13313,12 @@ public class ChipClusters {
 
     public void writeNullableInt48uAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt48uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt48uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt48uAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt48uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt48uAttribute(
@@ -10913,7 +13332,12 @@ public class ChipClusters {
 
     public void writeNullableInt56uAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt56uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt56uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt56uAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt56uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt56uAttribute(
@@ -10927,7 +13351,12 @@ public class ChipClusters {
 
     public void writeNullableInt64uAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt64uAttribute(chipClusterPtr, callback, value);
+      writeNullableInt64uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt64uAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt64uAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt64uAttribute(
@@ -10941,7 +13370,12 @@ public class ChipClusters {
 
     public void writeNullableInt8sAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableInt8sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt8sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt8sAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableInt8sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt8sAttribute(
@@ -10955,7 +13389,12 @@ public class ChipClusters {
 
     public void writeNullableInt16sAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableInt16sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt16sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt16sAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableInt16sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt16sAttribute(
@@ -10969,7 +13408,12 @@ public class ChipClusters {
 
     public void writeNullableInt24sAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt24sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt24sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt24sAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt24sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt24sAttribute(
@@ -10983,7 +13427,12 @@ public class ChipClusters {
 
     public void writeNullableInt32sAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt32sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt32sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt32sAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt32sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt32sAttribute(
@@ -10997,7 +13446,12 @@ public class ChipClusters {
 
     public void writeNullableInt40sAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt40sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt40sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt40sAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt40sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt40sAttribute(
@@ -11011,7 +13465,12 @@ public class ChipClusters {
 
     public void writeNullableInt48sAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt48sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt48sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt48sAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt48sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt48sAttribute(
@@ -11025,7 +13484,12 @@ public class ChipClusters {
 
     public void writeNullableInt56sAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt56sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt56sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt56sAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt56sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt56sAttribute(
@@ -11039,7 +13503,12 @@ public class ChipClusters {
 
     public void writeNullableInt64sAttribute(
         DefaultClusterCallback callback, @Nullable Long value) {
-      writeNullableInt64sAttribute(chipClusterPtr, callback, value);
+      writeNullableInt64sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableInt64sAttribute(
+        DefaultClusterCallback callback, @Nullable Long value, int timedWriteTimeoutMs) {
+      writeNullableInt64sAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableInt64sAttribute(
@@ -11053,7 +13522,12 @@ public class ChipClusters {
 
     public void writeNullableEnum8Attribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableEnum8Attribute(chipClusterPtr, callback, value);
+      writeNullableEnum8Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableEnum8Attribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableEnum8Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableEnum8Attribute(
@@ -11067,7 +13541,12 @@ public class ChipClusters {
 
     public void writeNullableEnum16Attribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableEnum16Attribute(chipClusterPtr, callback, value);
+      writeNullableEnum16Attribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableEnum16Attribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableEnum16Attribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableEnum16Attribute(
@@ -11081,7 +13560,12 @@ public class ChipClusters {
 
     public void writeNullableFloatSingleAttribute(
         DefaultClusterCallback callback, @Nullable Float value) {
-      writeNullableFloatSingleAttribute(chipClusterPtr, callback, value);
+      writeNullableFloatSingleAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableFloatSingleAttribute(
+        DefaultClusterCallback callback, @Nullable Float value, int timedWriteTimeoutMs) {
+      writeNullableFloatSingleAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableFloatSingleAttribute(
@@ -11095,7 +13579,12 @@ public class ChipClusters {
 
     public void writeNullableFloatDoubleAttribute(
         DefaultClusterCallback callback, @Nullable Double value) {
-      writeNullableFloatDoubleAttribute(chipClusterPtr, callback, value);
+      writeNullableFloatDoubleAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableFloatDoubleAttribute(
+        DefaultClusterCallback callback, @Nullable Double value, int timedWriteTimeoutMs) {
+      writeNullableFloatDoubleAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableFloatDoubleAttribute(
@@ -11109,7 +13598,12 @@ public class ChipClusters {
 
     public void writeNullableOctetStringAttribute(
         DefaultClusterCallback callback, @Nullable byte[] value) {
-      writeNullableOctetStringAttribute(chipClusterPtr, callback, value);
+      writeNullableOctetStringAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableOctetStringAttribute(
+        DefaultClusterCallback callback, @Nullable byte[] value, int timedWriteTimeoutMs) {
+      writeNullableOctetStringAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableOctetStringAttribute(
@@ -11123,7 +13617,12 @@ public class ChipClusters {
 
     public void writeNullableCharStringAttribute(
         DefaultClusterCallback callback, @Nullable String value) {
-      writeNullableCharStringAttribute(chipClusterPtr, callback, value);
+      writeNullableCharStringAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableCharStringAttribute(
+        DefaultClusterCallback callback, @Nullable String value, int timedWriteTimeoutMs) {
+      writeNullableCharStringAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableCharStringAttribute(
@@ -11137,7 +13636,12 @@ public class ChipClusters {
 
     public void writeNullableEnumAttrAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableEnumAttrAttribute(chipClusterPtr, callback, value);
+      writeNullableEnumAttrAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableEnumAttrAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableEnumAttrAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableEnumAttrAttribute(
@@ -11152,7 +13656,13 @@ public class ChipClusters {
 
     public void writeNullableRangeRestrictedInt8uAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableRangeRestrictedInt8uAttribute(chipClusterPtr, callback, value);
+      writeNullableRangeRestrictedInt8uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableRangeRestrictedInt8uAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableRangeRestrictedInt8uAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableRangeRestrictedInt8uAttribute(
@@ -11168,7 +13678,13 @@ public class ChipClusters {
 
     public void writeNullableRangeRestrictedInt8sAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableRangeRestrictedInt8sAttribute(chipClusterPtr, callback, value);
+      writeNullableRangeRestrictedInt8sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableRangeRestrictedInt8sAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableRangeRestrictedInt8sAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableRangeRestrictedInt8sAttribute(
@@ -11184,7 +13700,13 @@ public class ChipClusters {
 
     public void writeNullableRangeRestrictedInt16uAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableRangeRestrictedInt16uAttribute(chipClusterPtr, callback, value);
+      writeNullableRangeRestrictedInt16uAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableRangeRestrictedInt16uAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableRangeRestrictedInt16uAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableRangeRestrictedInt16uAttribute(
@@ -11200,7 +13722,13 @@ public class ChipClusters {
 
     public void writeNullableRangeRestrictedInt16sAttribute(
         DefaultClusterCallback callback, @Nullable Integer value) {
-      writeNullableRangeRestrictedInt16sAttribute(chipClusterPtr, callback, value);
+      writeNullableRangeRestrictedInt16sAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeNullableRangeRestrictedInt16sAttribute(
+        DefaultClusterCallback callback, @Nullable Integer value, int timedWriteTimeoutMs) {
+      writeNullableRangeRestrictedInt16sAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeNullableRangeRestrictedInt16sAttribute(
@@ -11226,7 +13754,10 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeBooleanAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeBooleanAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -11235,7 +13766,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeBitmap8Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeBitmap8Attribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11244,7 +13778,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeBitmap16Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeBitmap16Attribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11252,7 +13789,10 @@ public class ChipClusters {
     private native void readBitmap32Attribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeBitmap32Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeBitmap32Attribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11260,7 +13800,10 @@ public class ChipClusters {
     private native void readBitmap64Attribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeBitmap64Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeBitmap64Attribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11268,7 +13811,10 @@ public class ChipClusters {
     private native void readInt8uAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeInt8uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt8uAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11276,7 +13822,10 @@ public class ChipClusters {
     private native void readInt16uAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeInt16uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt16uAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11284,7 +13833,10 @@ public class ChipClusters {
     private native void readInt24uAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt24uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt24uAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11292,7 +13844,10 @@ public class ChipClusters {
     private native void readInt32uAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt32uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt32uAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11300,7 +13855,10 @@ public class ChipClusters {
     private native void readInt40uAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt40uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt40uAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11308,7 +13866,10 @@ public class ChipClusters {
     private native void readInt48uAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt48uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt48uAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11316,7 +13877,10 @@ public class ChipClusters {
     private native void readInt56uAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt56uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt56uAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11324,7 +13888,10 @@ public class ChipClusters {
     private native void readInt64uAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt64uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt64uAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11332,7 +13899,10 @@ public class ChipClusters {
     private native void readInt8sAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeInt8sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt8sAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11340,7 +13910,10 @@ public class ChipClusters {
     private native void readInt16sAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeInt16sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt16sAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11348,7 +13921,10 @@ public class ChipClusters {
     private native void readInt24sAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt24sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt24sAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11356,7 +13932,10 @@ public class ChipClusters {
     private native void readInt32sAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt32sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt32sAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11364,7 +13943,10 @@ public class ChipClusters {
     private native void readInt40sAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt40sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt40sAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11372,7 +13954,10 @@ public class ChipClusters {
     private native void readInt48sAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt48sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt48sAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11380,7 +13965,10 @@ public class ChipClusters {
     private native void readInt56sAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt56sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt56sAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11388,7 +13976,10 @@ public class ChipClusters {
     private native void readInt64sAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeInt64sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeInt64sAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11396,7 +13987,10 @@ public class ChipClusters {
     private native void readEnum8Attribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeEnum8Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEnum8Attribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11404,7 +13998,10 @@ public class ChipClusters {
     private native void readEnum16Attribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeEnum16Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEnum16Attribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11413,7 +14010,10 @@ public class ChipClusters {
         long chipClusterPtr, FloatAttributeCallback callback);
 
     private native void writeFloatSingleAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Float value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Float value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeFloatSingleAttribute(
         long chipClusterPtr, FloatAttributeCallback callback, int minInterval, int maxInterval);
@@ -11422,7 +14022,10 @@ public class ChipClusters {
         long chipClusterPtr, DoubleAttributeCallback callback);
 
     private native void writeFloatDoubleAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Double value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Double value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeFloatDoubleAttribute(
         long chipClusterPtr, DoubleAttributeCallback callback, int minInterval, int maxInterval);
@@ -11431,7 +14034,10 @@ public class ChipClusters {
         long chipClusterPtr, OctetStringAttributeCallback callback);
 
     private native void writeOctetStringAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, byte[] value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        byte[] value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOctetStringAttribute(
         long chipClusterPtr,
@@ -11452,7 +14058,10 @@ public class ChipClusters {
         long chipClusterPtr, OctetStringAttributeCallback callback);
 
     private native void writeLongOctetStringAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, byte[] value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        byte[] value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLongOctetStringAttribute(
         long chipClusterPtr,
@@ -11464,7 +14073,10 @@ public class ChipClusters {
         long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void writeCharStringAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeCharStringAttribute(
         long chipClusterPtr,
@@ -11476,7 +14088,10 @@ public class ChipClusters {
         long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void writeLongCharStringAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeLongCharStringAttribute(
         long chipClusterPtr,
@@ -11487,7 +14102,10 @@ public class ChipClusters {
     private native void readEpochUsAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeEpochUsAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEpochUsAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11495,7 +14113,10 @@ public class ChipClusters {
     private native void readEpochSAttribute(long chipClusterPtr, LongAttributeCallback callback);
 
     private native void writeEpochSAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEpochSAttribute(
         long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
@@ -11504,7 +14125,10 @@ public class ChipClusters {
         long chipClusterPtr, VendorIdAttributeCallback callback);
 
     private native void writeVendorIdAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeVendorIdAttribute(
         long chipClusterPtr, VendorIdAttributeCallback callback, int minInterval, int maxInterval);
@@ -11516,7 +14140,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeEnumAttrAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeEnumAttrAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11525,7 +14152,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeRangeRestrictedInt8uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeRangeRestrictedInt8uAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11534,7 +14164,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeRangeRestrictedInt8sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeRangeRestrictedInt8sAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11543,7 +14176,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeRangeRestrictedInt16uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeRangeRestrictedInt16uAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11552,7 +14188,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeRangeRestrictedInt16sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeRangeRestrictedInt16sAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -11564,13 +14203,19 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeTimedWriteBooleanAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void readUnsupportedAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeUnsupportedAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeUnsupportedAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback, int minInterval, int maxInterval);
@@ -11579,7 +14224,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableBooleanAttributeCallback callback);
 
     private native void writeNullableBooleanAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Boolean value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Boolean value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableBooleanAttribute(
         long chipClusterPtr,
@@ -11591,7 +14239,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableBitmap8AttributeCallback callback);
 
     private native void writeNullableBitmap8Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableBitmap8Attribute(
         long chipClusterPtr,
@@ -11603,7 +14254,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableBitmap16AttributeCallback callback);
 
     private native void writeNullableBitmap16Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableBitmap16Attribute(
         long chipClusterPtr,
@@ -11615,7 +14269,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableBitmap32AttributeCallback callback);
 
     private native void writeNullableBitmap32Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableBitmap32Attribute(
         long chipClusterPtr,
@@ -11627,7 +14284,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableBitmap64AttributeCallback callback);
 
     private native void writeNullableBitmap64Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableBitmap64Attribute(
         long chipClusterPtr,
@@ -11639,7 +14299,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt8uAttributeCallback callback);
 
     private native void writeNullableInt8uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt8uAttribute(
         long chipClusterPtr,
@@ -11651,7 +14314,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt16uAttributeCallback callback);
 
     private native void writeNullableInt16uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt16uAttribute(
         long chipClusterPtr,
@@ -11663,7 +14329,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt24uAttributeCallback callback);
 
     private native void writeNullableInt24uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt24uAttribute(
         long chipClusterPtr,
@@ -11675,7 +14344,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt32uAttributeCallback callback);
 
     private native void writeNullableInt32uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt32uAttribute(
         long chipClusterPtr,
@@ -11687,7 +14359,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt40uAttributeCallback callback);
 
     private native void writeNullableInt40uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt40uAttribute(
         long chipClusterPtr,
@@ -11699,7 +14374,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt48uAttributeCallback callback);
 
     private native void writeNullableInt48uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt48uAttribute(
         long chipClusterPtr,
@@ -11711,7 +14389,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt56uAttributeCallback callback);
 
     private native void writeNullableInt56uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt56uAttribute(
         long chipClusterPtr,
@@ -11723,7 +14404,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt64uAttributeCallback callback);
 
     private native void writeNullableInt64uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt64uAttribute(
         long chipClusterPtr,
@@ -11735,7 +14419,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt8sAttributeCallback callback);
 
     private native void writeNullableInt8sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt8sAttribute(
         long chipClusterPtr,
@@ -11747,7 +14434,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt16sAttributeCallback callback);
 
     private native void writeNullableInt16sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt16sAttribute(
         long chipClusterPtr,
@@ -11759,7 +14449,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt24sAttributeCallback callback);
 
     private native void writeNullableInt24sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt24sAttribute(
         long chipClusterPtr,
@@ -11771,7 +14464,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt32sAttributeCallback callback);
 
     private native void writeNullableInt32sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt32sAttribute(
         long chipClusterPtr,
@@ -11783,7 +14479,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt40sAttributeCallback callback);
 
     private native void writeNullableInt40sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt40sAttribute(
         long chipClusterPtr,
@@ -11795,7 +14494,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt48sAttributeCallback callback);
 
     private native void writeNullableInt48sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt48sAttribute(
         long chipClusterPtr,
@@ -11807,7 +14509,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt56sAttributeCallback callback);
 
     private native void writeNullableInt56sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt56sAttribute(
         long chipClusterPtr,
@@ -11819,7 +14524,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableInt64sAttributeCallback callback);
 
     private native void writeNullableInt64sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Long value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Long value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableInt64sAttribute(
         long chipClusterPtr,
@@ -11831,7 +14539,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableEnum8AttributeCallback callback);
 
     private native void writeNullableEnum8Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableEnum8Attribute(
         long chipClusterPtr,
@@ -11843,7 +14554,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableEnum16AttributeCallback callback);
 
     private native void writeNullableEnum16Attribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableEnum16Attribute(
         long chipClusterPtr,
@@ -11855,7 +14569,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableFloatSingleAttributeCallback callback);
 
     private native void writeNullableFloatSingleAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Float value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Float value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableFloatSingleAttribute(
         long chipClusterPtr,
@@ -11867,7 +14584,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableFloatDoubleAttributeCallback callback);
 
     private native void writeNullableFloatDoubleAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Double value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Double value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableFloatDoubleAttribute(
         long chipClusterPtr,
@@ -11879,7 +14599,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableOctetStringAttributeCallback callback);
 
     private native void writeNullableOctetStringAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable byte[] value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable byte[] value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableOctetStringAttribute(
         long chipClusterPtr,
@@ -11891,7 +14614,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableCharStringAttributeCallback callback);
 
     private native void writeNullableCharStringAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable String value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable String value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableCharStringAttribute(
         long chipClusterPtr,
@@ -11903,7 +14629,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableEnumAttrAttributeCallback callback);
 
     private native void writeNullableEnumAttrAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableEnumAttrAttribute(
         long chipClusterPtr,
@@ -11915,7 +14644,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableRangeRestrictedInt8uAttributeCallback callback);
 
     private native void writeNullableRangeRestrictedInt8uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableRangeRestrictedInt8uAttribute(
         long chipClusterPtr,
@@ -11927,7 +14659,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableRangeRestrictedInt8sAttributeCallback callback);
 
     private native void writeNullableRangeRestrictedInt8sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableRangeRestrictedInt8sAttribute(
         long chipClusterPtr,
@@ -11939,7 +14674,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableRangeRestrictedInt16uAttributeCallback callback);
 
     private native void writeNullableRangeRestrictedInt16uAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableRangeRestrictedInt16uAttribute(
         long chipClusterPtr,
@@ -11951,7 +14689,10 @@ public class ChipClusters {
         long chipClusterPtr, NullableRangeRestrictedInt16sAttributeCallback callback);
 
     private native void writeNullableRangeRestrictedInt16sAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, @Nullable Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        @Nullable Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeNullableRangeRestrictedInt16sAttribute(
         long chipClusterPtr,
@@ -11982,16 +14723,33 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void clearWeeklySchedule(DefaultClusterCallback callback) {
-      clearWeeklySchedule(chipClusterPtr, callback);
+      clearWeeklySchedule(chipClusterPtr, callback, null);
+    }
+
+    public void clearWeeklySchedule(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      clearWeeklySchedule(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void getRelayStatusLog(GetRelayStatusLogResponseCallback callback) {
-      getRelayStatusLog(chipClusterPtr, callback);
+      getRelayStatusLog(chipClusterPtr, callback, null);
+    }
+
+    public void getRelayStatusLog(
+        GetRelayStatusLogResponseCallback callback, int timedInvokeTimeoutMs) {
+      getRelayStatusLog(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void getWeeklySchedule(
         GetWeeklyScheduleResponseCallback callback, Integer daysToReturn, Integer modeToReturn) {
-      getWeeklySchedule(chipClusterPtr, callback, daysToReturn, modeToReturn);
+      getWeeklySchedule(chipClusterPtr, callback, daysToReturn, modeToReturn, null);
+    }
+
+    public void getWeeklySchedule(
+        GetWeeklyScheduleResponseCallback callback,
+        Integer daysToReturn,
+        Integer modeToReturn,
+        int timedInvokeTimeoutMs) {
+      getWeeklySchedule(chipClusterPtr, callback, daysToReturn, modeToReturn, timedInvokeTimeoutMs);
     }
 
     public void setWeeklySchedule(
@@ -12006,23 +14764,52 @@ public class ChipClusters {
           numberOfTransitionsForSequence,
           dayOfWeekForSequence,
           modeForSequence,
-          payload);
+          payload,
+          null);
+    }
+
+    public void setWeeklySchedule(
+        DefaultClusterCallback callback,
+        Integer numberOfTransitionsForSequence,
+        Integer dayOfWeekForSequence,
+        Integer modeForSequence,
+        Integer payload,
+        int timedInvokeTimeoutMs) {
+      setWeeklySchedule(
+          chipClusterPtr,
+          callback,
+          numberOfTransitionsForSequence,
+          dayOfWeekForSequence,
+          modeForSequence,
+          payload,
+          timedInvokeTimeoutMs);
     }
 
     public void setpointRaiseLower(DefaultClusterCallback callback, Integer mode, Integer amount) {
-      setpointRaiseLower(chipClusterPtr, callback, mode, amount);
+      setpointRaiseLower(chipClusterPtr, callback, mode, amount, null);
     }
 
-    private native void clearWeeklySchedule(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void setpointRaiseLower(
+        DefaultClusterCallback callback, Integer mode, Integer amount, int timedInvokeTimeoutMs) {
+      setpointRaiseLower(chipClusterPtr, callback, mode, amount, timedInvokeTimeoutMs);
+    }
+
+    private native void clearWeeklySchedule(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void getRelayStatusLog(
-        long chipClusterPtr, GetRelayStatusLogResponseCallback Callback);
+        long chipClusterPtr,
+        GetRelayStatusLogResponseCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void getWeeklySchedule(
         long chipClusterPtr,
         GetWeeklyScheduleResponseCallback Callback,
         Integer daysToReturn,
-        Integer modeToReturn);
+        Integer modeToReturn,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void setWeeklySchedule(
         long chipClusterPtr,
@@ -12030,10 +14817,15 @@ public class ChipClusters {
         Integer numberOfTransitionsForSequence,
         Integer dayOfWeekForSequence,
         Integer modeForSequence,
-        Integer payload);
+        Integer payload,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void setpointRaiseLower(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer mode, Integer amount);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer mode,
+        Integer amount,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface GetRelayStatusLogResponseCallback {
       void onSuccess(
@@ -12118,7 +14910,12 @@ public class ChipClusters {
 
     public void writeOccupiedCoolingSetpointAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeOccupiedCoolingSetpointAttribute(chipClusterPtr, callback, value);
+      writeOccupiedCoolingSetpointAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOccupiedCoolingSetpointAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOccupiedCoolingSetpointAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOccupiedCoolingSetpointAttribute(
@@ -12132,7 +14929,12 @@ public class ChipClusters {
 
     public void writeOccupiedHeatingSetpointAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeOccupiedHeatingSetpointAttribute(chipClusterPtr, callback, value);
+      writeOccupiedHeatingSetpointAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeOccupiedHeatingSetpointAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeOccupiedHeatingSetpointAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeOccupiedHeatingSetpointAttribute(
@@ -12145,7 +14947,12 @@ public class ChipClusters {
     }
 
     public void writeMinHeatSetpointLimitAttribute(DefaultClusterCallback callback, Integer value) {
-      writeMinHeatSetpointLimitAttribute(chipClusterPtr, callback, value);
+      writeMinHeatSetpointLimitAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeMinHeatSetpointLimitAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeMinHeatSetpointLimitAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeMinHeatSetpointLimitAttribute(
@@ -12158,7 +14965,12 @@ public class ChipClusters {
     }
 
     public void writeMaxHeatSetpointLimitAttribute(DefaultClusterCallback callback, Integer value) {
-      writeMaxHeatSetpointLimitAttribute(chipClusterPtr, callback, value);
+      writeMaxHeatSetpointLimitAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeMaxHeatSetpointLimitAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeMaxHeatSetpointLimitAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeMaxHeatSetpointLimitAttribute(
@@ -12171,7 +14983,12 @@ public class ChipClusters {
     }
 
     public void writeMinCoolSetpointLimitAttribute(DefaultClusterCallback callback, Integer value) {
-      writeMinCoolSetpointLimitAttribute(chipClusterPtr, callback, value);
+      writeMinCoolSetpointLimitAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeMinCoolSetpointLimitAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeMinCoolSetpointLimitAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeMinCoolSetpointLimitAttribute(
@@ -12184,7 +15001,12 @@ public class ChipClusters {
     }
 
     public void writeMaxCoolSetpointLimitAttribute(DefaultClusterCallback callback, Integer value) {
-      writeMaxCoolSetpointLimitAttribute(chipClusterPtr, callback, value);
+      writeMaxCoolSetpointLimitAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeMaxCoolSetpointLimitAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeMaxCoolSetpointLimitAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeMaxCoolSetpointLimitAttribute(
@@ -12197,7 +15019,12 @@ public class ChipClusters {
     }
 
     public void writeMinSetpointDeadBandAttribute(DefaultClusterCallback callback, Integer value) {
-      writeMinSetpointDeadBandAttribute(chipClusterPtr, callback, value);
+      writeMinSetpointDeadBandAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeMinSetpointDeadBandAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeMinSetpointDeadBandAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeMinSetpointDeadBandAttribute(
@@ -12211,7 +15038,13 @@ public class ChipClusters {
 
     public void writeControlSequenceOfOperationAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeControlSequenceOfOperationAttribute(chipClusterPtr, callback, value);
+      writeControlSequenceOfOperationAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeControlSequenceOfOperationAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeControlSequenceOfOperationAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeControlSequenceOfOperationAttribute(
@@ -12225,7 +15058,12 @@ public class ChipClusters {
     }
 
     public void writeSystemModeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeSystemModeAttribute(chipClusterPtr, callback, value);
+      writeSystemModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeSystemModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeSystemModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeSystemModeAttribute(
@@ -12318,7 +15156,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOccupiedCoolingSetpointAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOccupiedCoolingSetpointAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12327,7 +15168,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeOccupiedHeatingSetpointAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeOccupiedHeatingSetpointAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12336,7 +15180,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeMinHeatSetpointLimitAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeMinHeatSetpointLimitAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12345,7 +15192,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeMaxHeatSetpointLimitAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeMaxHeatSetpointLimitAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12354,7 +15204,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeMinCoolSetpointLimitAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeMinCoolSetpointLimitAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12363,7 +15216,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeMaxCoolSetpointLimitAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeMaxCoolSetpointLimitAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12372,7 +15228,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeMinSetpointDeadBandAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeMinSetpointDeadBandAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12381,7 +15240,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeControlSequenceOfOperationAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeControlSequenceOfOperationAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12390,7 +15252,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeSystemModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeSystemModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12455,7 +15320,12 @@ public class ChipClusters {
 
     public void writeTemperatureDisplayModeAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeTemperatureDisplayModeAttribute(chipClusterPtr, callback, value);
+      writeTemperatureDisplayModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeTemperatureDisplayModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeTemperatureDisplayModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeTemperatureDisplayModeAttribute(
@@ -12468,7 +15338,12 @@ public class ChipClusters {
     }
 
     public void writeKeypadLockoutAttribute(DefaultClusterCallback callback, Integer value) {
-      writeKeypadLockoutAttribute(chipClusterPtr, callback, value);
+      writeKeypadLockoutAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeKeypadLockoutAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeKeypadLockoutAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeKeypadLockoutAttribute(
@@ -12482,7 +15357,13 @@ public class ChipClusters {
 
     public void writeScheduleProgrammingVisibilityAttribute(
         DefaultClusterCallback callback, Integer value) {
-      writeScheduleProgrammingVisibilityAttribute(chipClusterPtr, callback, value);
+      writeScheduleProgrammingVisibilityAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeScheduleProgrammingVisibilityAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeScheduleProgrammingVisibilityAttribute(
+          chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeScheduleProgrammingVisibilityAttribute(
@@ -12508,7 +15389,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeTemperatureDisplayModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeTemperatureDisplayModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12517,7 +15401,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeKeypadLockoutAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeKeypadLockoutAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12526,7 +15413,10 @@ public class ChipClusters {
         long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeScheduleProgrammingVisibilityAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeScheduleProgrammingVisibilityAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
@@ -12554,10 +15444,17 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void resetCounts(DefaultClusterCallback callback) {
-      resetCounts(chipClusterPtr, callback);
+      resetCounts(chipClusterPtr, callback, null);
     }
 
-    private native void resetCounts(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void resetCounts(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      resetCounts(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void resetCounts(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public static class NeighborTableListAttribute {
       public Long extAddress;
@@ -14001,10 +16898,17 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void resetCounts(DefaultClusterCallback callback) {
-      resetCounts(chipClusterPtr, callback);
+      resetCounts(chipClusterPtr, callback, null);
     }
 
-    private native void resetCounts(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void resetCounts(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      resetCounts(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void resetCounts(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface AttributeListAttributeCallback {
       void onSuccess(List<Object> valueList);
@@ -14254,62 +17158,129 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void downOrClose(DefaultClusterCallback callback) {
-      downOrClose(chipClusterPtr, callback);
+      downOrClose(chipClusterPtr, callback, null);
+    }
+
+    public void downOrClose(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      downOrClose(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void goToLiftPercentage(
         DefaultClusterCallback callback,
         Integer liftPercentageValue,
         Integer liftPercent100thsValue) {
-      goToLiftPercentage(chipClusterPtr, callback, liftPercentageValue, liftPercent100thsValue);
+      goToLiftPercentage(
+          chipClusterPtr, callback, liftPercentageValue, liftPercent100thsValue, null);
+    }
+
+    public void goToLiftPercentage(
+        DefaultClusterCallback callback,
+        Integer liftPercentageValue,
+        Integer liftPercent100thsValue,
+        int timedInvokeTimeoutMs) {
+      goToLiftPercentage(
+          chipClusterPtr,
+          callback,
+          liftPercentageValue,
+          liftPercent100thsValue,
+          timedInvokeTimeoutMs);
     }
 
     public void goToLiftValue(DefaultClusterCallback callback, Integer liftValue) {
-      goToLiftValue(chipClusterPtr, callback, liftValue);
+      goToLiftValue(chipClusterPtr, callback, liftValue, null);
+    }
+
+    public void goToLiftValue(
+        DefaultClusterCallback callback, Integer liftValue, int timedInvokeTimeoutMs) {
+      goToLiftValue(chipClusterPtr, callback, liftValue, timedInvokeTimeoutMs);
     }
 
     public void goToTiltPercentage(
         DefaultClusterCallback callback,
         Integer tiltPercentageValue,
         Integer tiltPercent100thsValue) {
-      goToTiltPercentage(chipClusterPtr, callback, tiltPercentageValue, tiltPercent100thsValue);
+      goToTiltPercentage(
+          chipClusterPtr, callback, tiltPercentageValue, tiltPercent100thsValue, null);
+    }
+
+    public void goToTiltPercentage(
+        DefaultClusterCallback callback,
+        Integer tiltPercentageValue,
+        Integer tiltPercent100thsValue,
+        int timedInvokeTimeoutMs) {
+      goToTiltPercentage(
+          chipClusterPtr,
+          callback,
+          tiltPercentageValue,
+          tiltPercent100thsValue,
+          timedInvokeTimeoutMs);
     }
 
     public void goToTiltValue(DefaultClusterCallback callback, Integer tiltValue) {
-      goToTiltValue(chipClusterPtr, callback, tiltValue);
+      goToTiltValue(chipClusterPtr, callback, tiltValue, null);
+    }
+
+    public void goToTiltValue(
+        DefaultClusterCallback callback, Integer tiltValue, int timedInvokeTimeoutMs) {
+      goToTiltValue(chipClusterPtr, callback, tiltValue, timedInvokeTimeoutMs);
     }
 
     public void stopMotion(DefaultClusterCallback callback) {
-      stopMotion(chipClusterPtr, callback);
+      stopMotion(chipClusterPtr, callback, null);
+    }
+
+    public void stopMotion(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      stopMotion(chipClusterPtr, callback, timedInvokeTimeoutMs);
     }
 
     public void upOrOpen(DefaultClusterCallback callback) {
-      upOrOpen(chipClusterPtr, callback);
+      upOrOpen(chipClusterPtr, callback, null);
     }
 
-    private native void downOrClose(long chipClusterPtr, DefaultClusterCallback Callback);
+    public void upOrOpen(DefaultClusterCallback callback, int timedInvokeTimeoutMs) {
+      upOrOpen(chipClusterPtr, callback, timedInvokeTimeoutMs);
+    }
+
+    private native void downOrClose(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void goToLiftPercentage(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer liftPercentageValue,
-        Integer liftPercent100thsValue);
+        Integer liftPercent100thsValue,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void goToLiftValue(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer liftValue);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer liftValue,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void goToTiltPercentage(
         long chipClusterPtr,
         DefaultClusterCallback Callback,
         Integer tiltPercentageValue,
-        Integer tiltPercent100thsValue);
+        Integer tiltPercent100thsValue,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     private native void goToTiltValue(
-        long chipClusterPtr, DefaultClusterCallback Callback, Integer tiltValue);
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        Integer tiltValue,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void stopMotion(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void stopMotion(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
-    private native void upOrOpen(long chipClusterPtr, DefaultClusterCallback Callback);
+    private native void upOrOpen(
+        long chipClusterPtr,
+        DefaultClusterCallback Callback,
+        @Nullable Integer timedInvokeTimeoutMs);
 
     public interface CurrentPositionLiftAttributeCallback {
       void onSuccess(@Nullable Integer value);
@@ -14554,7 +17525,12 @@ public class ChipClusters {
     }
 
     public void writeModeAttribute(DefaultClusterCallback callback, Integer value) {
-      writeModeAttribute(chipClusterPtr, callback, value);
+      writeModeAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeModeAttribute(
+        DefaultClusterCallback callback, Integer value, int timedWriteTimeoutMs) {
+      writeModeAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
     }
 
     public void subscribeModeAttribute(
@@ -14715,7 +17691,10 @@ public class ChipClusters {
     private native void readModeAttribute(long chipClusterPtr, IntegerAttributeCallback callback);
 
     private native void writeModeAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, Integer value);
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        Integer value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeModeAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -4597,7 +4597,8 @@ public class ClusterInfoMapping {
               ((ChipClusters.AccountLoginCluster) cluster)
                   .getSetupPINRequest(
                       (ChipClusters.AccountLoginCluster.GetSetupPINResponseCallback) callback,
-                      (String) commandArguments.get("tempAccountIdentifier"));
+                      (String) commandArguments.get("tempAccountIdentifier"),
+                      10000);
             },
             () -> new DelegatedGetSetupPINResponseCallback(),
             accountLogingetSetupPINRequestCommandParams);
@@ -4636,7 +4637,7 @@ public class ClusterInfoMapping {
         new InteractionInfo(
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.AccountLoginCluster) cluster)
-                  .logoutRequest((DefaultClusterCallback) callback);
+                  .logoutRequest((DefaultClusterCallback) callback, 10000);
             },
             () -> new DelegatedDefaultClusterCallback(),
             accountLoginlogoutRequestCommandParams);
@@ -8976,7 +8977,7 @@ public class ClusterInfoMapping {
         new InteractionInfo(
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.TestClusterCluster) cluster)
-                  .timedInvokeRequest((DefaultClusterCallback) callback);
+                  .timedInvokeRequest((DefaultClusterCallback) callback, 10000);
             },
             () -> new DelegatedDefaultClusterCallback(),
             testClustertimedInvokeRequestCommandParams);

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterWriteMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterWriteMapping.java
@@ -1559,7 +1559,9 @@ public class ClusterWriteMapping {
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.TestClusterCluster) cluster)
                   .writeTimedWriteBooleanAttribute(
-                      (DefaultClusterCallback) callback, (Boolean) commandArguments.get("value"));
+                      (DefaultClusterCallback) callback,
+                      (Boolean) commandArguments.get("value"),
+                      10000);
             },
             () -> new ClusterInfoMapping.DelegatedDefaultClusterCallback(),
             writeTestClusterTimedWriteBooleanCommandParams);


### PR DESCRIPTION
#### Problem
For Android, timed invoke/write is hardcoded to 10 seconds, and only set at all for requests that require a timed interaction.

#### Change overview
Generate timeoutMs field for invoke and write, and pass it to C++ layer

#### Testing
Verify command/write failure with low timeout, and success with higher timeout.
