### PR TITLE
Rename LabelList to AttributeList to be used by all clusters

### DIFF
--- a/src/app/clusters/fixed-label-server/fixed-label-server.cpp
+++ b/src/app/clusters/fixed-label-server/fixed-label-server.cpp
@@ -53,7 +53,7 @@ private:
 CHIP_ERROR FixedLabelAttrAccess::ReadLabelList(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    DeviceLayer::LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, DeviceLayer::kMaxFixedLabels> labelList;
+    DeviceLayer::AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, DeviceLayer::kMaxFixedLabels> labelList;
 
     if (DeviceLayer::PlatformMgr().GetFixedLabelList(endpoint, labelList) == CHIP_NO_ERROR)
     {

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -57,7 +57,7 @@ UserLabelAttrAccess gAttrAccess;
 CHIP_ERROR UserLabelAttrAccess::ReadLabelList(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    DeviceLayer::LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabels> labelList;
+    DeviceLayer::AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabels> labelList;
 
     if (DeviceLayer::PlatformMgr().GetUserLabelList(endpoint, labelList) == CHIP_NO_ERROR)
     {
@@ -80,7 +80,7 @@ CHIP_ERROR UserLabelAttrAccess::ReadLabelList(EndpointId endpoint, AttributeValu
 
 CHIP_ERROR UserLabelAttrAccess::WriteLabelList(EndpointId endpoint, AttributeValueDecoder & aDecoder)
 {
-    DeviceLayer::LabelList<Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabels> labelList;
+    DeviceLayer::AttributeList<Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabels> labelList;
     LabelList::TypeInfo::DecodableType decodablelist;
 
     ReturnErrorOnFailure(aDecoder.Decode(decodablelist));

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *          This is a list of string tuples. Each entry is a LabelStruct.
+ *          This is a list of attribute. Each entry is an attribute of type T.
  */
 
 #pragma once
@@ -28,30 +28,27 @@
 namespace chip {
 namespace DeviceLayer {
 
-static constexpr size_t kMaxFixedLabels = 10;
-static constexpr size_t kMaxUserLabels  = 10;
-
 template <typename T, size_t N>
-class LabelList
+class AttributeList
 {
 public:
     /* The iterator */
     class Iterator
     {
     public:
-        Iterator(const LabelList<T, N> * LabelList, int index);
+        Iterator(const AttributeList<T, N> * AttributeList, int index);
         T operator*() const;
         Iterator & operator++();
         bool operator!=(const Iterator & other) const;
 
     private:
-        const LabelList<T, N> * mLabelListPtr;
+        const AttributeList<T, N> * mAttributeListPtr;
         int mIndex = -1;
     };
 
 public:
-    LabelList() = default;
-    ~LabelList() { mSize = 0; }
+    AttributeList() = default;
+    ~AttributeList() { mSize = 0; }
 
     CHIP_ERROR add(const T & label);
 
@@ -67,10 +64,10 @@ private:
 };
 
 /*
- * LabelList methods
+ * AttributeList methods
  **/
 template <typename T, size_t N>
-inline CHIP_ERROR LabelList<T, N>::add(const T & label)
+inline CHIP_ERROR AttributeList<T, N>::add(const T & label)
 {
     if (mSize == N)
     {
@@ -84,52 +81,53 @@ inline CHIP_ERROR LabelList<T, N>::add(const T & label)
 }
 
 template <typename T, size_t N>
-inline size_t LabelList<T, N>::size() const
+inline size_t AttributeList<T, N>::size() const
 {
     return static_cast<size_t>(mSize);
 }
 
 template <typename T, size_t N>
-inline const T & LabelList<T, N>::operator[](int index) const
+inline const T & AttributeList<T, N>::operator[](int index) const
 {
     VerifyOrDie(index < mSize);
     return mList[index];
 }
 
 template <typename T, size_t N>
-inline typename LabelList<T, N>::Iterator LabelList<T, N>::begin() const
+inline typename AttributeList<T, N>::Iterator AttributeList<T, N>::begin() const
 {
-    return LabelList<T, N>::Iterator{ this, 0 };
+    return AttributeList<T, N>::Iterator{ this, 0 };
 }
 
 template <typename T, size_t N>
-inline typename LabelList<T, N>::Iterator LabelList<T, N>::end() const
+inline typename AttributeList<T, N>::Iterator AttributeList<T, N>::end() const
 {
-    return LabelList<T, N>::Iterator{ this, mSize };
+    return AttributeList<T, N>::Iterator{ this, mSize };
 }
 
 /*
  * Iterator methods
  **/
 template <typename T, size_t N>
-inline LabelList<T, N>::Iterator::Iterator(const LabelList<T, N> * pLabelList, int index) : mLabelListPtr(pLabelList), mIndex(index)
+inline AttributeList<T, N>::Iterator::Iterator(const AttributeList<T, N> * pAttributeList, int index) :
+    mAttributeListPtr(pAttributeList), mIndex(index)
 {}
 
 template <typename T, size_t N>
-inline T LabelList<T, N>::Iterator::operator*() const
+inline T AttributeList<T, N>::Iterator::operator*() const
 {
-    return mLabelListPtr->operator[](mIndex);
+    return mAttributeListPtr->operator[](mIndex);
 }
 
 template <typename T, size_t N>
-inline typename LabelList<T, N>::Iterator & LabelList<T, N>::Iterator::operator++()
+inline typename AttributeList<T, N>::Iterator & AttributeList<T, N>::Iterator::operator++()
 {
     ++mIndex;
     return *this;
 }
 
 template <typename T, size_t N>
-inline bool LabelList<T, N>::Iterator::operator!=(const LabelList<T, N>::Iterator & other) const
+inline bool AttributeList<T, N>::Iterator::operator!=(const AttributeList<T, N>::Iterator & other) const
 {
     return mIndex != other.mIndex;
 }

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -23,9 +23,9 @@
 
 #pragma once
 
+#include <platform/AttributeList.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceEvent.h>
-#include <platform/LabelList.h>
 #include <system/PlatformEventSupport.h>
 #include <system/SystemLayer.h>
 
@@ -36,6 +36,9 @@ class DiscoveryImplPlatform;
 }
 
 namespace DeviceLayer {
+
+static constexpr size_t kMaxFixedLabels = 10;
+static constexpr size_t kMaxUserLabels  = 10;
 
 class PlatformManagerImpl;
 class ConnectivityManagerImpl;
@@ -179,11 +182,11 @@ public:
 #endif
 
     CHIP_ERROR GetFixedLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList);
+                                 AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList);
     CHIP_ERROR SetUserLabelList(EndpointId endpoint,
-                                LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
     CHIP_ERROR GetUserLabelList(EndpointId endpoint,
-                                LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
 
 private:
     bool mInitialized                   = false;
@@ -425,23 +428,22 @@ inline CHIP_ERROR PlatformManager::StartChipTimer(System::Clock::Timeout duratio
     return static_cast<ImplClass *>(this)->_StartChipTimer(duration);
 }
 
-inline CHIP_ERROR
-PlatformManager::GetFixedLabelList(EndpointId endpoint,
-                                   LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
+inline CHIP_ERROR PlatformManager::GetFixedLabelList(
+    EndpointId endpoint, AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
 {
     return static_cast<ImplClass *>(this)->_GetFixedLabelList(endpoint, labelList);
 }
 
 inline CHIP_ERROR
 PlatformManager::SetUserLabelList(EndpointId endpoint,
-                                  LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     return static_cast<ImplClass *>(this)->_SetUserLabelList(endpoint, labelList);
 }
 
 inline CHIP_ERROR
 PlatformManager::GetUserLabelList(EndpointId endpoint,
-                                  LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     return static_cast<ImplClass *>(this)->_GetUserLabelList(endpoint, labelList);
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -58,12 +58,13 @@ protected:
     void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg);
     void _DispatchEvent(const ChipDeviceEvent * event);
 
-    CHIP_ERROR _GetFixedLabelList(EndpointId endpoint,
-                                  LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList);
+    CHIP_ERROR
+    _GetFixedLabelList(EndpointId endpoint,
+                       AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList);
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
     CHIP_ERROR _GetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
 
     // ===== Support methods that can be overridden by the implementation subclass.
 
@@ -82,21 +83,21 @@ extern template class GenericPlatformManagerImpl<PlatformManagerImpl>;
 
 template <class ImplClass>
 inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_GetFixedLabelList(
-    EndpointId endpoint, LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
+    EndpointId endpoint, AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 template <class ImplClass>
 inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_SetUserLabelList(
-    EndpointId endpoint, LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 template <class ImplClass>
 inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_GetUserLabelList(
-    EndpointId endpoint, LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -127,8 +127,8 @@ CHIP_ERROR PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event)
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_SetUserLabelList(EndpointId endpoint,
-                                       LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+PlatformManagerImpl::_SetUserLabelList(
+    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -63,7 +63,7 @@ private:
     CHIP_ERROR _StopEventLoopTask();
 
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
 
     void _RunEventLoop();
     void _LockChipStack(){};

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -273,7 +273,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
 }
 
 CHIP_ERROR PlatformManagerImpl::_GetFixedLabelList(
-    EndpointId endpoint, LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
+    EndpointId endpoint, AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
 {
     // In Linux simulation, return following hardcoded labelList on all endpoints.
     FixedLabel::Structs::LabelStruct::Type room;
@@ -302,16 +302,16 @@ CHIP_ERROR PlatformManagerImpl::_GetFixedLabelList(
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_SetUserLabelList(EndpointId endpoint,
-                                       LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+PlatformManagerImpl::_SetUserLabelList(
+    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     // TODO:: store the user labelList, and read back stored user labelList if it has been set. Add yaml test to verify this.
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_GetUserLabelList(EndpointId endpoint,
-                                       LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+PlatformManagerImpl::_GetUserLabelList(
+    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
 {
     // In Linux simulation, return following hardcoded labelList on all endpoints.
     UserLabel::Structs::LabelStruct::Type room;

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -65,12 +65,13 @@ private:
 
     CHIP_ERROR _InitChipStack();
     CHIP_ERROR _Shutdown();
-    CHIP_ERROR _GetFixedLabelList(EndpointId endpoint,
-                                  LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList);
+    CHIP_ERROR
+    _GetFixedLabelList(EndpointId endpoint,
+                       AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList);
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
     CHIP_ERROR _GetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -99,19 +99,19 @@ private:
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     CHIP_ERROR _GetFixedLabelList(EndpointId endpoint,
-                                  LabelList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
+                                  AttributeList<app::Clusters::FixedLabel::Structs::LabelStruct::Type, kMaxFixedLabels> & labelList)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
     CHIP_ERROR _GetUserLabelList(EndpointId endpoint,
-                                 LabelList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, class LabelList is only used by Label cluster, we need to rename it to a more generic name so that this class can be used by other clusters, such as SupportedLocales list in Localization configuration cluster


#### Change overview
Rename LabelList to AttributeList to be used by all clusters

#### Testing
How was this tested? (at least one bullet point required)
* Rename only, regression test  is covered by CI.