### PR TITLE
Fix SEGFAULT when running minmdns client

### DIFF
--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -349,7 +349,7 @@ int main(int argc, char ** args)
         chip::System::Clock::Milliseconds32(gOptions.runtimeMs),
         [](System::Layer *, void *) {
             // Close all sockets BEFORE system layer is shut down, otherwise
-            // attempts to free UDP sockeds with system layer down will segfault
+            // attempts to free UDP sockets with system layer down will segfault
             gMdnsServer.Shutdown();
 
             DeviceLayer::PlatformMgr().StopEventLoopTask();

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -301,6 +301,8 @@ void BroadcastPacket(mdns::Minimal::ServerBase * server)
     }
 }
 
+mdns::Minimal::Server<20> gMdnsServer;
+
 } // namespace
 
 int main(int argc, char ** args)
@@ -324,17 +326,16 @@ int main(int argc, char ** args)
 
     printf("Running...\n");
 
-    mdns::Minimal::Server<20> mdnsServer;
     ReportDelegate reporter;
     CHIP_ERROR err;
 
-    mdnsServer.SetDelegate(&reporter);
+    gMdnsServer.SetDelegate(&reporter);
 
     {
 
         MdnsExample::AllInterfaces allInterfaces(gOptions.enableIpV4);
 
-        err = mdnsServer.Listen(chip::DeviceLayer::UDPEndPointManager(), &allInterfaces, gOptions.listenPort);
+        err = gMdnsServer.Listen(chip::DeviceLayer::UDPEndPointManager(), &allInterfaces, gOptions.listenPort);
         if (err != CHIP_NO_ERROR)
         {
             printf("Server failed to listen on all interfaces: %s\n", chip::ErrorStr(err));
@@ -342,11 +343,15 @@ int main(int argc, char ** args)
         }
     }
 
-    BroadcastPacket(&mdnsServer);
+    BroadcastPacket(&gMdnsServer);
 
     err = DeviceLayer::SystemLayer().StartTimer(
         chip::System::Clock::Milliseconds32(gOptions.runtimeMs),
         [](System::Layer *, void *) {
+            // Close all sockets BEFORE system layer is shut down, otherwise
+            // attempts to free UDP sockeds with system layer down will segfault
+            gMdnsServer.Shutdown();
+
             DeviceLayer::PlatformMgr().StopEventLoopTask();
             DeviceLayer::PlatformMgr().Shutdown();
         },

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -189,10 +189,7 @@ ServerBase::~ServerBase()
 
 void ServerBase::Shutdown()
 {
-    mEndpoints.ForEachActiveObject([&](auto * endpoint) {
-        ShutdownEndpoint(*endpoint);
-        return chip::Loop::Continue;
-    });
+    mEndpoints.ReleaseAll();
 }
 
 void ServerBase::ShutdownEndpoint(EndpointInfo & aEndpoint)


### PR DESCRIPTION
#### Problem
Chip MDNS client uses a timeout to schedule a 'platform shutdown'.
When shutting down, the MinMDNS Server still holds UDP references and attempts to  release them in its destructor,  which crashes since  SystemLayer  has been shut down and is likely deallocated.

#### Change overview
Shutdown the mdns server before attempting to shut down the rest of the platform.

#### Testing
Rand minmdns client binary and observed no more SEGFAULT.
