### PR TITLE
Test added jan 7

### DIFF
--- a/examples/chip-tool/templates/tests.js
+++ b/examples/chip-tool/templates/tests.js
@@ -204,9 +204,9 @@ function getTests()
   ];
 
   const SoftwareDiagnostics = [
-    'Test_TC_DIAGSW_1_1',
-    'Test_TC_DIAGSW_2_1',
-    'Test_TC_DIAGSW_3_2',
+    'Test_TC_SWDIAG_1_1',
+    'Test_TC_SWDIAG_2_1',
+    'Test_TC_SWDIAG_3_1',
   ];
 
   const Subscriptions = [

--- a/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 12.1.1. [TC-BI-1.1] Global attributes with server as DUT
+name: 18.1.1. [TC-BI-1.1] Global attributes with server as DUT
 
 config:
     cluster: "Binary Input (Basic)"
@@ -95,6 +95,7 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
@@ -105,6 +105,7 @@ tests:
     #Issue #11142 Disabled all optional attribute checks
     - label: "Read optional non-global attribute: ActiveText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "active text"
       response:
@@ -112,6 +113,7 @@ tests:
 
     - label: "Read optional non-global attribute constraints: ActiveText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "active text"
       response:
@@ -121,6 +123,7 @@ tests:
     - label:
           "Write the default values to optional non-global attribute: ActiveText"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "active text"
       arguments:
@@ -128,6 +131,7 @@ tests:
 
     - label: "Reads back the optional non-global attribute: ActiveText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "active text"
       response:
@@ -135,6 +139,7 @@ tests:
 
     - label: "Read optional non-global attribute: Description"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "description"
       response:
@@ -142,6 +147,7 @@ tests:
 
     - label: "Read optional non-global attribute constraints: Description"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "description"
       response:
@@ -152,6 +158,7 @@ tests:
           "Write the default values to optional non-global attribute:
           Description"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "description"
       arguments:
@@ -159,6 +166,7 @@ tests:
 
     - label: "Reads back the optional non-global attribute: Description"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "description"
       response:
@@ -166,6 +174,7 @@ tests:
 
     - label: "Read optional non-global attribute: InactiveText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "inactive text"
       response:
@@ -173,6 +182,7 @@ tests:
 
     - label: "Read optional non-global attribute constraints: InactiveText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "inactive text"
       response:
@@ -183,6 +193,7 @@ tests:
           "Write the default values to optional non-global attribute:
           InactiveText"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "inactive text"
       arguments:
@@ -190,6 +201,7 @@ tests:
 
     - label: "Reads back the optional non-global attribute: InactiveText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "inactive text"
       response:
@@ -197,6 +209,7 @@ tests:
 
     - label: "Read optional non-global attribute: Polarity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "polarity"
       response:
@@ -204,6 +217,7 @@ tests:
 
     - label: "Read optional non-global attribute constraints: Polarity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "polarity"
       response:
@@ -213,6 +227,7 @@ tests:
     - label:
           "Write the default values to optional non-global attribute: Polarity"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "polarity"
       arguments:
@@ -222,6 +237,7 @@ tests:
 
     - label: "Reads back the optional non-global attribute: Polarity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "polarity"
       response:
@@ -229,6 +245,7 @@ tests:
 
     - label: "Read optional non-global attribute: Reliability"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "reliability"
       response:
@@ -236,6 +253,7 @@ tests:
 
     - label: "Read optional non-global attribute constraints: Reliability"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "reliability"
       response:
@@ -246,6 +264,7 @@ tests:
           "Write the default values to optional non-global attribute:
           Reliability"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "reliability"
       arguments:
@@ -253,6 +272,7 @@ tests:
 
     - label: "Reads back the optional non-global attribute: Reliability"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "reliability"
       response:
@@ -260,6 +280,7 @@ tests:
 
     - label: "Read optional non-global attribute constraints: ApplicationType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "application type"
       response:
@@ -272,6 +293,7 @@ tests:
           "Write the default values to optional non-global attribute:
           ApplicationType"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "application type"
       arguments:
@@ -281,6 +303,7 @@ tests:
 
     - label: "Reads back the optional non-global attribute: ApplicationType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "application type"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 60.1.1. [TC-BOOL-1.1] Global attributes with server as DUT
+name: 68.1.1. [TC-BOOL-1.1] Global attributes with server as DUT
 
 config:
     cluster: "Boolean State"
@@ -95,6 +95,7 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BOOL_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_2_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 60.2.1. [TC-BOOL-2.1] Attributes with server as DUT
+name: 68.2.1. [TC-BOOL-2.1] Attributes with server as DUT
 
 config:
     cluster: "Boolean State"

--- a/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 21.1.1. [TC-CC-1.1] Global attributes with server as DUT
+name: 27.1.1. [TC-CC-1.1] Global attributes with server as DUT
 
 config:
     cluster: "Color Control"
@@ -97,6 +97,7 @@ tests:
 
     - label: "read the optional global attribute: FeatureMap"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
@@ -104,6 +105,7 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
@@ -112,6 +114,7 @@ tests:
 
     - label: "write the default values to optional global attribute: FeatureMap"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "FeatureMap"
       arguments:
@@ -121,6 +124,7 @@ tests:
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
@@ -522,6 +522,7 @@ tests:
           value: 65279
 
     - label: "Read the optional attribute: CoupleColorTempToLevelMinMireds"
+      optional: true
       command: "readAttribute"
       attribute: "couple color temp to level min-mireds"
       response:
@@ -531,6 +532,7 @@ tests:
     - label:
           "Write the default values to optional attribute:
           CoupleColorTempToLevelMinMireds"
+      optional: true
       command: "writeAttribute"
       attribute: "couple color temp to level min-mireds"
       arguments:
@@ -539,12 +541,14 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: CoupleColorTempToLevelMinMireds"
+      optional: true
       command: "readAttribute"
       attribute: "couple color temp to level min-mireds"
       response:
           value: 0
 
     - label: "Read the optional attribute: StartUpColorTemperatureMireds"
+      optional: true
       command: "readAttribute"
       attribute: "start up color temperature mireds"
       response:
@@ -556,24 +560,28 @@ tests:
     - label:
           "Write the default values to optional attribute:
           StartUpColorTemperatureMireds"
+      optional: true
       command: "writeAttribute"
       attribute: "start up color temperature mireds"
       arguments:
           value: 0
 
     - label: "Reads back optional attribute: StartUpColorTemperatureMireds"
+      optional: true
       command: "readAttribute"
       attribute: "start up color temperature mireds"
       response:
           value: 0
 
     - label: "Read the Optional attribute: RemainingTime"
+      optional: true
       command: "readAttribute"
       attribute: "remaining time"
       response:
           value: 0
 
     - label: "Validate constraints of attribute: RemainingTime"
+      optional: true
       command: "readAttribute"
       attribute: "remaining time"
       response:
@@ -583,6 +591,7 @@ tests:
               maxValue: 254
 
     - label: "Write the default values to optional attribute: RemainingTime"
+      optional: true
       command: "writeAttribute"
       attribute: "remaining time"
       arguments:
@@ -591,12 +600,14 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: RemainingTime"
+      optional: true
       command: "readAttribute"
       attribute: "remaining time"
       response:
           value: 0
 
     - label: "Read the optional attribute: DriftCompensation"
+      optional: true
       command: "readAttribute"
       attribute: "drift compensation"
       response:
@@ -606,6 +617,7 @@ tests:
               maxValue: 4
 
     - label: "Write the default values to optional attribute: DriftCompensation"
+      optional: true
       command: "writeAttribute"
       attribute: "drift compensation"
       arguments:
@@ -614,12 +626,14 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: DriftCompensation"
+      optional: true
       command: "readAttribute"
       attribute: "drift compensation"
       response:
           value: 0
 
     - label: "Read the optional attribute: CompensationText"
+      optional: true
       command: "readAttribute"
       attribute: "compensation text"
       response:
@@ -629,6 +643,7 @@ tests:
 
     - label: "Write the default values to optional attribute: CompensationText"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "compensation text"
       arguments:
@@ -638,6 +653,7 @@ tests:
 
     - label: "Reads back optional attribute: CompensationText"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "compensation text"
       response:
@@ -1085,6 +1101,7 @@ tests:
 
     #Defined Color Points Settings Attribute Set
     - label: "Read the optional attribute: WhitePointX"
+      optional: true
       command: "readAttribute"
       attribute: "white point x"
       response:
@@ -1094,18 +1111,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: WhitePointX"
+      optional: true
       command: "writeAttribute"
       attribute: "white point x"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: WhitePointX"
+      optional: true
       command: "readAttribute"
       attribute: "white point x"
       response:
           value: 0
 
     - label: "Read the optional attribute: WhitePointY"
+      optional: true
       command: "readAttribute"
       attribute: "white point y"
       response:
@@ -1115,18 +1135,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: WhitePointY"
+      optional: true
       command: "writeAttribute"
       attribute: "white point y"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: WhitePointY"
+      optional: true
       command: "readAttribute"
       attribute: "white point y"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointRX"
+      optional: true
       command: "readAttribute"
       attribute: "color point r x"
       response:
@@ -1136,18 +1159,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: ColorPointRX"
+      optional: true
       command: "writeAttribute"
       attribute: "color point r x"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: ColorPointRX"
+      optional: true
       command: "readAttribute"
       attribute: "color point r x"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointRY"
+      optional: true
       command: "readAttribute"
       attribute: "color point r y"
       response:
@@ -1157,18 +1183,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: ColorPointRY"
+      optional: true
       command: "writeAttribute"
       attribute: "color point r y"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: ColorPointRY"
+      optional: true
       command: "readAttribute"
       attribute: "color point r y"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointRIntensity"
+      optional: true
       command: "readAttribute"
       attribute: "color point r intensity"
       response:
@@ -1177,6 +1206,7 @@ tests:
 
     - label: "Write the default optional attribute: ColorPointRIntensity"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "color point r intensity"
       arguments:
@@ -1184,12 +1214,14 @@ tests:
 
     - label: "Read back the optional attribute: ColorPointRIntensity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "color point r intensity"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointGX"
+      optional: true
       command: "readAttribute"
       attribute: "color point g x"
       response:
@@ -1199,18 +1231,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: ColorPointGX"
+      optional: true
       command: "writeAttribute"
       attribute: "color point g x"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: ColorPointGX"
+      optional: true
       command: "readAttribute"
       attribute: "color point g x"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointGY"
+      optional: true
       command: "readAttribute"
       attribute: "color point g y"
       response:
@@ -1220,18 +1255,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: ColorPointGY"
+      optional: true
       command: "writeAttribute"
       attribute: "color point g y"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: ColorPointGY"
+      optional: true
       command: "readAttribute"
       attribute: "color point g y"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointGIntensity"
+      optional: true
       command: "readAttribute"
       attribute: "color point g intensity"
       response:
@@ -1240,6 +1278,7 @@ tests:
 
     - label: "Write the default optional attribute: ColorPointGIntensity"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "color point g intensity"
       arguments:
@@ -1247,12 +1286,14 @@ tests:
 
     - label: "Read back the optional attribute: ColorPointGIntensity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "color point g intensity"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointBX"
+      optional: true
       command: "readAttribute"
       attribute: "color point b x"
       response:
@@ -1262,18 +1303,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: ColorPointBX"
+      optional: true
       command: "writeAttribute"
       attribute: "color point b x"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: ColorPointBX"
+      optional: true
       command: "readAttribute"
       attribute: "color point b x"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointBY"
+      optional: true
       command: "readAttribute"
       attribute: "color point b y"
       response:
@@ -1283,18 +1327,21 @@ tests:
               maxValue: 65279
 
     - label: "Write the default optional attribute: ColorPointBY"
+      optional: true
       command: "writeAttribute"
       attribute: "color point b y"
       arguments:
           value: 0
 
     - label: "Read back the optional attribute: ColorPointBY"
+      optional: true
       command: "readAttribute"
       attribute: "color point b y"
       response:
           value: 0
 
     - label: "Read the optional attribute: ColorPointBIntensity"
+      optional: true
       command: "readAttribute"
       attribute: "color point b intensity"
       response:
@@ -1303,6 +1350,7 @@ tests:
 
     - label: "Write the default optional attribute: ColorPointBIntensity"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "color point b intensity"
       arguments:
@@ -1310,6 +1358,7 @@ tests:
 
     - label: "Read back the optional attribute: ColorPointBIntensity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "color point b intensity"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
@@ -69,15 +69,6 @@ tests:
       response:
           value: 1200
 
-    - label:
-          "Check Saturation attribute value matched the value sent by the last
-          command"
-      disabled: true
-      command: "readAttribute"
-      attribute: "current saturation"
-      response:
-          value: 90
-
     - label: "Turn off light that we turned on"
       cluster: "On/Off"
       command: "off"

--- a/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 27.1.1. [TC-FLW-1.1] Global attributes with server as DUT
+name: 33.1.1. [TC-FLW-1.1] Global attributes with server as DUT
 
 config:
     cluster: "Flow Measurement"
@@ -98,6 +98,7 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_FLW_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_2_1.yaml
@@ -45,7 +45,6 @@ tests:
               type: uint16
 
     - label: "write the default value to optional attribute: MeasuredValue"
-      disabled: true
       command: "writeAttribute"
       attribute: "MeasuredValue"
       arguments:
@@ -91,14 +90,14 @@ tests:
               type: uint16
 
     - label: "read the optional attribute: Tolerance"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
           value: 0
 
     - label: "read the optional attribute: Tolerance"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
@@ -108,7 +107,7 @@ tests:
               maxValue: 2048
 
     - label: "write the default value to optional attribute: Tolerance"
-      disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "Tolerance"
       arguments:
@@ -117,18 +116,8 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "read the optional attribute: Tolerance"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
           value: 0
-
-    - label: "read the optional attribute: Tolerance"
-      disabled: true
-      command: "readAttribute"
-      attribute: "Tolerance"
-      response:
-          constraints:
-              type: uint16
-              minValue: 0
-              maxValue: 2048

--- a/src/app/tests/suites/certification/Test_TC_FLW_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_2_2.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 33.2.1. [TC-FLW-2.1] Attributes with server as DUT
+name: 33.2.2. [TC-FLW-2.2] Primary functionality with server as DUT
 
 config:
     cluster: "Flow Measurement"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_1.yaml
@@ -25,7 +25,7 @@ tests:
 
     - label: "Send Select"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -33,7 +33,7 @@ tests:
 
     - label: "Send Up"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -41,7 +41,7 @@ tests:
 
     - label: "Send Down"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -49,14 +49,14 @@ tests:
 
     - label: "Send Left"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
                 value: 0x03
     - label: "Send Right"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -64,7 +64,7 @@ tests:
 
     - label: "Send RightUp"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -72,7 +72,7 @@ tests:
 
     - label: "Send RightDown"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -80,7 +80,7 @@ tests:
 
     - label: "Send LeftUp"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -88,7 +88,7 @@ tests:
 
     - label: "Send LeftDown"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -96,7 +96,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -104,7 +104,7 @@ tests:
 
     - label: "Send SetupMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -112,7 +112,7 @@ tests:
 
     - label: "Send ContentsMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -120,7 +120,7 @@ tests:
 
     - label: "Send FavoriteMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -128,7 +128,7 @@ tests:
 
     - label: "Send Exit"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -136,7 +136,7 @@ tests:
 
     - label: "Send Invalid"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_10.yaml
@@ -26,8 +26,8 @@ tests:
     # TDOD: Enable when SDK supports command
     - label: "Hide Input Status Command"
       disabled: true
-      command: "HideInputStatus"
+      command: "HideInputStatusRequest"
     # TDOD: Enable when SDK supports command
     - label: "Show Input Status Command"
       disabled: true
-      command: "ShowInputStatus"
+      command: "ShowInputStatusRequest"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_11.yaml
@@ -26,7 +26,7 @@ tests:
     # Remove disable flag when SDK supports command.
     - label: "Rename Input Command"
       disabled: true
-      command: "RenameInput"
+      command: "RenameInputRequest"
       arguments:
           values:
               - name: "index"
@@ -36,7 +36,7 @@ tests:
     # Remove disable flag when SDK supports command.
     - label: "Rename Input Command"
       disabled: true
-      command: "RenameInput"
+      command: "RenameInputRequest"
       arguments:
           values:
               - name: "index"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_2.yaml
@@ -25,7 +25,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -33,7 +33,7 @@ tests:
 
     - label: "Send SetupMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_3.yaml
@@ -25,7 +25,7 @@ tests:
 
     - label: "Send Numbers1"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -33,7 +33,7 @@ tests:
 
     - label: "Send Numbers2"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -41,7 +41,7 @@ tests:
 
     - label: "Send Numbers3"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -49,7 +49,7 @@ tests:
 
     - label: "Send Numbers4"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -57,7 +57,7 @@ tests:
 
     - label: "Send Numbers5"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -65,7 +65,7 @@ tests:
 
     - label: "Send Numbers6"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -73,7 +73,7 @@ tests:
 
     - label: "Send Numbers7"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -81,7 +81,7 @@ tests:
 
     - label: "Send Numbers8"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -89,7 +89,7 @@ tests:
 
     - label: "Send Numbers9"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_4.yaml
@@ -25,7 +25,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -33,7 +33,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -41,7 +41,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -49,7 +49,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -57,7 +57,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -65,7 +65,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -73,7 +73,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -81,7 +81,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -89,7 +89,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"
@@ -97,7 +97,7 @@ tests:
 
     - label: "Send RootMenu"
       disabled: true
-      command: "SendKey"
+      command: "SendKeyRequest"
       arguments:
           values:
               - name: "keyCode"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_6.yaml
@@ -26,7 +26,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"
       disabled: true
-      command: "LaunchApp"
+      command: "LaunchAppRequest"
       arguments:
           values:
               - name: "data"
@@ -59,7 +59,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Stop an app with the provided application ID"
       disabled: true
-      command: "StopApp"
+      command: "StopAppRequest"
       arguments:
           values:
               - name: "applicationId"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_7.yaml
@@ -26,7 +26,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"
       disabled: true
-      command: "LaunchApp"
+      command: "LaunchAppRequest"
       arguments:
           values:
               - name: "data"
@@ -39,7 +39,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Stop an app with the provided application ID"
       disabled: true
-      command: "StopApp"
+      command: "StopAppRequest"
       arguments:
           values:
               - name: "applicationId"
@@ -48,7 +48,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"
       disabled: true
-      command: "LaunchApp"
+      command: "LaunchAppRequest"
       arguments:
           values:
               - name: "data"
@@ -63,7 +63,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"
       disabled: true
-      command: "LaunchApp"
+      command: "LaunchAppRequest"
       arguments:
           values:
               - name: "data"
@@ -76,7 +76,7 @@ tests:
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"
       disabled: true
-      command: "LaunchApp"
+      command: "LaunchAppRequest"
       arguments:
           values:
               - name: "data"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_9.yaml
@@ -26,7 +26,7 @@ tests:
     # Remove disable flag when SDK supports command.
     - label: "Select Input Command"
       disabled: true
-      command: "SelectInput"
+      command: "SelectInputRequest"
       arguments:
           values:
               - name: "index"

--- a/src/app/tests/suites/certification/Test_TC_OO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_1.yaml
@@ -30,7 +30,6 @@ tests:
           value: 0
 
     - label: "write the default value of mandatory attribute: OnOff"
-      disabled: true
       command: "writeAttribute"
       attribute: "OnOff"
       arguments:
@@ -69,7 +68,6 @@ tests:
           value: 0
 
     - label: "write the default value to LT attribute: GlobalSceneControl"
-      disabled: true
       command: "writeAttribute"
       attribute: "GlobalSceneControl"
       arguments:
@@ -96,7 +94,6 @@ tests:
           value: 0
 
     - label: "reads back LT attribute: GlobalSceneControl"
-      disabled: true
       command: "readAttribute"
       attribute: "GlobalSceneControl"
       response:

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
@@ -45,7 +45,6 @@ tests:
           value: null
 
     - label: "read the mandatory attribute: MaxSpeed"
-      disabled: true
       command: "readAttribute"
       attribute: "MaxSpeed"
       response:
@@ -60,7 +59,6 @@ tests:
           value: null
 
     - label: "read the mandatory attribute: MaxFlow"
-      disabled: true
       command: "readAttribute"
       attribute: "MaxFlow"
       response:
@@ -185,7 +183,6 @@ tests:
           value: null
 
     - label: "read the mandatory attribute: MaxSpeed"
-      disabled: true
       command: "readAttribute"
       attribute: "MaxSpeed"
       response:
@@ -200,7 +197,6 @@ tests:
           value: null
 
     - label: "read the mandatory attribute: MaxFlow"
-      disabled: true
       command: "readAttribute"
       attribute: "MaxFlow"
       response:
@@ -251,13 +247,14 @@ tests:
 
     - label: "read the optional attribute: MinConstPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstPressure"
       response:
@@ -266,13 +263,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstPressure"
       response:
@@ -281,13 +279,14 @@ tests:
 
     - label: "read the optional attribute: MinCompPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinCompPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MinCompPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinCompPressure"
       response:
@@ -296,13 +295,14 @@ tests:
 
     - label: "read the optional attribute: MaxCompPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxCompPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MaxCompPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxCompPressure"
       response:
@@ -311,13 +311,14 @@ tests:
 
     - label: "read the optional attribute: MinConstSpeed"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstSpeed"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstSpeed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstSpeed"
       response:
@@ -326,13 +327,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstSpeed"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstSpeed"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstSpeed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstSpeed"
       response:
@@ -341,13 +343,14 @@ tests:
 
     - label: "read the optional attribute: MinConstFlow"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstFlow"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstFlow"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstFlow"
       response:
@@ -356,13 +359,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstFlow"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstFlow"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstFlow"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstFlow"
       response:
@@ -371,13 +375,14 @@ tests:
 
     - label: "read the optional attribute: MinConstTemp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstTemp"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstTemp"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstTemp"
       response:
@@ -387,13 +392,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstTemp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstTemp"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstTemp"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstTemp"
       response:
@@ -402,14 +408,14 @@ tests:
               minValue: -27315
 
     - label: "read the optional attribute: PumpStatus"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "PumpStatus"
       response:
           value: 0
 
     - label: "read the optional attribute: PumpStatus"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "PumpStatus"
       response:
@@ -418,13 +424,14 @@ tests:
 
     - label: "read the optional attribute: Speed"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Speed"
       response:
           value: null
 
     - label: "read the optional attribute: Speed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Speed"
       response:
@@ -432,14 +439,14 @@ tests:
               type: uint16
 
     - label: "read the optional attribute: LifetimeRunningHours"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeRunningHours"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeRunningHours"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeRunningHours"
       response:
@@ -448,13 +455,14 @@ tests:
 
     - label: "read the optional attribute: Power"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Power"
       response:
           value: null
 
     - label: "read the optional attribute: Power"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Power"
       response:
@@ -462,14 +470,14 @@ tests:
               type: uint24
 
     - label: "read the optional attribute: LifetimeEnergyConsumed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeEnergyConsumed"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeEnergyConsumed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeEnergyConsumed"
       response:
@@ -478,6 +486,7 @@ tests:
 
     - label: "write to the optional attribute: MinConstPressure"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MinConstPressure"
       arguments:
@@ -487,6 +496,7 @@ tests:
 
     - label: "write to the optional attribute: MaxConstPressure"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MaxConstPressure"
       arguments:
@@ -496,6 +506,7 @@ tests:
 
     - label: "write to the optional attribute: MinCompPressure"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MinCompPressure"
       arguments:
@@ -505,6 +516,7 @@ tests:
 
     - label: "write to the optional attribute: MaxCompPressure"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MaxCompPressure"
       arguments:
@@ -514,6 +526,7 @@ tests:
 
     - label: "write to the optional attribute: MinConstSpeed"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MinConstSpeed"
       arguments:
@@ -523,6 +536,7 @@ tests:
 
     - label: "write to the optional attribute: MaxConstSpeed"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MaxConstSpeed"
       arguments:
@@ -532,6 +546,7 @@ tests:
 
     - label: "write to the optional attribute: MinConstFlow"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MinConstFlow"
       arguments:
@@ -541,6 +556,7 @@ tests:
 
     - label: "write to the optional attribute: MaxConstFlow"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MaxConstFlow"
       arguments:
@@ -550,6 +566,7 @@ tests:
 
     - label: "write to the optional attribute: MinConstTemp"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MinConstTemp"
       arguments:
@@ -559,6 +576,7 @@ tests:
 
     - label: "write to the optional attribute: MaxConstTemp"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MaxConstTemp"
       arguments:
@@ -568,6 +586,7 @@ tests:
 
     - label: "write to the optional attribute: PumpStatus"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "PumpStatus"
       arguments:
@@ -577,6 +596,7 @@ tests:
 
     - label: "write to the optional attribute: Speed"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "Speed"
       arguments:
@@ -586,6 +606,7 @@ tests:
 
     - label: "write to the optional attribute: LifetimeRunningHours"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "LifetimeRunningHours"
       arguments:
@@ -593,6 +614,7 @@ tests:
 
     - label: "write to the optional attribute: Power"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "Power"
       arguments:
@@ -601,7 +623,7 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: LifetimeEnergyConsumed"
-      disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "LifetimeEnergyConsumed"
       arguments:
@@ -609,13 +631,14 @@ tests:
 
     - label: "read the optional attribute: MinConstPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstPressure"
       response:
@@ -624,13 +647,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstPressure"
       response:
@@ -639,13 +663,14 @@ tests:
 
     - label: "read the optional attribute: MinCompPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinCompPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MinCompPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinCompPressure"
       response:
@@ -654,13 +679,14 @@ tests:
 
     - label: "read the optional attribute: MaxCompPressure"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxCompPressure"
       response:
           value: null
 
     - label: "read the optional attribute: MaxCompPressure"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxCompPressure"
       response:
@@ -669,13 +695,14 @@ tests:
 
     - label: "read the optional attribute: MinConstSpeed"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstSpeed"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstSpeed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstSpeed"
       response:
@@ -684,13 +711,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstSpeed"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstSpeed"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstSpeed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstSpeed"
       response:
@@ -699,13 +727,14 @@ tests:
 
     - label: "read the optional attribute: MinConstFlow"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstFlow"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstFlow"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstFlow"
       response:
@@ -714,13 +743,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstFlow"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstFlow"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstFlow"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstFlow"
       response:
@@ -729,13 +759,14 @@ tests:
 
     - label: "read the optional attribute: MinConstTemp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstTemp"
       response:
           value: null
 
     - label: "read the optional attribute: MinConstTemp"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinConstTemp"
       response:
@@ -745,13 +776,14 @@ tests:
 
     - label: "read the optional attribute: MaxConstTemp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstTemp"
       response:
           value: null
 
     - label: "read the optional attribute: MaxConstTemp"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxConstTemp"
       response:
@@ -760,14 +792,14 @@ tests:
               minValue: -27315
 
     - label: "read the optional attribute: PumpStatus"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "PumpStatus"
       response:
           value: 0
 
     - label: "read the optional attribute: PumpStatus"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "PumpStatus"
       response:
@@ -776,13 +808,14 @@ tests:
 
     - label: "read the optional attribute: Speed"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Speed"
       response:
           value: null
 
     - label: "read the optional attribute: Speed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Speed"
       response:
@@ -790,14 +823,13 @@ tests:
               type: uint16
 
     - label: "read the optional attribute: LifetimeRunningHours"
-      disabled: true
       command: "readAttribute"
       attribute: "LifetimeRunningHours"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeRunningHours"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeRunningHours"
       response:
@@ -806,13 +838,14 @@ tests:
 
     - label: "read the optional attribute: Power"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Power"
       response:
           value: null
 
     - label: "read the optional attribute: Power"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Power"
       response:
@@ -820,14 +853,14 @@ tests:
               type: uint24
 
     - label: "read the optional attribute: LifetimeEnergyConsumed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeEnergyConsumed"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeEnergyConsumed"
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LifetimeEnergyConsumed"
       response:

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_3.yaml
@@ -38,7 +38,6 @@ tests:
           value: 0
 
     - label: "Write 0 to the ControlMode attribute to DUT"
-      disabled: true
       command: "writeAttribute"
       attribute: "ControlMode"
       PICS: A_CONTROLMODE
@@ -46,7 +45,6 @@ tests:
           value: 0
 
     - label: "Reads the attribute: EffectiveControlMode"
-      disabled: true
       command: "readAttribute"
       attribute: "EffectiveControlMode"
       PICS: A_EFFECTIVECONTROLMODE
@@ -54,7 +52,6 @@ tests:
           value: 0
 
     - label: "Write 1 to the ControlMode attribute to DUT"
-      disabled: true
       command: "writeAttribute"
       attribute: "ControlMode"
       PICS: A_CONTROLMODE
@@ -70,7 +67,6 @@ tests:
           value: 1
 
     - label: "Write 2 to the ControlMode attribute to DUT"
-      disabled: true
       command: "writeAttribute"
       attribute: "ControlMode"
       PICS: A_CONTROLMODE
@@ -86,7 +82,6 @@ tests:
           value: 2
 
     - label: "Write 3 to the ControlMode attribute to DUT"
-      disabled: true
       command: "writeAttribute"
       attribute: "ControlMode"
       PICS: A_CONTROLMODE
@@ -102,7 +97,6 @@ tests:
           value: 3
 
     - label: "Write 5 to the ControlMode attribute to DUT"
-      disabled: true
       command: "writeAttribute"
       attribute: "ControlMode"
       PICS: A_CONTROLMODE
@@ -118,7 +112,6 @@ tests:
           value: 5
 
     - label: "Write 7 to the ControlMode attribute to DUT"
-      disabled: true
       command: "writeAttribute"
       attribute: "ControlMode"
       PICS: A_CONTROLMODE

--- a/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
@@ -88,6 +88,7 @@ tests:
 
     - label: "Read the optional attribute: Tolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
@@ -95,6 +96,7 @@ tests:
 
     - label: "Write the default values to optional attribute: Tolerance"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "Tolerance"
       arguments:
@@ -104,6 +106,7 @@ tests:
 
     - label: "Reads back optional attribute: Tolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
@@ -112,6 +115,7 @@ tests:
     #Following attributes are based on the value of the extended feature in the cluster feature map
     - label: "Read the optional attribute: ScaledValue"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ScaledValue"
       response:
@@ -119,6 +123,7 @@ tests:
 
     - label: "Write the default values to optional attribute: ScaledValue"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ScaledValue"
       arguments:
@@ -128,6 +133,7 @@ tests:
 
     - label: "Reads back optional attribute: ScaledValue"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ScaledValue"
       response:
@@ -135,6 +141,7 @@ tests:
 
     - label: "Read the optional attribute: MinScaledValue"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinScaledValue"
       response:
@@ -142,6 +149,7 @@ tests:
 
     - label: "Write the default values to optional attribute: MinScaledValue"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MinScaledValue"
       arguments:
@@ -151,6 +159,7 @@ tests:
 
     - label: "Reads back optional attribute: MinScaledValue"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MinScaledValue"
       response:
@@ -158,6 +167,7 @@ tests:
 
     - label: "Read the optional attribute: MaxScaledValue"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxScaledValue"
       response:
@@ -165,6 +175,7 @@ tests:
 
     - label: "Write the default values to optional attribute: MaxScaledValue"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "MaxScaledValue"
       arguments:
@@ -174,6 +185,7 @@ tests:
 
     - label: "Reads back optional attribute: MaxScaledValue"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "MaxScaledValue"
       response:
@@ -181,6 +193,7 @@ tests:
 
     - label: "Read the optional attribute: ScaledTolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ScaledTolerance"
       response:
@@ -188,6 +201,7 @@ tests:
 
     - label: "Write the default values to optional attribute: ScaledTolerance"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ScaledTolerance"
       arguments:
@@ -197,6 +211,7 @@ tests:
 
     - label: "Reads back optional attribute: ScaledTolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ScaledTolerance"
       response:
@@ -204,6 +219,7 @@ tests:
 
     - label: "Read the optional attribute: Scale"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Scale"
       response:
@@ -211,6 +227,7 @@ tests:
 
     - label: "Write the default values to optional attribute: Scale"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "Scale"
       arguments:
@@ -220,6 +237,7 @@ tests:
 
     - label: "Reads back optional attribute: Scale"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Scale"
       response:

--- a/src/app/tests/suites/certification/Test_TC_RH_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_2_1.yaml
@@ -72,6 +72,7 @@ tests:
 
     - label: "Reads the optional attribute: Tolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "tolerance"
       response:
@@ -79,6 +80,7 @@ tests:
 
     - label: "Reads constraints of attribute: Tolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "tolerance"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_1_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 48.1.4. [TC-DIAGSW-3.2] Command received functionality with server as DUT
+name: 45.1.1. [TC-SWDIAG-1.1] Attributes with server as DUT
 
 config:
     cluster: "Software Diagnostics"
@@ -23,32 +23,41 @@ tests:
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
 
-    #issue #11578 ResetWatermarks command is Failing
-    - label: "Sends ResetWatermarks to DUT"
+    #Issue #11185 Disabled as ThreadMetrics attribute missing
+    - label:
+          "Reads a list of ThreadMetrics struct non-global attribute from DUT."
       disabled: true
-      command: "ResetWatermarks"
-      PICS: CR_RESETWATERMARKS
-
-    - label: "Reads a list of ThreadMetrics struct attribute from DUT."
-      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThreadMetrics"
       PICS: A_THREADMETRICS
       response:
-          value: 0
+          constraints:
+              value: 0
 
-    - label: "Reads CurrentHeapUsed attribute value from DUT"
-      disabled: true
+    - label: "Reads CurrentHeapFree non-global attribute value from DUT"
+      optional: true
+      command: "readAttribute"
+      attribute: "CurrentHeapFree"
+      response:
+          constraints:
+              type: uint64
+
+    - label: "Reads CurrentHeapUsed non-global attribute value from DUT"
+      optional: true
       command: "readAttribute"
       attribute: "CurrentHeapUsed"
       PICS: A_CURRENTHEAPUSED
       response:
-          value: 0
+          constraints:
+              type: uint64
 
-    - label: "Reads CurrentHeapHighWaterMark attribute value from DUT"
-      disabled: true
+    - label:
+          "Reads CurrentHeapHighWaterMark non-global attribute value from DUT"
+      optional: true
       command: "readAttribute"
       attribute: "CurrentHeapHighWatermark"
       PICS: A_CURRENTHEAPHIGHWATERMARK
       response:
-          value: 0
+          constraints:
+              type: uint64

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_2_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 48.1.3. [TC-DIAGSW-2.1] Event functionality with server as DUT
+name: 45.1.3. [TC-SWDIAG-2.1] Event functionality with server as DUT
 
 config:
     cluster: "Software Diagnostics"
@@ -22,6 +22,7 @@ tests:
     #issue #11725 Reading the List is not implemented in YAML framework
     - label: "Reads a list of SoftwareFault struct from DUT"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SoftwareFault"
       PICS: E_SOFTWAREFAULT

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 48.1.1. [TC-DIAGSW-1.1] Attributes with server as DUT
+name: 45.1.4. [TC-SWDIAG-3.1] Command received functionality with server as DUT
 
 config:
     cluster: "Software Diagnostics"
@@ -23,41 +23,36 @@ tests:
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
 
-    #Issue #11185 Disabled as ThreadMetrics attribute missing
-    - label:
-          "Reads a list of ThreadMetrics struct non-global attribute from DUT."
+    #issue #11578 ResetWatermarks command is Failing
+    - label: "Sends ResetWatermarks to DUT"
+      disabled: true
+      optional: true
+      command: "ResetWatermarks"
+      PICS: CR_RESETWATERMARKS
+
+    - label: "Reads a list of ThreadMetrics struct attribute from DUT."
       disabled: true
       optional: true
       command: "readAttribute"
       attribute: "ThreadMetrics"
       PICS: A_THREADMETRICS
       response:
-          constraints:
-              value: 0
+          value: 0
 
-    - label: "Reads CurrentHeapFree non-global attribute value from DUT"
-      command: "readAttribute"
-      attribute: "CurrentHeapFree"
+    - label: "Reads CurrentHeapUsed attribute value from DUT"
+      disabled: true
       optional: true
-      response:
-          constraints:
-              type: uint64
-
-    - label: "Reads CurrentHeapUsed non-global attribute value from DUT"
       command: "readAttribute"
       attribute: "CurrentHeapUsed"
       PICS: A_CURRENTHEAPUSED
-      optional: true
       response:
-          constraints:
-              type: uint64
+          value: 0
 
-    - label:
-          "Reads CurrentHeapHighWaterMark non-global attribute value from DUT"
+    - label: "Reads CurrentHeapHighWaterMark attribute value from DUT"
+      disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "CurrentHeapHighWatermark"
       PICS: A_CURRENTHEAPHIGHWATERMARK
-      optional: true
       response:
-          constraints:
-              type: uint64
+          value: 0

--- a/src/app/tests/suites/certification/Test_TC_TM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TM_2_1.yaml
@@ -52,6 +52,7 @@ tests:
 
     - label: "read the optional attribute: Tolerance"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -568,6 +568,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: OutdoorTemperature"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OutdoorTemperature"
       response:
@@ -576,6 +577,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: OutdoorTemperature"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OutdoorTemperature"
       response:
@@ -586,6 +588,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           OutdoorTemperature"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "OutdoorTemperature"
       arguments:
@@ -593,6 +596,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: OutdoorTemperature"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OutdoorTemperature"
       response:
@@ -600,6 +604,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: Occupancy"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Occupancy"
       response:
@@ -607,6 +612,7 @@ tests:
 
     - label: "Reads constraints of optional attributes from DUT: Occupancy"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Occupancy"
       response:
@@ -619,6 +625,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           Occupancy"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "Occupancy"
       arguments:
@@ -626,6 +633,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: Occupancy"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "Occupancy"
       response:
@@ -633,6 +641,7 @@ tests:
 
     - label: "Reads optionl attributes from DUT: HVACSystemTypeConfiguration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "HVACSystemTypeConfiguration"
       response:
@@ -642,6 +651,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           HVACSystemTypeConfiguration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "HVACSystemTypeConfiguration"
       response:
@@ -654,6 +664,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           HVACSystemTypeConfiguration"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "HVACSystemTypeConfiguration"
       arguments:
@@ -662,6 +673,7 @@ tests:
     - label:
           "Read back optional attributes from DUT: HVACSystemTypeConfiguration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "HVACSystemTypeConfiguration"
       response:
@@ -669,6 +681,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: LocalTemperatureCalibration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LocalTemperatureCalibration"
       response:
@@ -678,6 +691,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           LocalTemperatureCalibration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LocalTemperatureCalibration"
       response:
@@ -690,6 +704,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           LocalTemperatureCalibration"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "LocalTemperatureCalibration"
       arguments:
@@ -698,12 +713,14 @@ tests:
     - label:
           "Read back optional attributes from DUT: LocalTemperatureCalibration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "LocalTemperatureCalibration"
       response:
           value: 0
 
     - label: "Reads optional attributes from DUT: MinSetpointDeadBand"
+      optional: true
       command: "readAttribute"
       attribute: "min setpoint dead band"
       response:
@@ -712,6 +729,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT:
           MinSetpointDeadBand"
+      optional: true
       command: "readAttribute"
       attribute: "min setpoint dead band"
       response:
@@ -723,12 +741,14 @@ tests:
     - label:
           "Writes the respective default value to optional attributes to DUT:
           MinSetpointDeadBand"
+      optional: true
       command: "writeAttribute"
       attribute: "min setpoint dead band"
       arguments:
           value: 25
 
     - label: "Read back optional attributes from DUT: MinSetpointDeadBand"
+      optional: true
       command: "readAttribute"
       attribute: "min setpoint dead band"
       response:
@@ -736,6 +756,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: RemoteSensing"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "RemoteSensing"
       response:
@@ -743,6 +764,7 @@ tests:
 
     - label: "Reads constraints of optional attributes from DUT: RemoteSensing"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "RemoteSensing"
       response:
@@ -753,6 +775,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           RemoteSensing"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "RemoteSensing"
       arguments:
@@ -760,6 +783,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: RemoteSensing"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "RemoteSensing"
       response:
@@ -767,6 +791,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: AlarmMask"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "AlarmMask"
       response:
@@ -774,6 +799,7 @@ tests:
 
     - label: "Reads constraints of optional attributes from DUT: AlarmMask"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "AlarmMask"
       response:
@@ -786,6 +812,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           AlarmMask"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "AlarmMask"
       arguments:
@@ -795,6 +822,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: AlarmMask"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "AlarmMask"
       response:
@@ -802,6 +830,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ThermostatRunningMode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatRunningMode"
       response:
@@ -811,6 +840,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           ThermostatRunningMode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatRunningMode"
       response:
@@ -823,6 +853,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ThermostatRunningMode"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ThermostatRunningMode"
       arguments:
@@ -832,12 +863,14 @@ tests:
 
     - label: "Read back optional attributes from DUT: ThermostatRunningMode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatRunningMode"
       response:
           value: 0
 
     - label: "Reads constraints of optional attributes from DUT: StartOfWeek"
+      optional: true
       command: "readAttribute"
       attribute: "start of week"
       response:
@@ -849,6 +882,7 @@ tests:
     - label:
           "Writes the respective default value to optional attributes to DUT:
           StartOfWeek"
+      optional: true
       command: "writeAttribute"
       attribute: "start of week"
       arguments:
@@ -857,6 +891,7 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: StartOfWeek"
+      optional: true
       command: "readAttribute"
       attribute: "start of week"
       response:
@@ -865,6 +900,7 @@ tests:
     #issue #11625 default value is 0 as per spec but expecting 7
     - label: "Reads optional attributes from DUT: NumberOfWeeklyTransitions"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "number of weekly transitions"
       response:
@@ -873,6 +909,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT:
           NumberOfWeeklyTransitions"
+      optional: true
       command: "readAttribute"
       attribute: "number of weekly transitions"
       response:
@@ -882,6 +919,7 @@ tests:
     - label:
           "Writes the respective default value to optional attributes to DUT:
           NumberOfWeeklyTransitions"
+      optional: true
       command: "writeAttribute"
       attribute: "number of weekly transitions"
       arguments:
@@ -891,6 +929,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: NumberOfWeeklyTransitions"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "number of weekly transitions"
       response:
@@ -899,6 +938,7 @@ tests:
     #issue #11625 default value is 0 as per spec but expecting 4
     - label: "Reads optional attributes from DUT: NumberOfDailyTransitions"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "number of daily transitions"
       response:
@@ -907,6 +947,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT:
           NumberOfDailyTransitions"
+      optional: true
       command: "readAttribute"
       attribute: "number of daily transitions"
       response:
@@ -916,6 +957,7 @@ tests:
     - label:
           "Writes the respective default value to optional attributes to DUT:
           NumberOfDailyTransitions"
+      optional: true
       command: "writeAttribute"
       attribute: "number of daily transitions"
       arguments:
@@ -925,6 +967,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: NumberOfDailyTransitions"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "number of daily transitions"
       response:
@@ -932,6 +975,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: TemperatureSetpointHold"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "TemperatureSetpointHold"
       response:
@@ -941,6 +985,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           TemperatureSetpointHold"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "TemperatureSetpointHold"
       response:
@@ -953,6 +998,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           TemperatureSetpointHold"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "TemperatureSetpointHold"
       arguments:
@@ -960,6 +1006,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: TemperatureSetpointHold"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "TemperatureSetpointHold"
       response:
@@ -968,6 +1015,7 @@ tests:
     - label:
           "Reads optional attributes from DUT: TemperatureSetpointHoldDuration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "TemperatureSetpointHoldDuration"
       response:
@@ -977,6 +1025,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           TemperatureSetpointHoldDuration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "TemperatureSetpointHoldDuration"
       response:
@@ -989,6 +1038,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           TemperatureSetpointHoldDuration"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "TemperatureSetpointHoldDuration"
       arguments:
@@ -998,6 +1048,7 @@ tests:
           "Read back optional attributes from DUT:
           TemperatureSetpointHoldDuration"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "TemperatureSetpointHoldDuration"
       response:
@@ -1007,6 +1058,7 @@ tests:
           "Reads optional attributes from DUT:
           ThermostatProgrammingOperationMode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatProgrammingOperationMode"
       response:
@@ -1016,6 +1068,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           ThermostatProgrammingOperationMode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatProgrammingOperationMode"
       response:
@@ -1028,6 +1081,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ThermostatProgrammingOperationMode"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ThermostatProgrammingOperationMode"
       arguments:
@@ -1037,6 +1091,7 @@ tests:
           "Read back optional attributes from DUT:
           ThermostatProgrammingOperationMode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatProgrammingOperationMode"
       response:
@@ -1046,6 +1101,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           ThermostatRunningState"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatRunningState"
       response:
@@ -1058,6 +1114,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ThermostatRunningState"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ThermostatRunningState"
       arguments:
@@ -1067,6 +1124,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ThermostatRunningState"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ThermostatRunningState"
       response:
@@ -1074,6 +1132,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: SetpointChangeSource"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeSource"
       response:
@@ -1083,6 +1142,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           SetpointChangeSource"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeSource"
       response:
@@ -1095,6 +1155,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           SetpointChangeSource"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "SetpointChangeSource"
       arguments:
@@ -1104,6 +1165,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: SetpointChangeSource"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeSource"
       response:
@@ -1111,6 +1173,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: SetpointChangeAmount"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeAmount"
       response:
@@ -1120,6 +1183,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           SetpointChangeAmount"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeAmount"
       response:
@@ -1130,6 +1194,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           SetpointChangeAmount"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "SetpointChangeAmount"
       arguments:
@@ -1139,6 +1204,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: SetpointChangeAmount"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeAmount"
       response:
@@ -1146,6 +1212,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: SetpointChangeSourceTimestamp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeSourceTimestamp"
       response:
@@ -1155,6 +1222,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           SetpointChangeSourceTimestamp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeSourceTimestamp"
       response:
@@ -1165,6 +1233,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           SetpointChangeSourceTimestamp"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "SetpointChangeSourceTimestamp"
       arguments:
@@ -1175,6 +1244,7 @@ tests:
     - label:
           "Read back optional attributes from DUT: SetpointChangeSourceTimestamp"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "SetpointChangeSourceTimestamp"
       response:
@@ -1182,6 +1252,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: OccupiedSetback"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetback"
       response:
@@ -1190,6 +1261,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: OccupiedSetback"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetback"
       response:
@@ -1202,6 +1274,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           OccupiedSetback"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "OccupiedSetback"
       arguments:
@@ -1211,6 +1284,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: OccupiedSetback"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetback"
       response:
@@ -1218,6 +1292,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: OccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetbackMin"
       response:
@@ -1226,6 +1301,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: OccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetbackMin"
       response:
@@ -1238,6 +1314,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           OccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "OccupiedSetbackMin"
       arguments:
@@ -1245,6 +1322,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: OccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetbackMin"
       response:
@@ -1252,6 +1330,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: OccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetbackMax"
       response:
@@ -1260,6 +1339,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: OccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetbackMax"
       response:
@@ -1272,6 +1352,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           OccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "OccupiedSetbackMax"
       arguments:
@@ -1279,6 +1360,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: OccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "OccupiedSetbackMax"
       response:
@@ -1286,6 +1368,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: UnoccupiedSetback"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetback"
       response:
@@ -1294,6 +1377,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: UnoccupiedSetback"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetback"
       response:
@@ -1306,6 +1390,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           UnoccupiedSetback"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "UnoccupiedSetback"
       arguments:
@@ -1315,6 +1400,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: UnoccupiedSetback"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetback"
       response:
@@ -1322,6 +1408,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: UnoccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetbackMin"
       response:
@@ -1331,6 +1418,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           UnoccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetbackMin"
       response:
@@ -1343,6 +1431,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           UnoccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "UnoccupiedSetbackMin"
       arguments:
@@ -1350,6 +1439,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: UnoccupiedSetbackMin"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetbackMin"
       response:
@@ -1357,6 +1447,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: UnoccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetbackMax"
       response:
@@ -1366,6 +1457,7 @@ tests:
           "Reads constraints of optional attributes from DUT:
           UnoccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetbackMax"
       response:
@@ -1378,6 +1470,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           UnoccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "UnoccupiedSetbackMax"
       arguments:
@@ -1385,6 +1478,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: UnoccupiedSetbackMax"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "UnoccupiedSetbackMax"
       response:
@@ -1392,6 +1486,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: EmergencyHeatDelta"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "EmergencyHeatDelta"
       response:
@@ -1400,6 +1495,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: EmergencyHeatDelta"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "EmergencyHeatDelta"
       response:
@@ -1410,6 +1506,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           EmergencyHeatDelta"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "EmergencyHeatDelta"
       arguments:
@@ -1417,6 +1514,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: EmergencyHeatDelta"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "EmergencyHeatDelta"
       response:
@@ -1424,6 +1522,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACType"
       response:
@@ -1431,6 +1530,7 @@ tests:
 
     - label: "Reads constraints of optional attributes from DUT: ACType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACType"
       response:
@@ -1443,6 +1543,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACType"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACType"
       arguments:
@@ -1450,6 +1551,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACType"
       response:
@@ -1457,6 +1559,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACCapacity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCapacity"
       response:
@@ -1464,6 +1567,7 @@ tests:
 
     - label: "Reads constraints of optional attributes from DUT: ACCapacity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCapacity"
       response:
@@ -1474,6 +1578,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACCapacity"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACCapacity"
       arguments:
@@ -1481,6 +1586,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACCapacity"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCapacity"
       response:
@@ -1488,6 +1594,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACRefrigerantType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACRefrigerantType"
       response:
@@ -1496,6 +1603,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: ACRefrigerantType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACRefrigerantType"
       response:
@@ -1508,6 +1616,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACRefrigerantType"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACRefrigerantType"
       arguments:
@@ -1515,6 +1624,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACRefrigerantType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACRefrigerantType"
       response:
@@ -1522,6 +1632,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACCompressorType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCompressorType"
       response:
@@ -1530,6 +1641,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: ACCompressorType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCompressorType"
       response:
@@ -1542,6 +1654,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACCompressorType"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACCompressorType"
       arguments:
@@ -1549,6 +1662,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACCompressorType"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCompressorType"
       response:
@@ -1556,6 +1670,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACErrorCode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACErrorCode"
       response:
@@ -1563,6 +1678,7 @@ tests:
 
     - label: "Reads constraints of optional attributes from DUT: ACErrorCode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACErrorCode"
       response:
@@ -1573,6 +1689,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACErrorCode"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACErrorCode"
       arguments:
@@ -1580,6 +1697,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACErrorCode"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACErrorCode"
       response:
@@ -1587,6 +1705,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACLouverPosition"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACLouverPosition"
       response:
@@ -1595,6 +1714,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: ACLouverPosition"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACLouverPosition"
       response:
@@ -1607,6 +1727,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACLouverPosition"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACLouverPosition"
       arguments:
@@ -1614,6 +1735,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACLouverPosition"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACLouverPosition"
       response:
@@ -1621,6 +1743,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACCoilTemperature"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCoilTemperature"
       response:
@@ -1629,6 +1752,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: ACCoilTemperature"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCoilTemperature"
       response:
@@ -1639,6 +1763,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACCoilTemperature"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACCoilTemperature"
       arguments:
@@ -1648,6 +1773,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACCoilTemperature"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCoilTemperature"
       response:
@@ -1655,6 +1781,7 @@ tests:
 
     - label: "Reads optional attributes from DUT: ACCapacityFormat"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCapacityFormat"
       response:
@@ -1663,6 +1790,7 @@ tests:
     - label:
           "Reads constraints of optional attributes from DUT: ACCapacityFormat"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCapacityFormat"
       response:
@@ -1673,6 +1801,7 @@ tests:
           "Writes the respective default value to optional attributes to DUT:
           ACCapacityFormat"
       disabled: true
+      optional: true
       command: "writeAttribute"
       attribute: "ACCapacityFormat"
       arguments:
@@ -1680,6 +1809,7 @@ tests:
 
     - label: "Read back optional attributes from DUT: ACCapacityFormat"
       disabled: true
+      optional: true
       command: "readAttribute"
       attribute: "ACCapacityFormat"
       response:

--- a/src/darwin/Framework/CHIP/templates/tests.js
+++ b/src/darwin/Framework/CHIP/templates/tests.js
@@ -185,9 +185,9 @@ function getTests()
   ];
 
   const SoftwareDiagnostics = [
-    'Test_TC_DIAGSW_1_1',
-    'Test_TC_DIAGSW_2_1',
-    'Test_TC_DIAGSW_3_2',
+    'Test_TC_SWDIAG_1_1',
+    'Test_TC_SWDIAG_2_1',
+    'Test_TC_SWDIAG_3_1',
   ];
 
   const Subscriptions = [

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -2457,6 +2457,11 @@ CHIPDevice * GetConnectedDevice(void)
         readAttributeCoupleColorTempToLevelMinMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Read the optional attribute: CoupleColorTempToLevelMinMireds Error: %@", err);
 
+            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                [expectation fulfill];
+                return;
+            }
+
             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
             [expectation fulfill];
