### PR TITLE
Stop using GroupId for the type of a PAKE key id.

### DIFF
--- a/src/lib/core/NodeId.h
+++ b/src/lib/core/NodeId.h
@@ -78,7 +78,7 @@ constexpr NodeId NodeIdFromGroupId(GroupId aGroupId)
     return kMinGroupNodeId | aGroupId;
 }
 
-constexpr NodeId NodeIdFromPAKEKeyId(GroupId aPAKEKeyId)
+constexpr NodeId NodeIdFromPAKEKeyId(uint16_t aPAKEKeyId)
 {
     return kMinPAKEKeyId | aPAKEKeyId;
 }


### PR DESCRIPTION
A PAKE key id is a uint16_t, or maybe we should have a specific type
name for it, but it's not a GroupId.

#### Problem
Wrong type used for argument to NodeIdFromPAKEKeyId.

#### Change overview
Use the right type.

#### Testing
No behavior changes, since GroupId is currently a typedef for uint16_t, which is why this happened to work.