### PR TITLE
Add cats to subject descriptor

### DIFF
--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -27,8 +27,8 @@ Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
     {
         subjectDescriptor.authMode    = Access::AuthMode::kCase;
         subjectDescriptor.subject     = mPeerNodeId;
+        subjectDescriptor.cats        = mPeerCATs;
         subjectDescriptor.fabricIndex = mFabric;
-        // TODO(#10243): add CATs
     }
     else if (IsPAKEKeyId(mPeerNodeId))
     {


### PR DESCRIPTION
Meow.

#### Problem
CASE authenticated tags not yet set in subject descriptor.

#10243

#### Change overview
Set CASE authenticated tags in subject descriptor.

#### Testing
* Built (all-clusters-app, REPL) on Linux, ran
* Forced set of CAT in session, and forced matching ACL entry in cluster
* Checked log statements to ensure read was allowed/denied accordingly
