### PR TITLE
ESP: Add chip shell engine initializing for esp32 platform

### DIFF
--- a/examples/platform/esp32/shell_extension/launch.cpp
+++ b/examples/platform/esp32/shell_extension/launch.cpp
@@ -37,6 +37,7 @@ namespace chip {
 
 void LaunchShell()
 {
+    chip::Shell::Engine::Root().Init();
 #if CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
     idf::chip::RegisterHeapTraceCommands();
 #endif // CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING


### PR DESCRIPTION
#### Problem
The chip shell engine initializing was missing for esp32 platform. It cause a stack overflow for chip shell task. 

#### Change overview
And chip shell engine initializing.

#### Testing
Test with all-clusters-app.
