### PR TITLE
Revert "Bugfix: Add chip shell engine initializing for esp32 platform…

### DIFF
--- a/examples/platform/esp32/shell_extension/launch.cpp
+++ b/examples/platform/esp32/shell_extension/launch.cpp
@@ -37,7 +37,6 @@ namespace chip {
 
 void LaunchShell()
 {
-    chip::Shell::Engine::Root().Init();
 #if CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
     idf::chip::RegisterHeapTraceCommands();
 #endif // CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING


### PR DESCRIPTION
… (#13364)"

This reverts commit 0e5bc69f53562f9defbc6a59d0d1cac9772b6c95.

#### Problem
ESP32 does not compile.

This PR was depending on #13060 but that got  reverted in #13368

#### Change overview
Revert

#### Testing
CI will validate, but pure rollback of trivial change, so that should be safe.

I tested that m5stack all-clusters fails to compile on master but passes locally after this revert.