@@ -2482,6 +2487,11 @@ CHIPDevice * GetConnectedDevice(void)
                                                             @"CoupleColorTempToLevelMinMireds Error: %@",
                                                           err);
 
+                                                      if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                          [expectation fulfill];
+                                                          return;
+                                                      }
+
                                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
                                                           EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                       [expectation fulfill];
@@ -2502,6 +2512,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster
         readAttributeCoupleColorTempToLevelMinMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Reads back optional attribute: CoupleColorTempToLevelMinMireds Error: %@", err);
+
+            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                [expectation fulfill];
+                return;
+            }
 
             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2528,6 +2543,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster
         readAttributeStartUpColorTemperatureMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Read the optional attribute: StartUpColorTemperatureMireds Error: %@", err);
+
+            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                [expectation fulfill];
+                return;
+            }
 
             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2561,6 +2581,11 @@ CHIPDevice * GetConnectedDevice(void)
                                                           @"StartUpColorTemperatureMireds Error: %@",
                                                         err);
 
+                                                    if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                        [expectation fulfill];
+                                                        return;
+                                                    }
+
                                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                                     [expectation fulfill];
@@ -2581,6 +2606,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster
         readAttributeStartUpColorTemperatureMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Reads back optional attribute: StartUpColorTemperatureMireds Error: %@", err);
