### PR TITLE
Switch to having only one struct named LabelStruct.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -22,9 +22,17 @@
 // generated ones, so are placed here.
 namespace {
 
+{{#zcl_structs}}
+{{#if has_more_than_one_cluster}}
+CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns="detail" isArgument=true}} value);
+{{/if}}
+{{/zcl_structs}}
+
 {{#zcl_clusters}}
 {{#zcl_structs}}
+{{#unless has_more_than_one_cluster}}
 CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true}} value);
+{{/unless}}
 {{/zcl_structs}}
 {{/zcl_clusters}}
 
@@ -145,24 +153,17 @@ CHIP_ERROR LogValue(const char * label, size_t indent, const chip::Optional<T> &
 // be logging.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+{{#zcl_structs}}
+{{#if has_more_than_one_cluster}}
+{{> log_struct_value ns="detail"}}
+{{/if}}
+{{/zcl_structs}}
+
 {{#zcl_clusters}}
 {{#zcl_structs}}
-CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true}} value)
-{
-  ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
-{{#zcl_struct_items}}
-  {
-      CHIP_ERROR err = LogValue("{{asUpperCamelCase label}}", indent + 1, value.{{asLowerCamelCase label}});
-      if (err != CHIP_NO_ERROR)
-      {
-          ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for '{{asUpperCamelCase label}}'", IndentStr(indent + 1).c_str());
-          return err;
-      }
-  }
-{{/zcl_struct_items}}
-  ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
-  return CHIP_NO_ERROR;
-}
+{{#unless has_more_than_one_cluster}}
+{{> log_struct_value ns=parent.name}}
+{{/unless}}
 {{/zcl_structs}}
 {{/zcl_clusters}}
 #pragma GCC diagnostic pop

--- a/examples/chip-tool/templates/partials/log_struct_value.zapt
+++ b/examples/chip-tool/templates/partials/log_struct_value.zapt
@@ -1,0 +1,16 @@
+CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=ns isArgument=true}} value)
+{
+  ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+{{#zcl_struct_items}}
+  {
+      CHIP_ERROR err = LogValue("{{asUpperCamelCase label}}", indent + 1, value.{{asLowerCamelCase label}});
+      if (err != CHIP_NO_ERROR)
+      {
+          ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for '{{asUpperCamelCase label}}'", IndentStr(indent + 1).c_str());
+          return err;
+      }
+  }
+{{/zcl_struct_items}}
+  ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+  return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/templates/templates.json
+++ b/examples/chip-tool/templates/templates.json
@@ -35,6 +35,10 @@
         {
             "name": "valueEquals",
             "path": "partials/test_cluster_value_equals.zapt"
+        },
+        {
+            "name": "log_struct_value",
+            "path": "partials/log_struct_value.zapt"
         }
     ],
     "templates": [

--- a/src/app/common/templates/templates.json
+++ b/src/app/common/templates/templates.json
@@ -13,6 +13,10 @@
         {
             "name": "header",
             "path": "../../zap-templates/partials/header.zapt"
+        },
+        {
+            "name": "cluster_objects_struct",
+            "path": "../../zap-templates/partials/cluster-objects-struct.zapt"
         }
     ],
     "templates": [

--- a/src/app/zap-templates/partials/cluster-objects-struct.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-struct.zapt
@@ -1,0 +1,77 @@
+{{#if header}}
+namespace {{asUpperCamelCase name}} {
+    enum class Fields {
+    {{#zcl_struct_items}}
+    k{{asUpperCamelCase label}} = {{fieldIdentifier}},
+    {{/zcl_struct_items}}
+    };
+
+    struct Type {
+    public:
+        {{#zcl_struct_items}}
+        {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}};
+        {{/zcl_struct_items}}
+
+        CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
+        {{#unless struct_contains_array}}
+        CHIP_ERROR Decode(TLV::TLVReader &reader);
+        {{/unless}}
+        {{#if struct_is_fabric_scoped}}
+        bool MatchesFabricIndex(FabricIndex fabricIndex_) const {
+            return {{ asLowerCamelCase struct_fabric_idx_field }} == fabricIndex_;
+        }
+        {{/if}}
+    };
+
+    {{#if struct_contains_array}}
+    struct DecodableType {
+    public:
+        {{#zcl_struct_items}}
+        {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}};
+        {{/zcl_struct_items}}
+        CHIP_ERROR Decode(TLV::TLVReader &reader);
+    };
+    {{else}}
+    using DecodableType = Type;
+    {{/if}}
+
+} // namespace {{asUpperCamelCase name}}
+{{else}}
+namespace {{asUpperCamelCase name}} {
+CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    {{#zcl_struct_items}}
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::k{{asUpperCamelCase label}})), {{asLowerCamelCase label}}));
+    {{/zcl_struct_items}}
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR) {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+            {{#zcl_struct_items}}
+            case to_underlying(Fields::k{{asUpperCamelCase label}}):
+                ReturnErrorOnFailure(DataModel::Decode(reader, {{asLowerCamelCase label}}));
+                break;
+            {{/zcl_struct_items}}
+            default:
+                break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+} // namespace {{asUpperCamelCase name}}
+{{/if}}

--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -5,49 +5,27 @@
 namespace chip {
 namespace app {
 namespace Clusters {
+
+namespace detail {
+// Structs shared across multiple clusters.
+namespace Structs {
+{{#zcl_structs}}
+{{#if has_more_than_one_cluster}}
+{{> cluster_objects_struct header=false}}
+{{/if}}
+{{/zcl_structs}}
+} // namespace Structs
+} // namespace detail
+
 {{#zcl_clusters}}
 namespace {{asUpperCamelCase name}} {
 {{#zcl_structs}}
 {{#first}}
 namespace Structs {
 {{/first}}
-namespace {{asType label}} {
-CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    {{#zcl_struct_items}}
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::k{{asUpperCamelCase label}})), {{asLowerCamelCase label}}));
-    {{/zcl_struct_items}}
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR) {
-        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
-        switch (TLV::TagNumFromTag(reader.GetTag()))
-        {
-            {{#zcl_struct_items}}
-            case to_underlying(Fields::k{{asUpperCamelCase label}}):
-                ReturnErrorOnFailure(DataModel::Decode(reader, {{asLowerCamelCase label}}));
-                break;
-            {{/zcl_struct_items}}
-            default:
-                break;
-        }
-    }
-
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-} // namespace {{asType label}}
+{{#unless has_more_than_one_cluster}}
+{{> cluster_objects_struct header=false}}
+{{/unless}}
 {{#last}}
 } // namespace Structs
 {{/last}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -20,6 +20,17 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
+namespace detail {
+// Structs shared across multiple clusters.
+namespace Structs {
+{{#zcl_structs}}
+{{#if has_more_than_one_cluster}}
+{{> cluster_objects_struct header=true}}
+{{/if}}
+{{/zcl_structs}}
+} // namespace Structs
+} // namespace detail
+
 {{#zcl_clusters}}
 namespace {{asUpperCamelCase name}} {
 {{#zcl_enums}}
@@ -55,43 +66,11 @@ k{{asUpperCamelCase label}} = {{asHex mask}},
 {{#first}}
 namespace Structs {
 {{/first}}
-namespace {{asUpperCamelCase name}} {
-    enum class Fields {
-    {{#zcl_struct_items}}
-    k{{asUpperCamelCase label}} = {{fieldIdentifier}},
-    {{/zcl_struct_items}}
-    };
-
-    struct Type {
-    public:
-        {{#zcl_struct_items}}
-        {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}};
-        {{/zcl_struct_items}}
-
-        CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
-        {{#unless struct_contains_array}}
-        CHIP_ERROR Decode(TLV::TLVReader &reader);
-        {{/unless}}
-        {{#if struct_is_fabric_scoped}}
-        bool MatchesFabricIndex(FabricIndex fabricIndex_) const {
-            return {{ asLowerCamelCase struct_fabric_idx_field }} == fabricIndex_;
-        }
-        {{/if}}
-    };
-
-    {{#if struct_contains_array}}
-    struct DecodableType {
-    public:
-        {{#zcl_struct_items}}
-        {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}};
-        {{/zcl_struct_items}}
-        CHIP_ERROR Decode(TLV::TLVReader &reader);
-    };
-    {{else}}
-    using DecodableType = Type;
-    {{/if}}
-
-} // namespace {{asUpperCamelCase name}}
+{{#if has_more_than_one_cluster}}
+namespace {{asUpperCamelCase name}} = Clusters::detail::Structs::{{asUpperCamelCase name}};
+{{else}}
+{{> cluster_objects_struct header=true}}
+{{/if}}
 {{#last}}
 } // namespace Structs
 {{/last}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -352,6 +352,16 @@ function asMEI(prefix, suffix)
   return cHelper.asHex((prefix << 16) + suffix, 8);
 }
 
+// Not to be exported.
+function nsValueToNamespace(ns)
+{
+  if (ns == "detail") {
+    return ns;
+  }
+
+  return asUpperCamelCase(ns);
+}
+
 /*
  * @brief
  *
@@ -372,7 +382,7 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
   let passByReference = false;
   async function fn(pkgId)
   {
-    const ns          = options.hash.ns ? ('chip::app::Clusters::' + asUpperCamelCase(options.hash.ns) + '::') : '';
+    const ns          = options.hash.ns ? ('chip::app::Clusters::' + nsValueToNamespace(options.hash.ns) + '::') : '';
     const typeChecker = async (method) => zclHelper[method](this.global.db, type, pkgId).then(zclType => zclType != 'unknown');
 
     if (await typeChecker('isEnum')) {

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -19,6 +19,7 @@ limitations under the License.
 
   <struct name="LabelStruct">
     <cluster code="0x0040"/>
+    <cluster code="0x0041"/>
     <item name="label" type="CHAR_STRING" length="16"/>
     <item name="value" type="CHAR_STRING" length="16"/>
   </struct>

--- a/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
@@ -17,12 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <struct name="LabelStruct">
-    <cluster code="0x0041"/>
-    <item name="label" type="CHAR_STRING" length="16"/>
-    <item name="value" type="CHAR_STRING" length="16"/>
-  </struct>
-
   <cluster>
     <domain>General</domain>
     <name>User Label</name>

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -2889,12 +2889,6 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
                                                               length:entry_0.label.size()
                                                             encoding:NSUTF8StringEncoding];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                              length:entry_0.value.size()
-                                                            encoding:NSUTF8StringEncoding];
                 newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
                                                               length:entry_0.value.size()
                                                             encoding:NSUTF8StringEncoding];
@@ -8806,12 +8800,6 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 newElement_0 = [CHIPUserLabelClusterLabelStruct new];
                 newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
                                                               length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                              length:entry_0.value.size()
                                                             encoding:NSUTF8StringEncoding];
                 newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
                                                               length:entry_0.value.size()

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -2182,12 +2182,6 @@ void CHIPFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * cont
         newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
                                                       length:entry_0.label.size()
                                                     encoding:NSUTF8StringEncoding];
-        newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                      length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                      length:entry_0.value.size()
-                                                    encoding:NSUTF8StringEncoding];
         newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
                                                       length:entry_0.value.size()
                                                     encoding:NSUTF8StringEncoding];
@@ -4910,12 +4904,6 @@ void CHIPUserLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * conte
         newElement_0 = [CHIPUserLabelClusterLabelStruct new];
         newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
                                                       length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                      length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                      length:entry_0.value.size()
                                                     encoding:NSUTF8StringEncoding];
         newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
                                                       length:entry_0.value.size()

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -22033,8 +22033,6 @@ using namespace chip::app::Clusters;
                         }
                         auto element_0 = (CHIPUserLabelClusterLabelStruct *) value[i_0];
                         listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
-                        listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
-                        listHolder_0->mList[i_0].value = [self asCharSpan:element_0.value];
                         listHolder_0->mList[i_0].value = [self asCharSpan:element_0.value];
                     }
                     cppValue = ListType_0(listHolder_0->mList, value.count);

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -3853,8 +3853,6 @@ using namespace chip::app::Clusters;
                         }
                         auto element_0 = (CHIPFixedLabelClusterLabelStruct *) value[i_0];
                         listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
-                        listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
-                        listHolder_0->mList[i_0].value = [self asCharSpan:element_0.value];
                         listHolder_0->mList[i_0].value = [self asCharSpan:element_0.value];
                     }
                     cppValue = ListType_0(listHolder_0->mList, value.count);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -22,6 +22,53 @@
 namespace chip {
 namespace app {
 namespace Clusters {
+
+namespace detail {
+// Structs shared across multiple clusters.
+namespace Structs {
+namespace LabelStruct {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLabel)), label));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kValue)), value));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kLabel):
+            ReturnErrorOnFailure(DataModel::Decode(reader, label));
+            break;
+        case to_underlying(Fields::kValue):
+            ReturnErrorOnFailure(DataModel::Decode(reader, value));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+} // namespace LabelStruct
+} // namespace Structs
+} // namespace detail
+
 namespace PowerConfiguration {
 
 namespace Commands {
@@ -10639,46 +10686,6 @@ namespace Events {
 } // namespace GroupKeyManagement
 namespace FixedLabel {
 namespace Structs {
-namespace LabelStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLabel)), label));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kValue)), value));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
-        switch (TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case to_underlying(Fields::kLabel):
-            ReturnErrorOnFailure(DataModel::Decode(reader, label));
-            break;
-        case to_underlying(Fields::kValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, value));
-            break;
-        default:
-            break;
-        }
-    }
-
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-} // namespace LabelStruct
 } // namespace Structs
 
 namespace Commands {
@@ -10715,46 +10722,6 @@ namespace Events {
 } // namespace FixedLabel
 namespace UserLabel {
 namespace Structs {
-namespace LabelStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLabel)), label));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kValue)), value));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
-        switch (TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case to_underlying(Fields::kLabel):
-            ReturnErrorOnFailure(DataModel::Decode(reader, label));
-            break;
-        case to_underlying(Fields::kValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, value));
-            break;
-        default:
-            break;
-        }
-    }
-
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-} // namespace LabelStruct
 } // namespace Structs
 
 namespace Commands {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -37,6 +37,32 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
+namespace detail {
+// Structs shared across multiple clusters.
+namespace Structs {
+namespace LabelStruct {
+enum class Fields
+{
+    kLabel = 1,
+    kValue = 2,
+};
+
+struct Type
+{
+public:
+    chip::CharSpan label;
+    chip::CharSpan value;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+using DecodableType = Type;
+
+} // namespace LabelStruct
+} // namespace Structs
+} // namespace detail
+
 namespace PowerConfiguration {
 
 namespace Attributes {
@@ -15459,26 +15485,7 @@ struct TypeInfo
 namespace FixedLabel {
 
 namespace Structs {
-namespace LabelStruct {
-enum class Fields
-{
-    kLabel = 1,
-    kValue = 2,
-};
-
-struct Type
-{
-public:
-    chip::CharSpan label;
-    chip::CharSpan value;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-using DecodableType = Type;
-
-} // namespace LabelStruct
+namespace LabelStruct = Clusters::detail::Structs::LabelStruct;
 } // namespace Structs
 
 namespace Attributes {
@@ -15552,26 +15559,7 @@ struct TypeInfo
 namespace UserLabel {
 
 namespace Structs {
-namespace LabelStruct {
-enum class Fields
-{
-    kLabel = 1,
-    kValue = 2,
-};
-
-struct Type
-{
-public:
-    chip::CharSpan label;
-    chip::CharSpan value;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-using DecodableType = Type;
-
-} // namespace LabelStruct
+namespace LabelStruct = Clusters::detail::Structs::LabelStruct;
 } // namespace Structs
 
 namespace Attributes {

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -40,6 +40,9 @@
 namespace {
 
 CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::detail::Structs::LabelStruct::DecodableType & value);
+
+CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::Scenes::Structs::SceneExtensionFieldSet::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::PowerProfile::Structs::PowerProfileRecord::DecodableType & value);
@@ -94,10 +97,6 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeySet::DecodableType & value);
-CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType & value);
-CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::UserLabel::Structs::LabelStruct::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
@@ -268,6 +267,30 @@ CHIP_ERROR LogValue(const char * label, size_t indent, const chip::Optional<T> &
 // be logging.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::detail::Structs::LabelStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Label", indent + 1, value.label);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Label'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::Scenes::Structs::SceneExtensionFieldSet::DecodableType & value)
 {
@@ -1546,52 +1569,6 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
         {
             ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'EpochStartTime2'",
                             IndentStr(indent + 1).c_str());
-            return err;
-        }
-    }
-    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType & value)
-{
-    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
-    {
-        CHIP_ERROR err = LogValue("Label", indent + 1, value.label);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Label'", IndentStr(indent + 1).c_str());
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
-            return err;
-        }
-    }
-    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::UserLabel::Structs::LabelStruct::DecodableType & value)
-{
-    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
-    {
-        CHIP_ERROR err = LogValue("Label", indent + 1, value.label);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Label'", IndentStr(indent + 1).c_str());
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
             return err;
         }
     }


### PR DESCRIPTION
This is shared across the fixed label and user label clusters.

The struct definition is in the "detail" namespace, with alias
namespaces in the two clusters that use it.  Consumers are generally
expected to use the per-cluster aliases.

#### Problem
Multiple structs with the same name are a problem, because various places look up structs by name.

#### Change overview
Have only one struct with that name in XML.

Also have only one struct with that name in C++, so C++ consumers who only have a name without the cluster context (if any) don't necessarily have to guess the right cluster name and we can't get weird divergence between the per-cluster views of this struct.

#### Testing
Tree compiles, extra assignments are gone in Darwin code.