### PR TITLE
[K32W0] Enable SHA256 HW acceleration

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w0/main/main.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/main.cpp
@@ -62,6 +62,8 @@ extern "C" void main_task(void const * argument)
         (*pFunc)();
     }
 
+    SHA_ClkInit(SHA_INSTANCE);
+
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 
     /* Used for HW initializations */

--- a/examples/lock-app/nxp/k32w/k32w0/main/main.cpp
+++ b/examples/lock-app/nxp/k32w/k32w0/main/main.cpp
@@ -96,6 +96,8 @@ extern "C" void main_task(void const * argument)
         (*pFunc)();
     }
 
+    SHA_ClkInit(SHA_INSTANCE);
+
 #if defined(cPWR_UsePowerDownMode) && (cPWR_UsePowerDownMode)
     PWR_Init();
 

--- a/src/platform/nxp/k32w/k32w0/k32w0-chip-mbedtls-config.h
+++ b/src/platform/nxp/k32w/k32w0/k32w0-chip-mbedtls-config.h
@@ -121,7 +121,7 @@
 #if defined(FSL_FEATURE_SOC_SHA_COUNT) && (FSL_FEATURE_SOC_SHA_COUNT > 0)
 #include "fsl_sha.h"
 
-#define SHA_INSTANCE SHA0            /* SHA base register.*/
+#define SHA_INSTANCE SHA0          /* SHA base register.*/
 #define MBEDTLS_FREESCALE_LPC_SHA1 /* Enable use of LPC SHA.*/
 //#define MBEDTLS_FREESCALE_LPC_SHA256 /* Enable use of LPC SHA256.*/
 

--- a/src/platform/nxp/k32w/k32w0/k32w0-chip-mbedtls-config.h
+++ b/src/platform/nxp/k32w/k32w0/k32w0-chip-mbedtls-config.h
@@ -121,7 +121,7 @@
 #if defined(FSL_FEATURE_SOC_SHA_COUNT) && (FSL_FEATURE_SOC_SHA_COUNT > 0)
 #include "fsl_sha.h"
 
-//#define SHA_INSTANCE SHA0            /* AES base register.*/
+#define SHA_INSTANCE SHA0            /* SHA base register.*/
 #define MBEDTLS_FREESCALE_LPC_SHA1 /* Enable use of LPC SHA.*/
 //#define MBEDTLS_FREESCALE_LPC_SHA256 /* Enable use of LPC SHA256.*/
 
@@ -171,7 +171,7 @@
 #define MBEDTLS_SHA1_ALT
 #endif
 #if defined(MBEDTLS_FREESCALE_LTC_SHA256) || defined(MBEDTLS_FREESCALE_LPC_SHA256)
-//#define MBEDTLS_SHA256_ALT
+#define MBEDTLS_SHA256_ALT
 /*
  * LPC SHA module does not support SHA-224.
  *


### PR DESCRIPTION
Signed-off-by: Doru Gucea <doru-cristian.gucea@nxp.com>

#### Problem
* K32W061 was missing SHA256 HW acceleration

#### Change overview
* add SHA256 HW acceleration on K32W061

#### Testing
* tested using chip-tool (basic commissioning flow)