+
+            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                [expectation fulfill];
+                return;
+            }
 
             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2606,6 +2636,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeRemainingTimeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the Optional attribute: RemainingTime Error: %@", err);
 
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
         {
@@ -2629,6 +2664,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeRemainingTimeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Validate constraints of attribute: RemainingTime Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2661,6 +2701,11 @@ CHIPDevice * GetConnectedDevice(void)
                            completionHandler:^(NSError * _Nullable err) {
                                NSLog(@"Write the default values to optional attribute: RemainingTime Error: %@", err);
 
+                               if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   [expectation fulfill];
+                                   return;
+                               }
+
                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                [expectation fulfill];
                            }];
@@ -2678,6 +2723,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeRemainingTimeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads back optional attribute: RemainingTime Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2702,6 +2752,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeDriftCompensationWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: DriftCompensation Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2734,6 +2789,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default values to optional attribute: DriftCompensation Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                    [expectation fulfill];
                                }];
@@ -2751,6 +2811,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeDriftCompensationWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads back optional attribute: DriftCompensation Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -2775,6 +2840,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeCompensationTextWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: CompensationText Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -3838,6 +3908,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeWhitePointXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: WhitePointX Error: %@", err);
 
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
         {
@@ -3867,6 +3942,11 @@ CHIPDevice * GetConnectedDevice(void)
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write the default optional attribute: WhitePointX Error: %@", err);
 
+                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                      [expectation fulfill];
+                                      return;
+                                  }
+
                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                   [expectation fulfill];
