### PR TITLE
[nxp]: Fix CHIP Counter keys configuration

### DIFF
--- a/src/platform/nxp/k32w/k32w0/K32W0Config.h
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.h
@@ -66,7 +66,7 @@ public:
     using Key = uint32_t;
 
     // Key definitions for well-known configuration values.
-    // Factory config keys
+    // Factory Config Keys
     static constexpr Key kConfigKey_SerialNum           = K32WConfigKey(kPDMId_ChipFactory, 0x00);
     static constexpr Key kConfigKey_MfrDeviceId         = K32WConfigKey(kPDMId_ChipFactory, 0x01);
     static constexpr Key kConfigKey_MfrDeviceCert       = K32WConfigKey(kPDMId_ChipFactory, 0x02);
@@ -76,6 +76,7 @@ public:
     static constexpr Key kConfigKey_MfrDeviceICACerts   = K32WConfigKey(kPDMId_ChipFactory, 0x06);
     static constexpr Key kConfigKey_HardwareVersion     = K32WConfigKey(kPDMId_ChipFactory, 0x07);
     static constexpr Key kConfigKey_SetupDiscriminator  = K32WConfigKey(kPDMId_ChipFactory, 0x08);
+
     // CHIP Config Keys
     static constexpr Key kConfigKey_FabricId           = K32WConfigKey(kPDMId_ChipConfig, 0x00);
     static constexpr Key kConfigKey_ServiceConfig      = K32WConfigKey(kPDMId_ChipConfig, 0x01);
@@ -89,10 +90,10 @@ public:
     static constexpr Key kConfigKey_Breadcrumb         = K32WConfigKey(kPDMId_ChipConfig, 0x09);
 
     // CHIP Counter Keys
-    static constexpr Key kCounterKey_RebootCount           = K32WConfigKey(kPDMId_ChipConfig, 0x0A);
-    static constexpr Key kCounterKey_UpTime                = K32WConfigKey(kPDMId_ChipConfig, 0x0B);
-    static constexpr Key kCounterKey_TotalOperationalHours = K32WConfigKey(kPDMId_ChipConfig, 0x0C);
-    static constexpr Key kCounterKey_BootReason            = K32WConfigKey(kPDMId_ChipConfig, 0x0D);
+    static constexpr Key kCounterKey_RebootCount           = K32WConfigKey(kPDMId_ChipCounter, 0x00);
+    static constexpr Key kCounterKey_UpTime                = K32WConfigKey(kPDMId_ChipCounter, 0x01);
+    static constexpr Key kCounterKey_TotalOperationalHours = K32WConfigKey(kPDMId_ChipCounter, 0x02);
+    static constexpr Key kCounterKey_BootReason            = K32WConfigKey(kPDMId_ChipCounter, 0x03);
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = K32WConfigKey(kPDMId_ChipFactory, 0x00);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* CHIP Counter keys are configured using kPDMId_ChipConfig by mistake on NXP k32w platfrom


#### Change overview
Use kPDMId_ChipCounter instead of kPDMId_ChipConfig for CHIP Counter keys.

#### Testing
How was this tested? (at least one bullet point required)
* No source code change, regression is verified by CI 