### PR TITLE
Add shell to build_examples for host

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -152,6 +152,7 @@ def HostTargets():
         app_targets.append(target.Extend('thermostat', app=HostApp.THERMOSTAT))
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend('door-lock', app=HostApp.LOCK))
+        app_targets.append(target.Extend('shell', app=HostApp.SHELL))
 
     # Possible build variants. Note that number of potential
     # builds is exponential here

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -81,8 +81,8 @@ class HostApp(Enum):
         elif self == HostApp.TESTS:
             pass
         elif self == HostApp.SHELL:
-            yield 'chip-shell-app'
-            yield 'chip-shell-app.map'
+            yield 'chip-shell'
+            yield 'chip-shell.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -29,6 +29,7 @@ class HostApp(Enum):
     TV_APP = auto()
     LOCK = auto()
     TESTS = auto()
+    SHELL = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -47,6 +48,8 @@ class HostApp(Enum):
             return 'door-lock-app/linux'
         elif self == HostApp.TESTS:
             return '../'
+        elif self == HostApp.SHELL:
+            return 'shell/standalone'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -77,6 +80,9 @@ class HostApp(Enum):
             yield 'chip-door-lock-app.map'
         elif self == HostApp.TESTS:
             pass
+        elif self == HostApp.SHELL:
+            yield 'chip-shell-app'
+            yield 'chip-shell-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -41,6 +41,16 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
 
+# Generating linux-arm64-shell
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell'
+
+# Generating linux-arm64-shell-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell-ipv6only'
+
 # Generating linux-arm64-thermostat
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -81,6 +91,12 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
+# Generating linux-x64-shell
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone {out}/linux-x64-shell
+
+# Generating linux-x64-shell-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-shell-ipv6only
+
 # Generating linux-x64-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} --args=chip_build_tests=true {out}/linux-x64-tests
 
@@ -120,6 +136,12 @@ ninja -C {out}/linux-arm64-minmdns
 # Building linux-arm64-minmdns-ipv6only
 ninja -C {out}/linux-arm64-minmdns-ipv6only
 
+# Building linux-arm64-shell
+ninja -C {out}/linux-arm64-shell
+
+# Building linux-arm64-shell-ipv6only
+ninja -C {out}/linux-arm64-shell-ipv6only
+
 # Building linux-arm64-thermostat
 ninja -C {out}/linux-arm64-thermostat
 
@@ -155,6 +177,12 @@ ninja -C {out}/linux-x64-minmdns-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console
+
+# Building linux-x64-shell
+ninja -C {out}/linux-x64-shell
+
+# Building linux-x64-shell-ipv6only
+ninja -C {out}/linux-x64-shell-ipv6only
 
 # Building linux-x64-tests
 ninja -C {out}/linux-x64-tests check


### PR DESCRIPTION
#### Problem
Need to have build_examples be able to build as much as possible.

#### Change overview
Add shell builds to build_example.

#### Testing
Manually compiled, CI also validates.