@@ -3885,6 +3965,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeWhitePointXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: WhitePointX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -3909,6 +3994,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeWhitePointYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: WhitePointY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -3939,6 +4029,11 @@ CHIPDevice * GetConnectedDevice(void)
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write the default optional attribute: WhitePointY Error: %@", err);
 
+                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                      [expectation fulfill];
+                                      return;
+                                  }
+
                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                   [expectation fulfill];
@@ -3957,6 +4052,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeWhitePointYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: WhitePointY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -3981,6 +4081,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointRXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointRX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4011,6 +4116,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointRX Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                    [expectation fulfill];
@@ -4029,6 +4139,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointRXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointRX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4053,6 +4168,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointRYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointRY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4083,6 +4203,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointRY Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                    [expectation fulfill];
@@ -4101,6 +4226,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointRYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointRY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4126,6 +4256,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointRIntensity Error: %@", err);
 
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
         [expectation fulfill];
@@ -4144,6 +4279,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointGXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointGX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4174,6 +4314,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointGX Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                    [expectation fulfill];
@@ -4192,6 +4337,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointGXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointGX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4216,6 +4366,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointGYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointGY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4246,6 +4401,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointGY Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                    [expectation fulfill];
@@ -4264,6 +4424,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointGYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointGY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4289,6 +4454,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointGIntensity Error: %@", err);
 
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
         [expectation fulfill];
@@ -4307,6 +4477,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointBXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointBX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4337,6 +4512,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointBX Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                    [expectation fulfill];
@@ -4355,6 +4535,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointBXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointBX Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4379,6 +4564,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointBYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointBY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4409,6 +4599,11 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointBY Error: %@", err);
 
+                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                       [expectation fulfill];
+                                       return;
+                                   }
+
                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                    [expectation fulfill];
@@ -4427,6 +4622,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointBYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointBY Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -4451,6 +4651,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeColorPointBIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointBIntensity Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -9899,6 +10104,29 @@ CHIPDevice * GetConnectedDevice(void)
 - (void)testSendClusterTest_TC_FLW_2_1_000004_WriteAttribute
 {
     XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default value to optional attribute: MeasuredValue"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id measuredValueArgument;
+    measuredValueArgument = [NSNumber numberWithShort:0];
+    [cluster
+        writeAttributeMeasuredValueWithValue:measuredValueArgument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"write the default value to optional attribute: MeasuredValue Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_FLW_2_1_000005_WriteAttribute
+{
+    XCTestExpectation * expectation =
         [self expectationWithDescription:@"write the default value to optional attribute: MinMeasuredValue"];
 
     CHIPDevice * device = GetConnectedDevice();
@@ -9919,7 +10147,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_FLW_2_1_000005_WriteAttribute
+- (void)testSendClusterTest_TC_FLW_2_1_000006_WriteAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"write the default value to optional attribute: MaxMeasuredValue"];
@@ -9942,7 +10170,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_FLW_2_1_000006_ReadAttribute
+- (void)testSendClusterTest_TC_FLW_2_1_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MeasuredValue"];
 
@@ -9961,7 +10189,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_FLW_2_1_000007_ReadAttribute
+- (void)testSendClusterTest_TC_FLW_2_1_000008_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MinMeasuredValue"];
 
@@ -9980,7 +10208,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_FLW_2_1_000008_ReadAttribute
+- (void)testSendClusterTest_TC_FLW_2_1_000009_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MaxMeasuredValue"];
 
@@ -9993,6 +10221,121 @@ CHIPDevice * GetConnectedDevice(void)
         NSLog(@"read the mandatory attribute: MaxMeasuredValue Error: %@", err);
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_FLW_2_1_000010_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Tolerance"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Tolerance Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_FLW_2_1_000011_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Tolerance"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Tolerance Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            if (actualValue != nil) {
+                XCTAssertLessThanOrEqual([actualValue unsignedShortValue], 2048U);
+            }
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_FLW_2_1_000012_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to optional attribute: Tolerance"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id toleranceArgument;
+    toleranceArgument = [NSNumber numberWithUnsignedShort:0U];
+    [cluster writeAttributeToleranceWithValue:toleranceArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"write the default value to optional attribute: Tolerance Error: %@", err);
+
+                                if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                    [expectation fulfill];
+                                    return;
+                                }
+
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                [expectation fulfill];
+                            }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_FLW_2_1_000013_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Tolerance"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Tolerance Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+        }
 
         [expectation fulfill];
     }];
@@ -11926,7 +12269,28 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000002_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000002_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value of mandatory attribute: OnOff"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id onOffArgument;
+    onOffArgument = [NSNumber numberWithBool:0];
+    [cluster writeAttributeOnOffWithValue:onOffArgument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"write the default value of mandatory attribute: OnOff Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_OO_2_1_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back mandatory attribute: OnOff"];
 
@@ -11950,7 +12314,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000003_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000004_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: GlobalSceneControl"];
 
@@ -11974,7 +12338,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000004_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: OnTime"];
 
@@ -11998,7 +12362,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000005_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000006_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: OffWaitTime"];
 
@@ -12022,7 +12386,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000006_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: StartUpOnOff"];
 
@@ -12046,7 +12410,30 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000007_WriteAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000008_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default value to LT attribute: GlobalSceneControl"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id globalSceneControlArgument;
+    globalSceneControlArgument = [NSNumber numberWithBool:0];
+    [cluster writeAttributeGlobalSceneControlWithValue:globalSceneControlArgument
+                                     completionHandler:^(NSError * _Nullable err) {
+                                         NSLog(@"write the default value to LT attribute: GlobalSceneControl Error: %@", err);
+
+                                         XCTAssertEqual(
+                                             [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                         [expectation fulfill];
+                                     }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_OO_2_1_000009_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to LT attribute: OnTime"];
 
@@ -12068,7 +12455,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000008_WriteAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000010_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to LT attribute: OffWaitTime"];
 
@@ -12090,7 +12477,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000009_WriteAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000011_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to LT attribute: StartUpOnOff"];
 
@@ -12112,7 +12499,31 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000010_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000012_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: GlobalSceneControl"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeGlobalSceneControlWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"reads back LT attribute: GlobalSceneControl Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue boolValue], 1);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_OO_2_1_000013_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: OnTime"];
 
@@ -12136,7 +12547,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000011_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000014_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: OffWaitTime"];
 
@@ -12160,7 +12571,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OO_2_1_000012_ReadAttribute
+- (void)testSendClusterTest_TC_OO_2_1_000015_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: StartUpOnOff"];
 
@@ -13879,6 +14290,48 @@ CHIPDevice * GetConnectedDevice(void)
 }
 - (void)testSendClusterTest_TC_PCC_2_1_000002_ReadAttribute
 {
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MaxSpeed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the mandatory attribute: MaxSpeed Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000003_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MaxFlow"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the mandatory attribute: MaxFlow Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000004_ReadAttribute
+{
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: EffectiveOperationMode"];
 
     CHIPDevice * device = GetConnectedDevice();
@@ -13898,7 +14351,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_PCC_2_1_000003_ReadAttribute
+- (void)testSendClusterTest_TC_PCC_2_1_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: EffectiveControlMode"];
 
@@ -13919,7 +14372,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_PCC_2_1_000004_ReadAttribute
+- (void)testSendClusterTest_TC_PCC_2_1_000006_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: Capacity"];
 
@@ -13940,7 +14393,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_PCC_2_1_000005_ReadAttribute
+- (void)testSendClusterTest_TC_PCC_2_1_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MaxPressure"];
 
@@ -13961,7 +14414,49 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_PCC_2_1_000006_ReadAttribute
+- (void)testSendClusterTest_TC_PCC_2_1_000008_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MaxSpeed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the mandatory attribute: MaxSpeed Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000009_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: MaxFlow"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the mandatory attribute: MaxFlow Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: EffectiveOperationMode"];
 
@@ -13982,7 +14477,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_PCC_2_1_000007_ReadAttribute
+- (void)testSendClusterTest_TC_PCC_2_1_000011_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: EffectiveControlMode"];
 
@@ -14003,7 +14498,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_PCC_2_1_000008_ReadAttribute
+- (void)testSendClusterTest_TC_PCC_2_1_000012_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: Capacity"];
 
@@ -14016,6 +14511,1028 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeCapacityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the mandatory attribute: Capacity Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000013_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000014_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000015_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinCompPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinCompPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000016_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxCompPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxCompPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000017_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstSpeed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstSpeed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000018_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstSpeed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstSpeed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000019_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstFlow"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstFlow Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000020_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstFlow"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstFlow Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000021_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstTemp"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstTemp Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            if (actualValue != nil) {
+                XCTAssertGreaterThanOrEqual([actualValue shortValue], -27315);
+            }
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000022_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstTemp"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstTemp Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            if (actualValue != nil) {
+                XCTAssertGreaterThanOrEqual([actualValue shortValue], -27315);
+            }
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000023_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: PumpStatus"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000024_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: PumpStatus"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000025_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Speed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Speed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000026_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeRunningHours"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertFalse(actualValue == nil);
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000027_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeRunningHours"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000028_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Power"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributePowerWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Power Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000029_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeEnergyConsumed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertFalse(actualValue == nil);
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000030_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeEnergyConsumed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000031_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write to the optional attribute: LifetimeEnergyConsumed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id lifetimeEnergyConsumedArgument;
+    lifetimeEnergyConsumedArgument = [NSNumber numberWithUnsignedInt:0UL];
+    [cluster writeAttributeLifetimeEnergyConsumedWithValue:lifetimeEnergyConsumedArgument
+                                         completionHandler:^(NSError * _Nullable err) {
+                                             NSLog(@"write to the optional attribute: LifetimeEnergyConsumed Error: %@", err);
+
+                                             if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                 [expectation fulfill];
+                                                 return;
+                                             }
+
+                                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                             [expectation fulfill];
+                                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000032_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000033_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000034_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinCompPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinCompPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000035_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxCompPressure"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxCompPressure Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000036_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstSpeed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstSpeed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000037_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstSpeed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstSpeed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000038_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstFlow"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstFlow Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000039_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstFlow"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstFlow Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000040_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MinConstTemp"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMinConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MinConstTemp Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            if (actualValue != nil) {
+                XCTAssertGreaterThanOrEqual([actualValue shortValue], -27315);
+            }
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000041_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: MaxConstTemp"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: MaxConstTemp Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            if (actualValue != nil) {
+                XCTAssertGreaterThanOrEqual([actualValue shortValue], -27315);
+            }
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000042_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: PumpStatus"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000043_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: PumpStatus"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000044_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Speed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Speed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000045_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeRunningHours"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertFalse(actualValue == nil);
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000046_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeRunningHours"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000047_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: Power"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributePowerWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: Power Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000048_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeEnergyConsumed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertFalse(actualValue == nil);
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_1_000049_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional attribute: LifetimeEnergyConsumed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -14164,6 +15681,176 @@ CHIPDevice * GetConnectedDevice(void)
 
         [expectation fulfill];
     }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000003_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write 0 to the ControlMode attribute to DUT"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id controlModeArgument;
+    controlModeArgument = [NSNumber numberWithUnsignedChar:0];
+    [cluster writeAttributeControlModeWithValue:controlModeArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write 0 to the ControlMode attribute to DUT Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000004_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reads the attribute: EffectiveControlMode"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEffectiveControlModeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Reads the attribute: EffectiveControlMode Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], 0);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000005_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write 1 to the ControlMode attribute to DUT"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id controlModeArgument;
+    controlModeArgument = [NSNumber numberWithUnsignedChar:1];
+    [cluster writeAttributeControlModeWithValue:controlModeArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write 1 to the ControlMode attribute to DUT Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000006_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write 2 to the ControlMode attribute to DUT"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id controlModeArgument;
+    controlModeArgument = [NSNumber numberWithUnsignedChar:2];
+    [cluster writeAttributeControlModeWithValue:controlModeArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write 2 to the ControlMode attribute to DUT Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000007_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write 3 to the ControlMode attribute to DUT"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id controlModeArgument;
+    controlModeArgument = [NSNumber numberWithUnsignedChar:3];
+    [cluster writeAttributeControlModeWithValue:controlModeArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write 3 to the ControlMode attribute to DUT Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000008_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write 5 to the ControlMode attribute to DUT"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id controlModeArgument;
+    controlModeArgument = [NSNumber numberWithUnsignedChar:5];
+    [cluster writeAttributeControlModeWithValue:controlModeArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write 5 to the ControlMode attribute to DUT Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_PCC_2_3_000009_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write 7 to the ControlMode attribute to DUT"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id controlModeArgument;
+    controlModeArgument = [NSNumber numberWithUnsignedChar:7];
+    [cluster writeAttributeControlModeWithValue:controlModeArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write 7 to the ControlMode attribute to DUT Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -15913,6 +17600,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeMinSetpointDeadBandWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads optional attributes from DUT: MinSetpointDeadBand Error: %@", err);
 
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
         {
@@ -15937,6 +17629,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeMinSetpointDeadBandWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: MinSetpointDeadBand Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -15970,6 +17667,11 @@ CHIPDevice * GetConnectedDevice(void)
                                                 @"MinSetpointDeadBand Error: %@",
                                               err);
 
+                                          if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                              [expectation fulfill];
+                                              return;
+                                          }
+
                                           XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
                                           [expectation fulfill];
@@ -15989,6 +17691,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeMinSetpointDeadBandWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back optional attributes from DUT: MinSetpointDeadBand Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -16014,6 +17721,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeStartOfWeekWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: StartOfWeek Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -16046,6 +17758,11 @@ CHIPDevice * GetConnectedDevice(void)
                                   NSLog(@"Writes the respective default value to optional attributes to DUT: StartOfWeek Error: %@",
                                       err);
 
+                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                      [expectation fulfill];
+                                      return;
+                                  }
+
                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                   [expectation fulfill];
                               }];
@@ -16063,6 +17780,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeStartOfWeekWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back optional attributes from DUT: StartOfWeek Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -16089,6 +17811,11 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeNumberOfWeeklyTransitionsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: NumberOfWeeklyTransitions Error: %@", err);
 
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
         [expectation fulfill];
@@ -16114,6 +17841,11 @@ CHIPDevice * GetConnectedDevice(void)
                                                       @"NumberOfWeeklyTransitions Error: %@",
                                                     err);
 
+                                                if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                    [expectation fulfill];
+                                                    return;
+                                                }
+
                                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
                                                     EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                 [expectation fulfill];
@@ -16133,6 +17865,11 @@ CHIPDevice * GetConnectedDevice(void)
 
     [cluster readAttributeNumberOfDailyTransitionsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: NumberOfDailyTransitions Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
@@ -16158,6 +17895,11 @@ CHIPDevice * GetConnectedDevice(void)
                                                NSLog(@"Writes the respective default value to optional attributes to DUT: "
                                                      @"NumberOfDailyTransitions Error: %@",
                                                    err);
+
+                                               if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                   [expectation fulfill];
+                                                   return;
+                                               }
 
                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
                                                    EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
@@ -35840,7 +37582,7 @@ uint16_t readAttributeVendorIdDefaultValue;
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTest_TC_DIAGSW_1_1_000000_WaitForCommissionee
+- (void)testSendClusterTest_TC_SWDIAG_1_1_000000_WaitForCommissionee
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
@@ -35848,7 +37590,7 @@ uint16_t readAttributeVendorIdDefaultValue;
     WaitForCommissionee(expectation, queue);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_DIAGSW_1_1_000001_ReadAttribute
+- (void)testSendClusterTest_TC_SWDIAG_1_1_000001_ReadAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Reads CurrentHeapFree non-global attribute value from DUT"];
@@ -35873,7 +37615,7 @@ uint16_t readAttributeVendorIdDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_DIAGSW_1_1_000002_ReadAttribute
+- (void)testSendClusterTest_TC_SWDIAG_1_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Reads CurrentHeapUsed non-global attribute value from DUT"];
@@ -35898,7 +37640,7 @@ uint16_t readAttributeVendorIdDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_DIAGSW_1_1_000003_ReadAttribute
+- (void)testSendClusterTest_TC_SWDIAG_1_1_000003_ReadAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Reads CurrentHeapHighWaterMark non-global attribute value from DUT"];
@@ -35924,7 +37666,7 @@ uint16_t readAttributeVendorIdDefaultValue;
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTest_TC_DIAGSW_3_2_000000_WaitForCommissionee
+- (void)testSendClusterTest_TC_SWDIAG_3_1_000000_WaitForCommissionee
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -152,9 +152,9 @@ public:
         printf("TestOperationalCredentialsCluster\n");
         printf("TestModeSelectCluster\n");
         printf("TestGroupMessaging\n");
