### PR TITLE
[ESP32] Fix ota-provider-app build failure

### DIFF
--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#include <BdxOtaSender.h>
+#include <ota-provider-common/BdxOtaSender.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>

--- a/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
+++ b/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
@@ -89,6 +89,9 @@ public:
      */
     uint64_t GetTransferLength(void);
 
+    /* ota-provider-common/OTAProviderExample.cpp requires this */
+    void SetFilepath(const char * path) {}
+
 private:
     // Inherited from bdx::TransferFacilitator
     void HandleTransferSessionOutput(chip::bdx::TransferSession::OutputEvent & event) override;


### PR DESCRIPTION
#### Problem
- ota-provider-app/esp32 build is broken due to some common changes introduced in #13329 

#### Change overview
- Added the required changes introduced in #13329
- Fixed the build by moving `BdxOtaSender.h` to `examples/ota-provider-app/esp32/main/include/ota-provider-common` so that OTAProviderExample.h will include this header file based on include path.

This is the workaround to fix the build, we will need some interface which can be used by platforms for implementing OTA provider.

#### Testing
- Linux-ota-provider and Linux-ota-requestor
- ESP32-ota-provider and ESP32-ota-requestor
- Linux-ota-provider and ESP32-ota-requestor