### PR TITLE
[OpenThread Platform] Update the dnssd code to dispatch browse and re…

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -118,6 +118,9 @@ protected:
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
     CHIP_ERROR _DnsBrowse(const char * aServiceName, DnsBrowseCallback aCallback, void * aContext);
     CHIP_ERROR _DnsResolve(const char * aServiceName, const char * aInstanceName, DnsResolveCallback aCallback, void * aContext);
+    static void DispatchResolve(intptr_t context);
+    static void DispatchBrowseEmpty(intptr_t context);
+    static void DispatchBrowse(intptr_t context);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
@@ -226,8 +229,16 @@ private:
 
     struct DnsResult
     {
+        void * context;
         chip::Dnssd::DnssdService mMdnsService;
         DnsServiceTxtEntries mServiceTxtEntry;
+        CHIP_ERROR error;
+
+        DnsResult(void * cbContext, CHIP_ERROR aError)
+        {
+            context = cbContext;
+            error   = aError;
+        }
     };
 
     static void OnDnsBrowseResult(otError aError, const otDnsBrowseResponse * aResponse, void * aContext);


### PR DESCRIPTION
…solve results onto the chip thread

#### Problem

From #13258 

In the current implementation of Matter node running over Thread a successful DNS-SD resolution
results in CASE session establishment code being executed in the Thread task context.
This is problematic as the Tread task is not generally expected to have sufficient stack to handle Matter processing.
Another issue is that this may result in a semaphore block during an attempt to send a Thread message from the context of receiving a Thread message.


#### Change overview
 * Dispatch the dns resolution onto the chip thread

fixes #13258