-        printf("Test_TC_DIAGSW_1_1\n");
-        printf("Test_TC_DIAGSW_2_1\n");
-        printf("Test_TC_DIAGSW_3_2\n");
+        printf("Test_TC_SWDIAG_1_1\n");
+        printf("Test_TC_SWDIAG_2_1\n");
+        printf("Test_TC_SWDIAG_3_1\n");
         printf("TestSubscribe_OnOff\n");
 
         return CHIP_NO_ERROR;
@@ -4861,7 +4861,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_60(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_60(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_60(uint16_t coupleColorTempToLevelMinMireds)
     {
@@ -4904,7 +4907,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_62(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_62(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_62(uint16_t coupleColorTempToLevelMinMireds)
     {
@@ -4925,7 +4931,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_63(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_63(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_63(uint16_t startUpColorTemperatureMireds)
     {
@@ -4949,7 +4958,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_64(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_64(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_64() { NextTest(); }
 
@@ -4965,7 +4977,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_65(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_65(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_65(uint16_t startUpColorTemperatureMireds)
     {
@@ -4985,7 +5000,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_66(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_66(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_66(uint16_t remainingTime)
     {
@@ -5005,7 +5023,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_67(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_67(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_67(uint16_t remainingTime)
     {
@@ -5047,7 +5068,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_69(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_69(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_69(uint16_t remainingTime)
     {
@@ -5067,7 +5091,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_70(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_70(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_70(uint8_t driftCompensation)
     {
@@ -5109,7 +5136,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_72(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_72(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_72(uint8_t driftCompensation)
     {
@@ -5129,7 +5159,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_73(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_73(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_73(chip::CharSpan compensationText)
     {
@@ -6069,7 +6102,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_119(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_119(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_119(uint16_t whitePointX)
     {
@@ -6092,7 +6128,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_120(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_120(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_120() { NextTest(); }
 
@@ -6107,7 +6146,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_121(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_121(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_121(uint16_t whitePointX)
     {
@@ -6127,7 +6169,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_122(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_122(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_122(uint16_t whitePointY)
     {
@@ -6150,7 +6195,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_123(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_123(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_123() { NextTest(); }
 
@@ -6165,7 +6213,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_124(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_124(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_124(uint16_t whitePointY)
     {
@@ -6185,7 +6236,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_125(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_125(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_125(uint16_t colorPointRX)
     {
@@ -6208,7 +6262,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_126(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_126(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_126() { NextTest(); }
 
@@ -6223,7 +6280,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_127(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_127(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_127(uint16_t colorPointRX)
     {
@@ -6243,7 +6303,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_128(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_128(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_128(uint16_t colorPointRY)
     {
@@ -6266,7 +6329,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_129(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_129(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_129() { NextTest(); }
 
@@ -6281,7 +6347,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_130(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_130(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_130(uint16_t colorPointRY)
     {
@@ -6301,7 +6370,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_131(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_131(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_131(uint8_t colorPointRIntensity)
     {
@@ -6320,7 +6392,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_132(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_132(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_132(uint16_t colorPointGX)
     {
@@ -6343,7 +6418,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_133(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_133(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_133() { NextTest(); }
 
@@ -6358,7 +6436,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_134(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_134(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_134(uint16_t colorPointGX)
     {
@@ -6378,7 +6459,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_135(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_135(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_135(uint16_t colorPointGY)
     {
@@ -6401,7 +6485,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_136(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_136(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_136() { NextTest(); }
 
@@ -6416,7 +6503,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_137(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_137(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_137(uint16_t colorPointGY)
     {
@@ -6436,7 +6526,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_138(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_138(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_138(uint8_t colorPointGIntensity)
     {
@@ -6455,7 +6548,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_139(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_139(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_139(uint16_t colorPointBX)
     {
@@ -6478,7 +6574,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_140(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_140(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_140() { NextTest(); }
 
@@ -6493,7 +6592,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_141(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_141(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_141(uint16_t colorPointBX)
     {
@@ -6513,7 +6615,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_142(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_142(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_142(uint16_t colorPointBY)
     {
@@ -6536,7 +6641,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_143(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_143(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_143() { NextTest(); }
 
@@ -6551,7 +6659,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_144(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_144(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_144(uint16_t colorPointBY)
     {
@@ -6571,7 +6682,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_145(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_145(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_145(uint8_t colorPointBIntensity)
     {
@@ -15690,24 +15804,44 @@ public:
             err = TestReadTheMandatoryAttributeMaxMeasuredValue_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : write the default value to optional attribute: MinMeasuredValue\n");
-            err = TestWriteTheDefaultValueToOptionalAttributeMinMeasuredValue_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : write the default value to optional attribute: MeasuredValue\n");
+            err = TestWriteTheDefaultValueToOptionalAttributeMeasuredValue_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : write the default value to optional attribute: MaxMeasuredValue\n");
-            err = TestWriteTheDefaultValueToOptionalAttributeMaxMeasuredValue_5();
+            ChipLogProgress(chipTool, " ***** Test Step 5 : write the default value to optional attribute: MinMeasuredValue\n");
+            err = TestWriteTheDefaultValueToOptionalAttributeMinMeasuredValue_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : read the mandatory attribute: MeasuredValue\n");
-            err = TestReadTheMandatoryAttributeMeasuredValue_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : write the default value to optional attribute: MaxMeasuredValue\n");
+            err = TestWriteTheDefaultValueToOptionalAttributeMaxMeasuredValue_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : read the mandatory attribute: MinMeasuredValue\n");
-            err = TestReadTheMandatoryAttributeMinMeasuredValue_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : read the mandatory attribute: MeasuredValue\n");
+            err = TestReadTheMandatoryAttributeMeasuredValue_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : read the mandatory attribute: MaxMeasuredValue\n");
-            err = TestReadTheMandatoryAttributeMaxMeasuredValue_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : read the mandatory attribute: MinMeasuredValue\n");
+            err = TestReadTheMandatoryAttributeMinMeasuredValue_8();
+            break;
+        case 9:
+            ChipLogProgress(chipTool, " ***** Test Step 9 : read the mandatory attribute: MaxMeasuredValue\n");
+            err = TestReadTheMandatoryAttributeMaxMeasuredValue_9();
+            break;
+        case 10:
+            ChipLogProgress(chipTool, " ***** Test Step 10 : read the optional attribute: Tolerance\n");
+            err = TestReadTheOptionalAttributeTolerance_10();
+            break;
+        case 11:
+            ChipLogProgress(chipTool, " ***** Test Step 11 : read the optional attribute: Tolerance\n");
+            err = TestReadTheOptionalAttributeTolerance_11();
+            break;
+        case 12:
+            ChipLogProgress(chipTool, " ***** Test Step 12 : write the default value to optional attribute: Tolerance\n");
+            err = TestWriteTheDefaultValueToOptionalAttributeTolerance_12();
+            break;
+        case 13:
+            ChipLogProgress(chipTool, " ***** Test Step 13 : read the optional attribute: Tolerance\n");
+            err = TestReadTheOptionalAttributeTolerance_13();
             break;
         }
 
@@ -15720,7 +15854,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 9;
+    const uint16_t mTestCount = 14;
 
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
@@ -15774,19 +15908,16 @@ private:
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_6(status);
     }
 
-    static void OnSuccessCallback_6(void * context, int16_t measuredValue)
-    {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_6(measuredValue);
-    }
+    static void OnSuccessCallback_6(void * context) { (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_6(); }
 
     static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_7(status);
     }
 
-    static void OnSuccessCallback_7(void * context, int16_t minMeasuredValue)
+    static void OnSuccessCallback_7(void * context, int16_t measuredValue)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_7(minMeasuredValue);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_7(measuredValue);
     }
 
     static void OnFailureCallback_8(void * context, EmberAfStatus status)
@@ -15794,9 +15925,56 @@ private:
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_8(status);
     }
 
-    static void OnSuccessCallback_8(void * context, int16_t maxMeasuredValue)
+    static void OnSuccessCallback_8(void * context, int16_t minMeasuredValue)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_8(maxMeasuredValue);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_8(minMeasuredValue);
+    }
+
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_9(status);
+    }
+
+    static void OnSuccessCallback_9(void * context, int16_t maxMeasuredValue)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_9(maxMeasuredValue);
+    }
+
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_10(status);
+    }
+
+    static void OnSuccessCallback_10(void * context, uint16_t tolerance)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_10(tolerance);
+    }
+
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_11(status);
+    }
+
+    static void OnSuccessCallback_11(void * context, uint16_t tolerance)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_11(tolerance);
+    }
+
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_12(status);
+    }
+
+    static void OnSuccessCallback_12(void * context) { (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_12(); }
+
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_13(status);
+    }
+
+    static void OnSuccessCallback_13(void * context, uint16_t tolerance)
+    {
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_13(tolerance);
     }
 
     //
@@ -15866,17 +16044,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMinMeasuredValue_4()
+    CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMeasuredValue_4()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        int16_t minMeasuredValueArgument;
-        minMeasuredValueArgument = 0;
+        int16_t measuredValueArgument;
+        measuredValueArgument = 0;
 
-        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
-            minMeasuredValueArgument, this, OnSuccessCallback_4, OnFailureCallback_4));
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            measuredValueArgument, this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
     }
 
@@ -15888,17 +16066,17 @@ private:
 
     void OnSuccessResponse_4() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMaxMeasuredValue_5()
+    CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMinMeasuredValue_5()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        int16_t maxMeasuredValueArgument;
-        maxMeasuredValueArgument = 0;
+        int16_t minMeasuredValueArgument;
+        minMeasuredValueArgument = 0;
 
-        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
-            maxMeasuredValueArgument, this, OnSuccessCallback_5, OnFailureCallback_5));
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            minMeasuredValueArgument, this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
     }
 
@@ -15910,60 +16088,173 @@ private:
 
     void OnSuccessResponse_5() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_6()
+    CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMaxMeasuredValue_6()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        int16_t maxMeasuredValueArgument;
+        maxMeasuredValueArgument = 0;
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            maxMeasuredValueArgument, this, OnSuccessCallback_6, OnFailureCallback_6));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_6(EmberAfStatus status)
+    {
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
+        NextTest();
+    }
+
+    void OnSuccessResponse_6() { ThrowSuccessResponse(); }
+
+    CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_7()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
-            this, OnSuccessCallback_6, OnFailureCallback_6));
-        return CHIP_NO_ERROR;
-    }
-
-    void OnFailureResponse_6(EmberAfStatus status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_6(int16_t measuredValue)
-    {
-        VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
-        NextTest();
-    }
-
-    CHIP_ERROR TestReadTheMandatoryAttributeMinMeasuredValue_7()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
-
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_7(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_7(int16_t minMeasuredValue)
+    void OnSuccessResponse_7(int16_t measuredValue)
     {
-        VerifyOrReturn(CheckConstraintType("minMeasuredValue", "", "uint16"));
+        VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeMaxMeasuredValue_8()
+    CHIP_ERROR TestReadTheMandatoryAttributeMinMeasuredValue_8()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_8(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_8(int16_t maxMeasuredValue)
+    void OnSuccessResponse_8(int16_t minMeasuredValue)
+    {
+        VerifyOrReturn(CheckConstraintType("minMeasuredValue", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheMandatoryAttributeMaxMeasuredValue_9()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_9, OnFailureCallback_9));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_9(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_9(int16_t maxMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("maxMeasuredValue", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeTolerance_10()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_10(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_10(uint16_t tolerance)
+    {
+        VerifyOrReturn(CheckValue("tolerance", tolerance, 0U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeTolerance_11()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_11(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_11(uint16_t tolerance)
+    {
+        VerifyOrReturn(CheckConstraintType("tolerance", "", "uint16"));
+        VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("tolerance", tolerance, 2048U));
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeTolerance_12()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint16_t toleranceArgument;
+        toleranceArgument = 0U;
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
+            toleranceArgument, this, OnSuccessCallback_12, OnFailureCallback_12));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_12(EmberAfStatus status)
+    {
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
+        NextTest();
+    }
+
+    void OnSuccessResponse_12() { ThrowSuccessResponse(); }
+
+    CHIP_ERROR TestReadTheOptionalAttributeTolerance_13()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
+            this, OnSuccessCallback_13, OnFailureCallback_13));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_13(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_13(uint16_t tolerance)
+    {
+        VerifyOrReturn(CheckValue("tolerance", tolerance, 0U));
+
         NextTest();
     }
 };
@@ -19912,48 +20203,60 @@ public:
             err = TestReadTheMandatoryAttributeOnOff_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : reads back mandatory attribute: OnOff\n");
-            err = TestReadsBackMandatoryAttributeOnOff_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : write the default value of mandatory attribute: OnOff\n");
+            err = TestWriteTheDefaultValueOfMandatoryAttributeOnOff_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : read LT attribute: GlobalSceneControl\n");
-            err = TestReadLtAttributeGlobalSceneControl_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : reads back mandatory attribute: OnOff\n");
+            err = TestReadsBackMandatoryAttributeOnOff_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : read LT attribute: OnTime\n");
-            err = TestReadLtAttributeOnTime_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : read LT attribute: GlobalSceneControl\n");
+            err = TestReadLtAttributeGlobalSceneControl_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : read LT attribute: OffWaitTime\n");
-            err = TestReadLtAttributeOffWaitTime_5();
+            ChipLogProgress(chipTool, " ***** Test Step 5 : read LT attribute: OnTime\n");
+            err = TestReadLtAttributeOnTime_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : read LT attribute: StartUpOnOff\n");
-            err = TestReadLtAttributeStartUpOnOff_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : read LT attribute: OffWaitTime\n");
+            err = TestReadLtAttributeOffWaitTime_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : write the default value to LT attribute: OnTime\n");
-            err = TestWriteTheDefaultValueToLtAttributeOnTime_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : read LT attribute: StartUpOnOff\n");
+            err = TestReadLtAttributeStartUpOnOff_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : write the default value to LT attribute: OffWaitTime\n");
-            err = TestWriteTheDefaultValueToLtAttributeOffWaitTime_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : write the default value to LT attribute: GlobalSceneControl\n");
+            err = TestWriteTheDefaultValueToLtAttributeGlobalSceneControl_8();
             break;
         case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : write the default value to LT attribute: StartUpOnOff\n");
-            err = TestWriteTheDefaultValueToLtAttributeStartUpOnOff_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : write the default value to LT attribute: OnTime\n");
+            err = TestWriteTheDefaultValueToLtAttributeOnTime_9();
             break;
         case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : reads back LT attribute: OnTime\n");
-            err = TestReadsBackLtAttributeOnTime_10();
+            ChipLogProgress(chipTool, " ***** Test Step 10 : write the default value to LT attribute: OffWaitTime\n");
+            err = TestWriteTheDefaultValueToLtAttributeOffWaitTime_10();
             break;
         case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : reads back LT attribute: OffWaitTime\n");
-            err = TestReadsBackLtAttributeOffWaitTime_11();
+            ChipLogProgress(chipTool, " ***** Test Step 11 : write the default value to LT attribute: StartUpOnOff\n");
+            err = TestWriteTheDefaultValueToLtAttributeStartUpOnOff_11();
             break;
         case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : reads back LT attribute: StartUpOnOff\n");
-            err = TestReadsBackLtAttributeStartUpOnOff_12();
+            ChipLogProgress(chipTool, " ***** Test Step 12 : reads back LT attribute: GlobalSceneControl\n");
+            err = TestReadsBackLtAttributeGlobalSceneControl_12();
+            break;
+        case 13:
+            ChipLogProgress(chipTool, " ***** Test Step 13 : reads back LT attribute: OnTime\n");
+            err = TestReadsBackLtAttributeOnTime_13();
+            break;
+        case 14:
+            ChipLogProgress(chipTool, " ***** Test Step 14 : reads back LT attribute: OffWaitTime\n");
+            err = TestReadsBackLtAttributeOffWaitTime_14();
+            break;
+        case 15:
+            ChipLogProgress(chipTool, " ***** Test Step 15 : reads back LT attribute: StartUpOnOff\n");
+            err = TestReadsBackLtAttributeStartUpOnOff_15();
             break;
         }
 
@@ -19966,7 +20269,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 13;
+    const uint16_t mTestCount = 16;
 
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
@@ -19986,19 +20289,16 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_2(status);
     }
 
-    static void OnSuccessCallback_2(void * context, bool onOff)
-    {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_2(onOff);
-    }
+    static void OnSuccessCallback_2(void * context) { (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_2(); }
 
     static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_3(status);
     }
 
-    static void OnSuccessCallback_3(void * context, bool globalSceneControl)
+    static void OnSuccessCallback_3(void * context, bool onOff)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_3(globalSceneControl);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_3(onOff);
     }
 
     static void OnFailureCallback_4(void * context, EmberAfStatus status)
@@ -20006,9 +20306,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_4(status);
     }
 
-    static void OnSuccessCallback_4(void * context, uint16_t onTime)
+    static void OnSuccessCallback_4(void * context, bool globalSceneControl)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_4(onTime);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_4(globalSceneControl);
     }
 
     static void OnFailureCallback_5(void * context, EmberAfStatus status)
@@ -20016,9 +20316,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_5(status);
     }
 
-    static void OnSuccessCallback_5(void * context, uint16_t offWaitTime)
+    static void OnSuccessCallback_5(void * context, uint16_t onTime)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_5(offWaitTime);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_5(onTime);
     }
 
     static void OnFailureCallback_6(void * context, EmberAfStatus status)
@@ -20026,9 +20326,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_6(status);
     }
 
-    static void OnSuccessCallback_6(void * context, uint8_t startUpOnOff)
+    static void OnSuccessCallback_6(void * context, uint16_t offWaitTime)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_6(startUpOnOff);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_6(offWaitTime);
     }
 
     static void OnFailureCallback_7(void * context, EmberAfStatus status)
@@ -20036,7 +20336,10 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_7(status);
     }
 
-    static void OnSuccessCallback_7(void * context) { (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_7(); }
+    static void OnSuccessCallback_7(void * context, uint8_t startUpOnOff)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_7(startUpOnOff);
+    }
 
     static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
@@ -20057,29 +20360,53 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_10(status);
     }
 
-    static void OnSuccessCallback_10(void * context, uint16_t onTime)
-    {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_10(onTime);
-    }
+    static void OnSuccessCallback_10(void * context) { (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_10(); }
 
     static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_11(status);
     }
 
-    static void OnSuccessCallback_11(void * context, uint16_t offWaitTime)
-    {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_11(offWaitTime);
-    }
+    static void OnSuccessCallback_11(void * context) { (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_11(); }
 
     static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
         (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_12(status);
     }
 
-    static void OnSuccessCallback_12(void * context, uint8_t startUpOnOff)
+    static void OnSuccessCallback_12(void * context, bool globalSceneControl)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_12(startUpOnOff);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_12(globalSceneControl);
+    }
+
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_13(status);
+    }
+
+    static void OnSuccessCallback_13(void * context, uint16_t onTime)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_13(onTime);
+    }
+
+    static void OnFailureCallback_14(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_14(status);
+    }
+
+    static void OnSuccessCallback_14(void * context, uint16_t offWaitTime)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_14(offWaitTime);
+    }
+
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_15(status);
+    }
+
+    static void OnSuccessCallback_15(void * context, uint8_t startUpOnOff)
+    {
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_15(startUpOnOff);
     }
 
     //
@@ -20112,107 +20439,151 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestReadsBackMandatoryAttributeOnOff_2()
+    CHIP_ERROR TestWriteTheDefaultValueOfMandatoryAttributeOnOff_2()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        bool onOffArgument;
+        onOffArgument = 0;
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
+            onOffArgument, this, OnSuccessCallback_2, OnFailureCallback_2));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_2(EmberAfStatus status)
+    {
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
+        NextTest();
+    }
+
+    void OnSuccessResponse_2() { ThrowSuccessResponse(); }
+
+    CHIP_ERROR TestReadsBackMandatoryAttributeOnOff_3()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
-            this, OnSuccessCallback_2, OnFailureCallback_2));
-        return CHIP_NO_ERROR;
-    }
-
-    void OnFailureResponse_2(EmberAfStatus status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_2(bool onOff)
-    {
-        VerifyOrReturn(CheckValue("onOff", onOff, 0));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestReadLtAttributeGlobalSceneControl_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
-
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_3(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_3(bool globalSceneControl)
+    void OnSuccessResponse_3(bool onOff)
     {
-        VerifyOrReturn(CheckValue("globalSceneControl", globalSceneControl, 1));
+        VerifyOrReturn(CheckValue("onOff", onOff, 0));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadLtAttributeOnTime_4()
+    CHIP_ERROR TestReadLtAttributeGlobalSceneControl_4()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_4(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_4(uint16_t onTime)
+    void OnSuccessResponse_4(bool globalSceneControl)
     {
-        VerifyOrReturn(CheckValue("onTime", onTime, 0U));
+        VerifyOrReturn(CheckValue("globalSceneControl", globalSceneControl, 1));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadLtAttributeOffWaitTime_5()
+    CHIP_ERROR TestReadLtAttributeOnTime_5()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_5(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_5(uint16_t offWaitTime)
+    void OnSuccessResponse_5(uint16_t onTime)
     {
-        VerifyOrReturn(CheckValue("offWaitTime", offWaitTime, 0U));
+        VerifyOrReturn(CheckValue("onTime", onTime, 0U));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadLtAttributeStartUpOnOff_6()
+    CHIP_ERROR TestReadLtAttributeOffWaitTime_6()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_6(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_6(uint8_t startUpOnOff)
+    void OnSuccessResponse_6(uint16_t offWaitTime)
+    {
+        VerifyOrReturn(CheckValue("offWaitTime", offWaitTime, 0U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadLtAttributeStartUpOnOff_7()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_7(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_7(uint8_t startUpOnOff)
     {
         VerifyOrReturn(CheckValue("startUpOnOff", startUpOnOff, 0));
 
         NextTest();
     }
 
-    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeOnTime_7()
+    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeGlobalSceneControl_8()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        bool globalSceneControlArgument;
+        globalSceneControlArgument = 0;
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
+            globalSceneControlArgument, this, OnSuccessCallback_8, OnFailureCallback_8));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_8(EmberAfStatus status)
+    {
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
+        NextTest();
+    }
+
+    void OnSuccessResponse_8() { ThrowSuccessResponse(); }
+
+    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeOnTime_9()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
@@ -20222,15 +20593,15 @@ private:
         onTimeArgument = 0U;
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
-            onTimeArgument, this, OnSuccessCallback_7, OnFailureCallback_7));
+            onTimeArgument, this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_7(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_9(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_7() { NextTest(); }
+    void OnSuccessResponse_9() { NextTest(); }
 
-    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeOffWaitTime_8()
+    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeOffWaitTime_10()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
@@ -20240,15 +20611,15 @@ private:
         offWaitTimeArgument = 0U;
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
-            offWaitTimeArgument, this, OnSuccessCallback_8, OnFailureCallback_8));
+            offWaitTimeArgument, this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_8(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_10(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_8() { NextTest(); }
+    void OnSuccessResponse_10() { NextTest(); }
 
-    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeStartUpOnOff_9()
+    CHIP_ERROR TestWriteTheDefaultValueToLtAttributeStartUpOnOff_11()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
@@ -20258,68 +20629,88 @@ private:
         startUpOnOffArgument = 0;
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
-            startUpOnOffArgument, this, OnSuccessCallback_9, OnFailureCallback_9));
-        return CHIP_NO_ERROR;
-    }
-
-    void OnFailureResponse_9(EmberAfStatus status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_9() { NextTest(); }
-
-    CHIP_ERROR TestReadsBackLtAttributeOnTime_10()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
-
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
-            this, OnSuccessCallback_10, OnFailureCallback_10));
-        return CHIP_NO_ERROR;
-    }
-
-    void OnFailureResponse_10(EmberAfStatus status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_10(uint16_t onTime)
-    {
-        VerifyOrReturn(CheckValue("onTime", onTime, 0U));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestReadsBackLtAttributeOffWaitTime_11()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
-
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
-            this, OnSuccessCallback_11, OnFailureCallback_11));
+            startUpOnOffArgument, this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_11(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_11(uint16_t offWaitTime)
-    {
-        VerifyOrReturn(CheckValue("offWaitTime", offWaitTime, 0U));
+    void OnSuccessResponse_11() { NextTest(); }
 
-        NextTest();
-    }
-
-    CHIP_ERROR TestReadsBackLtAttributeStartUpOnOff_12()
+    CHIP_ERROR TestReadsBackLtAttributeGlobalSceneControl_12()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
         return CHIP_NO_ERROR;
     }
 
     void OnFailureResponse_12(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_12(uint8_t startUpOnOff)
+    void OnSuccessResponse_12(bool globalSceneControl)
+    {
+        VerifyOrReturn(CheckValue("globalSceneControl", globalSceneControl, 1));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadsBackLtAttributeOnTime_13()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
+            this, OnSuccessCallback_13, OnFailureCallback_13));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_13(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_13(uint16_t onTime)
+    {
+        VerifyOrReturn(CheckValue("onTime", onTime, 0U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadsBackLtAttributeOffWaitTime_14()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
+            this, OnSuccessCallback_14, OnFailureCallback_14));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_14(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_14(uint16_t offWaitTime)
+    {
+        VerifyOrReturn(CheckValue("offWaitTime", offWaitTime, 0U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadsBackLtAttributeStartUpOnOff_15()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
+            this, OnSuccessCallback_15, OnFailureCallback_15));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_15(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_15(uint8_t startUpOnOff)
     {
         VerifyOrReturn(CheckValue("startUpOnOff", startUpOnOff, 0));
 
@@ -23021,32 +23412,196 @@ public:
             err = TestReadTheMandatoryAttributeMaxPressure_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : read the mandatory attribute: EffectiveOperationMode\n");
-            err = TestReadTheMandatoryAttributeEffectiveOperationMode_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : read the mandatory attribute: MaxSpeed\n");
+            err = TestReadTheMandatoryAttributeMaxSpeed_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : read the mandatory attribute: EffectiveControlMode\n");
-            err = TestReadTheMandatoryAttributeEffectiveControlMode_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : read the mandatory attribute: MaxFlow\n");
+            err = TestReadTheMandatoryAttributeMaxFlow_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : read the mandatory attribute: Capacity\n");
-            err = TestReadTheMandatoryAttributeCapacity_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : read the mandatory attribute: EffectiveOperationMode\n");
+            err = TestReadTheMandatoryAttributeEffectiveOperationMode_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : read the mandatory attribute: MaxPressure\n");
-            err = TestReadTheMandatoryAttributeMaxPressure_5();
+            ChipLogProgress(chipTool, " ***** Test Step 5 : read the mandatory attribute: EffectiveControlMode\n");
+            err = TestReadTheMandatoryAttributeEffectiveControlMode_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : read the mandatory attribute: EffectiveOperationMode\n");
-            err = TestReadTheMandatoryAttributeEffectiveOperationMode_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : read the mandatory attribute: Capacity\n");
+            err = TestReadTheMandatoryAttributeCapacity_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : read the mandatory attribute: EffectiveControlMode\n");
-            err = TestReadTheMandatoryAttributeEffectiveControlMode_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : read the mandatory attribute: MaxPressure\n");
+            err = TestReadTheMandatoryAttributeMaxPressure_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : read the mandatory attribute: Capacity\n");
-            err = TestReadTheMandatoryAttributeCapacity_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : read the mandatory attribute: MaxSpeed\n");
+            err = TestReadTheMandatoryAttributeMaxSpeed_8();
+            break;
+        case 9:
+            ChipLogProgress(chipTool, " ***** Test Step 9 : read the mandatory attribute: MaxFlow\n");
+            err = TestReadTheMandatoryAttributeMaxFlow_9();
+            break;
+        case 10:
+            ChipLogProgress(chipTool, " ***** Test Step 10 : read the mandatory attribute: EffectiveOperationMode\n");
+            err = TestReadTheMandatoryAttributeEffectiveOperationMode_10();
+            break;
+        case 11:
+            ChipLogProgress(chipTool, " ***** Test Step 11 : read the mandatory attribute: EffectiveControlMode\n");
+            err = TestReadTheMandatoryAttributeEffectiveControlMode_11();
+            break;
+        case 12:
+            ChipLogProgress(chipTool, " ***** Test Step 12 : read the mandatory attribute: Capacity\n");
+            err = TestReadTheMandatoryAttributeCapacity_12();
+            break;
+        case 13:
+            ChipLogProgress(chipTool, " ***** Test Step 13 : read the optional attribute: MinConstPressure\n");
+            err = TestReadTheOptionalAttributeMinConstPressure_13();
+            break;
+        case 14:
+            ChipLogProgress(chipTool, " ***** Test Step 14 : read the optional attribute: MaxConstPressure\n");
+            err = TestReadTheOptionalAttributeMaxConstPressure_14();
+            break;
+        case 15:
+            ChipLogProgress(chipTool, " ***** Test Step 15 : read the optional attribute: MinCompPressure\n");
+            err = TestReadTheOptionalAttributeMinCompPressure_15();
+            break;
+        case 16:
+            ChipLogProgress(chipTool, " ***** Test Step 16 : read the optional attribute: MaxCompPressure\n");
+            err = TestReadTheOptionalAttributeMaxCompPressure_16();
+            break;
+        case 17:
+            ChipLogProgress(chipTool, " ***** Test Step 17 : read the optional attribute: MinConstSpeed\n");
+            err = TestReadTheOptionalAttributeMinConstSpeed_17();
+            break;
+        case 18:
+            ChipLogProgress(chipTool, " ***** Test Step 18 : read the optional attribute: MaxConstSpeed\n");
+            err = TestReadTheOptionalAttributeMaxConstSpeed_18();
+            break;
+        case 19:
+            ChipLogProgress(chipTool, " ***** Test Step 19 : read the optional attribute: MinConstFlow\n");
+            err = TestReadTheOptionalAttributeMinConstFlow_19();
+            break;
+        case 20:
+            ChipLogProgress(chipTool, " ***** Test Step 20 : read the optional attribute: MaxConstFlow\n");
+            err = TestReadTheOptionalAttributeMaxConstFlow_20();
+            break;
+        case 21:
+            ChipLogProgress(chipTool, " ***** Test Step 21 : read the optional attribute: MinConstTemp\n");
+            err = TestReadTheOptionalAttributeMinConstTemp_21();
+            break;
+        case 22:
+            ChipLogProgress(chipTool, " ***** Test Step 22 : read the optional attribute: MaxConstTemp\n");
+            err = TestReadTheOptionalAttributeMaxConstTemp_22();
+            break;
+        case 23:
+            ChipLogProgress(chipTool, " ***** Test Step 23 : read the optional attribute: PumpStatus\n");
+            err = TestReadTheOptionalAttributePumpStatus_23();
+            break;
+        case 24:
+            ChipLogProgress(chipTool, " ***** Test Step 24 : read the optional attribute: PumpStatus\n");
+            err = TestReadTheOptionalAttributePumpStatus_24();
+            break;
+        case 25:
+            ChipLogProgress(chipTool, " ***** Test Step 25 : read the optional attribute: Speed\n");
+            err = TestReadTheOptionalAttributeSpeed_25();
+            break;
+        case 26:
+            ChipLogProgress(chipTool, " ***** Test Step 26 : read the optional attribute: LifetimeRunningHours\n");
+            err = TestReadTheOptionalAttributeLifetimeRunningHours_26();
+            break;
+        case 27:
+            ChipLogProgress(chipTool, " ***** Test Step 27 : read the optional attribute: LifetimeRunningHours\n");
+            err = TestReadTheOptionalAttributeLifetimeRunningHours_27();
+            break;
+        case 28:
+            ChipLogProgress(chipTool, " ***** Test Step 28 : read the optional attribute: Power\n");
+            err = TestReadTheOptionalAttributePower_28();
+            break;
+        case 29:
+            ChipLogProgress(chipTool, " ***** Test Step 29 : read the optional attribute: LifetimeEnergyConsumed\n");
+            err = TestReadTheOptionalAttributeLifetimeEnergyConsumed_29();
+            break;
+        case 30:
+            ChipLogProgress(chipTool, " ***** Test Step 30 : read the optional attribute: LifetimeEnergyConsumed\n");
+            err = TestReadTheOptionalAttributeLifetimeEnergyConsumed_30();
+            break;
+        case 31:
+            ChipLogProgress(chipTool, " ***** Test Step 31 : write to the optional attribute: LifetimeEnergyConsumed\n");
+            err = TestWriteToTheOptionalAttributeLifetimeEnergyConsumed_31();
+            break;
+        case 32:
+            ChipLogProgress(chipTool, " ***** Test Step 32 : read the optional attribute: MinConstPressure\n");
+            err = TestReadTheOptionalAttributeMinConstPressure_32();
+            break;
+        case 33:
+            ChipLogProgress(chipTool, " ***** Test Step 33 : read the optional attribute: MaxConstPressure\n");
+            err = TestReadTheOptionalAttributeMaxConstPressure_33();
+            break;
+        case 34:
+            ChipLogProgress(chipTool, " ***** Test Step 34 : read the optional attribute: MinCompPressure\n");
+            err = TestReadTheOptionalAttributeMinCompPressure_34();
+            break;
+        case 35:
+            ChipLogProgress(chipTool, " ***** Test Step 35 : read the optional attribute: MaxCompPressure\n");
+            err = TestReadTheOptionalAttributeMaxCompPressure_35();
+            break;
+        case 36:
+            ChipLogProgress(chipTool, " ***** Test Step 36 : read the optional attribute: MinConstSpeed\n");
+            err = TestReadTheOptionalAttributeMinConstSpeed_36();
+            break;
+        case 37:
+            ChipLogProgress(chipTool, " ***** Test Step 37 : read the optional attribute: MaxConstSpeed\n");
+            err = TestReadTheOptionalAttributeMaxConstSpeed_37();
+            break;
+        case 38:
+            ChipLogProgress(chipTool, " ***** Test Step 38 : read the optional attribute: MinConstFlow\n");
+            err = TestReadTheOptionalAttributeMinConstFlow_38();
+            break;
+        case 39:
+            ChipLogProgress(chipTool, " ***** Test Step 39 : read the optional attribute: MaxConstFlow\n");
+            err = TestReadTheOptionalAttributeMaxConstFlow_39();
+            break;
+        case 40:
+            ChipLogProgress(chipTool, " ***** Test Step 40 : read the optional attribute: MinConstTemp\n");
+            err = TestReadTheOptionalAttributeMinConstTemp_40();
+            break;
+        case 41:
+            ChipLogProgress(chipTool, " ***** Test Step 41 : read the optional attribute: MaxConstTemp\n");
+            err = TestReadTheOptionalAttributeMaxConstTemp_41();
+            break;
+        case 42:
+            ChipLogProgress(chipTool, " ***** Test Step 42 : read the optional attribute: PumpStatus\n");
+            err = TestReadTheOptionalAttributePumpStatus_42();
+            break;
+        case 43:
+            ChipLogProgress(chipTool, " ***** Test Step 43 : read the optional attribute: PumpStatus\n");
+            err = TestReadTheOptionalAttributePumpStatus_43();
+            break;
+        case 44:
+            ChipLogProgress(chipTool, " ***** Test Step 44 : read the optional attribute: Speed\n");
+            err = TestReadTheOptionalAttributeSpeed_44();
+            break;
+        case 45:
+            ChipLogProgress(chipTool, " ***** Test Step 45 : read the optional attribute: LifetimeRunningHours\n");
+            err = TestReadTheOptionalAttributeLifetimeRunningHours_45();
+            break;
+        case 46:
+            ChipLogProgress(chipTool, " ***** Test Step 46 : read the optional attribute: LifetimeRunningHours\n");
+            err = TestReadTheOptionalAttributeLifetimeRunningHours_46();
+            break;
+        case 47:
+            ChipLogProgress(chipTool, " ***** Test Step 47 : read the optional attribute: Power\n");
+            err = TestReadTheOptionalAttributePower_47();
+            break;
+        case 48:
+            ChipLogProgress(chipTool, " ***** Test Step 48 : read the optional attribute: LifetimeEnergyConsumed\n");
+            err = TestReadTheOptionalAttributeLifetimeEnergyConsumed_48();
+            break;
+        case 49:
+            ChipLogProgress(chipTool, " ***** Test Step 49 : read the optional attribute: LifetimeEnergyConsumed\n");
+            err = TestReadTheOptionalAttributeLifetimeEnergyConsumed_49();
             break;
         }
 
@@ -23059,7 +23614,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 9;
+    const uint16_t mTestCount = 50;
 
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
@@ -23079,9 +23634,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_2(status);
     }
 
-    static void OnSuccessCallback_2(void * context, uint8_t effectiveOperationMode)
+    static void OnSuccessCallback_2(void * context, uint16_t maxSpeed)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_2(effectiveOperationMode);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_2(maxSpeed);
     }
 
     static void OnFailureCallback_3(void * context, EmberAfStatus status)
@@ -23089,9 +23644,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_3(status);
     }
 
-    static void OnSuccessCallback_3(void * context, uint8_t effectiveControlMode)
+    static void OnSuccessCallback_3(void * context, uint16_t maxFlow)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_3(effectiveControlMode);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_3(maxFlow);
     }
 
     static void OnFailureCallback_4(void * context, EmberAfStatus status)
@@ -23099,9 +23654,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_4(status);
     }
 
-    static void OnSuccessCallback_4(void * context, int16_t capacity)
+    static void OnSuccessCallback_4(void * context, uint8_t effectiveOperationMode)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_4(capacity);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_4(effectiveOperationMode);
     }
 
     static void OnFailureCallback_5(void * context, EmberAfStatus status)
@@ -23109,9 +23664,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_5(status);
     }
 
-    static void OnSuccessCallback_5(void * context, int16_t maxPressure)
+    static void OnSuccessCallback_5(void * context, uint8_t effectiveControlMode)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_5(maxPressure);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_5(effectiveControlMode);
     }
 
     static void OnFailureCallback_6(void * context, EmberAfStatus status)
@@ -23119,9 +23674,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_6(status);
     }
 
-    static void OnSuccessCallback_6(void * context, uint8_t effectiveOperationMode)
+    static void OnSuccessCallback_6(void * context, int16_t capacity)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_6(effectiveOperationMode);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_6(capacity);
     }
 
     static void OnFailureCallback_7(void * context, EmberAfStatus status)
@@ -23129,9 +23684,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_7(status);
     }
 
-    static void OnSuccessCallback_7(void * context, uint8_t effectiveControlMode)
+    static void OnSuccessCallback_7(void * context, int16_t maxPressure)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_7(effectiveControlMode);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_7(maxPressure);
     }
 
     static void OnFailureCallback_8(void * context, EmberAfStatus status)
@@ -23139,9 +23694,416 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_8(status);
     }
 
-    static void OnSuccessCallback_8(void * context, int16_t capacity)
+    static void OnSuccessCallback_8(void * context, uint16_t maxSpeed)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_8(capacity);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_8(maxSpeed);
+    }
+
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_9(status);
+    }
+
+    static void OnSuccessCallback_9(void * context, uint16_t maxFlow)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_9(maxFlow);
+    }
+
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_10(status);
+    }
+
+    static void OnSuccessCallback_10(void * context, uint8_t effectiveOperationMode)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_10(effectiveOperationMode);
+    }
+
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_11(status);
+    }
+
+    static void OnSuccessCallback_11(void * context, uint8_t effectiveControlMode)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_11(effectiveControlMode);
+    }
+
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_12(status);
+    }
+
+    static void OnSuccessCallback_12(void * context, int16_t capacity)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_12(capacity);
+    }
+
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_13(status);
+    }
+
+    static void OnSuccessCallback_13(void * context, int16_t minConstPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_13(minConstPressure);
+    }
+
+    static void OnFailureCallback_14(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_14(status);
+    }
+
+    static void OnSuccessCallback_14(void * context, int16_t maxConstPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_14(maxConstPressure);
+    }
+
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_15(status);
+    }
+
+    static void OnSuccessCallback_15(void * context, int16_t minCompPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_15(minCompPressure);
+    }
+
+    static void OnFailureCallback_16(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_16(status);
+    }
+
+    static void OnSuccessCallback_16(void * context, int16_t maxCompPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_16(maxCompPressure);
+    }
+
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_17(status);
+    }
+
+    static void OnSuccessCallback_17(void * context, uint16_t minConstSpeed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_17(minConstSpeed);
+    }
+
+    static void OnFailureCallback_18(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_18(status);
+    }
+
+    static void OnSuccessCallback_18(void * context, uint16_t maxConstSpeed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_18(maxConstSpeed);
+    }
+
+    static void OnFailureCallback_19(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_19(status);
+    }
+
+    static void OnSuccessCallback_19(void * context, uint16_t minConstFlow)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_19(minConstFlow);
+    }
+
+    static void OnFailureCallback_20(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_20(status);
+    }
+
+    static void OnSuccessCallback_20(void * context, uint16_t maxConstFlow)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_20(maxConstFlow);
+    }
+
+    static void OnFailureCallback_21(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_21(status);
+    }
+
+    static void OnSuccessCallback_21(void * context, int16_t minConstTemp)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_21(minConstTemp);
+    }
+
+    static void OnFailureCallback_22(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_22(status);
+    }
+
+    static void OnSuccessCallback_22(void * context, int16_t maxConstTemp)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_22(maxConstTemp);
+    }
+
+    static void OnFailureCallback_23(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_23(status);
+    }
+
+    static void OnSuccessCallback_23(void * context, uint16_t pumpStatus)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_23(pumpStatus);
+    }
+
+    static void OnFailureCallback_24(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_24(status);
+    }
+
+    static void OnSuccessCallback_24(void * context, uint16_t pumpStatus)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_24(pumpStatus);
+    }
+
+    static void OnFailureCallback_25(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_25(status);
+    }
+
+    static void OnSuccessCallback_25(void * context, uint16_t speed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_25(speed);
+    }
+
+    static void OnFailureCallback_26(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_26(status);
+    }
+
+    static void OnSuccessCallback_26(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_26(lifetimeRunningHours);
+    }
+
+    static void OnFailureCallback_27(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_27(status);
+    }
+
+    static void OnSuccessCallback_27(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_27(lifetimeRunningHours);
+    }
+
+    static void OnFailureCallback_28(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_28(status);
+    }
+
+    static void OnSuccessCallback_28(void * context, uint32_t power)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_28(power);
+    }
+
+    static void OnFailureCallback_29(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_29(status);
+    }
+
+    static void OnSuccessCallback_29(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_29(lifetimeEnergyConsumed);
+    }
+
+    static void OnFailureCallback_30(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_30(status);
+    }
+
+    static void OnSuccessCallback_30(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_30(lifetimeEnergyConsumed);
+    }
+
+    static void OnFailureCallback_31(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_31(status);
+    }
+
+    static void OnSuccessCallback_31(void * context) { (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_31(); }
+
+    static void OnFailureCallback_32(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_32(status);
+    }
+
+    static void OnSuccessCallback_32(void * context, int16_t minConstPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_32(minConstPressure);
+    }
+
+    static void OnFailureCallback_33(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_33(status);
+    }
+
+    static void OnSuccessCallback_33(void * context, int16_t maxConstPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_33(maxConstPressure);
+    }
+
+    static void OnFailureCallback_34(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_34(status);
+    }
+
+    static void OnSuccessCallback_34(void * context, int16_t minCompPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_34(minCompPressure);
+    }
+
+    static void OnFailureCallback_35(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_35(status);
+    }
+
+    static void OnSuccessCallback_35(void * context, int16_t maxCompPressure)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_35(maxCompPressure);
+    }
+
+    static void OnFailureCallback_36(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_36(status);
+    }
+
+    static void OnSuccessCallback_36(void * context, uint16_t minConstSpeed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_36(minConstSpeed);
+    }
+
+    static void OnFailureCallback_37(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_37(status);
+    }
+
+    static void OnSuccessCallback_37(void * context, uint16_t maxConstSpeed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_37(maxConstSpeed);
+    }
+
+    static void OnFailureCallback_38(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_38(status);
+    }
+
+    static void OnSuccessCallback_38(void * context, uint16_t minConstFlow)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_38(minConstFlow);
+    }
+
+    static void OnFailureCallback_39(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_39(status);
+    }
+
+    static void OnSuccessCallback_39(void * context, uint16_t maxConstFlow)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_39(maxConstFlow);
+    }
+
+    static void OnFailureCallback_40(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_40(status);
+    }
+
+    static void OnSuccessCallback_40(void * context, int16_t minConstTemp)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_40(minConstTemp);
+    }
+
+    static void OnFailureCallback_41(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_41(status);
+    }
+
+    static void OnSuccessCallback_41(void * context, int16_t maxConstTemp)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_41(maxConstTemp);
+    }
+
+    static void OnFailureCallback_42(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_42(status);
+    }
+
+    static void OnSuccessCallback_42(void * context, uint16_t pumpStatus)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_42(pumpStatus);
+    }
+
+    static void OnFailureCallback_43(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_43(status);
+    }
+
+    static void OnSuccessCallback_43(void * context, uint16_t pumpStatus)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_43(pumpStatus);
+    }
+
+    static void OnFailureCallback_44(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_44(status);
+    }
+
+    static void OnSuccessCallback_44(void * context, uint16_t speed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_44(speed);
+    }
+
+    static void OnFailureCallback_45(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_45(status);
+    }
+
+    static void OnSuccessCallback_45(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_45(lifetimeRunningHours);
+    }
+
+    static void OnFailureCallback_46(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_46(status);
+    }
+
+    static void OnSuccessCallback_46(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_46(lifetimeRunningHours);
+    }
+
+    static void OnFailureCallback_47(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_47(status);
+    }
+
+    static void OnSuccessCallback_47(void * context, uint32_t power)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_47(power);
+    }
+
+    static void OnFailureCallback_48(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_48(status);
+    }
+
+    static void OnSuccessCallback_48(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_48(lifetimeEnergyConsumed);
+    }
+
+    static void OnFailureCallback_49(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_49(status);
+    }
+
+    static void OnSuccessCallback_49(void * context, const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_49(lifetimeEnergyConsumed);
     }
 
     //
@@ -23174,7 +24136,46 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveOperationMode_2()
+    CHIP_ERROR TestReadTheMandatoryAttributeMaxSpeed_2()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxSpeed::TypeInfo>(
+                this, OnSuccessCallback_2, OnFailureCallback_2));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_2(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_2(uint16_t maxSpeed)
+    {
+        VerifyOrReturn(CheckConstraintType("maxSpeed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheMandatoryAttributeMaxFlow_3()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxFlow::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_3(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_3(uint16_t maxFlow)
+    {
+        VerifyOrReturn(CheckConstraintType("maxFlow", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveOperationMode_4()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23182,19 +24183,19 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
-                this, OnSuccessCallback_2, OnFailureCallback_2));
+                this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_2(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_4(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_2(uint8_t effectiveOperationMode)
+    void OnSuccessResponse_4(uint8_t effectiveOperationMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveOperationMode", "", "enum8"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveControlMode_3()
+    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveControlMode_5()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23202,19 +24203,19 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
-                this, OnSuccessCallback_3, OnFailureCallback_3));
+                this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_3(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_5(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_3(uint8_t effectiveControlMode)
+    void OnSuccessResponse_5(uint8_t effectiveControlMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveControlMode", "", "enum8"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeCapacity_4()
+    CHIP_ERROR TestReadTheMandatoryAttributeCapacity_6()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23222,19 +24223,19 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
-                this, OnSuccessCallback_4, OnFailureCallback_4));
+                this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_4(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_6(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_4(int16_t capacity)
+    void OnSuccessResponse_6(int16_t capacity)
     {
         VerifyOrReturn(CheckConstraintType("capacity", "", "int16"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeMaxPressure_5()
+    CHIP_ERROR TestReadTheMandatoryAttributeMaxPressure_7()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23242,19 +24243,58 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo>(
-                this, OnSuccessCallback_5, OnFailureCallback_5));
+                this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_5(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_7(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_5(int16_t maxPressure)
+    void OnSuccessResponse_7(int16_t maxPressure)
     {
         VerifyOrReturn(CheckConstraintType("maxPressure", "", "int16"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveOperationMode_6()
+    CHIP_ERROR TestReadTheMandatoryAttributeMaxSpeed_8()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxSpeed::TypeInfo>(
+                this, OnSuccessCallback_8, OnFailureCallback_8));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_8(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_8(uint16_t maxSpeed)
+    {
+        VerifyOrReturn(CheckConstraintType("maxSpeed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheMandatoryAttributeMaxFlow_9()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxFlow::TypeInfo>(
+            this, OnSuccessCallback_9, OnFailureCallback_9));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_9(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_9(uint16_t maxFlow)
+    {
+        VerifyOrReturn(CheckConstraintType("maxFlow", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveOperationMode_10()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23262,19 +24302,19 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
-                this, OnSuccessCallback_6, OnFailureCallback_6));
+                this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_6(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_10(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_6(uint8_t effectiveOperationMode)
+    void OnSuccessResponse_10(uint8_t effectiveOperationMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveOperationMode", "", "enum8"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveControlMode_7()
+    CHIP_ERROR TestReadTheMandatoryAttributeEffectiveControlMode_11()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23282,19 +24322,19 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
-                this, OnSuccessCallback_7, OnFailureCallback_7));
+                this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_7(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_11(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_7(uint8_t effectiveControlMode)
+    void OnSuccessResponse_11(uint8_t effectiveControlMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveControlMode", "", "enum8"));
         NextTest();
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeCapacity_8()
+    CHIP_ERROR TestReadTheMandatoryAttributeCapacity_12()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
@@ -23302,15 +24342,873 @@ private:
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
-                this, OnSuccessCallback_8, OnFailureCallback_8));
+                this, OnSuccessCallback_12, OnFailureCallback_12));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_8(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_12(EmberAfStatus status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_8(int16_t capacity)
+    void OnSuccessResponse_12(int16_t capacity)
     {
         VerifyOrReturn(CheckConstraintType("capacity", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstPressure_13()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstPressure::TypeInfo>(
+                this, OnSuccessCallback_13, OnFailureCallback_13));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_13(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_13(int16_t minConstPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstPressure_14()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstPressure::TypeInfo>(
+                this, OnSuccessCallback_14, OnFailureCallback_14));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_14(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_14(int16_t maxConstPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinCompPressure_15()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinCompPressure::TypeInfo>(
+                this, OnSuccessCallback_15, OnFailureCallback_15));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_15(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_15(int16_t minCompPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("minCompPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxCompPressure_16()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxCompPressure::TypeInfo>(
+                this, OnSuccessCallback_16, OnFailureCallback_16));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_16(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_16(int16_t maxCompPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("maxCompPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstSpeed_17()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstSpeed::TypeInfo>(
+                this, OnSuccessCallback_17, OnFailureCallback_17));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_17(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_17(uint16_t minConstSpeed)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstSpeed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstSpeed_18()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstSpeed::TypeInfo>(
+                this, OnSuccessCallback_18, OnFailureCallback_18));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_18(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_18(uint16_t maxConstSpeed)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstSpeed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstFlow_19()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstFlow::TypeInfo>(
+                this, OnSuccessCallback_19, OnFailureCallback_19));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_19(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_19(uint16_t minConstFlow)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstFlow", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstFlow_20()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstFlow::TypeInfo>(
+                this, OnSuccessCallback_20, OnFailureCallback_20));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_20(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_20(uint16_t maxConstFlow)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstFlow", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstTemp_21()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstTemp::TypeInfo>(
+                this, OnSuccessCallback_21, OnFailureCallback_21));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_21(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_21(int16_t minConstTemp)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstTemp", "", "int16"));
+        VerifyOrReturn(CheckConstraintMinValue<int16_t>("minConstTemp", minConstTemp, -27315));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstTemp_22()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstTemp::TypeInfo>(
+                this, OnSuccessCallback_22, OnFailureCallback_22));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_22(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_22(int16_t maxConstTemp)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstTemp", "", "int16"));
+        VerifyOrReturn(CheckConstraintMinValue<int16_t>("maxConstTemp", maxConstTemp, -27315));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributePumpStatus_23()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
+                this, OnSuccessCallback_23, OnFailureCallback_23));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_23(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_23(uint16_t pumpStatus)
+    {
+        VerifyOrReturn(CheckValue("pumpStatus", pumpStatus, 0U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributePumpStatus_24()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
+                this, OnSuccessCallback_24, OnFailureCallback_24));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_24(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_24(uint16_t pumpStatus)
+    {
+        VerifyOrReturn(CheckConstraintType("pumpStatus", "", "map16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeSpeed_25()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Speed::TypeInfo>(
+            this, OnSuccessCallback_25, OnFailureCallback_25));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_25(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_25(uint16_t speed)
+    {
+        VerifyOrReturn(CheckConstraintType("speed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeRunningHours_26()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
+                this, OnSuccessCallback_26, OnFailureCallback_26));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_26(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_26(const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        VerifyOrReturn(CheckValueNonNull("lifetimeRunningHours", lifetimeRunningHours));
+        VerifyOrReturn(CheckValue("lifetimeRunningHours.Value()", lifetimeRunningHours.Value(), 0UL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeRunningHours_27()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
+                this, OnSuccessCallback_27, OnFailureCallback_27));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_27(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_27(const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        VerifyOrReturn(CheckConstraintType("lifetimeRunningHours", "", "uint24"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributePower_28()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Power::TypeInfo>(
+            this, OnSuccessCallback_28, OnFailureCallback_28));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_28(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_28(uint32_t power)
+    {
+        VerifyOrReturn(CheckConstraintType("power", "", "uint24"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeEnergyConsumed_29()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
+                this, OnSuccessCallback_29, OnFailureCallback_29));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_29(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_29(const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        VerifyOrReturn(CheckValueNonNull("lifetimeEnergyConsumed", lifetimeEnergyConsumed));
+        VerifyOrReturn(CheckValue("lifetimeEnergyConsumed.Value()", lifetimeEnergyConsumed.Value(), 0UL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeEnergyConsumed_30()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
+                this, OnSuccessCallback_30, OnFailureCallback_30));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_30(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_30(const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        VerifyOrReturn(CheckConstraintType("lifetimeEnergyConsumed", "", "uint32"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteToTheOptionalAttributeLifetimeEnergyConsumed_31()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        chip::app::DataModel::Nullable<uint32_t> lifetimeEnergyConsumedArgument;
+        lifetimeEnergyConsumedArgument.SetNonNull();
+        lifetimeEnergyConsumedArgument.Value() = 0UL;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
+                lifetimeEnergyConsumedArgument, this, OnSuccessCallback_31, OnFailureCallback_31));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_31(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_31() { NextTest(); }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstPressure_32()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstPressure::TypeInfo>(
+                this, OnSuccessCallback_32, OnFailureCallback_32));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_32(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_32(int16_t minConstPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstPressure_33()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstPressure::TypeInfo>(
+                this, OnSuccessCallback_33, OnFailureCallback_33));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_33(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_33(int16_t maxConstPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinCompPressure_34()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinCompPressure::TypeInfo>(
+                this, OnSuccessCallback_34, OnFailureCallback_34));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_34(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_34(int16_t minCompPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("minCompPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxCompPressure_35()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxCompPressure::TypeInfo>(
+                this, OnSuccessCallback_35, OnFailureCallback_35));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_35(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_35(int16_t maxCompPressure)
+    {
+        VerifyOrReturn(CheckConstraintType("maxCompPressure", "", "int16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstSpeed_36()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstSpeed::TypeInfo>(
+                this, OnSuccessCallback_36, OnFailureCallback_36));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_36(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_36(uint16_t minConstSpeed)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstSpeed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstSpeed_37()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstSpeed::TypeInfo>(
+                this, OnSuccessCallback_37, OnFailureCallback_37));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_37(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_37(uint16_t maxConstSpeed)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstSpeed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstFlow_38()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstFlow::TypeInfo>(
+                this, OnSuccessCallback_38, OnFailureCallback_38));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_38(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_38(uint16_t minConstFlow)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstFlow", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstFlow_39()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstFlow::TypeInfo>(
+                this, OnSuccessCallback_39, OnFailureCallback_39));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_39(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_39(uint16_t maxConstFlow)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstFlow", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMinConstTemp_40()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstTemp::TypeInfo>(
+                this, OnSuccessCallback_40, OnFailureCallback_40));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_40(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_40(int16_t minConstTemp)
+    {
+        VerifyOrReturn(CheckConstraintType("minConstTemp", "", "int16"));
+        VerifyOrReturn(CheckConstraintMinValue<int16_t>("minConstTemp", minConstTemp, -27315));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeMaxConstTemp_41()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstTemp::TypeInfo>(
+                this, OnSuccessCallback_41, OnFailureCallback_41));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_41(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_41(int16_t maxConstTemp)
+    {
+        VerifyOrReturn(CheckConstraintType("maxConstTemp", "", "int16"));
+        VerifyOrReturn(CheckConstraintMinValue<int16_t>("maxConstTemp", maxConstTemp, -27315));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributePumpStatus_42()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
+                this, OnSuccessCallback_42, OnFailureCallback_42));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_42(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_42(uint16_t pumpStatus)
+    {
+        VerifyOrReturn(CheckValue("pumpStatus", pumpStatus, 0U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributePumpStatus_43()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
+                this, OnSuccessCallback_43, OnFailureCallback_43));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_43(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_43(uint16_t pumpStatus)
+    {
+        VerifyOrReturn(CheckConstraintType("pumpStatus", "", "map16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeSpeed_44()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Speed::TypeInfo>(
+            this, OnSuccessCallback_44, OnFailureCallback_44));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_44(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_44(uint16_t speed)
+    {
+        VerifyOrReturn(CheckConstraintType("speed", "", "uint16"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeRunningHours_45()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
+                this, OnSuccessCallback_45, OnFailureCallback_45));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_45(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_45(const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        VerifyOrReturn(CheckValueNonNull("lifetimeRunningHours", lifetimeRunningHours));
+        VerifyOrReturn(CheckValue("lifetimeRunningHours.Value()", lifetimeRunningHours.Value(), 0UL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeRunningHours_46()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
+                this, OnSuccessCallback_46, OnFailureCallback_46));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_46(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_46(const chip::app::DataModel::Nullable<uint32_t> & lifetimeRunningHours)
+    {
+        VerifyOrReturn(CheckConstraintType("lifetimeRunningHours", "", "uint24"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributePower_47()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Power::TypeInfo>(
+            this, OnSuccessCallback_47, OnFailureCallback_47));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_47(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_47(uint32_t power)
+    {
+        VerifyOrReturn(CheckConstraintType("power", "", "uint24"));
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeEnergyConsumed_48()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
+                this, OnSuccessCallback_48, OnFailureCallback_48));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_48(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_48(const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        VerifyOrReturn(CheckValueNonNull("lifetimeEnergyConsumed", lifetimeEnergyConsumed));
+        VerifyOrReturn(CheckValue("lifetimeEnergyConsumed.Value()", lifetimeEnergyConsumed.Value(), 0UL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadTheOptionalAttributeLifetimeEnergyConsumed_49()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
+                this, OnSuccessCallback_49, OnFailureCallback_49));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_49(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_49(const chip::app::DataModel::Nullable<uint32_t> & lifetimeEnergyConsumed)
+    {
+        VerifyOrReturn(CheckConstraintType("lifetimeEnergyConsumed", "", "uint32"));
         NextTest();
     }
 };
@@ -23516,6 +25414,34 @@ public:
             ChipLogProgress(chipTool, " ***** Test Step 2 : Reads the attribute: EffectiveOperationMode\n");
             err = ShouldSkip("A_EFFECTIVEOPERATIONMODE") ? CHIP_NO_ERROR : TestReadsTheAttributeEffectiveOperationMode_2();
             break;
+        case 3:
+            ChipLogProgress(chipTool, " ***** Test Step 3 : Write 0 to the ControlMode attribute to DUT\n");
+            err = ShouldSkip("A_CONTROLMODE") ? CHIP_NO_ERROR : TestWrite0ToTheControlModeAttributeToDut_3();
+            break;
+        case 4:
+            ChipLogProgress(chipTool, " ***** Test Step 4 : Reads the attribute: EffectiveControlMode\n");
+            err = ShouldSkip("A_EFFECTIVECONTROLMODE") ? CHIP_NO_ERROR : TestReadsTheAttributeEffectiveControlMode_4();
+            break;
+        case 5:
+            ChipLogProgress(chipTool, " ***** Test Step 5 : Write 1 to the ControlMode attribute to DUT\n");
+            err = ShouldSkip("A_CONTROLMODE") ? CHIP_NO_ERROR : TestWrite1ToTheControlModeAttributeToDut_5();
+            break;
+        case 6:
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Write 2 to the ControlMode attribute to DUT\n");
+            err = ShouldSkip("A_CONTROLMODE") ? CHIP_NO_ERROR : TestWrite2ToTheControlModeAttributeToDut_6();
+            break;
+        case 7:
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Write 3 to the ControlMode attribute to DUT\n");
+            err = ShouldSkip("A_CONTROLMODE") ? CHIP_NO_ERROR : TestWrite3ToTheControlModeAttributeToDut_7();
+            break;
+        case 8:
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Write 5 to the ControlMode attribute to DUT\n");
+            err = ShouldSkip("A_CONTROLMODE") ? CHIP_NO_ERROR : TestWrite5ToTheControlModeAttributeToDut_8();
+            break;
+        case 9:
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Write 7 to the ControlMode attribute to DUT\n");
+            err = ShouldSkip("A_CONTROLMODE") ? CHIP_NO_ERROR : TestWrite7ToTheControlModeAttributeToDut_9();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -23527,7 +25453,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 3;
+    const uint16_t mTestCount = 10;
 
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
@@ -23548,6 +25474,58 @@ private:
     {
         (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_2(effectiveOperationMode);
     }
+
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_3(status);
+    }
+
+    static void OnSuccessCallback_3(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_3(); }
+
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_4(status);
+    }
+
+    static void OnSuccessCallback_4(void * context, uint8_t effectiveControlMode)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_4(effectiveControlMode);
+    }
+
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_5(status);
+    }
+
+    static void OnSuccessCallback_5(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_5(); }
+
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_6(status);
+    }
+
+    static void OnSuccessCallback_6(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_6(); }
+
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_7(status);
+    }
+
+    static void OnSuccessCallback_7(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_7(); }
+
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_8(status);
+    }
+
+    static void OnSuccessCallback_8(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_8(); }
+
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
+    {
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_9(status);
+    }
+
+    static void OnSuccessCallback_9(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_9(); }
 
     //
     // Tests methods
@@ -23598,6 +25576,141 @@ private:
 
         NextTest();
     }
+
+    CHIP_ERROR TestWrite0ToTheControlModeAttributeToDut_3()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint8_t controlModeArgument;
+        controlModeArgument = 0;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+                controlModeArgument, this, OnSuccessCallback_3, OnFailureCallback_3));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_3(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_3() { NextTest(); }
+
+    CHIP_ERROR TestReadsTheAttributeEffectiveControlMode_4()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(
+            cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
+                this, OnSuccessCallback_4, OnFailureCallback_4));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_4(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_4(uint8_t effectiveControlMode)
+    {
+        VerifyOrReturn(CheckValue("effectiveControlMode", effectiveControlMode, 0));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWrite1ToTheControlModeAttributeToDut_5()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint8_t controlModeArgument;
+        controlModeArgument = 1;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+                controlModeArgument, this, OnSuccessCallback_5, OnFailureCallback_5));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_5(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_5() { NextTest(); }
+
+    CHIP_ERROR TestWrite2ToTheControlModeAttributeToDut_6()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint8_t controlModeArgument;
+        controlModeArgument = 2;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+                controlModeArgument, this, OnSuccessCallback_6, OnFailureCallback_6));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_6(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_6() { NextTest(); }
+
+    CHIP_ERROR TestWrite3ToTheControlModeAttributeToDut_7()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint8_t controlModeArgument;
+        controlModeArgument = 3;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+                controlModeArgument, this, OnSuccessCallback_7, OnFailureCallback_7));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_7(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_7() { NextTest(); }
+
+    CHIP_ERROR TestWrite5ToTheControlModeAttributeToDut_8()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint8_t controlModeArgument;
+        controlModeArgument = 5;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+                controlModeArgument, this, OnSuccessCallback_8, OnFailureCallback_8));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_8(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_8() { NextTest(); }
+
+    CHIP_ERROR TestWrite7ToTheControlModeAttributeToDut_9()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        uint8_t controlModeArgument;
+        controlModeArgument = 7;
+
+        ReturnErrorOnFailure(
+            cluster.WriteAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo>(
+                controlModeArgument, this, OnSuccessCallback_9, OnFailureCallback_9));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_9(EmberAfStatus status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_9() { NextTest(); }
 };
 
 class Test_TC_RH_1_1 : public TestCommand
@@ -26500,7 +28613,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_50(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_50(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_50(int8_t minSetpointDeadBand)
     {
@@ -26520,7 +28636,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_51(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_51(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_51(int8_t minSetpointDeadBand)
     {
@@ -26543,7 +28662,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_52(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_52(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_52() { NextTest(); }
 
@@ -26558,7 +28680,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_53(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_53(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_53(int8_t minSetpointDeadBand)
     {
@@ -26578,7 +28703,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_54(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_54(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_54(uint8_t startOfWeek)
     {
@@ -26620,7 +28748,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_56(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_56(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_56(uint8_t startOfWeek)
     {
@@ -26641,7 +28772,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_57(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_57(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_57(uint8_t numberOfWeeklyTransitions)
     {
@@ -26683,7 +28817,10 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_59(EmberAfStatus status) { ThrowFailureResponse(); }
+    void OnFailureResponse_59(EmberAfStatus status)
+    {
+        (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
+    }
 
     void OnSuccessResponse_59(uint8_t numberOfDailyTransitions)
     {
@@ -58282,10 +60419,10 @@ private:
     void OnDoneResponse_2() { NextTest(); }
 };
 
-class Test_TC_DIAGSW_1_1 : public TestCommand
+class Test_TC_SWDIAG_1_1 : public TestCommand
 {
 public:
-    Test_TC_DIAGSW_1_1() : TestCommand("Test_TC_DIAGSW_1_1"), mTestIndex(0)
+    Test_TC_SWDIAG_1_1() : TestCommand("Test_TC_SWDIAG_1_1"), mTestIndex(0)
     {
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
@@ -58298,12 +60435,12 @@ public:
 
         if (0 == mTestIndex)
         {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DIAGSW_1_1\n");
+            ChipLogProgress(chipTool, " **** Test Start: Test_TC_SWDIAG_1_1\n");
         }
 
         if (mTestCount == mTestIndex)
         {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DIAGSW_1_1\n");
+            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_SWDIAG_1_1\n");
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
@@ -58351,32 +60488,32 @@ private:
 
     static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_SWDIAG_1_1 *>(context))->OnFailureResponse_1(status);
     }
 
     static void OnSuccessCallback_1(void * context, uint64_t currentHeapFree)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnSuccessResponse_1(currentHeapFree);
+        (static_cast<Test_TC_SWDIAG_1_1 *>(context))->OnSuccessResponse_1(currentHeapFree);
     }
 
     static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_SWDIAG_1_1 *>(context))->OnFailureResponse_2(status);
     }
 
     static void OnSuccessCallback_2(void * context, uint64_t currentHeapUsed)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnSuccessResponse_2(currentHeapUsed);
+        (static_cast<Test_TC_SWDIAG_1_1 *>(context))->OnSuccessResponse_2(currentHeapUsed);
     }
 
     static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_SWDIAG_1_1 *>(context))->OnFailureResponse_3(status);
     }
 
     static void OnSuccessCallback_3(void * context, uint64_t currentHeapHighWatermark)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnSuccessResponse_3(currentHeapHighWatermark);
+        (static_cast<Test_TC_SWDIAG_1_1 *>(context))->OnSuccessResponse_3(currentHeapHighWatermark);
     }
 
     //
@@ -58457,10 +60594,10 @@ private:
     }
 };
 
-class Test_TC_DIAGSW_2_1 : public TestCommand
+class Test_TC_SWDIAG_2_1 : public TestCommand
 {
 public:
-    Test_TC_DIAGSW_2_1() : TestCommand("Test_TC_DIAGSW_2_1"), mTestIndex(0)
+    Test_TC_SWDIAG_2_1() : TestCommand("Test_TC_SWDIAG_2_1"), mTestIndex(0)
     {
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
@@ -58473,12 +60610,12 @@ public:
 
         if (0 == mTestIndex)
         {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DIAGSW_2_1\n");
+            ChipLogProgress(chipTool, " **** Test Start: Test_TC_SWDIAG_2_1\n");
         }
 
         if (mTestCount == mTestIndex)
         {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DIAGSW_2_1\n");
+            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_SWDIAG_2_1\n");
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
@@ -58512,10 +60649,10 @@ private:
     //
 };
 
-class Test_TC_DIAGSW_3_2 : public TestCommand
+class Test_TC_SWDIAG_3_1 : public TestCommand
 {
 public:
-    Test_TC_DIAGSW_3_2() : TestCommand("Test_TC_DIAGSW_3_2"), mTestIndex(0)
+    Test_TC_SWDIAG_3_1() : TestCommand("Test_TC_SWDIAG_3_1"), mTestIndex(0)
     {
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
@@ -58528,12 +60665,12 @@ public:
 
         if (0 == mTestIndex)
         {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DIAGSW_3_2\n");
+            ChipLogProgress(chipTool, " **** Test Start: Test_TC_SWDIAG_3_1\n");
         }
 
         if (mTestCount == mTestIndex)
         {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DIAGSW_3_2\n");
+            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_SWDIAG_3_1\n");
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
@@ -59014,9 +61151,9 @@ void registerCommandsTests(Commands & commands)
         make_unique<TestOperationalCredentialsCluster>(),
         make_unique<TestModeSelectCluster>(),
         make_unique<TestGroupMessaging>(),
-        make_unique<Test_TC_DIAGSW_1_1>(),
-        make_unique<Test_TC_DIAGSW_2_1>(),
-        make_unique<Test_TC_DIAGSW_3_2>(),
+        make_unique<Test_TC_SWDIAG_1_1>(),
+        make_unique<Test_TC_SWDIAG_2_1>(),
+        make_unique<Test_TC_SWDIAG_3_1>(),
         make_unique<TestSubscribe_OnOff>(),
     };
 


### PR DESCRIPTION

Modified following scripts as per latest testplan and added optional parameter:

1.TC-BI-1.1
2.TC-BI-2.1
3.TC-BOOL-1.1
4.TC-BOOL-2.1
5.TC-CC-1.1
6.TC-CC-2.1
7.TC-CC-7.4
8.TC-FLW-1.1
9.TC-FLW-2.1
10.TC-FLW-2.2
11.TC-MC-3.1
12.TC-MC-3.2
13.TC-MC-3.3
14.TC-MC-3.4
15.TC-MC-3.6
16.TC-MC-3.7
17.TC-MC-3.9
18.TC-MC-3.10
19.TC-MC-3.11
20.TC-OO-2.1
21.TC-PCC-2.1
22.TC-PCC-2.3
23.TC-PRS-2.1
24.TC-RH-2.1
25.TC-SWDIAG-1.1
26.TC-SWDIAG-2.1
27.TC-SWDIAG-3.1
28.TC-TM-2.1
29.TC-TSTAT-2.1

Executed all YAML test scripts, attached logs for reference:
[execution_logs.zip](https://github.com/project-chip/connectedhomeip/files/7828842/execution_logs.zip)

