### PR TITLE
Use GetAccessingFabricIndex in a few more places.

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -114,7 +114,7 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     {
         // TODO: This uses the current node as the provider to supply the OTA image. This can be configurable such that the provider
         // supplying the response is not the provider supplying the OTA image.
-        FabricIndex fabricIndex = commandObj->GetExchangeContext()->GetSessionHandle()->AsSecureSession()->GetFabricIndex();
+        FabricIndex fabricIndex = commandObj->GetAccessingFabricIndex();
         FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
         NodeId nodeId           = fabricInfo->GetPeerId().GetNodeId();
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -200,7 +200,7 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
     }
 
     mProviderNodeId      = providerNodeId;
-    mProviderFabricIndex = commandObj->GetExchangeContext()->GetSessionHandle()->AsSecureSession()->GetFabricIndex();
+    mProviderFabricIndex = commandObj->GetAccessingFabricIndex();
     mProviderEndpointId  = providerEndpoint;
 
     ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -65,13 +65,6 @@ uint8_t emberAfPluginScenesServerEntriesInUse = 0;
 EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[EMBER_AF_PLUGIN_SCENES_TABLE_SIZE];
 #endif
 
-static FabricIndex GetFabricIndex(app::CommandHandler * commandObj)
-{
-    VerifyOrReturnError(nullptr != commandObj, 0);
-    VerifyOrReturnError(nullptr != commandObj->GetExchangeContext(), 0);
-    return commandObj->GetExchangeContext()->GetSessionHandle()->AsSecureSession()->GetFabricIndex();
-}
-
 static bool readServerAttribute(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, const char * name,
                                 uint8_t * data, uint8_t size)
 {
@@ -252,7 +245,7 @@ bool emberAfScenesClusterViewSceneCallback(app::CommandHandler * commandObj, con
 bool emberAfScenesClusterRemoveSceneCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                              const Commands::RemoveScene::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
     auto & groupId   = commandData.groupId;
     auto & sceneId   = commandData.sceneId;
 
@@ -311,7 +304,7 @@ exit:
 bool emberAfScenesClusterRemoveAllScenesCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::RemoveAllScenes::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
     auto & groupId   = commandData.groupId;
 
     EmberAfStatus status = EMBER_ZCL_STATUS_INVALID_FIELD;
@@ -363,7 +356,7 @@ exit:
 bool emberAfScenesClusterStoreSceneCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                             const Commands::StoreScene::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
     auto & groupId   = commandData.groupId;
     auto & sceneId   = commandData.sceneId;
 
@@ -399,7 +392,7 @@ exit:
 bool emberAfScenesClusterRecallSceneCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                              const Commands::RecallScene::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
     auto & groupId   = commandData.groupId;
     auto & sceneId   = commandData.sceneId;
 
@@ -437,7 +430,7 @@ bool emberAfScenesClusterRecallSceneCallback(app::CommandHandler * commandObj, c
 bool emberAfScenesClusterGetSceneMembershipCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                     const Commands::GetSceneMembership::DecodableType & commandData)
 {
-    auto fabricIndex = GetFabricIndex(commandObj);
+    auto fabricIndex = commandObj->GetAccessingFabricIndex();
     auto & groupId   = commandData.groupId;
 
     CHIP_ERROR err       = CHIP_NO_ERROR;
@@ -768,7 +761,7 @@ bool emberAfPluginScenesServerParseAddScene(
     EmberAfSceneTableEntry entry;
     EmberAfStatus status;
     bool enhanced       = (cmd->commandId == ZCL_ENHANCED_ADD_SCENE_COMMAND_ID);
-    auto fabricIndex    = GetFabricIndex(commandObj);
+    auto fabricIndex    = commandObj->GetAccessingFabricIndex();
     EndpointId endpoint = cmd->apsFrame->destinationEndpoint;
     uint8_t i, index = EMBER_AF_SCENE_TABLE_NULL_INDEX;
 
@@ -1105,7 +1098,7 @@ bool emberAfPluginScenesServerParseViewScene(app::CommandHandler * commandObj, c
     EmberAfSceneTableEntry entry = {};
     EmberAfStatus status         = EMBER_ZCL_STATUS_NOT_FOUND;
     bool enhanced                = (cmd->commandId == ZCL_ENHANCED_VIEW_SCENE_COMMAND_ID);
-    FabricIndex fabricIndex      = GetFabricIndex(commandObj);
+    FabricIndex fabricIndex      = commandObj->GetAccessingFabricIndex();
     EndpointId endpoint          = cmd->apsFrame->destinationEndpoint;
 
     emberAfScenesClusterPrintln("RX: %pViewScene 0x%2x, 0x%x", (enhanced ? "Enhanced" : ""), groupId, sceneId);


### PR DESCRIPTION
People keep copy/pasting the
GetExchangeContext()->GetSessionHandle()->AsSecureSession()->GetFabricIndex()
when they really don't need it....

#### Problem
Unsafe code being used.  In particular, that code would would crash if one of the scenes commands were groupcast, because `AsSecureSession()` would crash.  Need more tests, clearly.

#### Change overview
Use the existing `GetAccessingFabricIndex()` API on CommandHandler, which should do the right thing.

#### Testing
Not sure how to test the scenes commands with groupcast.  @jepenven-silabs do you know offhand?