### PR TITLE
[shell] Improve session pretty print to properly handle all types.

### DIFF
--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -29,10 +29,13 @@
 #include <app/util/attribute-storage.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <transport/Session.h>
+
 using namespace chip;
 using namespace chip::Shell;
 using namespace chip::Credentials;
 using namespace chip::ArgParser;
+using namespace chip::Transport;
 
 // Anonymous namespace for file-scoped, static variables.
 namespace {
@@ -106,9 +109,35 @@ static CHIP_ERROR CmdAppServerUdcPort(int argc, char ** argv)
 
 static bool PrintServerSession(void * context, SessionHandle & session)
 {
-    streamer_printf(streamer_get(), "session id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
-                    session->AsSecureSession()->GetLocalSessionId(), session->AsSecureSession()->GetPeerSessionId(),
-                    session->AsSecureSession()->GetPeerNodeId(), session->AsSecureSession()->GetFabricIndex());
+    switch (session->GetSessionType())
+    {
+    case Session::SessionType::kSecure: {
+        SecureSession * secureSession         = session->AsSecureSession();
+        SecureSession::Type secureSessionType = secureSession->GetSecureSessionType();
+        streamer_printf(
+            streamer_get(), "session type=SECURE %s id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
+            secureSessionType == SecureSession::Type::kCASE ? "CASE" : "PASE", secureSession->GetLocalSessionId(),
+            secureSession->AsSecureSession()->GetPeerSessionId(), secureSession->GetPeerNodeId(), secureSession->GetFabricIndex());
+        break;
+    }
+
+    case Session::SessionType::kUnauthenticated: {
+        UnauthenticatedSession * unsecuredSession = session->AsUnauthenticatedSession();
+        streamer_printf(streamer_get(), "session type=UNSECURED id=0x0000 peerNodeId=0x%016\r\n",
+                        unsecuredSession->GetPeerNodeId());
+        break;
+    }
+
+    case Session::SessionType::kGroup: {
+        GroupSession * groupSession = session->AsGroupSession();
+        streamer_printf(streamer_get(), "session type=GROUP id=0x%04x fabricIdx=%d\r\n", groupSession->GetGroupId(),
+                        groupSession->GetFabricIndex());
+        break;
+    }
+
+    default:
+        streamer_printf(streamer_get(), "session type=UNDEFINED\r\n");
+    }
     return true;
 }
 


### PR DESCRIPTION
#### Problem
The shell `server sessions` command assumes all sessions are secure.

#### Change overview
Improve `server sessions` command to properly reflect on session type and print relevant information for each.

#### Testing
Manual and CI.