### PR TITLE
Set peer node ID for PASE sessions

### DIFF
--- a/src/lib/core/NodeId.h
+++ b/src/lib/core/NodeId.h
@@ -78,4 +78,9 @@ constexpr NodeId NodeIdFromGroupId(GroupId aGroupId)
     return kMinGroupNodeId | aGroupId;
 }
 
+constexpr NodeId NodeIdFromPAKEKeyId(GroupId aPAKEKeyId)
+{
+    return kMinPAKEKeyId | aPAKEKeyId;
+}
+
 } // namespace chip

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -284,6 +284,8 @@ CHIP_ERROR PASESession::WaitForPairing(uint32_t mySetUpPINCode, uint32_t pbkdf2I
     mPasscodeID      = 0;
     mLocalMRPConfig  = mrpConfig;
 
+    SetPeerNodeId(NodeIdFromPAKEKeyId(mPasscodeID));
+
     ChipLogDetail(SecureChannel, "Waiting for PBKDF param request");
 
 exit:
@@ -298,11 +300,14 @@ CHIP_ERROR PASESession::WaitForPairing(const PASEVerifier & verifier, uint32_t p
                                        uint16_t passcodeID, uint16_t mySessionId, Optional<ReliableMessageProtocolConfig> mrpConfig,
                                        SessionEstablishmentDelegate * delegate)
 {
+    ReturnErrorCodeIf(passcodeID == 0, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(WaitForPairing(0, pbkdf2IterCount, salt, mySessionId, mrpConfig, delegate));
 
     memmove(&mPASEVerifier, &verifier, sizeof(verifier));
     mComputeVerifier = false;
     mPasscodeID      = passcodeID;
+
+    SetPeerNodeId(NodeIdFromPAKEKeyId(mPasscodeID));
 
     return CHIP_NO_ERROR;
 }
@@ -319,6 +324,7 @@ CHIP_ERROR PASESession::Pair(const Transport::PeerAddress peerAddress, uint32_t 
     mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout + mExchangeCtxt->GetAckTimeout());
 
     SetPeerAddress(peerAddress);
+    SetPeerNodeId(NodeIdFromPAKEKeyId(mPasscodeID));
 
     mLocalMRPConfig = mrpConfig;
 

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -90,8 +90,8 @@ public:
 
     virtual ~PASESession();
 
-    // TODO: The SetPeerNodeId method should not be exposed; we should not need
-    // to associate a node ID with a PASE session.
+    // TODO: The SetPeerNodeId method should not be exposed; PASE sessions
+    // should not need to be told their peer node ID
     using PairingSession::SetPeerNodeId;
 
     /**


### PR DESCRIPTION
#### Problem
PASE sessions do not have peer node ID properly set, so subject descriptor
cannot identify them for access control

Needed for #10242

#### Change overview
Peer node ID for PASE sessions is the passcode ID with discriminant in
the top bits (to discriminate it from other kinds of node ID).

Also, passcode ID cannot be zero in non-default commissioning cases.

#### Testing
* Built and ran (all-clusters-app with REPL on Linux) with temp log statements