### PR TITLE
Use enum class for GeneralCommissioning::RegulatoryLocationType

### DIFF
--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -152,7 +152,9 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(app::CommandH
                                                                    const Commands::SetRegulatoryConfig::DecodableType & commandData)
 {
     DeviceControlServer * server = &DeviceLayer::DeviceControlServer::DeviceControlSvr();
-    CheckSuccess(server->SetRegulatoryConfig(commandData.location, commandData.countryCode, commandData.breadcrumb), Failure);
+
+    CheckSuccess(server->SetRegulatoryConfig(to_underlying(commandData.location), commandData.countryCode, commandData.breadcrumb),
+                 Failure);
 
     Commands::SetRegulatoryConfigResponse::Type response;
     response.errorCode = GeneralCommissioningError::kOk;

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -653,7 +653,6 @@ function isWeaklyTypedEnum(label)
     "PHYRateType",
     "RadioFaultType",
     "RoutingRole",
-    "RegulatoryLocationType",
     "SaturationMoveMode",
     "SaturationStepMode",
     "SecurityType",

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1766,7 +1766,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         // TODO(cecille): Worthwhile to keep this around as part of the class?
         // TODO(cecille): Where is the country config actually set?
         ChipLogProgress(Controller, "Setting Regulatory Config");
-        uint8_t regulatoryLocation = EMBER_ZCL_REGULATORY_LOCATION_TYPE_OUTDOOR;
+        uint8_t regulatoryLocation = to_underlying(app::Clusters::GeneralCommissioning::RegulatoryLocationType::kOutdoor);
 #if CONFIG_DEVICE_LAYER
         CHIP_ERROR status = DeviceLayer::ConfigurationMgr().GetRegulatoryLocation(regulatoryLocation);
 #else

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -26,7 +26,7 @@
 
 #include <cstdint>
 
-#include <app-common/zap-generated/enums.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <lib/support/Span.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/PersistedStorage.h>
@@ -191,7 +191,7 @@ extern void SetConfigurationMgr(ConfigurationManager * configurationManager);
 
 inline CHIP_ERROR ConfigurationManager::GetLocationCapability(uint8_t & location)
 {
-    location = EMBER_ZCL_REGULATORY_LOCATION_TYPE_INDOOR;
+    location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -25,7 +25,7 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <app-common/zap-generated/enums.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <ifaddrs.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
@@ -94,14 +94,14 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_RegulatoryLocation))
     {
-        uint32_t location = EMBER_ZCL_REGULATORY_LOCATION_TYPE_INDOOR;
+        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
         err               = WriteConfigValue(PosixConfig::kConfigKey_RegulatoryLocation, location);
         SuccessOrExit(err);
     }
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_LocationCapability))
     {
-        uint32_t location = EMBER_ZCL_REGULATORY_LOCATION_TYPE_INDOOR;
+        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
         err               = WriteConfigValue(PosixConfig::kConfigKey_LocationCapability, location);
         SuccessOrExit(err);
     }

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -9624,9 +9624,6 @@ enum class GeneralCommissioningError : uint8_t
     kInvalidAuthentication = 0x02,
     kNotCommissioning      = 0x03,
 };
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for RegulatoryLocationType
 enum class RegulatoryLocationType : uint8_t
 {
@@ -9634,9 +9631,6 @@ enum class RegulatoryLocationType : uint8_t
     kOutdoor       = 0x01,
     kIndoorOutdoor = 0x02,
 };
-#else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using RegulatoryLocationType          = EmberAfRegulatoryLocationType;
-#endif
 
 namespace Structs {
 namespace BasicCommissioningInfoType {

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -413,14 +413,6 @@ enum EmberAfRadioFaultType : uint8_t
     EMBER_ZCL_RADIO_FAULT_TYPE_ETHERNET_FAULT = 6,
 };
 
-// Enum for RegulatoryLocationType
-enum EmberAfRegulatoryLocationType : uint8_t
-{
-    EMBER_ZCL_REGULATORY_LOCATION_TYPE_INDOOR         = 0,
-    EMBER_ZCL_REGULATORY_LOCATION_TYPE_OUTDOOR        = 1,
-    EMBER_ZCL_REGULATORY_LOCATION_TYPE_INDOOR_OUTDOOR = 2,
-};
-
 // Enum for RoutingRole
 enum EmberAfRoutingRole : uint8_t
 {


### PR DESCRIPTION
#### Problem

`RegulatoryLocationType` from https://github.com/project-chip/connectedhomeip/blob/d24eff1b14c212bdff9c98aa14255753082543ba/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml#L26 is still beeing generated as a weakly typed enum.

#### Change overview
 * Remove it from the list of executions in `isWeaklyTypedEnum`
 * Update the code accordingly

