### PR TITLE
Ensure all fields in cluster-objects structs are default-initialized.

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -262,8 +262,6 @@ void Instance::HandleRemoveNetwork(HandlerContext & ctx, const Commands::RemoveN
 
 void Instance::HandleConnectNetwork(HandlerContext & ctx, const Commands::ConnectNetwork::DecodableType & req)
 {
-    Commands::ConnectNetworkResponse::Type response;
-
     mAsyncCommandHandle = app::CommandHandler::Handle(&ctx.mCommandHandler);
     mpWirelessDriver->ConnectNetwork(req.networkID, this);
 }

--- a/src/app/common/templates/templates.json
+++ b/src/app/common/templates/templates.json
@@ -17,6 +17,10 @@
         {
             "name": "cluster_objects_struct",
             "path": "../../zap-templates/partials/cluster-objects-struct.zapt"
+        },
+        {
+            "name": "cluster_objects_field_init",
+            "path": "../../zap-templates/partials/cluster-objects-field-init.zapt"
         }
     ],
     "templates": [

--- a/src/app/data-model/DecodableList.h
+++ b/src/app/data-model/DecodableList.h
@@ -38,6 +38,12 @@ template <typename T>
 class DecodableList
 {
 public:
+    DecodableList()
+    {
+        // Init to an empty list.
+        mReader.Init(nullptr, 0);
+    }
+
     /*
      * @brief
      *

--- a/src/app/zap-templates/partials/cluster-objects-field-init.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-field-init.zapt
@@ -1,0 +1,17 @@
+{{! For now, just initialize fields to type defaults.  Longer-term, we
+    may want to use spec-defined default values here. }}
+{{#unless isOptional}} {{! Optionals inited by constructor }}
+  {{~#unless isNullable}} {{! Nullables inited by constructor }}
+    {{~#unless isArray}} {{! DataModel lists inited by constructor }}
+      {{~#unless entryType}} {{! DataModel lists (for attributes) inited by constructor }}
+        {{~#unless (isString type)}} {{! Strings are Spans, inited by constructor }}
+          {{~#if_is_struct type}}
+            {{! Structs have their own initializers }}
+          {{~else~}}
+          = static_cast<{{zapTypeToEncodableClusterObjectType type}}>(0)
+          {{~/if_is_struct}}
+        {{~/unless}}
+      {{~/unless}}
+    {{~/unless}}
+  {{~/unless}}
+{{~/unless}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -111,7 +111,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}};
+    {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
     {{/zcl_command_arguments}}
 
     CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
@@ -132,7 +132,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}};
+    {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
     {{/zcl_command_arguments}}
     CHIP_ERROR Decode(TLV::TLVReader &reader);
 };
@@ -174,7 +174,9 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader &reader, const ConcreteAttributePath &path);
 
 {{#zcl_attributes_server}}
-        Attributes::{{asUpperCamelCase label}}::TypeInfo::DecodableType {{asLowerCamelCase label}};
+        {{! isOptional=false because optional attributes don't get represented
+            as Optional types here. }}
+        Attributes::{{asUpperCamelCase label}}::TypeInfo::DecodableType {{asLowerCamelCase label}}{{> cluster_objects_field_init isOptional=false}};
 {{/zcl_attributes_server}}
     };
 };
@@ -201,7 +203,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_event_fields}}
-    {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase name}};
+    {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
     {{/zcl_event_fields}}
 
     CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
@@ -214,7 +216,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_event_fields}}
-    {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase name}};
+    {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
     {{/zcl_event_fields}}
 
     CHIP_ERROR Decode(TLV::TLVReader &reader);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -796,66 +796,68 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MainsVoltage::TypeInfo::DecodableType mainsVoltage;
-        Attributes::MainsFrequency::TypeInfo::DecodableType mainsFrequency;
-        Attributes::MainsAlarmMask::TypeInfo::DecodableType mainsAlarmMask;
-        Attributes::MainsVoltageMinThreshold::TypeInfo::DecodableType mainsVoltageMinThreshold;
-        Attributes::MainsVoltageMaxThreshold::TypeInfo::DecodableType mainsVoltageMaxThreshold;
-        Attributes::MainsVoltageDwellTrip::TypeInfo::DecodableType mainsVoltageDwellTrip;
-        Attributes::BatteryVoltage::TypeInfo::DecodableType batteryVoltage;
-        Attributes::BatteryPercentageRemaining::TypeInfo::DecodableType batteryPercentageRemaining;
+        Attributes::MainsVoltage::TypeInfo::DecodableType mainsVoltage                             = static_cast<uint16_t>(0);
+        Attributes::MainsFrequency::TypeInfo::DecodableType mainsFrequency                         = static_cast<uint8_t>(0);
+        Attributes::MainsAlarmMask::TypeInfo::DecodableType mainsAlarmMask                         = static_cast<uint8_t>(0);
+        Attributes::MainsVoltageMinThreshold::TypeInfo::DecodableType mainsVoltageMinThreshold     = static_cast<uint16_t>(0);
+        Attributes::MainsVoltageMaxThreshold::TypeInfo::DecodableType mainsVoltageMaxThreshold     = static_cast<uint16_t>(0);
+        Attributes::MainsVoltageDwellTrip::TypeInfo::DecodableType mainsVoltageDwellTrip           = static_cast<uint16_t>(0);
+        Attributes::BatteryVoltage::TypeInfo::DecodableType batteryVoltage                         = static_cast<uint8_t>(0);
+        Attributes::BatteryPercentageRemaining::TypeInfo::DecodableType batteryPercentageRemaining = static_cast<uint8_t>(0);
         Attributes::BatteryManufacturer::TypeInfo::DecodableType batteryManufacturer;
-        Attributes::BatterySize::TypeInfo::DecodableType batterySize;
-        Attributes::BatteryAhrRating::TypeInfo::DecodableType batteryAhrRating;
-        Attributes::BatteryQuantity::TypeInfo::DecodableType batteryQuantity;
-        Attributes::BatteryRatedVoltage::TypeInfo::DecodableType batteryRatedVoltage;
-        Attributes::BatteryAlarmMask::TypeInfo::DecodableType batteryAlarmMask;
-        Attributes::BatteryVoltageMinThreshold::TypeInfo::DecodableType batteryVoltageMinThreshold;
-        Attributes::BatteryVoltageThreshold1::TypeInfo::DecodableType batteryVoltageThreshold1;
-        Attributes::BatteryVoltageThreshold2::TypeInfo::DecodableType batteryVoltageThreshold2;
-        Attributes::BatteryVoltageThreshold3::TypeInfo::DecodableType batteryVoltageThreshold3;
-        Attributes::BatteryPercentageMinThreshold::TypeInfo::DecodableType batteryPercentageMinThreshold;
-        Attributes::BatteryPercentageThreshold1::TypeInfo::DecodableType batteryPercentageThreshold1;
-        Attributes::BatteryPercentageThreshold2::TypeInfo::DecodableType batteryPercentageThreshold2;
-        Attributes::BatteryPercentageThreshold3::TypeInfo::DecodableType batteryPercentageThreshold3;
-        Attributes::BatteryAlarmState::TypeInfo::DecodableType batteryAlarmState;
-        Attributes::Battery2Voltage::TypeInfo::DecodableType battery2Voltage;
-        Attributes::Battery2PercentageRemaining::TypeInfo::DecodableType battery2PercentageRemaining;
+        Attributes::BatterySize::TypeInfo::DecodableType batterySize                                     = static_cast<uint8_t>(0);
+        Attributes::BatteryAhrRating::TypeInfo::DecodableType batteryAhrRating                           = static_cast<uint16_t>(0);
+        Attributes::BatteryQuantity::TypeInfo::DecodableType batteryQuantity                             = static_cast<uint8_t>(0);
+        Attributes::BatteryRatedVoltage::TypeInfo::DecodableType batteryRatedVoltage                     = static_cast<uint8_t>(0);
+        Attributes::BatteryAlarmMask::TypeInfo::DecodableType batteryAlarmMask                           = static_cast<uint8_t>(0);
+        Attributes::BatteryVoltageMinThreshold::TypeInfo::DecodableType batteryVoltageMinThreshold       = static_cast<uint8_t>(0);
+        Attributes::BatteryVoltageThreshold1::TypeInfo::DecodableType batteryVoltageThreshold1           = static_cast<uint8_t>(0);
+        Attributes::BatteryVoltageThreshold2::TypeInfo::DecodableType batteryVoltageThreshold2           = static_cast<uint8_t>(0);
+        Attributes::BatteryVoltageThreshold3::TypeInfo::DecodableType batteryVoltageThreshold3           = static_cast<uint8_t>(0);
+        Attributes::BatteryPercentageMinThreshold::TypeInfo::DecodableType batteryPercentageMinThreshold = static_cast<uint8_t>(0);
+        Attributes::BatteryPercentageThreshold1::TypeInfo::DecodableType batteryPercentageThreshold1     = static_cast<uint8_t>(0);
+        Attributes::BatteryPercentageThreshold2::TypeInfo::DecodableType batteryPercentageThreshold2     = static_cast<uint8_t>(0);
+        Attributes::BatteryPercentageThreshold3::TypeInfo::DecodableType batteryPercentageThreshold3     = static_cast<uint8_t>(0);
+        Attributes::BatteryAlarmState::TypeInfo::DecodableType batteryAlarmState                         = static_cast<uint32_t>(0);
+        Attributes::Battery2Voltage::TypeInfo::DecodableType battery2Voltage                             = static_cast<uint8_t>(0);
+        Attributes::Battery2PercentageRemaining::TypeInfo::DecodableType battery2PercentageRemaining     = static_cast<uint8_t>(0);
         Attributes::Battery2Manufacturer::TypeInfo::DecodableType battery2Manufacturer;
-        Attributes::Battery2Size::TypeInfo::DecodableType battery2Size;
-        Attributes::Battery2AhrRating::TypeInfo::DecodableType battery2AhrRating;
-        Attributes::Battery2Quantity::TypeInfo::DecodableType battery2Quantity;
-        Attributes::Battery2RatedVoltage::TypeInfo::DecodableType battery2RatedVoltage;
-        Attributes::Battery2AlarmMask::TypeInfo::DecodableType battery2AlarmMask;
-        Attributes::Battery2VoltageMinThreshold::TypeInfo::DecodableType battery2VoltageMinThreshold;
-        Attributes::Battery2VoltageThreshold1::TypeInfo::DecodableType battery2VoltageThreshold1;
-        Attributes::Battery2VoltageThreshold2::TypeInfo::DecodableType battery2VoltageThreshold2;
-        Attributes::Battery2VoltageThreshold3::TypeInfo::DecodableType battery2VoltageThreshold3;
-        Attributes::Battery2PercentageMinThreshold::TypeInfo::DecodableType battery2PercentageMinThreshold;
-        Attributes::Battery2PercentageThreshold1::TypeInfo::DecodableType battery2PercentageThreshold1;
-        Attributes::Battery2PercentageThreshold2::TypeInfo::DecodableType battery2PercentageThreshold2;
-        Attributes::Battery2PercentageThreshold3::TypeInfo::DecodableType battery2PercentageThreshold3;
-        Attributes::Battery2AlarmState::TypeInfo::DecodableType battery2AlarmState;
-        Attributes::Battery3Voltage::TypeInfo::DecodableType battery3Voltage;
-        Attributes::Battery3PercentageRemaining::TypeInfo::DecodableType battery3PercentageRemaining;
+        Attributes::Battery2Size::TypeInfo::DecodableType battery2Size                               = static_cast<uint8_t>(0);
+        Attributes::Battery2AhrRating::TypeInfo::DecodableType battery2AhrRating                     = static_cast<uint16_t>(0);
+        Attributes::Battery2Quantity::TypeInfo::DecodableType battery2Quantity                       = static_cast<uint8_t>(0);
+        Attributes::Battery2RatedVoltage::TypeInfo::DecodableType battery2RatedVoltage               = static_cast<uint8_t>(0);
+        Attributes::Battery2AlarmMask::TypeInfo::DecodableType battery2AlarmMask                     = static_cast<uint8_t>(0);
+        Attributes::Battery2VoltageMinThreshold::TypeInfo::DecodableType battery2VoltageMinThreshold = static_cast<uint8_t>(0);
+        Attributes::Battery2VoltageThreshold1::TypeInfo::DecodableType battery2VoltageThreshold1     = static_cast<uint8_t>(0);
+        Attributes::Battery2VoltageThreshold2::TypeInfo::DecodableType battery2VoltageThreshold2     = static_cast<uint8_t>(0);
+        Attributes::Battery2VoltageThreshold3::TypeInfo::DecodableType battery2VoltageThreshold3     = static_cast<uint8_t>(0);
+        Attributes::Battery2PercentageMinThreshold::TypeInfo::DecodableType battery2PercentageMinThreshold =
+            static_cast<uint8_t>(0);
+        Attributes::Battery2PercentageThreshold1::TypeInfo::DecodableType battery2PercentageThreshold1 = static_cast<uint8_t>(0);
+        Attributes::Battery2PercentageThreshold2::TypeInfo::DecodableType battery2PercentageThreshold2 = static_cast<uint8_t>(0);
+        Attributes::Battery2PercentageThreshold3::TypeInfo::DecodableType battery2PercentageThreshold3 = static_cast<uint8_t>(0);
+        Attributes::Battery2AlarmState::TypeInfo::DecodableType battery2AlarmState                     = static_cast<uint32_t>(0);
+        Attributes::Battery3Voltage::TypeInfo::DecodableType battery3Voltage                           = static_cast<uint8_t>(0);
+        Attributes::Battery3PercentageRemaining::TypeInfo::DecodableType battery3PercentageRemaining   = static_cast<uint8_t>(0);
         Attributes::Battery3Manufacturer::TypeInfo::DecodableType battery3Manufacturer;
-        Attributes::Battery3Size::TypeInfo::DecodableType battery3Size;
-        Attributes::Battery3AhrRating::TypeInfo::DecodableType battery3AhrRating;
-        Attributes::Battery3Quantity::TypeInfo::DecodableType battery3Quantity;
-        Attributes::Battery3RatedVoltage::TypeInfo::DecodableType battery3RatedVoltage;
-        Attributes::Battery3AlarmMask::TypeInfo::DecodableType battery3AlarmMask;
-        Attributes::Battery3VoltageMinThreshold::TypeInfo::DecodableType battery3VoltageMinThreshold;
-        Attributes::Battery3VoltageThreshold1::TypeInfo::DecodableType battery3VoltageThreshold1;
-        Attributes::Battery3VoltageThreshold2::TypeInfo::DecodableType battery3VoltageThreshold2;
-        Attributes::Battery3VoltageThreshold3::TypeInfo::DecodableType battery3VoltageThreshold3;
-        Attributes::Battery3PercentageMinThreshold::TypeInfo::DecodableType battery3PercentageMinThreshold;
-        Attributes::Battery3PercentageThreshold1::TypeInfo::DecodableType battery3PercentageThreshold1;
-        Attributes::Battery3PercentageThreshold2::TypeInfo::DecodableType battery3PercentageThreshold2;
-        Attributes::Battery3PercentageThreshold3::TypeInfo::DecodableType battery3PercentageThreshold3;
-        Attributes::Battery3AlarmState::TypeInfo::DecodableType battery3AlarmState;
+        Attributes::Battery3Size::TypeInfo::DecodableType battery3Size                               = static_cast<uint8_t>(0);
+        Attributes::Battery3AhrRating::TypeInfo::DecodableType battery3AhrRating                     = static_cast<uint16_t>(0);
+        Attributes::Battery3Quantity::TypeInfo::DecodableType battery3Quantity                       = static_cast<uint8_t>(0);
+        Attributes::Battery3RatedVoltage::TypeInfo::DecodableType battery3RatedVoltage               = static_cast<uint8_t>(0);
+        Attributes::Battery3AlarmMask::TypeInfo::DecodableType battery3AlarmMask                     = static_cast<uint8_t>(0);
+        Attributes::Battery3VoltageMinThreshold::TypeInfo::DecodableType battery3VoltageMinThreshold = static_cast<uint8_t>(0);
+        Attributes::Battery3VoltageThreshold1::TypeInfo::DecodableType battery3VoltageThreshold1     = static_cast<uint8_t>(0);
+        Attributes::Battery3VoltageThreshold2::TypeInfo::DecodableType battery3VoltageThreshold2     = static_cast<uint8_t>(0);
+        Attributes::Battery3VoltageThreshold3::TypeInfo::DecodableType battery3VoltageThreshold3     = static_cast<uint8_t>(0);
+        Attributes::Battery3PercentageMinThreshold::TypeInfo::DecodableType battery3PercentageMinThreshold =
+            static_cast<uint8_t>(0);
+        Attributes::Battery3PercentageThreshold1::TypeInfo::DecodableType battery3PercentageThreshold1 = static_cast<uint8_t>(0);
+        Attributes::Battery3PercentageThreshold2::TypeInfo::DecodableType battery3PercentageThreshold2 = static_cast<uint8_t>(0);
+        Attributes::Battery3PercentageThreshold3::TypeInfo::DecodableType battery3PercentageThreshold3 = static_cast<uint8_t>(0);
+        Attributes::Battery3AlarmState::TypeInfo::DecodableType battery3AlarmState                     = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -1017,18 +1019,18 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::CurrentTemperature::TypeInfo::DecodableType currentTemperature;
-        Attributes::MinTempExperienced::TypeInfo::DecodableType minTempExperienced;
-        Attributes::MaxTempExperienced::TypeInfo::DecodableType maxTempExperienced;
-        Attributes::OverTempTotalDwell::TypeInfo::DecodableType overTempTotalDwell;
-        Attributes::DeviceTempAlarmMask::TypeInfo::DecodableType deviceTempAlarmMask;
-        Attributes::LowTempThreshold::TypeInfo::DecodableType lowTempThreshold;
-        Attributes::HighTempThreshold::TypeInfo::DecodableType highTempThreshold;
-        Attributes::LowTempDwellTripPoint::TypeInfo::DecodableType lowTempDwellTripPoint;
-        Attributes::HighTempDwellTripPoint::TypeInfo::DecodableType highTempDwellTripPoint;
+        Attributes::CurrentTemperature::TypeInfo::DecodableType currentTemperature         = static_cast<int16_t>(0);
+        Attributes::MinTempExperienced::TypeInfo::DecodableType minTempExperienced         = static_cast<int16_t>(0);
+        Attributes::MaxTempExperienced::TypeInfo::DecodableType maxTempExperienced         = static_cast<int16_t>(0);
+        Attributes::OverTempTotalDwell::TypeInfo::DecodableType overTempTotalDwell         = static_cast<uint16_t>(0);
+        Attributes::DeviceTempAlarmMask::TypeInfo::DecodableType deviceTempAlarmMask       = static_cast<uint8_t>(0);
+        Attributes::LowTempThreshold::TypeInfo::DecodableType lowTempThreshold             = static_cast<int16_t>(0);
+        Attributes::HighTempThreshold::TypeInfo::DecodableType highTempThreshold           = static_cast<int16_t>(0);
+        Attributes::LowTempDwellTripPoint::TypeInfo::DecodableType lowTempDwellTripPoint   = static_cast<uint32_t>(0);
+        Attributes::HighTempDwellTripPoint::TypeInfo::DecodableType highTempDwellTripPoint = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -1117,7 +1119,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Identify::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
-    uint16_t identifyTime;
+    uint16_t identifyTime = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1132,7 +1134,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Identify::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
-    uint16_t identifyTime;
+    uint16_t identifyTime = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Identify
@@ -1149,7 +1151,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::IdentifyQueryResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
-    uint16_t timeout;
+    uint16_t timeout = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1164,7 +1166,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::IdentifyQueryResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
-    uint16_t timeout;
+    uint16_t timeout = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace IdentifyQueryResponse
@@ -1210,8 +1212,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TriggerEffect::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
-    IdentifyEffectIdentifier effectIdentifier;
-    IdentifyEffectVariant effectVariant;
+    IdentifyEffectIdentifier effectIdentifier = static_cast<IdentifyEffectIdentifier>(0);
+    IdentifyEffectVariant effectVariant       = static_cast<IdentifyEffectVariant>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1226,8 +1228,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TriggerEffect::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
-    IdentifyEffectIdentifier effectIdentifier;
-    IdentifyEffectVariant effectVariant;
+    IdentifyEffectIdentifier effectIdentifier = static_cast<IdentifyEffectIdentifier>(0);
+    IdentifyEffectVariant effectVariant       = static_cast<IdentifyEffectVariant>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TriggerEffect
@@ -1304,11 +1306,11 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::IdentifyTime::TypeInfo::DecodableType identifyTime;
-        Attributes::IdentifyType::TypeInfo::DecodableType identifyType;
+        Attributes::IdentifyTime::TypeInfo::DecodableType identifyTime = static_cast<uint16_t>(0);
+        Attributes::IdentifyType::TypeInfo::DecodableType identifyType = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -1385,7 +1387,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1401,7 +1403,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1420,8 +1422,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1436,8 +1438,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddGroupResponse
@@ -1454,7 +1456,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1469,7 +1471,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ViewGroup
@@ -1488,8 +1490,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1505,8 +1507,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
     chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1557,7 +1559,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t capacity;
+    uint8_t capacity = static_cast<uint8_t>(0);
     DataModel::List<const uint16_t> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1573,7 +1575,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t capacity;
+    uint8_t capacity = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint16_t> groupList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1591,7 +1593,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1606,7 +1608,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveGroup
@@ -1624,8 +1626,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1640,8 +1642,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveGroupResponse
@@ -1687,7 +1689,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupIfIdentifying::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1703,7 +1705,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupIfIdentifying::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1769,10 +1771,10 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::NameSupport::TypeInfo::DecodableType nameSupport;
+        Attributes::NameSupport::TypeInfo::DecodableType nameSupport = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -1928,9 +1930,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
@@ -1947,9 +1949,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -1970,9 +1972,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1987,9 +1989,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddSceneResponse
@@ -2007,8 +2009,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2023,8 +2025,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ViewScene
@@ -2046,10 +2048,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint8_t status          = static_cast<uint8_t>(0);
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
@@ -2066,10 +2068,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint8_t status          = static_cast<uint8_t>(0);
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -2089,8 +2091,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2105,8 +2107,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveScene
@@ -2125,9 +2127,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2142,9 +2144,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveSceneResponse
@@ -2161,7 +2163,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenes::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2176,7 +2178,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenes::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveAllScenes
@@ -2194,8 +2196,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenesResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2210,8 +2212,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenesResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveAllScenesResponse
@@ -2229,8 +2231,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StoreScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2245,8 +2247,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StoreScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StoreScene
@@ -2265,9 +2267,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StoreSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2282,9 +2284,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StoreSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StoreSceneResponse
@@ -2303,9 +2305,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RecallScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2320,9 +2322,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RecallScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RecallScene
@@ -2339,7 +2341,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetSceneMembership::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2354,7 +2356,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetSceneMembership::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
+    uint16_t groupId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetSceneMembership
@@ -2375,10 +2377,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetSceneMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint8_t capacity;
-    uint16_t groupId;
-    uint8_t sceneCount;
+    uint8_t status     = static_cast<uint8_t>(0);
+    uint8_t capacity   = static_cast<uint8_t>(0);
+    uint16_t groupId   = static_cast<uint16_t>(0);
+    uint8_t sceneCount = static_cast<uint8_t>(0);
     DataModel::List<const uint8_t> sceneList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -2394,10 +2396,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetSceneMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint8_t capacity;
-    uint16_t groupId;
-    uint8_t sceneCount;
+    uint8_t status     = static_cast<uint8_t>(0);
+    uint8_t capacity   = static_cast<uint8_t>(0);
+    uint16_t groupId   = static_cast<uint16_t>(0);
+    uint8_t sceneCount = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint8_t> sceneList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2419,9 +2421,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedAddScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
@@ -2438,9 +2440,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedAddScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -2461,9 +2463,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedAddSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2478,9 +2480,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedAddSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint8_t status   = static_cast<uint8_t>(0);
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnhancedAddSceneResponse
@@ -2498,8 +2500,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedViewScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2514,8 +2516,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedViewScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint16_t groupId;
-    uint8_t sceneId;
+    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t sceneId  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnhancedViewScene
@@ -2537,10 +2539,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedViewSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint8_t status          = static_cast<uint8_t>(0);
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
@@ -2557,10 +2559,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedViewSceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupId;
-    uint8_t sceneId;
-    uint16_t transitionTime;
+    uint8_t status          = static_cast<uint8_t>(0);
+    uint16_t groupId        = static_cast<uint16_t>(0);
+    uint8_t sceneId         = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -2583,11 +2585,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CopyScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    chip::BitFlags<ScenesCopyMode> mode;
-    uint16_t groupIdFrom;
-    uint8_t sceneIdFrom;
-    uint16_t groupIdTo;
-    uint8_t sceneIdTo;
+    chip::BitFlags<ScenesCopyMode> mode = static_cast<chip::BitFlags<ScenesCopyMode>>(0);
+    uint16_t groupIdFrom                = static_cast<uint16_t>(0);
+    uint8_t sceneIdFrom                 = static_cast<uint8_t>(0);
+    uint16_t groupIdTo                  = static_cast<uint16_t>(0);
+    uint8_t sceneIdTo                   = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2602,11 +2604,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CopyScene::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    chip::BitFlags<ScenesCopyMode> mode;
-    uint16_t groupIdFrom;
-    uint8_t sceneIdFrom;
-    uint16_t groupIdTo;
-    uint8_t sceneIdTo;
+    chip::BitFlags<ScenesCopyMode> mode = static_cast<chip::BitFlags<ScenesCopyMode>>(0);
+    uint16_t groupIdFrom                = static_cast<uint16_t>(0);
+    uint8_t sceneIdFrom                 = static_cast<uint8_t>(0);
+    uint16_t groupIdTo                  = static_cast<uint16_t>(0);
+    uint8_t sceneIdTo                   = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CopyScene
@@ -2625,9 +2627,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CopySceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupIdFrom;
-    uint8_t sceneIdFrom;
+    uint8_t status       = static_cast<uint8_t>(0);
+    uint16_t groupIdFrom = static_cast<uint16_t>(0);
+    uint8_t sceneIdFrom  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2642,9 +2644,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CopySceneResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
-    uint8_t status;
-    uint16_t groupIdFrom;
-    uint8_t sceneIdFrom;
+    uint8_t status       = static_cast<uint8_t>(0);
+    uint16_t groupIdFrom = static_cast<uint16_t>(0);
+    uint8_t sceneIdFrom  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CopySceneResponse
@@ -2769,15 +2771,15 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::SceneCount::TypeInfo::DecodableType sceneCount;
-        Attributes::CurrentScene::TypeInfo::DecodableType currentScene;
-        Attributes::CurrentGroup::TypeInfo::DecodableType currentGroup;
-        Attributes::SceneValid::TypeInfo::DecodableType sceneValid;
-        Attributes::NameSupport::TypeInfo::DecodableType nameSupport;
-        Attributes::LastConfiguredBy::TypeInfo::DecodableType lastConfiguredBy;
+        Attributes::SceneCount::TypeInfo::DecodableType sceneCount             = static_cast<uint8_t>(0);
+        Attributes::CurrentScene::TypeInfo::DecodableType currentScene         = static_cast<uint8_t>(0);
+        Attributes::CurrentGroup::TypeInfo::DecodableType currentGroup         = static_cast<uint16_t>(0);
+        Attributes::SceneValid::TypeInfo::DecodableType sceneValid             = static_cast<bool>(0);
+        Attributes::NameSupport::TypeInfo::DecodableType nameSupport           = static_cast<uint8_t>(0);
+        Attributes::LastConfiguredBy::TypeInfo::DecodableType lastConfiguredBy = static_cast<chip::NodeId>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -2960,8 +2962,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OffWithEffect::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
-    OnOffEffectIdentifier effectId;
-    OnOffDelayedAllOffEffectVariant effectVariant;
+    OnOffEffectIdentifier effectId                = static_cast<OnOffEffectIdentifier>(0);
+    OnOffDelayedAllOffEffectVariant effectVariant = static_cast<OnOffDelayedAllOffEffectVariant>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -2976,8 +2978,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OffWithEffect::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
-    OnOffEffectIdentifier effectId;
-    OnOffDelayedAllOffEffectVariant effectVariant;
+    OnOffEffectIdentifier effectId                = static_cast<OnOffEffectIdentifier>(0);
+    OnOffDelayedAllOffEffectVariant effectVariant = static_cast<OnOffDelayedAllOffEffectVariant>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OffWithEffect
@@ -3024,9 +3026,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OnWithTimedOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
-    chip::BitFlags<OnOffControl> onOffControl;
-    uint16_t onTime;
-    uint16_t offWaitTime;
+    chip::BitFlags<OnOffControl> onOffControl = static_cast<chip::BitFlags<OnOffControl>>(0);
+    uint16_t onTime                           = static_cast<uint16_t>(0);
+    uint16_t offWaitTime                      = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3041,9 +3043,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OnWithTimedOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
-    chip::BitFlags<OnOffControl> onOffControl;
-    uint16_t onTime;
-    uint16_t offWaitTime;
+    chip::BitFlags<OnOffControl> onOffControl = static_cast<chip::BitFlags<OnOffControl>>(0);
+    uint16_t onTime                           = static_cast<uint16_t>(0);
+    uint16_t offWaitTime                      = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OnWithTimedOff
@@ -3156,14 +3158,14 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::OnOff::TypeInfo::DecodableType onOff;
-        Attributes::GlobalSceneControl::TypeInfo::DecodableType globalSceneControl;
-        Attributes::OnTime::TypeInfo::DecodableType onTime;
-        Attributes::OffWaitTime::TypeInfo::DecodableType offWaitTime;
-        Attributes::StartUpOnOff::TypeInfo::DecodableType startUpOnOff;
+        Attributes::OnOff::TypeInfo::DecodableType onOff                           = static_cast<bool>(0);
+        Attributes::GlobalSceneControl::TypeInfo::DecodableType globalSceneControl = static_cast<bool>(0);
+        Attributes::OnTime::TypeInfo::DecodableType onTime                         = static_cast<uint16_t>(0);
+        Attributes::OffWaitTime::TypeInfo::DecodableType offWaitTime               = static_cast<uint16_t>(0);
+        Attributes::StartUpOnOff::TypeInfo::DecodableType startUpOnOff             = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -3241,11 +3243,11 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::SwitchType::TypeInfo::DecodableType switchType;
-        Attributes::SwitchActions::TypeInfo::DecodableType switchActions;
+        Attributes::SwitchType::TypeInfo::DecodableType switchType       = static_cast<uint8_t>(0);
+        Attributes::SwitchActions::TypeInfo::DecodableType switchActions = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -3338,10 +3340,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToLevel::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    uint8_t level;
-    uint16_t transitionTime;
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    uint8_t level           = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionMask      = static_cast<uint8_t>(0);
+    uint8_t optionOverride  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3356,10 +3358,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToLevel::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    uint8_t level;
-    uint16_t transitionTime;
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    uint8_t level           = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionMask      = static_cast<uint8_t>(0);
+    uint8_t optionOverride  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToLevel
@@ -3379,10 +3381,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Move::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    MoveMode moveMode;
-    uint8_t rate;
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    MoveMode moveMode      = static_cast<MoveMode>(0);
+    uint8_t rate           = static_cast<uint8_t>(0);
+    uint8_t optionMask     = static_cast<uint8_t>(0);
+    uint8_t optionOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3397,10 +3399,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Move::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    MoveMode moveMode;
-    uint8_t rate;
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    MoveMode moveMode      = static_cast<MoveMode>(0);
+    uint8_t rate           = static_cast<uint8_t>(0);
+    uint8_t optionMask     = static_cast<uint8_t>(0);
+    uint8_t optionOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Move
@@ -3421,11 +3423,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Step::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    StepMode stepMode;
-    uint8_t stepSize;
-    uint16_t transitionTime;
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    StepMode stepMode       = static_cast<StepMode>(0);
+    uint8_t stepSize        = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionMask      = static_cast<uint8_t>(0);
+    uint8_t optionOverride  = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3440,11 +3442,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Step::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    StepMode stepMode;
-    uint8_t stepSize;
-    uint16_t transitionTime;
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    StepMode stepMode       = static_cast<StepMode>(0);
+    uint8_t stepSize        = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionMask      = static_cast<uint8_t>(0);
+    uint8_t optionOverride  = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Step
@@ -3462,8 +3464,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Stop::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    uint8_t optionMask     = static_cast<uint8_t>(0);
+    uint8_t optionOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3478,8 +3480,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Stop::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    uint8_t optionMask;
-    uint8_t optionOverride;
+    uint8_t optionMask     = static_cast<uint8_t>(0);
+    uint8_t optionOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Stop
@@ -3497,8 +3499,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToLevelWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    uint8_t level;
-    uint16_t transitionTime;
+    uint8_t level           = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3513,8 +3515,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToLevelWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    uint8_t level;
-    uint16_t transitionTime;
+    uint8_t level           = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToLevelWithOnOff
@@ -3532,8 +3534,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    MoveMode moveMode;
-    uint8_t rate;
+    MoveMode moveMode = static_cast<MoveMode>(0);
+    uint8_t rate      = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3548,8 +3550,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    MoveMode moveMode;
-    uint8_t rate;
+    MoveMode moveMode = static_cast<MoveMode>(0);
+    uint8_t rate      = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveWithOnOff
@@ -3568,9 +3570,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    StepMode stepMode;
-    uint8_t stepSize;
-    uint16_t transitionTime;
+    StepMode stepMode       = static_cast<StepMode>(0);
+    uint8_t stepSize        = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3585,9 +3587,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
-    StepMode stepMode;
-    uint8_t stepSize;
-    uint16_t transitionTime;
+    StepMode stepMode       = static_cast<StepMode>(0);
+    uint8_t stepSize        = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StepWithOnOff
@@ -3836,23 +3838,23 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::CurrentLevel::TypeInfo::DecodableType currentLevel;
-        Attributes::RemainingTime::TypeInfo::DecodableType remainingTime;
-        Attributes::MinLevel::TypeInfo::DecodableType minLevel;
-        Attributes::MaxLevel::TypeInfo::DecodableType maxLevel;
-        Attributes::CurrentFrequency::TypeInfo::DecodableType currentFrequency;
-        Attributes::MinFrequency::TypeInfo::DecodableType minFrequency;
-        Attributes::MaxFrequency::TypeInfo::DecodableType maxFrequency;
-        Attributes::Options::TypeInfo::DecodableType options;
-        Attributes::OnOffTransitionTime::TypeInfo::DecodableType onOffTransitionTime;
+        Attributes::CurrentLevel::TypeInfo::DecodableType currentLevel               = static_cast<uint8_t>(0);
+        Attributes::RemainingTime::TypeInfo::DecodableType remainingTime             = static_cast<uint16_t>(0);
+        Attributes::MinLevel::TypeInfo::DecodableType minLevel                       = static_cast<uint8_t>(0);
+        Attributes::MaxLevel::TypeInfo::DecodableType maxLevel                       = static_cast<uint8_t>(0);
+        Attributes::CurrentFrequency::TypeInfo::DecodableType currentFrequency       = static_cast<uint16_t>(0);
+        Attributes::MinFrequency::TypeInfo::DecodableType minFrequency               = static_cast<uint16_t>(0);
+        Attributes::MaxFrequency::TypeInfo::DecodableType maxFrequency               = static_cast<uint16_t>(0);
+        Attributes::Options::TypeInfo::DecodableType options                         = static_cast<uint8_t>(0);
+        Attributes::OnOffTransitionTime::TypeInfo::DecodableType onOffTransitionTime = static_cast<uint16_t>(0);
         Attributes::OnLevel::TypeInfo::DecodableType onLevel;
         Attributes::OnTransitionTime::TypeInfo::DecodableType onTransitionTime;
         Attributes::OffTransitionTime::TypeInfo::DecodableType offTransitionTime;
         Attributes::DefaultMoveRate::TypeInfo::DecodableType defaultMoveRate;
-        Attributes::StartUpCurrentLevel::TypeInfo::DecodableType startUpCurrentLevel;
+        Attributes::StartUpCurrentLevel::TypeInfo::DecodableType startUpCurrentLevel = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -3909,8 +3911,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ResetAlarm::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
-    uint8_t alarmCode;
-    chip::ClusterId clusterId;
+    uint8_t alarmCode         = static_cast<uint8_t>(0);
+    chip::ClusterId clusterId = static_cast<chip::ClusterId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3925,8 +3927,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ResetAlarm::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
-    uint8_t alarmCode;
-    chip::ClusterId clusterId;
+    uint8_t alarmCode         = static_cast<uint8_t>(0);
+    chip::ClusterId clusterId = static_cast<chip::ClusterId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ResetAlarm
@@ -3944,8 +3946,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Alarm::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
-    uint8_t alarmCode;
-    chip::ClusterId clusterId;
+    uint8_t alarmCode         = static_cast<uint8_t>(0);
+    chip::ClusterId clusterId = static_cast<chip::ClusterId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -3960,8 +3962,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Alarm::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
-    uint8_t alarmCode;
-    chip::ClusterId clusterId;
+    uint8_t alarmCode         = static_cast<uint8_t>(0);
+    chip::ClusterId clusterId = static_cast<chip::ClusterId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Alarm
@@ -4009,10 +4011,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetAlarmResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
-    uint8_t status;
-    uint8_t alarmCode;
-    chip::ClusterId clusterId;
-    uint32_t timeStamp;
+    uint8_t status            = static_cast<uint8_t>(0);
+    uint8_t alarmCode         = static_cast<uint8_t>(0);
+    chip::ClusterId clusterId = static_cast<chip::ClusterId>(0);
+    uint32_t timeStamp        = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -4027,10 +4029,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetAlarmResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
-    uint8_t status;
-    uint8_t alarmCode;
-    chip::ClusterId clusterId;
-    uint32_t timeStamp;
+    uint8_t status            = static_cast<uint8_t>(0);
+    uint8_t alarmCode         = static_cast<uint8_t>(0);
+    chip::ClusterId clusterId = static_cast<chip::ClusterId>(0);
+    uint32_t timeStamp        = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetAlarmResponse
@@ -4151,10 +4153,10 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::AlarmCount::TypeInfo::DecodableType alarmCount;
+        Attributes::AlarmCount::TypeInfo::DecodableType alarmCount = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -4328,19 +4330,19 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Time::TypeInfo::DecodableType time;
-        Attributes::TimeStatus::TypeInfo::DecodableType timeStatus;
-        Attributes::TimeZone::TypeInfo::DecodableType timeZone;
-        Attributes::DstStart::TypeInfo::DecodableType dstStart;
-        Attributes::DstEnd::TypeInfo::DecodableType dstEnd;
-        Attributes::DstShift::TypeInfo::DecodableType dstShift;
-        Attributes::StandardTime::TypeInfo::DecodableType standardTime;
-        Attributes::LocalTime::TypeInfo::DecodableType localTime;
-        Attributes::LastSetTime::TypeInfo::DecodableType lastSetTime;
-        Attributes::ValidUntilTime::TypeInfo::DecodableType validUntilTime;
+        Attributes::Time::TypeInfo::DecodableType time                     = static_cast<uint32_t>(0);
+        Attributes::TimeStatus::TypeInfo::DecodableType timeStatus         = static_cast<uint8_t>(0);
+        Attributes::TimeZone::TypeInfo::DecodableType timeZone             = static_cast<int32_t>(0);
+        Attributes::DstStart::TypeInfo::DecodableType dstStart             = static_cast<uint32_t>(0);
+        Attributes::DstEnd::TypeInfo::DecodableType dstEnd                 = static_cast<uint32_t>(0);
+        Attributes::DstShift::TypeInfo::DecodableType dstShift             = static_cast<int32_t>(0);
+        Attributes::StandardTime::TypeInfo::DecodableType standardTime     = static_cast<uint32_t>(0);
+        Attributes::LocalTime::TypeInfo::DecodableType localTime           = static_cast<uint32_t>(0);
+        Attributes::LastSetTime::TypeInfo::DecodableType lastSetTime       = static_cast<uint32_t>(0);
+        Attributes::ValidUntilTime::TypeInfo::DecodableType validUntilTime = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -4505,15 +4507,15 @@ struct TypeInfo
         Attributes::ActiveText::TypeInfo::DecodableType activeText;
         Attributes::Description::TypeInfo::DecodableType description;
         Attributes::InactiveText::TypeInfo::DecodableType inactiveText;
-        Attributes::OutOfService::TypeInfo::DecodableType outOfService;
-        Attributes::Polarity::TypeInfo::DecodableType polarity;
-        Attributes::PresentValue::TypeInfo::DecodableType presentValue;
-        Attributes::Reliability::TypeInfo::DecodableType reliability;
-        Attributes::StatusFlags::TypeInfo::DecodableType statusFlags;
-        Attributes::ApplicationType::TypeInfo::DecodableType applicationType;
+        Attributes::OutOfService::TypeInfo::DecodableType outOfService       = static_cast<bool>(0);
+        Attributes::Polarity::TypeInfo::DecodableType polarity               = static_cast<uint8_t>(0);
+        Attributes::PresentValue::TypeInfo::DecodableType presentValue       = static_cast<bool>(0);
+        Attributes::Reliability::TypeInfo::DecodableType reliability         = static_cast<uint8_t>(0);
+        Attributes::StatusFlags::TypeInfo::DecodableType statusFlags         = static_cast<uint8_t>(0);
+        Attributes::ApplicationType::TypeInfo::DecodableType applicationType = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -4719,7 +4721,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -4734,7 +4736,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PowerProfileRequest
@@ -4754,9 +4756,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t totalProfileNum;
-    uint8_t powerProfileId;
-    uint8_t numOfTransferredPhases;
+    uint8_t totalProfileNum        = static_cast<uint8_t>(0);
+    uint8_t powerProfileId         = static_cast<uint8_t>(0);
+    uint8_t numOfTransferredPhases = static_cast<uint8_t>(0);
     DataModel::List<const Structs::TransferredPhase::Type> transferredPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -4772,9 +4774,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t totalProfileNum;
-    uint8_t powerProfileId;
-    uint8_t numOfTransferredPhases;
+    uint8_t totalProfileNum        = static_cast<uint8_t>(0);
+    uint8_t powerProfileId         = static_cast<uint8_t>(0);
+    uint8_t numOfTransferredPhases = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::TransferredPhase::DecodableType> transferredPhases;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4823,9 +4825,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t totalProfileNum;
-    uint8_t powerProfileId;
-    uint8_t numOfTransferredPhases;
+    uint8_t totalProfileNum        = static_cast<uint8_t>(0);
+    uint8_t powerProfileId         = static_cast<uint8_t>(0);
+    uint8_t numOfTransferredPhases = static_cast<uint8_t>(0);
     DataModel::List<const Structs::TransferredPhase::Type> transferredPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -4841,9 +4843,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t totalProfileNum;
-    uint8_t powerProfileId;
-    uint8_t numOfTransferredPhases;
+    uint8_t totalProfileNum        = static_cast<uint8_t>(0);
+    uint8_t powerProfileId         = static_cast<uint8_t>(0);
+    uint8_t numOfTransferredPhases = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::TransferredPhase::DecodableType> transferredPhases;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4864,10 +4866,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t currency;
-    uint32_t price;
-    uint8_t priceTrailingDigit;
+    uint8_t powerProfileId     = static_cast<uint8_t>(0);
+    uint16_t currency          = static_cast<uint16_t>(0);
+    uint32_t price             = static_cast<uint32_t>(0);
+    uint8_t priceTrailingDigit = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -4882,10 +4884,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t currency;
-    uint32_t price;
-    uint8_t priceTrailingDigit;
+    uint8_t powerProfileId     = static_cast<uint8_t>(0);
+    uint16_t currency          = static_cast<uint16_t>(0);
+    uint32_t price             = static_cast<uint32_t>(0);
+    uint8_t priceTrailingDigit = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPowerProfilePriceResponse
@@ -4903,7 +4905,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileStateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileCount;
+    uint8_t powerProfileCount = static_cast<uint8_t>(0);
     DataModel::List<const Structs::PowerProfileRecord::Type> powerProfileRecords;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -4919,7 +4921,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileStateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileCount;
+    uint8_t powerProfileCount = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::PowerProfileRecord::DecodableType> powerProfileRecords;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4939,9 +4941,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetOverallSchedulePriceResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint16_t currency;
-    uint32_t price;
-    uint8_t priceTrailingDigit;
+    uint16_t currency          = static_cast<uint16_t>(0);
+    uint32_t price             = static_cast<uint32_t>(0);
+    uint8_t priceTrailingDigit = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -4956,9 +4958,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetOverallSchedulePriceResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint16_t currency;
-    uint32_t price;
-    uint8_t priceTrailingDigit;
+    uint16_t currency          = static_cast<uint16_t>(0);
+    uint32_t price             = static_cast<uint32_t>(0);
+    uint8_t priceTrailingDigit = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetOverallSchedulePriceResponse
@@ -4975,7 +4977,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePrice::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -4990,7 +4992,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePrice::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPowerProfilePrice
@@ -5009,8 +5011,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -5026,8 +5028,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::ScheduledPhase::DecodableType> scheduledPhases;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5046,7 +5048,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfilesStateNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileCount;
+    uint8_t powerProfileCount = static_cast<uint8_t>(0);
     DataModel::List<const Structs::PowerProfileRecord::Type> powerProfileRecords;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -5062,7 +5064,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfilesStateNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileCount;
+    uint8_t powerProfileCount = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::PowerProfileRecord::DecodableType> powerProfileRecords;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5082,8 +5084,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -5099,8 +5101,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::ScheduledPhase::DecodableType> scheduledPhases;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5146,7 +5148,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5161,7 +5163,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PowerProfileScheduleConstraintsRequest
@@ -5178,7 +5180,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5193,7 +5195,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnergyPhasesScheduleRequest
@@ -5210,7 +5212,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5225,7 +5227,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnergyPhasesScheduleStateRequest
@@ -5244,8 +5246,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -5261,8 +5263,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::ScheduledPhase::DecodableType> scheduledPhases;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5283,10 +5285,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtendedResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t currency;
-    uint32_t price;
-    uint8_t priceTrailingDigit;
+    uint8_t powerProfileId     = static_cast<uint8_t>(0);
+    uint16_t currency          = static_cast<uint16_t>(0);
+    uint32_t price             = static_cast<uint32_t>(0);
+    uint8_t priceTrailingDigit = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5301,10 +5303,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtendedResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t currency;
-    uint32_t price;
-    uint8_t priceTrailingDigit;
+    uint8_t powerProfileId     = static_cast<uint8_t>(0);
+    uint16_t currency          = static_cast<uint16_t>(0);
+    uint32_t price             = static_cast<uint32_t>(0);
+    uint8_t priceTrailingDigit = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPowerProfilePriceExtendedResponse
@@ -5323,8 +5325,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -5340,8 +5342,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint8_t numOfScheduledPhases;
+    uint8_t powerProfileId       = static_cast<uint8_t>(0);
+    uint8_t numOfScheduledPhases = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::ScheduledPhase::DecodableType> scheduledPhases;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5361,9 +5363,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t startAfter;
-    uint16_t stopBefore;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
+    uint16_t startAfter    = static_cast<uint16_t>(0);
+    uint16_t stopBefore    = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5378,9 +5380,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t startAfter;
-    uint16_t stopBefore;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
+    uint16_t startAfter    = static_cast<uint16_t>(0);
+    uint16_t stopBefore    = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PowerProfileScheduleConstraintsNotification
@@ -5399,9 +5401,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t startAfter;
-    uint16_t stopBefore;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
+    uint16_t startAfter    = static_cast<uint16_t>(0);
+    uint16_t stopBefore    = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5416,9 +5418,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t powerProfileId;
-    uint16_t startAfter;
-    uint16_t stopBefore;
+    uint8_t powerProfileId = static_cast<uint8_t>(0);
+    uint16_t startAfter    = static_cast<uint16_t>(0);
+    uint16_t stopBefore    = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PowerProfileScheduleConstraintsResponse
@@ -5437,9 +5439,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtended::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t options;
-    uint8_t powerProfileId;
-    uint16_t powerProfileStartTime;
+    uint8_t options                = static_cast<uint8_t>(0);
+    uint8_t powerProfileId         = static_cast<uint8_t>(0);
+    uint16_t powerProfileStartTime = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5454,9 +5456,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtended::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
-    uint8_t options;
-    uint8_t powerProfileId;
-    uint16_t powerProfileStartTime;
+    uint8_t options                = static_cast<uint8_t>(0);
+    uint8_t powerProfileId         = static_cast<uint8_t>(0);
+    uint16_t powerProfileStartTime = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPowerProfilePriceExtended
@@ -5569,14 +5571,14 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::TotalProfileNum::TypeInfo::DecodableType totalProfileNum;
-        Attributes::MultipleScheduling::TypeInfo::DecodableType multipleScheduling;
-        Attributes::EnergyFormatting::TypeInfo::DecodableType energyFormatting;
-        Attributes::EnergyRemote::TypeInfo::DecodableType energyRemote;
-        Attributes::ScheduleMode::TypeInfo::DecodableType scheduleMode;
+        Attributes::TotalProfileNum::TypeInfo::DecodableType totalProfileNum       = static_cast<uint8_t>(0);
+        Attributes::MultipleScheduling::TypeInfo::DecodableType multipleScheduling = static_cast<bool>(0);
+        Attributes::EnergyFormatting::TypeInfo::DecodableType energyFormatting     = static_cast<uint8_t>(0);
+        Attributes::EnergyRemote::TypeInfo::DecodableType energyRemote             = static_cast<bool>(0);
+        Attributes::ScheduleMode::TypeInfo::DecodableType scheduleMode             = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -5692,7 +5694,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ExecutionOfACommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    CommandIdentification commandId;
+    CommandIdentification commandId = static_cast<CommandIdentification>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5707,7 +5709,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ExecutionOfACommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    CommandIdentification commandId;
+    CommandIdentification commandId = static_cast<CommandIdentification>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ExecutionOfACommand
@@ -5726,9 +5728,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SignalStateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    ApplianceStatus applianceStatus;
-    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
-    ApplianceStatus applianceStatus2;
+    ApplianceStatus applianceStatus = static_cast<ApplianceStatus>(0);
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2 =
+        static_cast<chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2>>(0);
+    ApplianceStatus applianceStatus2 = static_cast<ApplianceStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5743,9 +5746,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SignalStateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    ApplianceStatus applianceStatus;
-    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
-    ApplianceStatus applianceStatus2;
+    ApplianceStatus applianceStatus = static_cast<ApplianceStatus>(0);
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2 =
+        static_cast<chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2>>(0);
+    ApplianceStatus applianceStatus2 = static_cast<ApplianceStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SignalStateResponse
@@ -5792,9 +5796,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SignalStateNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    ApplianceStatus applianceStatus;
-    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
-    ApplianceStatus applianceStatus2;
+    ApplianceStatus applianceStatus = static_cast<ApplianceStatus>(0);
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2 =
+        static_cast<chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2>>(0);
+    ApplianceStatus applianceStatus2 = static_cast<ApplianceStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5809,9 +5814,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SignalStateNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    ApplianceStatus applianceStatus;
-    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
-    ApplianceStatus applianceStatus2;
+    ApplianceStatus applianceStatus = static_cast<ApplianceStatus>(0);
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2 =
+        static_cast<chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2>>(0);
+    ApplianceStatus applianceStatus2 = static_cast<ApplianceStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SignalStateNotification
@@ -5830,8 +5836,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::WriteFunctions::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    uint16_t functionId;
-    uint8_t functionDataType;
+    uint16_t functionId      = static_cast<uint16_t>(0);
+    uint8_t functionDataType = static_cast<uint8_t>(0);
     DataModel::List<const uint8_t> functionData;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -5847,8 +5853,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::WriteFunctions::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    uint16_t functionId;
-    uint8_t functionDataType;
+    uint16_t functionId      = static_cast<uint16_t>(0);
+    uint8_t functionDataType = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint8_t> functionData;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5922,7 +5928,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OverloadWarning::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    WarningEvent warningEvent;
+    WarningEvent warningEvent = static_cast<WarningEvent>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -5937,7 +5943,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OverloadWarning::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
-    WarningEvent warningEvent;
+    WarningEvent warningEvent = static_cast<WarningEvent>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OverloadWarning
@@ -6026,12 +6032,12 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::StartTime::TypeInfo::DecodableType startTime;
-        Attributes::FinishTime::TypeInfo::DecodableType finishTime;
-        Attributes::RemainingTime::TypeInfo::DecodableType remainingTime;
+        Attributes::StartTime::TypeInfo::DecodableType startTime         = static_cast<uint16_t>(0);
+        Attributes::FinishTime::TypeInfo::DecodableType finishTime       = static_cast<uint16_t>(0);
+        Attributes::RemainingTime::TypeInfo::DecodableType remainingTime = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -6086,8 +6092,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -6218,8 +6224,8 @@ struct TypeInfo
         Attributes::ClientList::TypeInfo::DecodableType clientList;
         Attributes::PartsList::TypeInfo::DecodableType partsList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -6258,10 +6264,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Bind::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
-    chip::NodeId nodeId;
-    chip::GroupId groupId;
-    chip::EndpointId endpointId;
-    chip::ClusterId clusterId;
+    chip::NodeId nodeId         = static_cast<chip::NodeId>(0);
+    chip::GroupId groupId       = static_cast<chip::GroupId>(0);
+    chip::EndpointId endpointId = static_cast<chip::EndpointId>(0);
+    chip::ClusterId clusterId   = static_cast<chip::ClusterId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -6276,10 +6282,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Bind::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
-    chip::NodeId nodeId;
-    chip::GroupId groupId;
-    chip::EndpointId endpointId;
-    chip::ClusterId clusterId;
+    chip::NodeId nodeId         = static_cast<chip::NodeId>(0);
+    chip::GroupId groupId       = static_cast<chip::GroupId>(0);
+    chip::EndpointId endpointId = static_cast<chip::EndpointId>(0);
+    chip::ClusterId clusterId   = static_cast<chip::ClusterId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Bind
@@ -6299,10 +6305,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Unbind::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
-    chip::NodeId nodeId;
-    chip::GroupId groupId;
-    chip::EndpointId endpointId;
-    chip::ClusterId clusterId;
+    chip::NodeId nodeId         = static_cast<chip::NodeId>(0);
+    chip::GroupId groupId       = static_cast<chip::GroupId>(0);
+    chip::EndpointId endpointId = static_cast<chip::EndpointId>(0);
+    chip::ClusterId clusterId   = static_cast<chip::ClusterId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -6317,10 +6323,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Unbind::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
-    chip::NodeId nodeId;
-    chip::GroupId groupId;
-    chip::EndpointId endpointId;
-    chip::ClusterId clusterId;
+    chip::NodeId nodeId         = static_cast<chip::NodeId>(0);
+    chip::GroupId groupId       = static_cast<chip::GroupId>(0);
+    chip::EndpointId endpointId = static_cast<chip::EndpointId>(0);
+    chip::ClusterId clusterId   = static_cast<chip::ClusterId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Unbind
@@ -6374,8 +6380,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -6557,8 +6563,8 @@ struct TypeInfo
         Attributes::Acl::TypeInfo::DecodableType acl;
         Attributes::Extension::TypeInfo::DecodableType extension;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -6638,8 +6644,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CheckInResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
-    bool startFastPolling;
-    uint16_t fastPollTimeout;
+    bool startFastPolling    = static_cast<bool>(0);
+    uint16_t fastPollTimeout = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -6654,8 +6660,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CheckInResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
-    bool startFastPolling;
-    uint16_t fastPollTimeout;
+    bool startFastPolling    = static_cast<bool>(0);
+    uint16_t fastPollTimeout = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CheckInResponse
@@ -6700,7 +6706,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetLongPollInterval::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
-    uint32_t newLongPollInterval;
+    uint32_t newLongPollInterval = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -6715,7 +6721,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetLongPollInterval::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
-    uint32_t newLongPollInterval;
+    uint32_t newLongPollInterval = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetLongPollInterval
@@ -6732,7 +6738,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetShortPollInterval::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
-    uint16_t newShortPollInterval;
+    uint16_t newShortPollInterval = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -6747,7 +6753,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetShortPollInterval::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
-    uint16_t newShortPollInterval;
+    uint16_t newShortPollInterval = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetShortPollInterval
@@ -6884,16 +6890,16 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::CheckInInterval::TypeInfo::DecodableType checkInInterval;
-        Attributes::LongPollInterval::TypeInfo::DecodableType longPollInterval;
-        Attributes::ShortPollInterval::TypeInfo::DecodableType shortPollInterval;
-        Attributes::FastPollTimeout::TypeInfo::DecodableType fastPollTimeout;
-        Attributes::CheckInIntervalMin::TypeInfo::DecodableType checkInIntervalMin;
-        Attributes::LongPollIntervalMin::TypeInfo::DecodableType longPollIntervalMin;
-        Attributes::FastPollTimeoutMax::TypeInfo::DecodableType fastPollTimeoutMax;
+        Attributes::CheckInInterval::TypeInfo::DecodableType checkInInterval         = static_cast<uint32_t>(0);
+        Attributes::LongPollInterval::TypeInfo::DecodableType longPollInterval       = static_cast<uint32_t>(0);
+        Attributes::ShortPollInterval::TypeInfo::DecodableType shortPollInterval     = static_cast<uint16_t>(0);
+        Attributes::FastPollTimeout::TypeInfo::DecodableType fastPollTimeout         = static_cast<uint16_t>(0);
+        Attributes::CheckInIntervalMin::TypeInfo::DecodableType checkInIntervalMin   = static_cast<uint32_t>(0);
+        Attributes::LongPollIntervalMin::TypeInfo::DecodableType longPollIntervalMin = static_cast<uint32_t>(0);
+        Attributes::FastPollTimeoutMax::TypeInfo::DecodableType fastPollTimeoutMax   = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -7091,7 +7097,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::InstantAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7107,7 +7113,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::InstantAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7127,9 +7133,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::InstantActionWithTransition::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint16_t transitionTime;
+    uint16_t transitionTime = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -7144,9 +7150,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::InstantActionWithTransition::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint16_t transitionTime;
+    uint16_t transitionTime = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace InstantActionWithTransition
@@ -7164,7 +7170,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StartAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7180,7 +7186,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StartAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7200,9 +7206,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StartActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -7217,9 +7223,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StartActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StartActionWithDuration
@@ -7237,7 +7243,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StopAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7253,7 +7259,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StopAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7272,7 +7278,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PauseAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7288,7 +7294,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PauseAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7308,9 +7314,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PauseActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -7325,9 +7331,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PauseActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PauseActionWithDuration
@@ -7345,7 +7351,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ResumeAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7361,7 +7367,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ResumeAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7380,7 +7386,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnableAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7396,7 +7402,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnableAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7416,9 +7422,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnableActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -7433,9 +7439,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnableActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnableActionWithDuration
@@ -7453,7 +7459,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisableAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -7469,7 +7475,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisableAction::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7489,9 +7495,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisableActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -7506,9 +7512,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisableActionWithDuration::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
+    uint16_t actionID = static_cast<uint16_t>(0);
     Optional<uint32_t> invokeID;
-    uint32_t duration;
+    uint32_t duration = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace DisableActionWithDuration
@@ -7605,8 +7611,8 @@ struct TypeInfo
         Attributes::EndpointList::TypeInfo::DecodableType endpointList;
         Attributes::SetupUrl::TypeInfo::DecodableType setupUrl;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -7629,9 +7635,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
-    uint32_t invokeID;
-    ActionStateEnum newState;
+    uint16_t actionID        = static_cast<uint16_t>(0);
+    uint32_t invokeID        = static_cast<uint32_t>(0);
+    ActionStateEnum newState = static_cast<ActionStateEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -7643,9 +7649,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
-    uint32_t invokeID;
-    ActionStateEnum newState;
+    uint16_t actionID        = static_cast<uint16_t>(0);
+    uint32_t invokeID        = static_cast<uint32_t>(0);
+    ActionStateEnum newState = static_cast<ActionStateEnum>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7669,10 +7675,10 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
-    uint32_t invokeID;
-    ActionStateEnum newState;
-    ActionErrorEnum error;
+    uint16_t actionID        = static_cast<uint16_t>(0);
+    uint32_t invokeID        = static_cast<uint32_t>(0);
+    ActionStateEnum newState = static_cast<ActionStateEnum>(0);
+    ActionErrorEnum error    = static_cast<ActionErrorEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -7684,10 +7690,10 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
 
-    uint16_t actionID;
-    uint32_t invokeID;
-    ActionStateEnum newState;
-    ActionErrorEnum error;
+    uint16_t actionID        = static_cast<uint16_t>(0);
+    uint32_t invokeID        = static_cast<uint32_t>(0);
+    ActionStateEnum newState = static_cast<ActionStateEnum>(0);
+    ActionErrorEnum error    = static_cast<ActionErrorEnum>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8012,28 +8018,28 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::InteractionModelVersion::TypeInfo::DecodableType interactionModelVersion;
+        Attributes::InteractionModelVersion::TypeInfo::DecodableType interactionModelVersion = static_cast<uint16_t>(0);
         Attributes::VendorName::TypeInfo::DecodableType vendorName;
-        Attributes::VendorID::TypeInfo::DecodableType vendorID;
+        Attributes::VendorID::TypeInfo::DecodableType vendorID = static_cast<chip::VendorId>(0);
         Attributes::ProductName::TypeInfo::DecodableType productName;
-        Attributes::ProductID::TypeInfo::DecodableType productID;
+        Attributes::ProductID::TypeInfo::DecodableType productID = static_cast<uint16_t>(0);
         Attributes::NodeLabel::TypeInfo::DecodableType nodeLabel;
         Attributes::Location::TypeInfo::DecodableType location;
-        Attributes::HardwareVersion::TypeInfo::DecodableType hardwareVersion;
+        Attributes::HardwareVersion::TypeInfo::DecodableType hardwareVersion = static_cast<uint16_t>(0);
         Attributes::HardwareVersionString::TypeInfo::DecodableType hardwareVersionString;
-        Attributes::SoftwareVersion::TypeInfo::DecodableType softwareVersion;
+        Attributes::SoftwareVersion::TypeInfo::DecodableType softwareVersion = static_cast<uint32_t>(0);
         Attributes::SoftwareVersionString::TypeInfo::DecodableType softwareVersionString;
         Attributes::ManufacturingDate::TypeInfo::DecodableType manufacturingDate;
         Attributes::PartNumber::TypeInfo::DecodableType partNumber;
         Attributes::ProductURL::TypeInfo::DecodableType productURL;
         Attributes::ProductLabel::TypeInfo::DecodableType productLabel;
         Attributes::SerialNumber::TypeInfo::DecodableType serialNumber;
-        Attributes::LocalConfigDisabled::TypeInfo::DecodableType localConfigDisabled;
-        Attributes::Reachable::TypeInfo::DecodableType reachable;
+        Attributes::LocalConfigDisabled::TypeInfo::DecodableType localConfigDisabled = static_cast<bool>(0);
+        Attributes::Reachable::TypeInfo::DecodableType reachable                     = static_cast<bool>(0);
         Attributes::UniqueID::TypeInfo::DecodableType uniqueID;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -8054,7 +8060,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
-    uint32_t softwareVersion;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8066,7 +8072,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
-    uint32_t softwareVersion;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8143,7 +8149,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
-    bool reachableNewValue;
+    bool reachableNewValue = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8155,7 +8161,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
-    bool reachableNewValue;
+    bool reachableNewValue = static_cast<bool>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8238,9 +8244,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::QueryImage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
-    chip::VendorId vendorId;
-    uint16_t productId;
-    uint32_t softwareVersion;
+    chip::VendorId vendorId  = static_cast<chip::VendorId>(0);
+    uint16_t productId       = static_cast<uint16_t>(0);
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
     DataModel::List<const OTADownloadProtocol> protocolsSupported;
     Optional<uint16_t> hardwareVersion;
     Optional<chip::CharSpan> location;
@@ -8260,9 +8266,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::QueryImage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
-    chip::VendorId vendorId;
-    uint16_t productId;
-    uint32_t softwareVersion;
+    chip::VendorId vendorId  = static_cast<chip::VendorId>(0);
+    uint16_t productId       = static_cast<uint16_t>(0);
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
     DataModel::DecodableList<OTADownloadProtocol> protocolsSupported;
     Optional<uint16_t> hardwareVersion;
     Optional<chip::CharSpan> location;
@@ -8291,7 +8297,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::QueryImageResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
-    OTAQueryStatus status;
+    OTAQueryStatus status = static_cast<OTAQueryStatus>(0);
     Optional<uint32_t> delayedActionTime;
     Optional<chip::CharSpan> imageURI;
     Optional<uint32_t> softwareVersion;
@@ -8313,7 +8319,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::QueryImageResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
-    OTAQueryStatus status;
+    OTAQueryStatus status = static_cast<OTAQueryStatus>(0);
     Optional<uint32_t> delayedActionTime;
     Optional<chip::CharSpan> imageURI;
     Optional<uint32_t> softwareVersion;
@@ -8339,7 +8345,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
-    uint32_t newVersion;
+    uint32_t newVersion = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -8355,7 +8361,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
-    uint32_t newVersion;
+    uint32_t newVersion = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ApplyUpdateRequest
@@ -8373,8 +8379,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ApplyUpdateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
-    OTAApplyUpdateAction action;
-    uint32_t delayedActionTime;
+    OTAApplyUpdateAction action = static_cast<OTAApplyUpdateAction>(0);
+    uint32_t delayedActionTime  = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -8389,8 +8395,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ApplyUpdateResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
-    OTAApplyUpdateAction action;
-    uint32_t delayedActionTime;
+    OTAApplyUpdateAction action = static_cast<OTAApplyUpdateAction>(0);
+    uint32_t delayedActionTime  = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ApplyUpdateResponse
@@ -8409,7 +8415,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
-    uint32_t softwareVersion;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -8425,7 +8431,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
-    uint32_t softwareVersion;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace NotifyUpdateApplied
@@ -8479,8 +8485,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -8570,11 +8576,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AnnounceOtaProvider::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
-    chip::NodeId providerNodeId;
-    chip::VendorId vendorId;
-    OTAAnnouncementReason announcementReason;
+    chip::NodeId providerNodeId              = static_cast<chip::NodeId>(0);
+    chip::VendorId vendorId                  = static_cast<chip::VendorId>(0);
+    OTAAnnouncementReason announcementReason = static_cast<OTAAnnouncementReason>(0);
     Optional<chip::ByteSpan> metadataForNode;
-    chip::EndpointId endpoint;
+    chip::EndpointId endpoint = static_cast<chip::EndpointId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -8589,11 +8595,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AnnounceOtaProvider::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
-    chip::NodeId providerNodeId;
-    chip::VendorId vendorId;
-    OTAAnnouncementReason announcementReason;
+    chip::NodeId providerNodeId              = static_cast<chip::NodeId>(0);
+    chip::VendorId vendorId                  = static_cast<chip::VendorId>(0);
+    OTAAnnouncementReason announcementReason = static_cast<OTAAnnouncementReason>(0);
     Optional<chip::ByteSpan> metadataForNode;
-    chip::EndpointId endpoint;
+    chip::EndpointId endpoint = static_cast<chip::EndpointId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AnnounceOtaProvider
@@ -8697,12 +8703,12 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::DefaultOtaProviders::TypeInfo::DecodableType defaultOtaProviders;
-        Attributes::UpdatePossible::TypeInfo::DecodableType updatePossible;
-        Attributes::UpdateState::TypeInfo::DecodableType updateState;
+        Attributes::UpdatePossible::TypeInfo::DecodableType updatePossible = static_cast<bool>(0);
+        Attributes::UpdateState::TypeInfo::DecodableType updateState       = static_cast<OTAUpdateStateEnum>(0);
         Attributes::UpdateStateProgress::TypeInfo::DecodableType updateStateProgress;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -8727,8 +8733,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
     DataModel::Nullable<OTAUpdateStateEnum> previousState;
-    OTAUpdateStateEnum newState;
-    OTAChangeReasonEnum reason;
+    OTAUpdateStateEnum newState = static_cast<OTAUpdateStateEnum>(0);
+    OTAChangeReasonEnum reason  = static_cast<OTAChangeReasonEnum>(0);
     DataModel::Nullable<uint32_t> targetSoftwareVersion;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -8742,8 +8748,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
     DataModel::Nullable<OTAUpdateStateEnum> previousState;
-    OTAUpdateStateEnum newState;
-    OTAChangeReasonEnum reason;
+    OTAUpdateStateEnum newState = static_cast<OTAUpdateStateEnum>(0);
+    OTAChangeReasonEnum reason  = static_cast<OTAChangeReasonEnum>(0);
     DataModel::Nullable<uint32_t> targetSoftwareVersion;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -8766,8 +8772,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
-    uint32_t softwareVersion;
-    uint16_t productID;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
+    uint16_t productID       = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8779,8 +8785,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
-    uint32_t softwareVersion;
-    uint16_t productID;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
+    uint16_t productID       = static_cast<uint16_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8804,9 +8810,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
-    uint32_t softwareVersion;
-    uint64_t bytesDownloaded;
-    uint8_t progressPercent;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
+    uint64_t bytesDownloaded = static_cast<uint64_t>(0);
+    uint8_t progressPercent  = static_cast<uint8_t>(0);
     DataModel::Nullable<int64_t> platformCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -8819,9 +8825,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
-    uint32_t softwareVersion;
-    uint64_t bytesDownloaded;
-    uint8_t progressPercent;
+    uint32_t softwareVersion = static_cast<uint32_t>(0);
+    uint64_t bytesDownloaded = static_cast<uint64_t>(0);
+    uint8_t progressPercent  = static_cast<uint8_t>(0);
     DataModel::Nullable<int64_t> platformCode;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -8905,8 +8911,8 @@ struct TypeInfo
         Attributes::ActiveLocale::TypeInfo::DecodableType activeLocale;
         Attributes::SupportedLocales::TypeInfo::DecodableType supportedLocales;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -9018,12 +9024,12 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::HourFormat::TypeInfo::DecodableType hourFormat;
-        Attributes::CalendarType::TypeInfo::DecodableType calendarType;
+        Attributes::HourFormat::TypeInfo::DecodableType hourFormat     = static_cast<uint8_t>(0);
+        Attributes::CalendarType::TypeInfo::DecodableType calendarType = static_cast<uint8_t>(0);
         Attributes::SupportedCalendarTypes::TypeInfo::DecodableType supportedCalendarTypes;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -9091,8 +9097,8 @@ struct TypeInfo
 
         Attributes::Sources::TypeInfo::DecodableType sources;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -9527,40 +9533,40 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Status::TypeInfo::DecodableType status;
-        Attributes::Order::TypeInfo::DecodableType order;
+        Attributes::Status::TypeInfo::DecodableType status = static_cast<uint8_t>(0);
+        Attributes::Order::TypeInfo::DecodableType order   = static_cast<uint8_t>(0);
         Attributes::Description::TypeInfo::DecodableType description;
-        Attributes::WiredAssessedInputVoltage::TypeInfo::DecodableType wiredAssessedInputVoltage;
-        Attributes::WiredAssessedInputFrequency::TypeInfo::DecodableType wiredAssessedInputFrequency;
-        Attributes::WiredCurrentType::TypeInfo::DecodableType wiredCurrentType;
-        Attributes::WiredAssessedCurrent::TypeInfo::DecodableType wiredAssessedCurrent;
-        Attributes::WiredNominalVoltage::TypeInfo::DecodableType wiredNominalVoltage;
-        Attributes::WiredMaximumCurrent::TypeInfo::DecodableType wiredMaximumCurrent;
-        Attributes::WiredPresent::TypeInfo::DecodableType wiredPresent;
+        Attributes::WiredAssessedInputVoltage::TypeInfo::DecodableType wiredAssessedInputVoltage     = static_cast<uint32_t>(0);
+        Attributes::WiredAssessedInputFrequency::TypeInfo::DecodableType wiredAssessedInputFrequency = static_cast<uint16_t>(0);
+        Attributes::WiredCurrentType::TypeInfo::DecodableType wiredCurrentType                       = static_cast<uint8_t>(0);
+        Attributes::WiredAssessedCurrent::TypeInfo::DecodableType wiredAssessedCurrent               = static_cast<uint32_t>(0);
+        Attributes::WiredNominalVoltage::TypeInfo::DecodableType wiredNominalVoltage                 = static_cast<uint32_t>(0);
+        Attributes::WiredMaximumCurrent::TypeInfo::DecodableType wiredMaximumCurrent                 = static_cast<uint32_t>(0);
+        Attributes::WiredPresent::TypeInfo::DecodableType wiredPresent                               = static_cast<bool>(0);
         Attributes::ActiveWiredFaults::TypeInfo::DecodableType activeWiredFaults;
-        Attributes::BatteryVoltage::TypeInfo::DecodableType batteryVoltage;
-        Attributes::BatteryPercentRemaining::TypeInfo::DecodableType batteryPercentRemaining;
-        Attributes::BatteryTimeRemaining::TypeInfo::DecodableType batteryTimeRemaining;
-        Attributes::BatteryChargeLevel::TypeInfo::DecodableType batteryChargeLevel;
-        Attributes::BatteryReplacementNeeded::TypeInfo::DecodableType batteryReplacementNeeded;
-        Attributes::BatteryReplaceability::TypeInfo::DecodableType batteryReplaceability;
-        Attributes::BatteryPresent::TypeInfo::DecodableType batteryPresent;
+        Attributes::BatteryVoltage::TypeInfo::DecodableType batteryVoltage                     = static_cast<uint32_t>(0);
+        Attributes::BatteryPercentRemaining::TypeInfo::DecodableType batteryPercentRemaining   = static_cast<uint8_t>(0);
+        Attributes::BatteryTimeRemaining::TypeInfo::DecodableType batteryTimeRemaining         = static_cast<uint32_t>(0);
+        Attributes::BatteryChargeLevel::TypeInfo::DecodableType batteryChargeLevel             = static_cast<uint8_t>(0);
+        Attributes::BatteryReplacementNeeded::TypeInfo::DecodableType batteryReplacementNeeded = static_cast<bool>(0);
+        Attributes::BatteryReplaceability::TypeInfo::DecodableType batteryReplaceability       = static_cast<uint8_t>(0);
+        Attributes::BatteryPresent::TypeInfo::DecodableType batteryPresent                     = static_cast<bool>(0);
         Attributes::ActiveBatteryFaults::TypeInfo::DecodableType activeBatteryFaults;
         Attributes::BatteryReplacementDescription::TypeInfo::DecodableType batteryReplacementDescription;
-        Attributes::BatteryCommonDesignation::TypeInfo::DecodableType batteryCommonDesignation;
+        Attributes::BatteryCommonDesignation::TypeInfo::DecodableType batteryCommonDesignation = static_cast<uint32_t>(0);
         Attributes::BatteryANSIDesignation::TypeInfo::DecodableType batteryANSIDesignation;
         Attributes::BatteryIECDesignation::TypeInfo::DecodableType batteryIECDesignation;
-        Attributes::BatteryApprovedChemistry::TypeInfo::DecodableType batteryApprovedChemistry;
-        Attributes::BatteryCapacity::TypeInfo::DecodableType batteryCapacity;
-        Attributes::BatteryQuantity::TypeInfo::DecodableType batteryQuantity;
-        Attributes::BatteryChargeState::TypeInfo::DecodableType batteryChargeState;
-        Attributes::BatteryTimeToFullCharge::TypeInfo::DecodableType batteryTimeToFullCharge;
-        Attributes::BatteryFunctionalWhileCharging::TypeInfo::DecodableType batteryFunctionalWhileCharging;
-        Attributes::BatteryChargingCurrent::TypeInfo::DecodableType batteryChargingCurrent;
+        Attributes::BatteryApprovedChemistry::TypeInfo::DecodableType batteryApprovedChemistry = static_cast<uint32_t>(0);
+        Attributes::BatteryCapacity::TypeInfo::DecodableType batteryCapacity                   = static_cast<uint32_t>(0);
+        Attributes::BatteryQuantity::TypeInfo::DecodableType batteryQuantity                   = static_cast<uint8_t>(0);
+        Attributes::BatteryChargeState::TypeInfo::DecodableType batteryChargeState             = static_cast<uint8_t>(0);
+        Attributes::BatteryTimeToFullCharge::TypeInfo::DecodableType batteryTimeToFullCharge   = static_cast<uint32_t>(0);
+        Attributes::BatteryFunctionalWhileCharging::TypeInfo::DecodableType batteryFunctionalWhileCharging = static_cast<bool>(0);
+        Attributes::BatteryChargingCurrent::TypeInfo::DecodableType batteryChargingCurrent = static_cast<uint32_t>(0);
         Attributes::ActiveBatteryChargeFaults::TypeInfo::DecodableType activeBatteryChargeFaults;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -9654,9 +9660,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ArmFailSafe::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    uint16_t expiryLengthSeconds;
-    uint64_t breadcrumb;
-    uint32_t timeoutMs;
+    uint16_t expiryLengthSeconds = static_cast<uint16_t>(0);
+    uint64_t breadcrumb          = static_cast<uint64_t>(0);
+    uint32_t timeoutMs           = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -9671,9 +9677,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ArmFailSafe::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    uint16_t expiryLengthSeconds;
-    uint64_t breadcrumb;
-    uint32_t timeoutMs;
+    uint16_t expiryLengthSeconds = static_cast<uint16_t>(0);
+    uint64_t breadcrumb          = static_cast<uint64_t>(0);
+    uint32_t timeoutMs           = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ArmFailSafe
@@ -9691,7 +9697,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ArmFailSafeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    GeneralCommissioningError errorCode;
+    GeneralCommissioningError errorCode = static_cast<GeneralCommissioningError>(0);
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -9707,7 +9713,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ArmFailSafeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    GeneralCommissioningError errorCode;
+    GeneralCommissioningError errorCode = static_cast<GeneralCommissioningError>(0);
     chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -9728,10 +9734,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfig::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    RegulatoryLocationType location;
+    RegulatoryLocationType location = static_cast<RegulatoryLocationType>(0);
     chip::CharSpan countryCode;
-    uint64_t breadcrumb;
-    uint32_t timeoutMs;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    uint32_t timeoutMs  = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -9746,10 +9752,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfig::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    RegulatoryLocationType location;
+    RegulatoryLocationType location = static_cast<RegulatoryLocationType>(0);
     chip::CharSpan countryCode;
-    uint64_t breadcrumb;
-    uint32_t timeoutMs;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    uint32_t timeoutMs  = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetRegulatoryConfig
@@ -9767,7 +9773,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfigResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    GeneralCommissioningError errorCode;
+    GeneralCommissioningError errorCode = static_cast<GeneralCommissioningError>(0);
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -9783,7 +9789,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfigResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    GeneralCommissioningError errorCode;
+    GeneralCommissioningError errorCode = static_cast<GeneralCommissioningError>(0);
     chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -9830,7 +9836,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CommissioningCompleteResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    GeneralCommissioningError errorCode;
+    GeneralCommissioningError errorCode = static_cast<GeneralCommissioningError>(0);
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -9846,7 +9852,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CommissioningCompleteResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
-    GeneralCommissioningError errorCode;
+    GeneralCommissioningError errorCode = static_cast<GeneralCommissioningError>(0);
     chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -9951,13 +9957,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Breadcrumb::TypeInfo::DecodableType breadcrumb;
+        Attributes::Breadcrumb::TypeInfo::DecodableType breadcrumb = static_cast<uint64_t>(0);
         Attributes::BasicCommissioningInfoList::TypeInfo::DecodableType basicCommissioningInfoList;
-        Attributes::RegulatoryConfig::TypeInfo::DecodableType regulatoryConfig;
-        Attributes::LocationCapability::TypeInfo::DecodableType locationCapability;
+        Attributes::RegulatoryConfig::TypeInfo::DecodableType regulatoryConfig     = static_cast<uint8_t>(0);
+        Attributes::LocationCapability::TypeInfo::DecodableType locationCapability = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -10139,7 +10145,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10155,7 +10161,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ScanNetworks
@@ -10175,7 +10181,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ScanNetworksResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
-    NetworkCommissioningStatus networkingStatus;
+    NetworkCommissioningStatus networkingStatus = static_cast<NetworkCommissioningStatus>(0);
     chip::CharSpan debugText;
     Optional<DataModel::List<const Structs::WiFiInterfaceScanResult::Type>> wiFiScanResults;
     Optional<DataModel::List<const Structs::ThreadInterfaceScanResult::Type>> threadScanResults;
@@ -10193,7 +10199,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ScanNetworksResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
-    NetworkCommissioningStatus networkingStatus;
+    NetworkCommissioningStatus networkingStatus = static_cast<NetworkCommissioningStatus>(0);
     chip::CharSpan debugText;
     Optional<DataModel::DecodableList<Structs::WiFiInterfaceScanResult::DecodableType>> wiFiScanResults;
     Optional<DataModel::DecodableList<Structs::ThreadInterfaceScanResult::DecodableType>> threadScanResults;
@@ -10217,7 +10223,7 @@ public:
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10234,7 +10240,7 @@ public:
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddOrUpdateWiFiNetwork
@@ -10253,7 +10259,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10269,7 +10275,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddOrUpdateThreadNetwork
@@ -10288,7 +10294,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10304,7 +10310,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveNetwork
@@ -10322,7 +10328,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NetworkConfigResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
-    NetworkCommissioningStatus networkingStatus;
+    NetworkCommissioningStatus networkingStatus = static_cast<NetworkCommissioningStatus>(0);
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -10338,7 +10344,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NetworkConfigResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
-    NetworkCommissioningStatus networkingStatus;
+    NetworkCommissioningStatus networkingStatus = static_cast<NetworkCommissioningStatus>(0);
     chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -10358,7 +10364,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10374,7 +10380,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb;
+    uint64_t breadcrumb = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ConnectNetwork
@@ -10393,9 +10399,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ConnectNetworkResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
-    NetworkCommissioningStatus networkingStatus;
+    NetworkCommissioningStatus networkingStatus = static_cast<NetworkCommissioningStatus>(0);
     chip::CharSpan debugText;
-    int32_t errorValue;
+    int32_t errorValue = static_cast<int32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10410,9 +10416,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ConnectNetworkResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
-    NetworkCommissioningStatus networkingStatus;
+    NetworkCommissioningStatus networkingStatus = static_cast<NetworkCommissioningStatus>(0);
     chip::CharSpan debugText;
-    int32_t errorValue;
+    int32_t errorValue = static_cast<int32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ConnectNetworkResponse
@@ -10432,8 +10438,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint8_t networkIndex;
-    uint64_t breadcrumb;
+    uint8_t networkIndex = static_cast<uint8_t>(0);
+    uint64_t breadcrumb  = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10449,8 +10455,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint8_t networkIndex;
-    uint64_t breadcrumb;
+    uint8_t networkIndex = static_cast<uint8_t>(0);
+    uint64_t breadcrumb  = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ReorderNetwork
@@ -10601,17 +10607,17 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MaxNetworks::TypeInfo::DecodableType maxNetworks;
+        Attributes::MaxNetworks::TypeInfo::DecodableType maxNetworks = static_cast<uint8_t>(0);
         Attributes::Networks::TypeInfo::DecodableType networks;
-        Attributes::ScanMaxTimeSeconds::TypeInfo::DecodableType scanMaxTimeSeconds;
-        Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType connectMaxTimeSeconds;
-        Attributes::InterfaceEnabled::TypeInfo::DecodableType interfaceEnabled;
-        Attributes::LastNetworkingStatus::TypeInfo::DecodableType lastNetworkingStatus;
+        Attributes::ScanMaxTimeSeconds::TypeInfo::DecodableType scanMaxTimeSeconds       = static_cast<uint8_t>(0);
+        Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType connectMaxTimeSeconds = static_cast<uint8_t>(0);
+        Attributes::InterfaceEnabled::TypeInfo::DecodableType interfaceEnabled           = static_cast<bool>(0);
+        Attributes::LastNetworkingStatus::TypeInfo::DecodableType lastNetworkingStatus = static_cast<NetworkCommissioningStatus>(0);
         Attributes::LastNetworkID::TypeInfo::DecodableType lastNetworkID;
-        Attributes::LastConnectErrorValue::TypeInfo::DecodableType lastConnectErrorValue;
+        Attributes::LastConnectErrorValue::TypeInfo::DecodableType lastConnectErrorValue = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -10671,8 +10677,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
-    LogsIntent intent;
-    LogsTransferProtocol requestedProtocol;
+    LogsIntent intent                      = static_cast<LogsIntent>(0);
+    LogsTransferProtocol requestedProtocol = static_cast<LogsTransferProtocol>(0);
     chip::ByteSpan transferFileDesignator;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -10688,8 +10694,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
-    LogsIntent intent;
-    LogsTransferProtocol requestedProtocol;
+    LogsIntent intent                      = static_cast<LogsIntent>(0);
+    LogsTransferProtocol requestedProtocol = static_cast<LogsTransferProtocol>(0);
     chip::ByteSpan transferFileDesignator;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -10710,10 +10716,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
-    LogsStatus status;
+    LogsStatus status = static_cast<LogsStatus>(0);
     chip::ByteSpan content;
-    uint32_t timeStamp;
-    uint32_t timeSinceBoot;
+    uint32_t timeStamp     = static_cast<uint32_t>(0);
+    uint32_t timeSinceBoot = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10728,10 +10734,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
-    LogsStatus status;
+    LogsStatus status = static_cast<LogsStatus>(0);
     chip::ByteSpan content;
-    uint32_t timeStamp;
-    uint32_t timeSinceBoot;
+    uint32_t timeStamp     = static_cast<uint32_t>(0);
+    uint32_t timeSinceBoot = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RetrieveLogsResponse
@@ -10785,8 +10791,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -11054,16 +11060,16 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::NetworkInterfaces::TypeInfo::DecodableType networkInterfaces;
-        Attributes::RebootCount::TypeInfo::DecodableType rebootCount;
-        Attributes::UpTime::TypeInfo::DecodableType upTime;
-        Attributes::TotalOperationalHours::TypeInfo::DecodableType totalOperationalHours;
-        Attributes::BootReasons::TypeInfo::DecodableType bootReasons;
+        Attributes::RebootCount::TypeInfo::DecodableType rebootCount                     = static_cast<uint16_t>(0);
+        Attributes::UpTime::TypeInfo::DecodableType upTime                               = static_cast<uint64_t>(0);
+        Attributes::TotalOperationalHours::TypeInfo::DecodableType totalOperationalHours = static_cast<uint32_t>(0);
+        Attributes::BootReasons::TypeInfo::DecodableType bootReasons                     = static_cast<uint8_t>(0);
         Attributes::ActiveHardwareFaults::TypeInfo::DecodableType activeHardwareFaults;
         Attributes::ActiveRadioFaults::TypeInfo::DecodableType activeRadioFaults;
         Attributes::ActiveNetworkFaults::TypeInfo::DecodableType activeNetworkFaults;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -11192,7 +11198,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
 
-    BootReasonType bootReason;
+    BootReasonType bootReason = static_cast<BootReasonType>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -11204,7 +11210,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
 
-    BootReasonType bootReason;
+    BootReasonType bootReason = static_cast<BootReasonType>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -11403,12 +11409,12 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::ThreadMetrics::TypeInfo::DecodableType threadMetrics;
-        Attributes::CurrentHeapFree::TypeInfo::DecodableType currentHeapFree;
-        Attributes::CurrentHeapUsed::TypeInfo::DecodableType currentHeapUsed;
-        Attributes::CurrentHeapHighWatermark::TypeInfo::DecodableType currentHeapHighWatermark;
+        Attributes::CurrentHeapFree::TypeInfo::DecodableType currentHeapFree                   = static_cast<uint64_t>(0);
+        Attributes::CurrentHeapUsed::TypeInfo::DecodableType currentHeapUsed                   = static_cast<uint64_t>(0);
+        Attributes::CurrentHeapHighWatermark::TypeInfo::DecodableType currentHeapHighWatermark = static_cast<uint64_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -12478,72 +12484,73 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Channel::TypeInfo::DecodableType channel;
-        Attributes::RoutingRole::TypeInfo::DecodableType routingRole;
+        Attributes::Channel::TypeInfo::DecodableType channel         = static_cast<uint16_t>(0);
+        Attributes::RoutingRole::TypeInfo::DecodableType routingRole = static_cast<uint8_t>(0);
         Attributes::NetworkName::TypeInfo::DecodableType networkName;
-        Attributes::PanId::TypeInfo::DecodableType panId;
-        Attributes::ExtendedPanId::TypeInfo::DecodableType extendedPanId;
+        Attributes::PanId::TypeInfo::DecodableType panId                 = static_cast<uint16_t>(0);
+        Attributes::ExtendedPanId::TypeInfo::DecodableType extendedPanId = static_cast<uint64_t>(0);
         Attributes::MeshLocalPrefix::TypeInfo::DecodableType meshLocalPrefix;
-        Attributes::OverrunCount::TypeInfo::DecodableType overrunCount;
+        Attributes::OverrunCount::TypeInfo::DecodableType overrunCount = static_cast<uint64_t>(0);
         Attributes::NeighborTableList::TypeInfo::DecodableType neighborTableList;
         Attributes::RouteTableList::TypeInfo::DecodableType routeTableList;
-        Attributes::PartitionId::TypeInfo::DecodableType partitionId;
-        Attributes::Weighting::TypeInfo::DecodableType weighting;
-        Attributes::DataVersion::TypeInfo::DecodableType dataVersion;
-        Attributes::StableDataVersion::TypeInfo::DecodableType stableDataVersion;
-        Attributes::LeaderRouterId::TypeInfo::DecodableType leaderRouterId;
-        Attributes::DetachedRoleCount::TypeInfo::DecodableType detachedRoleCount;
-        Attributes::ChildRoleCount::TypeInfo::DecodableType childRoleCount;
-        Attributes::RouterRoleCount::TypeInfo::DecodableType routerRoleCount;
-        Attributes::LeaderRoleCount::TypeInfo::DecodableType leaderRoleCount;
-        Attributes::AttachAttemptCount::TypeInfo::DecodableType attachAttemptCount;
-        Attributes::PartitionIdChangeCount::TypeInfo::DecodableType partitionIdChangeCount;
-        Attributes::BetterPartitionAttachAttemptCount::TypeInfo::DecodableType betterPartitionAttachAttemptCount;
-        Attributes::ParentChangeCount::TypeInfo::DecodableType parentChangeCount;
-        Attributes::TxTotalCount::TypeInfo::DecodableType txTotalCount;
-        Attributes::TxUnicastCount::TypeInfo::DecodableType txUnicastCount;
-        Attributes::TxBroadcastCount::TypeInfo::DecodableType txBroadcastCount;
-        Attributes::TxAckRequestedCount::TypeInfo::DecodableType txAckRequestedCount;
-        Attributes::TxAckedCount::TypeInfo::DecodableType txAckedCount;
-        Attributes::TxNoAckRequestedCount::TypeInfo::DecodableType txNoAckRequestedCount;
-        Attributes::TxDataCount::TypeInfo::DecodableType txDataCount;
-        Attributes::TxDataPollCount::TypeInfo::DecodableType txDataPollCount;
-        Attributes::TxBeaconCount::TypeInfo::DecodableType txBeaconCount;
-        Attributes::TxBeaconRequestCount::TypeInfo::DecodableType txBeaconRequestCount;
-        Attributes::TxOtherCount::TypeInfo::DecodableType txOtherCount;
-        Attributes::TxRetryCount::TypeInfo::DecodableType txRetryCount;
-        Attributes::TxDirectMaxRetryExpiryCount::TypeInfo::DecodableType txDirectMaxRetryExpiryCount;
-        Attributes::TxIndirectMaxRetryExpiryCount::TypeInfo::DecodableType txIndirectMaxRetryExpiryCount;
-        Attributes::TxErrCcaCount::TypeInfo::DecodableType txErrCcaCount;
-        Attributes::TxErrAbortCount::TypeInfo::DecodableType txErrAbortCount;
-        Attributes::TxErrBusyChannelCount::TypeInfo::DecodableType txErrBusyChannelCount;
-        Attributes::RxTotalCount::TypeInfo::DecodableType rxTotalCount;
-        Attributes::RxUnicastCount::TypeInfo::DecodableType rxUnicastCount;
-        Attributes::RxBroadcastCount::TypeInfo::DecodableType rxBroadcastCount;
-        Attributes::RxDataCount::TypeInfo::DecodableType rxDataCount;
-        Attributes::RxDataPollCount::TypeInfo::DecodableType rxDataPollCount;
-        Attributes::RxBeaconCount::TypeInfo::DecodableType rxBeaconCount;
-        Attributes::RxBeaconRequestCount::TypeInfo::DecodableType rxBeaconRequestCount;
-        Attributes::RxOtherCount::TypeInfo::DecodableType rxOtherCount;
-        Attributes::RxAddressFilteredCount::TypeInfo::DecodableType rxAddressFilteredCount;
-        Attributes::RxDestAddrFilteredCount::TypeInfo::DecodableType rxDestAddrFilteredCount;
-        Attributes::RxDuplicatedCount::TypeInfo::DecodableType rxDuplicatedCount;
-        Attributes::RxErrNoFrameCount::TypeInfo::DecodableType rxErrNoFrameCount;
-        Attributes::RxErrUnknownNeighborCount::TypeInfo::DecodableType rxErrUnknownNeighborCount;
-        Attributes::RxErrInvalidSrcAddrCount::TypeInfo::DecodableType rxErrInvalidSrcAddrCount;
-        Attributes::RxErrSecCount::TypeInfo::DecodableType rxErrSecCount;
-        Attributes::RxErrFcsCount::TypeInfo::DecodableType rxErrFcsCount;
-        Attributes::RxErrOtherCount::TypeInfo::DecodableType rxErrOtherCount;
-        Attributes::ActiveTimestamp::TypeInfo::DecodableType activeTimestamp;
-        Attributes::PendingTimestamp::TypeInfo::DecodableType pendingTimestamp;
-        Attributes::Delay::TypeInfo::DecodableType delay;
+        Attributes::PartitionId::TypeInfo::DecodableType partitionId                       = static_cast<uint32_t>(0);
+        Attributes::Weighting::TypeInfo::DecodableType weighting                           = static_cast<uint8_t>(0);
+        Attributes::DataVersion::TypeInfo::DecodableType dataVersion                       = static_cast<uint8_t>(0);
+        Attributes::StableDataVersion::TypeInfo::DecodableType stableDataVersion           = static_cast<uint8_t>(0);
+        Attributes::LeaderRouterId::TypeInfo::DecodableType leaderRouterId                 = static_cast<uint8_t>(0);
+        Attributes::DetachedRoleCount::TypeInfo::DecodableType detachedRoleCount           = static_cast<uint16_t>(0);
+        Attributes::ChildRoleCount::TypeInfo::DecodableType childRoleCount                 = static_cast<uint16_t>(0);
+        Attributes::RouterRoleCount::TypeInfo::DecodableType routerRoleCount               = static_cast<uint16_t>(0);
+        Attributes::LeaderRoleCount::TypeInfo::DecodableType leaderRoleCount               = static_cast<uint16_t>(0);
+        Attributes::AttachAttemptCount::TypeInfo::DecodableType attachAttemptCount         = static_cast<uint16_t>(0);
+        Attributes::PartitionIdChangeCount::TypeInfo::DecodableType partitionIdChangeCount = static_cast<uint16_t>(0);
+        Attributes::BetterPartitionAttachAttemptCount::TypeInfo::DecodableType betterPartitionAttachAttemptCount =
+            static_cast<uint16_t>(0);
+        Attributes::ParentChangeCount::TypeInfo::DecodableType parentChangeCount                         = static_cast<uint16_t>(0);
+        Attributes::TxTotalCount::TypeInfo::DecodableType txTotalCount                                   = static_cast<uint32_t>(0);
+        Attributes::TxUnicastCount::TypeInfo::DecodableType txUnicastCount                               = static_cast<uint32_t>(0);
+        Attributes::TxBroadcastCount::TypeInfo::DecodableType txBroadcastCount                           = static_cast<uint32_t>(0);
+        Attributes::TxAckRequestedCount::TypeInfo::DecodableType txAckRequestedCount                     = static_cast<uint32_t>(0);
+        Attributes::TxAckedCount::TypeInfo::DecodableType txAckedCount                                   = static_cast<uint32_t>(0);
+        Attributes::TxNoAckRequestedCount::TypeInfo::DecodableType txNoAckRequestedCount                 = static_cast<uint32_t>(0);
+        Attributes::TxDataCount::TypeInfo::DecodableType txDataCount                                     = static_cast<uint32_t>(0);
+        Attributes::TxDataPollCount::TypeInfo::DecodableType txDataPollCount                             = static_cast<uint32_t>(0);
+        Attributes::TxBeaconCount::TypeInfo::DecodableType txBeaconCount                                 = static_cast<uint32_t>(0);
+        Attributes::TxBeaconRequestCount::TypeInfo::DecodableType txBeaconRequestCount                   = static_cast<uint32_t>(0);
+        Attributes::TxOtherCount::TypeInfo::DecodableType txOtherCount                                   = static_cast<uint32_t>(0);
+        Attributes::TxRetryCount::TypeInfo::DecodableType txRetryCount                                   = static_cast<uint32_t>(0);
+        Attributes::TxDirectMaxRetryExpiryCount::TypeInfo::DecodableType txDirectMaxRetryExpiryCount     = static_cast<uint32_t>(0);
+        Attributes::TxIndirectMaxRetryExpiryCount::TypeInfo::DecodableType txIndirectMaxRetryExpiryCount = static_cast<uint32_t>(0);
+        Attributes::TxErrCcaCount::TypeInfo::DecodableType txErrCcaCount                                 = static_cast<uint32_t>(0);
+        Attributes::TxErrAbortCount::TypeInfo::DecodableType txErrAbortCount                             = static_cast<uint32_t>(0);
+        Attributes::TxErrBusyChannelCount::TypeInfo::DecodableType txErrBusyChannelCount                 = static_cast<uint32_t>(0);
+        Attributes::RxTotalCount::TypeInfo::DecodableType rxTotalCount                                   = static_cast<uint32_t>(0);
+        Attributes::RxUnicastCount::TypeInfo::DecodableType rxUnicastCount                               = static_cast<uint32_t>(0);
+        Attributes::RxBroadcastCount::TypeInfo::DecodableType rxBroadcastCount                           = static_cast<uint32_t>(0);
+        Attributes::RxDataCount::TypeInfo::DecodableType rxDataCount                                     = static_cast<uint32_t>(0);
+        Attributes::RxDataPollCount::TypeInfo::DecodableType rxDataPollCount                             = static_cast<uint32_t>(0);
+        Attributes::RxBeaconCount::TypeInfo::DecodableType rxBeaconCount                                 = static_cast<uint32_t>(0);
+        Attributes::RxBeaconRequestCount::TypeInfo::DecodableType rxBeaconRequestCount                   = static_cast<uint32_t>(0);
+        Attributes::RxOtherCount::TypeInfo::DecodableType rxOtherCount                                   = static_cast<uint32_t>(0);
+        Attributes::RxAddressFilteredCount::TypeInfo::DecodableType rxAddressFilteredCount               = static_cast<uint32_t>(0);
+        Attributes::RxDestAddrFilteredCount::TypeInfo::DecodableType rxDestAddrFilteredCount             = static_cast<uint32_t>(0);
+        Attributes::RxDuplicatedCount::TypeInfo::DecodableType rxDuplicatedCount                         = static_cast<uint32_t>(0);
+        Attributes::RxErrNoFrameCount::TypeInfo::DecodableType rxErrNoFrameCount                         = static_cast<uint32_t>(0);
+        Attributes::RxErrUnknownNeighborCount::TypeInfo::DecodableType rxErrUnknownNeighborCount         = static_cast<uint32_t>(0);
+        Attributes::RxErrInvalidSrcAddrCount::TypeInfo::DecodableType rxErrInvalidSrcAddrCount           = static_cast<uint32_t>(0);
+        Attributes::RxErrSecCount::TypeInfo::DecodableType rxErrSecCount                                 = static_cast<uint32_t>(0);
+        Attributes::RxErrFcsCount::TypeInfo::DecodableType rxErrFcsCount                                 = static_cast<uint32_t>(0);
+        Attributes::RxErrOtherCount::TypeInfo::DecodableType rxErrOtherCount                             = static_cast<uint32_t>(0);
+        Attributes::ActiveTimestamp::TypeInfo::DecodableType activeTimestamp                             = static_cast<uint64_t>(0);
+        Attributes::PendingTimestamp::TypeInfo::DecodableType pendingTimestamp                           = static_cast<uint64_t>(0);
+        Attributes::Delay::TypeInfo::DecodableType delay                                                 = static_cast<uint32_t>(0);
         Attributes::SecurityPolicy::TypeInfo::DecodableType securityPolicy;
         Attributes::ChannelMask::TypeInfo::DecodableType channelMask;
         Attributes::OperationalDatasetComponents::TypeInfo::DecodableType operationalDatasetComponents;
         Attributes::ActiveNetworkFaultsList::TypeInfo::DecodableType activeNetworkFaultsList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -12564,7 +12571,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
 
-    ThreadConnectionStatus connectionStatus;
+    ThreadConnectionStatus connectionStatus = static_cast<ThreadConnectionStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12576,7 +12583,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
 
-    ThreadConnectionStatus connectionStatus;
+    ThreadConnectionStatus connectionStatus = static_cast<ThreadConnectionStatus>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12876,21 +12883,21 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::Bssid::TypeInfo::DecodableType bssid;
-        Attributes::SecurityType::TypeInfo::DecodableType securityType;
-        Attributes::WiFiVersion::TypeInfo::DecodableType wiFiVersion;
-        Attributes::ChannelNumber::TypeInfo::DecodableType channelNumber;
-        Attributes::Rssi::TypeInfo::DecodableType rssi;
-        Attributes::BeaconLostCount::TypeInfo::DecodableType beaconLostCount;
-        Attributes::BeaconRxCount::TypeInfo::DecodableType beaconRxCount;
-        Attributes::PacketMulticastRxCount::TypeInfo::DecodableType packetMulticastRxCount;
-        Attributes::PacketMulticastTxCount::TypeInfo::DecodableType packetMulticastTxCount;
-        Attributes::PacketUnicastRxCount::TypeInfo::DecodableType packetUnicastRxCount;
-        Attributes::PacketUnicastTxCount::TypeInfo::DecodableType packetUnicastTxCount;
-        Attributes::CurrentMaxRate::TypeInfo::DecodableType currentMaxRate;
-        Attributes::OverrunCount::TypeInfo::DecodableType overrunCount;
+        Attributes::SecurityType::TypeInfo::DecodableType securityType                     = static_cast<uint8_t>(0);
+        Attributes::WiFiVersion::TypeInfo::DecodableType wiFiVersion                       = static_cast<uint8_t>(0);
+        Attributes::ChannelNumber::TypeInfo::DecodableType channelNumber                   = static_cast<uint16_t>(0);
+        Attributes::Rssi::TypeInfo::DecodableType rssi                                     = static_cast<int8_t>(0);
+        Attributes::BeaconLostCount::TypeInfo::DecodableType beaconLostCount               = static_cast<uint32_t>(0);
+        Attributes::BeaconRxCount::TypeInfo::DecodableType beaconRxCount                   = static_cast<uint32_t>(0);
+        Attributes::PacketMulticastRxCount::TypeInfo::DecodableType packetMulticastRxCount = static_cast<uint32_t>(0);
+        Attributes::PacketMulticastTxCount::TypeInfo::DecodableType packetMulticastTxCount = static_cast<uint32_t>(0);
+        Attributes::PacketUnicastRxCount::TypeInfo::DecodableType packetUnicastRxCount     = static_cast<uint32_t>(0);
+        Attributes::PacketUnicastTxCount::TypeInfo::DecodableType packetUnicastTxCount     = static_cast<uint32_t>(0);
+        Attributes::CurrentMaxRate::TypeInfo::DecodableType currentMaxRate                 = static_cast<uint64_t>(0);
+        Attributes::OverrunCount::TypeInfo::DecodableType overrunCount                     = static_cast<uint64_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -12911,7 +12918,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
-    uint16_t reasonCode;
+    uint16_t reasonCode = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12923,7 +12930,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
-    uint16_t reasonCode;
+    uint16_t reasonCode = static_cast<uint16_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12945,8 +12952,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
-    AssociationFailureCause associationFailure;
-    uint16_t status;
+    AssociationFailureCause associationFailure = static_cast<AssociationFailureCause>(0);
+    uint16_t status                            = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12958,8 +12965,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
-    AssociationFailureCause associationFailure;
-    uint16_t status;
+    AssociationFailureCause associationFailure = static_cast<AssociationFailureCause>(0);
+    uint16_t status                            = static_cast<uint16_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12980,7 +12987,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
-    WiFiConnectionStatus connectionStatus;
+    WiFiConnectionStatus connectionStatus = static_cast<WiFiConnectionStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12992,7 +12999,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
-    WiFiConnectionStatus connectionStatus;
+    WiFiConnectionStatus connectionStatus = static_cast<WiFiConnectionStatus>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13217,18 +13224,18 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::PHYRate::TypeInfo::DecodableType PHYRate;
-        Attributes::FullDuplex::TypeInfo::DecodableType fullDuplex;
-        Attributes::PacketRxCount::TypeInfo::DecodableType packetRxCount;
-        Attributes::PacketTxCount::TypeInfo::DecodableType packetTxCount;
-        Attributes::TxErrCount::TypeInfo::DecodableType txErrCount;
-        Attributes::CollisionCount::TypeInfo::DecodableType collisionCount;
-        Attributes::OverrunCount::TypeInfo::DecodableType overrunCount;
-        Attributes::CarrierDetect::TypeInfo::DecodableType carrierDetect;
-        Attributes::TimeSinceReset::TypeInfo::DecodableType timeSinceReset;
+        Attributes::PHYRate::TypeInfo::DecodableType PHYRate               = static_cast<uint8_t>(0);
+        Attributes::FullDuplex::TypeInfo::DecodableType fullDuplex         = static_cast<bool>(0);
+        Attributes::PacketRxCount::TypeInfo::DecodableType packetRxCount   = static_cast<uint64_t>(0);
+        Attributes::PacketTxCount::TypeInfo::DecodableType packetTxCount   = static_cast<uint64_t>(0);
+        Attributes::TxErrCount::TypeInfo::DecodableType txErrCount         = static_cast<uint64_t>(0);
+        Attributes::CollisionCount::TypeInfo::DecodableType collisionCount = static_cast<uint64_t>(0);
+        Attributes::OverrunCount::TypeInfo::DecodableType overrunCount     = static_cast<uint64_t>(0);
+        Attributes::CarrierDetect::TypeInfo::DecodableType carrierDetect   = static_cast<bool>(0);
+        Attributes::TimeSinceReset::TypeInfo::DecodableType timeSinceReset = static_cast<uint64_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -13283,8 +13290,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -13659,23 +13666,23 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::VendorName::TypeInfo::DecodableType vendorName;
-        Attributes::VendorID::TypeInfo::DecodableType vendorID;
+        Attributes::VendorID::TypeInfo::DecodableType vendorID = static_cast<uint16_t>(0);
         Attributes::ProductName::TypeInfo::DecodableType productName;
         Attributes::NodeLabel::TypeInfo::DecodableType nodeLabel;
-        Attributes::HardwareVersion::TypeInfo::DecodableType hardwareVersion;
+        Attributes::HardwareVersion::TypeInfo::DecodableType hardwareVersion = static_cast<uint16_t>(0);
         Attributes::HardwareVersionString::TypeInfo::DecodableType hardwareVersionString;
-        Attributes::SoftwareVersion::TypeInfo::DecodableType softwareVersion;
+        Attributes::SoftwareVersion::TypeInfo::DecodableType softwareVersion = static_cast<uint32_t>(0);
         Attributes::SoftwareVersionString::TypeInfo::DecodableType softwareVersionString;
         Attributes::ManufacturingDate::TypeInfo::DecodableType manufacturingDate;
         Attributes::PartNumber::TypeInfo::DecodableType partNumber;
         Attributes::ProductURL::TypeInfo::DecodableType productURL;
         Attributes::ProductLabel::TypeInfo::DecodableType productLabel;
         Attributes::SerialNumber::TypeInfo::DecodableType serialNumber;
-        Attributes::Reachable::TypeInfo::DecodableType reachable;
+        Attributes::Reachable::TypeInfo::DecodableType reachable = static_cast<bool>(0);
         Attributes::UniqueID::TypeInfo::DecodableType uniqueID;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -13765,12 +13772,12 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::NumberOfPositions::TypeInfo::DecodableType numberOfPositions;
-        Attributes::CurrentPosition::TypeInfo::DecodableType currentPosition;
-        Attributes::MultiPressMax::TypeInfo::DecodableType multiPressMax;
+        Attributes::NumberOfPositions::TypeInfo::DecodableType numberOfPositions = static_cast<uint8_t>(0);
+        Attributes::CurrentPosition::TypeInfo::DecodableType currentPosition     = static_cast<uint8_t>(0);
+        Attributes::MultiPressMax::TypeInfo::DecodableType multiPressMax         = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -13791,7 +13798,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
+    uint8_t newPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13803,7 +13810,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
+    uint8_t newPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13824,7 +13831,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
+    uint8_t newPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13836,7 +13843,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
+    uint8_t newPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13857,7 +13864,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
+    uint8_t newPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13869,7 +13876,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
+    uint8_t newPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13890,7 +13897,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t previousPosition;
+    uint8_t previousPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13902,7 +13909,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t previousPosition;
+    uint8_t previousPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13923,7 +13930,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t previousPosition;
+    uint8_t previousPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13935,7 +13942,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t previousPosition;
+    uint8_t previousPosition = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13957,8 +13964,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
-    uint8_t currentNumberOfPressesCounted;
+    uint8_t newPosition                   = static_cast<uint8_t>(0);
+    uint8_t currentNumberOfPressesCounted = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13970,8 +13977,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
-    uint8_t currentNumberOfPressesCounted;
+    uint8_t newPosition                   = static_cast<uint8_t>(0);
+    uint8_t currentNumberOfPressesCounted = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13993,8 +14000,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
-    uint8_t totalNumberOfPressesCounted;
+    uint8_t newPosition                 = static_cast<uint8_t>(0);
+    uint8_t totalNumberOfPressesCounted = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -14006,8 +14013,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
 
-    uint8_t newPosition;
-    uint8_t totalNumberOfPressesCounted;
+    uint8_t newPosition                 = static_cast<uint8_t>(0);
+    uint8_t totalNumberOfPressesCounted = static_cast<uint8_t>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -14075,12 +14082,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OpenCommissioningWindow::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
-    uint16_t commissioningTimeout;
+    uint16_t commissioningTimeout = static_cast<uint16_t>(0);
     chip::ByteSpan PAKEVerifier;
-    uint16_t discriminator;
-    uint32_t iterations;
+    uint16_t discriminator = static_cast<uint16_t>(0);
+    uint32_t iterations    = static_cast<uint32_t>(0);
     chip::ByteSpan salt;
-    uint16_t passcodeID;
+    uint16_t passcodeID = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -14095,12 +14102,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OpenCommissioningWindow::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
-    uint16_t commissioningTimeout;
+    uint16_t commissioningTimeout = static_cast<uint16_t>(0);
     chip::ByteSpan PAKEVerifier;
-    uint16_t discriminator;
-    uint32_t iterations;
+    uint16_t discriminator = static_cast<uint16_t>(0);
+    uint32_t iterations    = static_cast<uint32_t>(0);
     chip::ByteSpan salt;
-    uint16_t passcodeID;
+    uint16_t passcodeID = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OpenCommissioningWindow
@@ -14117,7 +14124,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OpenBasicCommissioningWindow::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
-    uint16_t commissioningTimeout;
+    uint16_t commissioningTimeout = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -14132,7 +14139,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OpenBasicCommissioningWindow::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
-    uint16_t commissioningTimeout;
+    uint16_t commissioningTimeout = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OpenBasicCommissioningWindow
@@ -14249,12 +14256,12 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::WindowStatus::TypeInfo::DecodableType windowStatus;
-        Attributes::AdminFabricIndex::TypeInfo::DecodableType adminFabricIndex;
-        Attributes::AdminVendorId::TypeInfo::DecodableType adminVendorId;
+        Attributes::WindowStatus::TypeInfo::DecodableType windowStatus         = static_cast<uint8_t>(0);
+        Attributes::AdminFabricIndex::TypeInfo::DecodableType adminFabricIndex = static_cast<chip::FabricIndex>(0);
+        Attributes::AdminVendorId::TypeInfo::DecodableType adminVendorId       = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -14483,7 +14490,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CertificateChainRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
-    uint8_t certificateType;
+    uint8_t certificateType = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -14498,7 +14505,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CertificateChainRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
-    uint8_t certificateType;
+    uint8_t certificateType = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CertificateChainRequest
@@ -14621,8 +14628,8 @@ public:
     chip::ByteSpan NOCValue;
     Optional<chip::ByteSpan> ICACValue;
     chip::ByteSpan IPKValue;
-    chip::NodeId caseAdminNode;
-    uint16_t adminVendorId;
+    chip::NodeId caseAdminNode = static_cast<chip::NodeId>(0);
+    uint16_t adminVendorId     = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -14640,8 +14647,8 @@ public:
     chip::ByteSpan NOCValue;
     Optional<chip::ByteSpan> ICACValue;
     chip::ByteSpan IPKValue;
-    chip::NodeId caseAdminNode;
-    uint16_t adminVendorId;
+    chip::NodeId caseAdminNode = static_cast<chip::NodeId>(0);
+    uint16_t adminVendorId     = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddNOC
@@ -14695,8 +14702,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NOCResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
-    uint8_t statusCode;
-    uint8_t fabricIndex;
+    uint8_t statusCode  = static_cast<uint8_t>(0);
+    uint8_t fabricIndex = static_cast<uint8_t>(0);
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -14712,8 +14719,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NOCResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
-    uint8_t statusCode;
-    uint8_t fabricIndex;
+    uint8_t statusCode  = static_cast<uint8_t>(0);
+    uint8_t fabricIndex = static_cast<uint8_t>(0);
     chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -14763,7 +14770,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveFabric::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
-    uint8_t fabricIndex;
+    uint8_t fabricIndex = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -14778,7 +14785,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveFabric::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
-    uint8_t fabricIndex;
+    uint8_t fabricIndex = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveFabric
@@ -14958,13 +14965,13 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::FabricsList::TypeInfo::DecodableType fabricsList;
-        Attributes::SupportedFabrics::TypeInfo::DecodableType supportedFabrics;
-        Attributes::CommissionedFabrics::TypeInfo::DecodableType commissionedFabrics;
+        Attributes::SupportedFabrics::TypeInfo::DecodableType supportedFabrics       = static_cast<uint8_t>(0);
+        Attributes::CommissionedFabrics::TypeInfo::DecodableType commissionedFabrics = static_cast<uint8_t>(0);
         Attributes::TrustedRootCertificates::TypeInfo::DecodableType trustedRootCertificates;
-        Attributes::CurrentFabricIndex::TypeInfo::DecodableType currentFabricIndex;
+        Attributes::CurrentFabricIndex::TypeInfo::DecodableType currentFabricIndex = static_cast<chip::FabricIndex>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15147,7 +15154,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::KeySetRead::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
 
-    uint16_t groupKeySetID;
+    uint16_t groupKeySetID = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -15162,7 +15169,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::KeySetRead::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
 
-    uint16_t groupKeySetID;
+    uint16_t groupKeySetID = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace KeySetRead
@@ -15211,7 +15218,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::KeySetRemove::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
 
-    uint16_t groupKeySetID;
+    uint16_t groupKeySetID = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -15226,7 +15233,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::KeySetRemove::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
 
-    uint16_t groupKeySetID;
+    uint16_t groupKeySetID = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace KeySetRemove
@@ -15397,11 +15404,11 @@ struct TypeInfo
 
         Attributes::GroupKeyMap::TypeInfo::DecodableType groupKeyMap;
         Attributes::GroupTable::TypeInfo::DecodableType groupTable;
-        Attributes::MaxGroupsPerFabric::TypeInfo::DecodableType maxGroupsPerFabric;
-        Attributes::MaxGroupKeysPerFabric::TypeInfo::DecodableType maxGroupKeysPerFabric;
+        Attributes::MaxGroupsPerFabric::TypeInfo::DecodableType maxGroupsPerFabric       = static_cast<uint16_t>(0);
+        Attributes::MaxGroupKeysPerFabric::TypeInfo::DecodableType maxGroupKeysPerFabric = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15474,8 +15481,8 @@ struct TypeInfo
 
         Attributes::LabelList::TypeInfo::DecodableType labelList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15548,8 +15555,8 @@ struct TypeInfo
 
         Attributes::LabelList::TypeInfo::DecodableType labelList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15604,8 +15611,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15660,8 +15667,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15716,8 +15723,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15783,10 +15790,10 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::StateValue::TypeInfo::DecodableType stateValue;
+        Attributes::StateValue::TypeInfo::DecodableType stateValue = static_cast<bool>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -15807,7 +15814,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
 
-    bool stateValue;
+    bool stateValue = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -15819,7 +15826,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
 
-    bool stateValue;
+    bool stateValue = static_cast<bool>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -15897,7 +15904,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeToMode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
 
-    uint8_t newMode;
+    uint8_t newMode = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -15912,7 +15919,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeToMode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
 
-    uint8_t newMode;
+    uint8_t newMode = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ChangeToMode
@@ -16027,14 +16034,14 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::CurrentMode::TypeInfo::DecodableType currentMode;
+        Attributes::CurrentMode::TypeInfo::DecodableType currentMode = static_cast<uint8_t>(0);
         Attributes::SupportedModes::TypeInfo::DecodableType supportedModes;
-        Attributes::OnMode::TypeInfo::DecodableType onMode;
-        Attributes::StartUpMode::TypeInfo::DecodableType startUpMode;
+        Attributes::OnMode::TypeInfo::DecodableType onMode           = static_cast<uint8_t>(0);
+        Attributes::StartUpMode::TypeInfo::DecodableType startUpMode = static_cast<uint8_t>(0);
         Attributes::Description::TypeInfo::DecodableType description;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -16148,14 +16155,14 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::PhysicalClosedLimit::TypeInfo::DecodableType physicalClosedLimit;
-        Attributes::MotorStepSize::TypeInfo::DecodableType motorStepSize;
-        Attributes::Status::TypeInfo::DecodableType status;
-        Attributes::ClosedLimit::TypeInfo::DecodableType closedLimit;
-        Attributes::Mode::TypeInfo::DecodableType mode;
+        Attributes::PhysicalClosedLimit::TypeInfo::DecodableType physicalClosedLimit = static_cast<uint16_t>(0);
+        Attributes::MotorStepSize::TypeInfo::DecodableType motorStepSize             = static_cast<uint8_t>(0);
+        Attributes::Status::TypeInfo::DecodableType status                           = static_cast<uint8_t>(0);
+        Attributes::ClosedLimit::TypeInfo::DecodableType closedLimit                 = static_cast<uint16_t>(0);
+        Attributes::Mode::TypeInfo::DecodableType mode                               = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -16884,7 +16891,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::UnlockWithTimeout::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t timeout;
+    uint16_t timeout = static_cast<uint16_t>(0);
     Optional<chip::ByteSpan> pinCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -16900,7 +16907,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::UnlockWithTimeout::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t timeout;
+    uint16_t timeout = static_cast<uint16_t>(0);
     Optional<chip::ByteSpan> pinCode;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -16918,7 +16925,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetLogRecord::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t logIndex;
+    uint16_t logIndex = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -16933,7 +16940,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetLogRecord::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t logIndex;
+    uint16_t logIndex = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetLogRecord
@@ -16956,12 +16963,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetLogRecordResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t logEntryId;
-    uint32_t timestamp;
-    uint8_t eventType;
-    uint8_t source;
-    uint8_t eventIdOrAlarmCode;
-    uint16_t userId;
+    uint16_t logEntryId        = static_cast<uint16_t>(0);
+    uint32_t timestamp         = static_cast<uint32_t>(0);
+    uint8_t eventType          = static_cast<uint8_t>(0);
+    uint8_t source             = static_cast<uint8_t>(0);
+    uint8_t eventIdOrAlarmCode = static_cast<uint8_t>(0);
+    uint16_t userId            = static_cast<uint16_t>(0);
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -16977,12 +16984,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetLogRecordResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t logEntryId;
-    uint32_t timestamp;
-    uint8_t eventType;
-    uint8_t source;
-    uint8_t eventIdOrAlarmCode;
-    uint16_t userId;
+    uint16_t logEntryId        = static_cast<uint16_t>(0);
+    uint32_t timestamp         = static_cast<uint32_t>(0);
+    uint8_t eventType          = static_cast<uint8_t>(0);
+    uint8_t source             = static_cast<uint8_t>(0);
+    uint8_t eventIdOrAlarmCode = static_cast<uint8_t>(0);
+    uint16_t userId            = static_cast<uint16_t>(0);
     chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -17003,9 +17010,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetPINCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
-    DlUserType userType;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
+    DlUserType userType     = static_cast<DlUserType>(0);
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -17021,9 +17028,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetPINCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
-    DlUserType userType;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
+    DlUserType userType     = static_cast<DlUserType>(0);
     chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -17041,7 +17048,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPINCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17056,7 +17063,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPINCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPINCode
@@ -17076,7 +17083,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPINCodeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     DataModel::Nullable<DlUserStatus> userStatus;
     DataModel::Nullable<DlUserType> userType;
     DataModel::Nullable<chip::ByteSpan> pin;
@@ -17094,7 +17101,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPINCodeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     DataModel::Nullable<DlUserStatus> userStatus;
     DataModel::Nullable<DlUserType> userType;
     DataModel::Nullable<chip::ByteSpan> pin;
@@ -17114,7 +17121,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearPINCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t pinSlotIndex;
+    uint16_t pinSlotIndex = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17129,7 +17136,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearPINCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t pinSlotIndex;
+    uint16_t pinSlotIndex = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ClearPINCode
@@ -17175,8 +17182,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetUserStatus::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17191,8 +17198,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetUserStatus::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetUserStatus
@@ -17209,7 +17216,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserStatus::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17224,7 +17231,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserStatus::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetUserStatus
@@ -17242,8 +17249,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17258,8 +17265,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetUserStatusResponse
@@ -17282,13 +17289,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetWeekDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
-    chip::BitFlags<DlDaysMaskMap> daysMask;
-    uint8_t startHour;
-    uint8_t startMinute;
-    uint8_t endHour;
-    uint8_t endMinute;
+    uint8_t weekDayIndex                   = static_cast<uint8_t>(0);
+    uint16_t userIndex                     = static_cast<uint16_t>(0);
+    chip::BitFlags<DlDaysMaskMap> daysMask = static_cast<chip::BitFlags<DlDaysMaskMap>>(0);
+    uint8_t startHour                      = static_cast<uint8_t>(0);
+    uint8_t startMinute                    = static_cast<uint8_t>(0);
+    uint8_t endHour                        = static_cast<uint8_t>(0);
+    uint8_t endMinute                      = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17303,13 +17310,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetWeekDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
-    chip::BitFlags<DlDaysMaskMap> daysMask;
-    uint8_t startHour;
-    uint8_t startMinute;
-    uint8_t endHour;
-    uint8_t endMinute;
+    uint8_t weekDayIndex                   = static_cast<uint8_t>(0);
+    uint16_t userIndex                     = static_cast<uint16_t>(0);
+    chip::BitFlags<DlDaysMaskMap> daysMask = static_cast<chip::BitFlags<DlDaysMaskMap>>(0);
+    uint8_t startHour                      = static_cast<uint8_t>(0);
+    uint8_t startMinute                    = static_cast<uint8_t>(0);
+    uint8_t endHour                        = static_cast<uint8_t>(0);
+    uint8_t endMinute                      = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetWeekDaySchedule
@@ -17327,8 +17334,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeekDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
+    uint8_t weekDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17343,8 +17350,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeekDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
+    uint8_t weekDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetWeekDaySchedule
@@ -17368,14 +17375,14 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeekDayScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
-    DlStatus status;
-    chip::BitFlags<DlDaysMaskMap> daysMask;
-    uint8_t startHour;
-    uint8_t startMinute;
-    uint8_t endHour;
-    uint8_t endMinute;
+    uint8_t weekDayIndex                   = static_cast<uint8_t>(0);
+    uint16_t userIndex                     = static_cast<uint16_t>(0);
+    DlStatus status                        = static_cast<DlStatus>(0);
+    chip::BitFlags<DlDaysMaskMap> daysMask = static_cast<chip::BitFlags<DlDaysMaskMap>>(0);
+    uint8_t startHour                      = static_cast<uint8_t>(0);
+    uint8_t startMinute                    = static_cast<uint8_t>(0);
+    uint8_t endHour                        = static_cast<uint8_t>(0);
+    uint8_t endMinute                      = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17390,14 +17397,14 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeekDayScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
-    DlStatus status;
-    chip::BitFlags<DlDaysMaskMap> daysMask;
-    uint8_t startHour;
-    uint8_t startMinute;
-    uint8_t endHour;
-    uint8_t endMinute;
+    uint8_t weekDayIndex                   = static_cast<uint8_t>(0);
+    uint16_t userIndex                     = static_cast<uint16_t>(0);
+    DlStatus status                        = static_cast<DlStatus>(0);
+    chip::BitFlags<DlDaysMaskMap> daysMask = static_cast<chip::BitFlags<DlDaysMaskMap>>(0);
+    uint8_t startHour                      = static_cast<uint8_t>(0);
+    uint8_t startMinute                    = static_cast<uint8_t>(0);
+    uint8_t endHour                        = static_cast<uint8_t>(0);
+    uint8_t endMinute                      = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetWeekDayScheduleResponse
@@ -17415,8 +17422,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearWeekDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
+    uint8_t weekDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17431,8 +17438,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearWeekDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t weekDayIndex;
-    uint16_t userIndex;
+    uint8_t weekDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ClearWeekDaySchedule
@@ -17452,10 +17459,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetYearDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
+    uint8_t yearDayIndex    = static_cast<uint8_t>(0);
+    uint16_t userIndex      = static_cast<uint16_t>(0);
+    uint32_t localStartTime = static_cast<uint32_t>(0);
+    uint32_t localEndTime   = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17470,10 +17477,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetYearDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
+    uint8_t yearDayIndex    = static_cast<uint8_t>(0);
+    uint16_t userIndex      = static_cast<uint16_t>(0);
+    uint32_t localStartTime = static_cast<uint32_t>(0);
+    uint32_t localEndTime   = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetYearDaySchedule
@@ -17491,8 +17498,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetYearDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
+    uint8_t yearDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17507,8 +17514,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetYearDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
+    uint8_t yearDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetYearDaySchedule
@@ -17529,11 +17536,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetYearDayScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
-    DlStatus status;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
+    uint8_t yearDayIndex    = static_cast<uint8_t>(0);
+    uint16_t userIndex      = static_cast<uint16_t>(0);
+    DlStatus status         = static_cast<DlStatus>(0);
+    uint32_t localStartTime = static_cast<uint32_t>(0);
+    uint32_t localEndTime   = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17548,11 +17555,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetYearDayScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
-    DlStatus status;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
+    uint8_t yearDayIndex    = static_cast<uint8_t>(0);
+    uint16_t userIndex      = static_cast<uint16_t>(0);
+    DlStatus status         = static_cast<DlStatus>(0);
+    uint32_t localStartTime = static_cast<uint32_t>(0);
+    uint32_t localEndTime   = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetYearDayScheduleResponse
@@ -17570,8 +17577,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearYearDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
+    uint8_t yearDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17586,8 +17593,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearYearDaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t yearDayIndex;
-    uint16_t userIndex;
+    uint8_t yearDayIndex = static_cast<uint8_t>(0);
+    uint16_t userIndex   = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ClearYearDaySchedule
@@ -17607,10 +17614,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetHolidaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
-    DlOperatingMode operatingMode;
+    uint8_t holidayIndex          = static_cast<uint8_t>(0);
+    uint32_t localStartTime       = static_cast<uint32_t>(0);
+    uint32_t localEndTime         = static_cast<uint32_t>(0);
+    DlOperatingMode operatingMode = static_cast<DlOperatingMode>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17625,10 +17632,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetHolidaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
-    DlOperatingMode operatingMode;
+    uint8_t holidayIndex          = static_cast<uint8_t>(0);
+    uint32_t localStartTime       = static_cast<uint32_t>(0);
+    uint32_t localEndTime         = static_cast<uint32_t>(0);
+    DlOperatingMode operatingMode = static_cast<DlOperatingMode>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetHolidaySchedule
@@ -17645,7 +17652,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetHolidaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
+    uint8_t holidayIndex = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17660,7 +17667,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetHolidaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
+    uint8_t holidayIndex = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetHolidaySchedule
@@ -17681,11 +17688,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetHolidayScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
-    DlStatus status;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
-    DlOperatingMode operatingMode;
+    uint8_t holidayIndex          = static_cast<uint8_t>(0);
+    DlStatus status               = static_cast<DlStatus>(0);
+    uint32_t localStartTime       = static_cast<uint32_t>(0);
+    uint32_t localEndTime         = static_cast<uint32_t>(0);
+    DlOperatingMode operatingMode = static_cast<DlOperatingMode>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17700,11 +17707,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetHolidayScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
-    DlStatus status;
-    uint32_t localStartTime;
-    uint32_t localEndTime;
-    DlOperatingMode operatingMode;
+    uint8_t holidayIndex          = static_cast<uint8_t>(0);
+    DlStatus status               = static_cast<DlStatus>(0);
+    uint32_t localStartTime       = static_cast<uint32_t>(0);
+    uint32_t localEndTime         = static_cast<uint32_t>(0);
+    DlOperatingMode operatingMode = static_cast<DlOperatingMode>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetHolidayScheduleResponse
@@ -17721,7 +17728,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearHolidaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
+    uint8_t holidayIndex = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17736,7 +17743,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearHolidaySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t holidayIndex;
+    uint8_t holidayIndex = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ClearHolidaySchedule
@@ -17754,8 +17761,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetUserType::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserType userType;
+    uint16_t userId     = static_cast<uint16_t>(0);
+    DlUserType userType = static_cast<DlUserType>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17770,8 +17777,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetUserType::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserType userType;
+    uint16_t userId     = static_cast<uint16_t>(0);
+    DlUserType userType = static_cast<DlUserType>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetUserType
@@ -17788,7 +17795,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserType::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17803,7 +17810,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserType::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetUserType
@@ -17821,8 +17828,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserTypeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserType userType;
+    uint16_t userId     = static_cast<uint16_t>(0);
+    DlUserType userType = static_cast<DlUserType>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17837,8 +17844,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserTypeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserType userType;
+    uint16_t userId     = static_cast<uint16_t>(0);
+    DlUserType userType = static_cast<DlUserType>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetUserTypeResponse
@@ -17858,9 +17865,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetRFIDCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
-    DlUserType userType;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
+    DlUserType userType     = static_cast<DlUserType>(0);
     chip::ByteSpan rfidCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -17876,9 +17883,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetRFIDCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
-    DlUserStatus userStatus;
-    DlUserType userType;
+    uint16_t userId         = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
+    DlUserType userType     = static_cast<DlUserType>(0);
     chip::ByteSpan rfidCode;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -17896,7 +17903,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetRFIDCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17911,7 +17918,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetRFIDCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetRFIDCode
@@ -17931,7 +17938,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetRFIDCodeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     DataModel::Nullable<DlUserStatus> userStatus;
     DataModel::Nullable<DlUserType> userType;
     DataModel::Nullable<chip::ByteSpan> rfidCode;
@@ -17949,7 +17956,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetRFIDCodeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userId;
+    uint16_t userId = static_cast<uint16_t>(0);
     DataModel::Nullable<DlUserStatus> userStatus;
     DataModel::Nullable<DlUserType> userType;
     DataModel::Nullable<chip::ByteSpan> rfidCode;
@@ -17969,7 +17976,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearRFIDCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t rfidSlotIndex;
+    uint16_t rfidSlotIndex = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -17984,7 +17991,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearRFIDCode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t rfidSlotIndex;
+    uint16_t rfidSlotIndex = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ClearRFIDCode
@@ -18035,13 +18042,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetUser::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlDataOperationType operationType;
-    uint16_t userIndex;
+    DlDataOperationType operationType = static_cast<DlDataOperationType>(0);
+    uint16_t userIndex                = static_cast<uint16_t>(0);
     DataModel::Nullable<chip::CharSpan> userName;
     DataModel::Nullable<uint32_t> userUniqueId;
-    DlUserStatus userStatus;
-    DlUserType userType;
-    DlCredentialRule credentialRule;
+    DlUserStatus userStatus         = static_cast<DlUserStatus>(0);
+    DlUserType userType             = static_cast<DlUserType>(0);
+    DlCredentialRule credentialRule = static_cast<DlCredentialRule>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -18056,13 +18063,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetUser::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlDataOperationType operationType;
-    uint16_t userIndex;
+    DlDataOperationType operationType = static_cast<DlDataOperationType>(0);
+    uint16_t userIndex                = static_cast<uint16_t>(0);
     DataModel::Nullable<chip::CharSpan> userName;
     DataModel::Nullable<uint32_t> userUniqueId;
-    DlUserStatus userStatus;
-    DlUserType userType;
-    DlCredentialRule credentialRule;
+    DlUserStatus userStatus         = static_cast<DlUserStatus>(0);
+    DlUserType userType             = static_cast<DlUserType>(0);
+    DlCredentialRule credentialRule = static_cast<DlCredentialRule>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetUser
@@ -18079,7 +18086,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUser::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userIndex;
+    uint16_t userIndex = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -18094,7 +18101,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUser::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userIndex;
+    uint16_t userIndex = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetUser
@@ -18120,7 +18127,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userIndex;
+    uint16_t userIndex = static_cast<uint16_t>(0);
     DataModel::Nullable<chip::CharSpan> userName;
     DataModel::Nullable<uint32_t> userUniqueId;
     DataModel::Nullable<DlUserStatus> userStatus;
@@ -18129,7 +18136,7 @@ public:
     DataModel::Nullable<DataModel::List<const Structs::DlCredential::Type>> credentials;
     DataModel::Nullable<chip::FabricIndex> creatorFabricIndex;
     DataModel::Nullable<chip::FabricIndex> lastModifiedFabricIndex;
-    uint16_t nextUserIndex;
+    uint16_t nextUserIndex = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -18144,7 +18151,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetUserResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userIndex;
+    uint16_t userIndex = static_cast<uint16_t>(0);
     DataModel::Nullable<chip::CharSpan> userName;
     DataModel::Nullable<uint32_t> userUniqueId;
     DataModel::Nullable<DlUserStatus> userStatus;
@@ -18153,7 +18160,7 @@ public:
     DataModel::Nullable<DataModel::DecodableList<Structs::DlCredential::DecodableType>> credentials;
     DataModel::Nullable<chip::FabricIndex> creatorFabricIndex;
     DataModel::Nullable<chip::FabricIndex> lastModifiedFabricIndex;
-    uint16_t nextUserIndex;
+    uint16_t nextUserIndex = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetUserResponse
@@ -18170,7 +18177,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearUser::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userIndex;
+    uint16_t userIndex = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -18185,7 +18192,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ClearUser::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint16_t userIndex;
+    uint16_t userIndex = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ClearUser
@@ -18207,11 +18214,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OperatingEventNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t operationEventSource;
-    uint8_t operationEventCode;
-    uint16_t userId;
+    uint8_t operationEventSource = static_cast<uint8_t>(0);
+    uint8_t operationEventCode   = static_cast<uint8_t>(0);
+    uint16_t userId              = static_cast<uint16_t>(0);
     chip::ByteSpan pin;
-    uint32_t localTime;
+    uint32_t localTime = static_cast<uint32_t>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -18227,11 +18234,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::OperatingEventNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t operationEventSource;
-    uint8_t operationEventCode;
-    uint16_t userId;
+    uint8_t operationEventSource = static_cast<uint8_t>(0);
+    uint8_t operationEventCode   = static_cast<uint8_t>(0);
+    uint16_t userId              = static_cast<uint16_t>(0);
     chip::ByteSpan pin;
-    uint32_t localTime;
+    uint32_t localTime = static_cast<uint32_t>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -18256,13 +18263,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ProgrammingEventNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t programEventSource;
-    uint8_t programEventCode;
-    uint16_t userId;
+    uint8_t programEventSource = static_cast<uint8_t>(0);
+    uint8_t programEventCode   = static_cast<uint8_t>(0);
+    uint16_t userId            = static_cast<uint16_t>(0);
     chip::ByteSpan pin;
-    DlUserType userType;
-    DlUserStatus userStatus;
-    uint32_t localTime;
+    DlUserType userType     = static_cast<DlUserType>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
+    uint32_t localTime      = static_cast<uint32_t>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -18278,13 +18285,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ProgrammingEventNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    uint8_t programEventSource;
-    uint8_t programEventCode;
-    uint16_t userId;
+    uint8_t programEventSource = static_cast<uint8_t>(0);
+    uint8_t programEventCode   = static_cast<uint8_t>(0);
+    uint16_t userId            = static_cast<uint16_t>(0);
     chip::ByteSpan pin;
-    DlUserType userType;
-    DlUserStatus userStatus;
-    uint32_t localTime;
+    DlUserType userType     = static_cast<DlUserType>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
+    uint32_t localTime      = static_cast<uint32_t>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -18306,11 +18313,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetCredential::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlDataOperationType operationType;
+    DlDataOperationType operationType = static_cast<DlDataOperationType>(0);
     Structs::DlCredential::Type credential;
     chip::ByteSpan credentialData;
-    uint16_t userIndex;
-    DlUserStatus userStatus;
+    uint16_t userIndex      = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -18325,11 +18332,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetCredential::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlDataOperationType operationType;
+    DlDataOperationType operationType = static_cast<DlDataOperationType>(0);
     Structs::DlCredential::DecodableType credential;
     chip::ByteSpan credentialData;
-    uint16_t userIndex;
-    DlUserStatus userStatus;
+    uint16_t userIndex      = static_cast<uint16_t>(0);
+    DlUserStatus userStatus = static_cast<DlUserStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetCredential
@@ -18348,7 +18355,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetCredentialResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlStatus status;
+    DlStatus status = static_cast<DlStatus>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<uint16_t> nextCredentialIndex;
 
@@ -18365,7 +18372,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetCredentialResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlStatus status;
+    DlStatus status = static_cast<DlStatus>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<uint16_t> nextCredentialIndex;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -18418,7 +18425,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetCredentialStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    bool credentialExists;
+    bool credentialExists = static_cast<bool>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<uint16_t> nextCredentialIndex;
 
@@ -18435,7 +18442,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetCredentialStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    bool credentialExists;
+    bool credentialExists = static_cast<bool>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<uint16_t> nextCredentialIndex;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -19063,53 +19070,56 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::LockState::TypeInfo::DecodableType lockState;
-        Attributes::LockType::TypeInfo::DecodableType lockType;
-        Attributes::ActuatorEnabled::TypeInfo::DecodableType actuatorEnabled;
+        Attributes::LockType::TypeInfo::DecodableType lockType               = static_cast<DlLockType>(0);
+        Attributes::ActuatorEnabled::TypeInfo::DecodableType actuatorEnabled = static_cast<bool>(0);
         Attributes::DoorState::TypeInfo::DecodableType doorState;
-        Attributes::DoorOpenEvents::TypeInfo::DecodableType doorOpenEvents;
-        Attributes::DoorClosedEvents::TypeInfo::DecodableType doorClosedEvents;
-        Attributes::OpenPeriod::TypeInfo::DecodableType openPeriod;
-        Attributes::NumberOfLogRecordsSupported::TypeInfo::DecodableType numberOfLogRecordsSupported;
-        Attributes::NumberOfTotalUsersSupported::TypeInfo::DecodableType numberOfTotalUsersSupported;
-        Attributes::NumberOfPINUsersSupported::TypeInfo::DecodableType numberOfPINUsersSupported;
-        Attributes::NumberOfRFIDUsersSupported::TypeInfo::DecodableType numberOfRFIDUsersSupported;
-        Attributes::NumberOfWeekDaySchedulesSupportedPerUser::TypeInfo::DecodableType numberOfWeekDaySchedulesSupportedPerUser;
-        Attributes::NumberOfYearDaySchedulesSupportedPerUser::TypeInfo::DecodableType numberOfYearDaySchedulesSupportedPerUser;
-        Attributes::NumberOfHolidaySchedulesSupported::TypeInfo::DecodableType numberOfHolidaySchedulesSupported;
-        Attributes::MaxPINCodeLength::TypeInfo::DecodableType maxPINCodeLength;
-        Attributes::MinPINCodeLength::TypeInfo::DecodableType minPINCodeLength;
-        Attributes::MaxRFIDCodeLength::TypeInfo::DecodableType maxRFIDCodeLength;
-        Attributes::MinRFIDCodeLength::TypeInfo::DecodableType minRFIDCodeLength;
-        Attributes::CredentialRulesSupport::TypeInfo::DecodableType credentialRulesSupport;
-        Attributes::EnableLogging::TypeInfo::DecodableType enableLogging;
+        Attributes::DoorOpenEvents::TypeInfo::DecodableType doorOpenEvents                           = static_cast<uint32_t>(0);
+        Attributes::DoorClosedEvents::TypeInfo::DecodableType doorClosedEvents                       = static_cast<uint32_t>(0);
+        Attributes::OpenPeriod::TypeInfo::DecodableType openPeriod                                   = static_cast<uint16_t>(0);
+        Attributes::NumberOfLogRecordsSupported::TypeInfo::DecodableType numberOfLogRecordsSupported = static_cast<uint16_t>(0);
+        Attributes::NumberOfTotalUsersSupported::TypeInfo::DecodableType numberOfTotalUsersSupported = static_cast<uint16_t>(0);
+        Attributes::NumberOfPINUsersSupported::TypeInfo::DecodableType numberOfPINUsersSupported     = static_cast<uint16_t>(0);
+        Attributes::NumberOfRFIDUsersSupported::TypeInfo::DecodableType numberOfRFIDUsersSupported   = static_cast<uint16_t>(0);
+        Attributes::NumberOfWeekDaySchedulesSupportedPerUser::TypeInfo::DecodableType numberOfWeekDaySchedulesSupportedPerUser =
+            static_cast<uint16_t>(0);
+        Attributes::NumberOfYearDaySchedulesSupportedPerUser::TypeInfo::DecodableType numberOfYearDaySchedulesSupportedPerUser =
+            static_cast<uint16_t>(0);
+        Attributes::NumberOfHolidaySchedulesSupported::TypeInfo::DecodableType numberOfHolidaySchedulesSupported =
+            static_cast<uint16_t>(0);
+        Attributes::MaxPINCodeLength::TypeInfo::DecodableType maxPINCodeLength             = static_cast<uint8_t>(0);
+        Attributes::MinPINCodeLength::TypeInfo::DecodableType minPINCodeLength             = static_cast<uint8_t>(0);
+        Attributes::MaxRFIDCodeLength::TypeInfo::DecodableType maxRFIDCodeLength           = static_cast<uint8_t>(0);
+        Attributes::MinRFIDCodeLength::TypeInfo::DecodableType minRFIDCodeLength           = static_cast<uint8_t>(0);
+        Attributes::CredentialRulesSupport::TypeInfo::DecodableType credentialRulesSupport = static_cast<uint8_t>(0);
+        Attributes::EnableLogging::TypeInfo::DecodableType enableLogging                   = static_cast<bool>(0);
         Attributes::Language::TypeInfo::DecodableType language;
-        Attributes::LEDSettings::TypeInfo::DecodableType LEDSettings;
-        Attributes::AutoRelockTime::TypeInfo::DecodableType autoRelockTime;
-        Attributes::SoundVolume::TypeInfo::DecodableType soundVolume;
-        Attributes::OperatingMode::TypeInfo::DecodableType operatingMode;
-        Attributes::SupportedOperatingModes::TypeInfo::DecodableType supportedOperatingModes;
-        Attributes::DefaultConfigurationRegister::TypeInfo::DecodableType defaultConfigurationRegister;
-        Attributes::EnableLocalProgramming::TypeInfo::DecodableType enableLocalProgramming;
-        Attributes::EnableOneTouchLocking::TypeInfo::DecodableType enableOneTouchLocking;
-        Attributes::EnableInsideStatusLED::TypeInfo::DecodableType enableInsideStatusLED;
-        Attributes::EnablePrivacyModeButton::TypeInfo::DecodableType enablePrivacyModeButton;
-        Attributes::LocalProgrammingFeatures::TypeInfo::DecodableType localProgrammingFeatures;
-        Attributes::WrongCodeEntryLimit::TypeInfo::DecodableType wrongCodeEntryLimit;
-        Attributes::UserCodeTemporaryDisableTime::TypeInfo::DecodableType userCodeTemporaryDisableTime;
-        Attributes::SendPINOverTheAir::TypeInfo::DecodableType sendPINOverTheAir;
-        Attributes::RequirePINforRemoteOperation::TypeInfo::DecodableType requirePINforRemoteOperation;
-        Attributes::ExpiringUserTimeout::TypeInfo::DecodableType expiringUserTimeout;
-        Attributes::AlarmMask::TypeInfo::DecodableType alarmMask;
-        Attributes::KeypadOperationEventMask::TypeInfo::DecodableType keypadOperationEventMask;
-        Attributes::RemoteOperationEventMask::TypeInfo::DecodableType remoteOperationEventMask;
-        Attributes::ManualOperationEventMask::TypeInfo::DecodableType manualOperationEventMask;
-        Attributes::RFIDOperationEventMask::TypeInfo::DecodableType RFIDOperationEventMask;
-        Attributes::KeypadProgrammingEventMask::TypeInfo::DecodableType keypadProgrammingEventMask;
-        Attributes::RemoteProgrammingEventMask::TypeInfo::DecodableType remoteProgrammingEventMask;
-        Attributes::RFIDProgrammingEventMask::TypeInfo::DecodableType RFIDProgrammingEventMask;
+        Attributes::LEDSettings::TypeInfo::DecodableType LEDSettings                         = static_cast<uint8_t>(0);
+        Attributes::AutoRelockTime::TypeInfo::DecodableType autoRelockTime                   = static_cast<uint32_t>(0);
+        Attributes::SoundVolume::TypeInfo::DecodableType soundVolume                         = static_cast<uint8_t>(0);
+        Attributes::OperatingMode::TypeInfo::DecodableType operatingMode                     = static_cast<DlOperatingMode>(0);
+        Attributes::SupportedOperatingModes::TypeInfo::DecodableType supportedOperatingModes = static_cast<uint16_t>(0);
+        Attributes::DefaultConfigurationRegister::TypeInfo::DecodableType defaultConfigurationRegister = static_cast<uint16_t>(0);
+        Attributes::EnableLocalProgramming::TypeInfo::DecodableType enableLocalProgramming             = static_cast<bool>(0);
+        Attributes::EnableOneTouchLocking::TypeInfo::DecodableType enableOneTouchLocking               = static_cast<bool>(0);
+        Attributes::EnableInsideStatusLED::TypeInfo::DecodableType enableInsideStatusLED               = static_cast<bool>(0);
+        Attributes::EnablePrivacyModeButton::TypeInfo::DecodableType enablePrivacyModeButton           = static_cast<bool>(0);
+        Attributes::LocalProgrammingFeatures::TypeInfo::DecodableType localProgrammingFeatures         = static_cast<uint8_t>(0);
+        Attributes::WrongCodeEntryLimit::TypeInfo::DecodableType wrongCodeEntryLimit                   = static_cast<uint8_t>(0);
+        Attributes::UserCodeTemporaryDisableTime::TypeInfo::DecodableType userCodeTemporaryDisableTime = static_cast<uint8_t>(0);
+        Attributes::SendPINOverTheAir::TypeInfo::DecodableType sendPINOverTheAir                       = static_cast<bool>(0);
+        Attributes::RequirePINforRemoteOperation::TypeInfo::DecodableType requirePINforRemoteOperation = static_cast<bool>(0);
+        Attributes::ExpiringUserTimeout::TypeInfo::DecodableType expiringUserTimeout                   = static_cast<uint16_t>(0);
+        Attributes::AlarmMask::TypeInfo::DecodableType alarmMask                                       = static_cast<uint16_t>(0);
+        Attributes::KeypadOperationEventMask::TypeInfo::DecodableType keypadOperationEventMask         = static_cast<uint16_t>(0);
+        Attributes::RemoteOperationEventMask::TypeInfo::DecodableType remoteOperationEventMask         = static_cast<uint16_t>(0);
+        Attributes::ManualOperationEventMask::TypeInfo::DecodableType manualOperationEventMask         = static_cast<uint16_t>(0);
+        Attributes::RFIDOperationEventMask::TypeInfo::DecodableType RFIDOperationEventMask             = static_cast<uint16_t>(0);
+        Attributes::KeypadProgrammingEventMask::TypeInfo::DecodableType keypadProgrammingEventMask     = static_cast<uint16_t>(0);
+        Attributes::RemoteProgrammingEventMask::TypeInfo::DecodableType remoteProgrammingEventMask     = static_cast<uint16_t>(0);
+        Attributes::RFIDProgrammingEventMask::TypeInfo::DecodableType RFIDProgrammingEventMask         = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -19130,7 +19140,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlAlarmCode alarmCode;
+    DlAlarmCode alarmCode = static_cast<DlAlarmCode>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19142,7 +19152,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlAlarmCode alarmCode;
+    DlAlarmCode alarmCode = static_cast<DlAlarmCode>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19163,7 +19173,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlDoorState doorState;
+    DlDoorState doorState = static_cast<DlDoorState>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19175,7 +19185,7 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlDoorState doorState;
+    DlDoorState doorState = static_cast<DlDoorState>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19201,8 +19211,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlLockOperationType lockOperationType;
-    DlOperationSource operationSource;
+    DlLockOperationType lockOperationType = static_cast<DlLockOperationType>(0);
+    DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
@@ -19218,8 +19228,8 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlLockOperationType lockOperationType;
-    DlOperationSource operationSource;
+    DlLockOperationType lockOperationType = static_cast<DlLockOperationType>(0);
+    DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
@@ -19250,9 +19260,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlLockOperationType lockOperationType;
-    DlOperationSource operationSource;
-    DlOperationError operationError;
+    DlLockOperationType lockOperationType = static_cast<DlLockOperationType>(0);
+    DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
+    DlOperationError operationError       = static_cast<DlOperationError>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
@@ -19268,9 +19278,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlLockOperationType lockOperationType;
-    DlOperationSource operationSource;
-    DlOperationError operationError;
+    DlLockOperationType lockOperationType = static_cast<DlLockOperationType>(0);
+    DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
+    DlOperationError operationError       = static_cast<DlOperationError>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
@@ -19301,9 +19311,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlLockDataType lockDataType;
-    DlDataOperationType dataOperationType;
-    DlOperationSource operationSource;
+    DlLockDataType lockDataType           = static_cast<DlLockDataType>(0);
+    DlDataOperationType dataOperationType = static_cast<DlDataOperationType>(0);
+    DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
@@ -19319,9 +19329,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
-    DlLockDataType lockDataType;
-    DlDataOperationType dataOperationType;
-    DlOperationSource operationSource;
+    DlLockDataType lockDataType           = static_cast<DlLockDataType>(0);
+    DlDataOperationType dataOperationType = static_cast<DlDataOperationType>(0);
+    DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
     DataModel::Nullable<uint16_t> userIndex;
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
@@ -19528,7 +19538,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToLiftValue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    uint16_t liftValue;
+    uint16_t liftValue = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -19543,7 +19553,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToLiftValue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    uint16_t liftValue;
+    uint16_t liftValue = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GoToLiftValue
@@ -19561,8 +19571,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToLiftPercentage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    chip::Percent liftPercentageValue;
-    chip::Percent100ths liftPercent100thsValue;
+    chip::Percent liftPercentageValue          = static_cast<chip::Percent>(0);
+    chip::Percent100ths liftPercent100thsValue = static_cast<chip::Percent100ths>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -19577,8 +19587,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToLiftPercentage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    chip::Percent liftPercentageValue;
-    chip::Percent100ths liftPercent100thsValue;
+    chip::Percent liftPercentageValue          = static_cast<chip::Percent>(0);
+    chip::Percent100ths liftPercent100thsValue = static_cast<chip::Percent100ths>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GoToLiftPercentage
@@ -19595,7 +19605,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToTiltValue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    uint16_t tiltValue;
+    uint16_t tiltValue = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -19610,7 +19620,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToTiltValue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    uint16_t tiltValue;
+    uint16_t tiltValue = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GoToTiltValue
@@ -19628,8 +19638,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToTiltPercentage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    chip::Percent tiltPercentageValue;
-    chip::Percent100ths tiltPercent100thsValue;
+    chip::Percent tiltPercentageValue          = static_cast<chip::Percent>(0);
+    chip::Percent100ths tiltPercent100thsValue = static_cast<chip::Percent100ths>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -19644,8 +19654,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GoToTiltPercentage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
-    chip::Percent tiltPercentageValue;
-    chip::Percent100ths tiltPercent100thsValue;
+    chip::Percent tiltPercentageValue          = static_cast<chip::Percent>(0);
+    chip::Percent100ths tiltPercent100thsValue = static_cast<chip::Percent100ths>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GoToTiltPercentage
@@ -19962,31 +19972,31 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Type::TypeInfo::DecodableType type;
-        Attributes::PhysicalClosedLimitLift::TypeInfo::DecodableType physicalClosedLimitLift;
-        Attributes::PhysicalClosedLimitTilt::TypeInfo::DecodableType physicalClosedLimitTilt;
+        Attributes::Type::TypeInfo::DecodableType type                                       = static_cast<uint8_t>(0);
+        Attributes::PhysicalClosedLimitLift::TypeInfo::DecodableType physicalClosedLimitLift = static_cast<uint16_t>(0);
+        Attributes::PhysicalClosedLimitTilt::TypeInfo::DecodableType physicalClosedLimitTilt = static_cast<uint16_t>(0);
         Attributes::CurrentPositionLift::TypeInfo::DecodableType currentPositionLift;
         Attributes::CurrentPositionTilt::TypeInfo::DecodableType currentPositionTilt;
-        Attributes::NumberOfActuationsLift::TypeInfo::DecodableType numberOfActuationsLift;
-        Attributes::NumberOfActuationsTilt::TypeInfo::DecodableType numberOfActuationsTilt;
-        Attributes::ConfigStatus::TypeInfo::DecodableType configStatus;
+        Attributes::NumberOfActuationsLift::TypeInfo::DecodableType numberOfActuationsLift = static_cast<uint16_t>(0);
+        Attributes::NumberOfActuationsTilt::TypeInfo::DecodableType numberOfActuationsTilt = static_cast<uint16_t>(0);
+        Attributes::ConfigStatus::TypeInfo::DecodableType configStatus                     = static_cast<uint8_t>(0);
         Attributes::CurrentPositionLiftPercentage::TypeInfo::DecodableType currentPositionLiftPercentage;
         Attributes::CurrentPositionTiltPercentage::TypeInfo::DecodableType currentPositionTiltPercentage;
-        Attributes::OperationalStatus::TypeInfo::DecodableType operationalStatus;
+        Attributes::OperationalStatus::TypeInfo::DecodableType operationalStatus = static_cast<uint8_t>(0);
         Attributes::TargetPositionLiftPercent100ths::TypeInfo::DecodableType targetPositionLiftPercent100ths;
         Attributes::TargetPositionTiltPercent100ths::TypeInfo::DecodableType targetPositionTiltPercent100ths;
-        Attributes::EndProductType::TypeInfo::DecodableType endProductType;
+        Attributes::EndProductType::TypeInfo::DecodableType endProductType = static_cast<uint8_t>(0);
         Attributes::CurrentPositionLiftPercent100ths::TypeInfo::DecodableType currentPositionLiftPercent100ths;
         Attributes::CurrentPositionTiltPercent100ths::TypeInfo::DecodableType currentPositionTiltPercent100ths;
-        Attributes::InstalledOpenLimitLift::TypeInfo::DecodableType installedOpenLimitLift;
-        Attributes::InstalledClosedLimitLift::TypeInfo::DecodableType installedClosedLimitLift;
-        Attributes::InstalledOpenLimitTilt::TypeInfo::DecodableType installedOpenLimitTilt;
-        Attributes::InstalledClosedLimitTilt::TypeInfo::DecodableType installedClosedLimitTilt;
-        Attributes::Mode::TypeInfo::DecodableType mode;
-        Attributes::SafetyStatus::TypeInfo::DecodableType safetyStatus;
+        Attributes::InstalledOpenLimitLift::TypeInfo::DecodableType installedOpenLimitLift     = static_cast<uint16_t>(0);
+        Attributes::InstalledClosedLimitLift::TypeInfo::DecodableType installedClosedLimitLift = static_cast<uint16_t>(0);
+        Attributes::InstalledOpenLimitTilt::TypeInfo::DecodableType installedOpenLimitTilt     = static_cast<uint16_t>(0);
+        Attributes::InstalledClosedLimitTilt::TypeInfo::DecodableType installedClosedLimitTilt = static_cast<uint16_t>(0);
+        Attributes::Mode::TypeInfo::DecodableType mode                                         = static_cast<uint8_t>(0);
+        Attributes::SafetyStatus::TypeInfo::DecodableType safetyStatus                         = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -20022,7 +20032,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::BarrierControlGoToPercent::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
-    uint8_t percentOpen;
+    uint8_t percentOpen = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -20037,7 +20047,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::BarrierControlGoToPercent::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
-    uint8_t percentOpen;
+    uint8_t percentOpen = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace BarrierControlGoToPercent
@@ -20238,19 +20248,19 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::BarrierMovingState::TypeInfo::DecodableType barrierMovingState;
-        Attributes::BarrierSafetyStatus::TypeInfo::DecodableType barrierSafetyStatus;
-        Attributes::BarrierCapabilities::TypeInfo::DecodableType barrierCapabilities;
-        Attributes::BarrierOpenEvents::TypeInfo::DecodableType barrierOpenEvents;
-        Attributes::BarrierCloseEvents::TypeInfo::DecodableType barrierCloseEvents;
-        Attributes::BarrierCommandOpenEvents::TypeInfo::DecodableType barrierCommandOpenEvents;
-        Attributes::BarrierCommandCloseEvents::TypeInfo::DecodableType barrierCommandCloseEvents;
-        Attributes::BarrierOpenPeriod::TypeInfo::DecodableType barrierOpenPeriod;
-        Attributes::BarrierClosePeriod::TypeInfo::DecodableType barrierClosePeriod;
-        Attributes::BarrierPosition::TypeInfo::DecodableType barrierPosition;
+        Attributes::BarrierMovingState::TypeInfo::DecodableType barrierMovingState               = static_cast<uint8_t>(0);
+        Attributes::BarrierSafetyStatus::TypeInfo::DecodableType barrierSafetyStatus             = static_cast<uint16_t>(0);
+        Attributes::BarrierCapabilities::TypeInfo::DecodableType barrierCapabilities             = static_cast<uint8_t>(0);
+        Attributes::BarrierOpenEvents::TypeInfo::DecodableType barrierOpenEvents                 = static_cast<uint16_t>(0);
+        Attributes::BarrierCloseEvents::TypeInfo::DecodableType barrierCloseEvents               = static_cast<uint16_t>(0);
+        Attributes::BarrierCommandOpenEvents::TypeInfo::DecodableType barrierCommandOpenEvents   = static_cast<uint16_t>(0);
+        Attributes::BarrierCommandCloseEvents::TypeInfo::DecodableType barrierCommandCloseEvents = static_cast<uint16_t>(0);
+        Attributes::BarrierOpenPeriod::TypeInfo::DecodableType barrierOpenPeriod                 = static_cast<uint16_t>(0);
+        Attributes::BarrierClosePeriod::TypeInfo::DecodableType barrierClosePeriod               = static_cast<uint16_t>(0);
+        Attributes::BarrierPosition::TypeInfo::DecodableType barrierPosition                     = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -20624,33 +20634,33 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MaxPressure::TypeInfo::DecodableType maxPressure;
-        Attributes::MaxSpeed::TypeInfo::DecodableType maxSpeed;
-        Attributes::MaxFlow::TypeInfo::DecodableType maxFlow;
-        Attributes::MinConstPressure::TypeInfo::DecodableType minConstPressure;
-        Attributes::MaxConstPressure::TypeInfo::DecodableType maxConstPressure;
-        Attributes::MinCompPressure::TypeInfo::DecodableType minCompPressure;
-        Attributes::MaxCompPressure::TypeInfo::DecodableType maxCompPressure;
-        Attributes::MinConstSpeed::TypeInfo::DecodableType minConstSpeed;
-        Attributes::MaxConstSpeed::TypeInfo::DecodableType maxConstSpeed;
-        Attributes::MinConstFlow::TypeInfo::DecodableType minConstFlow;
-        Attributes::MaxConstFlow::TypeInfo::DecodableType maxConstFlow;
-        Attributes::MinConstTemp::TypeInfo::DecodableType minConstTemp;
-        Attributes::MaxConstTemp::TypeInfo::DecodableType maxConstTemp;
-        Attributes::PumpStatus::TypeInfo::DecodableType pumpStatus;
-        Attributes::EffectiveOperationMode::TypeInfo::DecodableType effectiveOperationMode;
-        Attributes::EffectiveControlMode::TypeInfo::DecodableType effectiveControlMode;
-        Attributes::Capacity::TypeInfo::DecodableType capacity;
-        Attributes::Speed::TypeInfo::DecodableType speed;
+        Attributes::MaxPressure::TypeInfo::DecodableType maxPressure                       = static_cast<int16_t>(0);
+        Attributes::MaxSpeed::TypeInfo::DecodableType maxSpeed                             = static_cast<uint16_t>(0);
+        Attributes::MaxFlow::TypeInfo::DecodableType maxFlow                               = static_cast<uint16_t>(0);
+        Attributes::MinConstPressure::TypeInfo::DecodableType minConstPressure             = static_cast<int16_t>(0);
+        Attributes::MaxConstPressure::TypeInfo::DecodableType maxConstPressure             = static_cast<int16_t>(0);
+        Attributes::MinCompPressure::TypeInfo::DecodableType minCompPressure               = static_cast<int16_t>(0);
+        Attributes::MaxCompPressure::TypeInfo::DecodableType maxCompPressure               = static_cast<int16_t>(0);
+        Attributes::MinConstSpeed::TypeInfo::DecodableType minConstSpeed                   = static_cast<uint16_t>(0);
+        Attributes::MaxConstSpeed::TypeInfo::DecodableType maxConstSpeed                   = static_cast<uint16_t>(0);
+        Attributes::MinConstFlow::TypeInfo::DecodableType minConstFlow                     = static_cast<uint16_t>(0);
+        Attributes::MaxConstFlow::TypeInfo::DecodableType maxConstFlow                     = static_cast<uint16_t>(0);
+        Attributes::MinConstTemp::TypeInfo::DecodableType minConstTemp                     = static_cast<int16_t>(0);
+        Attributes::MaxConstTemp::TypeInfo::DecodableType maxConstTemp                     = static_cast<int16_t>(0);
+        Attributes::PumpStatus::TypeInfo::DecodableType pumpStatus                         = static_cast<uint16_t>(0);
+        Attributes::EffectiveOperationMode::TypeInfo::DecodableType effectiveOperationMode = static_cast<uint8_t>(0);
+        Attributes::EffectiveControlMode::TypeInfo::DecodableType effectiveControlMode     = static_cast<uint8_t>(0);
+        Attributes::Capacity::TypeInfo::DecodableType capacity                             = static_cast<int16_t>(0);
+        Attributes::Speed::TypeInfo::DecodableType speed                                   = static_cast<uint16_t>(0);
         Attributes::LifetimeRunningHours::TypeInfo::DecodableType lifetimeRunningHours;
-        Attributes::Power::TypeInfo::DecodableType power;
+        Attributes::Power::TypeInfo::DecodableType power = static_cast<uint32_t>(0);
         Attributes::LifetimeEnergyConsumed::TypeInfo::DecodableType lifetimeEnergyConsumed;
-        Attributes::OperationMode::TypeInfo::DecodableType operationMode;
-        Attributes::ControlMode::TypeInfo::DecodableType controlMode;
-        Attributes::AlarmMask::TypeInfo::DecodableType alarmMask;
+        Attributes::OperationMode::TypeInfo::DecodableType operationMode = static_cast<uint8_t>(0);
+        Attributes::ControlMode::TypeInfo::DecodableType controlMode     = static_cast<uint8_t>(0);
+        Attributes::AlarmMask::TypeInfo::DecodableType alarmMask         = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -21234,8 +21244,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetpointRaiseLower::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    SetpointAdjustMode mode;
-    int8_t amount;
+    SetpointAdjustMode mode = static_cast<SetpointAdjustMode>(0);
+    int8_t amount           = static_cast<int8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -21250,8 +21260,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetpointRaiseLower::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    SetpointAdjustMode mode;
-    int8_t amount;
+    SetpointAdjustMode mode = static_cast<SetpointAdjustMode>(0);
+    int8_t amount           = static_cast<int8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetpointRaiseLower
@@ -21271,9 +21281,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeeklyScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    uint8_t numberOfTransitionsForSequence;
-    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
-    chip::BitFlags<ModeForSequence> modeForSequence;
+    uint8_t numberOfTransitionsForSequence          = static_cast<uint8_t>(0);
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence  = static_cast<chip::BitFlags<DayOfWeek>>(0);
+    chip::BitFlags<ModeForSequence> modeForSequence = static_cast<chip::BitFlags<ModeForSequence>>(0);
     DataModel::List<const uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -21289,9 +21299,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeeklyScheduleResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    uint8_t numberOfTransitionsForSequence;
-    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
-    chip::BitFlags<ModeForSequence> modeForSequence;
+    uint8_t numberOfTransitionsForSequence          = static_cast<uint8_t>(0);
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence  = static_cast<chip::BitFlags<DayOfWeek>>(0);
+    chip::BitFlags<ModeForSequence> modeForSequence = static_cast<chip::BitFlags<ModeForSequence>>(0);
     DataModel::DecodableList<uint8_t> payload;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21312,9 +21322,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    uint8_t numberOfTransitionsForSequence;
-    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
-    chip::BitFlags<ModeForSequence> modeForSequence;
+    uint8_t numberOfTransitionsForSequence          = static_cast<uint8_t>(0);
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence  = static_cast<chip::BitFlags<DayOfWeek>>(0);
+    chip::BitFlags<ModeForSequence> modeForSequence = static_cast<chip::BitFlags<ModeForSequence>>(0);
     DataModel::List<const uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -21330,9 +21340,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    uint8_t numberOfTransitionsForSequence;
-    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
-    chip::BitFlags<ModeForSequence> modeForSequence;
+    uint8_t numberOfTransitionsForSequence          = static_cast<uint8_t>(0);
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence  = static_cast<chip::BitFlags<DayOfWeek>>(0);
+    chip::BitFlags<ModeForSequence> modeForSequence = static_cast<chip::BitFlags<ModeForSequence>>(0);
     DataModel::DecodableList<uint8_t> payload;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21355,12 +21365,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetRelayStatusLogResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    uint16_t timeOfDay;
-    uint16_t relayStatus;
-    int16_t localTemperature;
-    uint8_t humidityInPercentage;
-    int16_t setpoint;
-    uint16_t unreadEntries;
+    uint16_t timeOfDay           = static_cast<uint16_t>(0);
+    uint16_t relayStatus         = static_cast<uint16_t>(0);
+    int16_t localTemperature     = static_cast<int16_t>(0);
+    uint8_t humidityInPercentage = static_cast<uint8_t>(0);
+    int16_t setpoint             = static_cast<int16_t>(0);
+    uint16_t unreadEntries       = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -21375,12 +21385,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetRelayStatusLogResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    uint16_t timeOfDay;
-    uint16_t relayStatus;
-    int16_t localTemperature;
-    uint8_t humidityInPercentage;
-    int16_t setpoint;
-    uint16_t unreadEntries;
+    uint16_t timeOfDay           = static_cast<uint16_t>(0);
+    uint16_t relayStatus         = static_cast<uint16_t>(0);
+    int16_t localTemperature     = static_cast<int16_t>(0);
+    uint8_t humidityInPercentage = static_cast<uint8_t>(0);
+    int16_t setpoint             = static_cast<int16_t>(0);
+    uint16_t unreadEntries       = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetRelayStatusLogResponse
@@ -21398,8 +21408,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    chip::BitFlags<DayOfWeek> daysToReturn;
-    chip::BitFlags<ModeForSequence> modeToReturn;
+    chip::BitFlags<DayOfWeek> daysToReturn       = static_cast<chip::BitFlags<DayOfWeek>>(0);
+    chip::BitFlags<ModeForSequence> modeToReturn = static_cast<chip::BitFlags<ModeForSequence>>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -21414,8 +21424,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
-    chip::BitFlags<DayOfWeek> daysToReturn;
-    chip::BitFlags<ModeForSequence> modeToReturn;
+    chip::BitFlags<DayOfWeek> daysToReturn       = static_cast<chip::BitFlags<DayOfWeek>>(0);
+    chip::BitFlags<ModeForSequence> modeToReturn = static_cast<chip::BitFlags<ModeForSequence>>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetWeeklySchedule
@@ -22040,52 +22050,54 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::LocalTemperature::TypeInfo::DecodableType localTemperature;
-        Attributes::OutdoorTemperature::TypeInfo::DecodableType outdoorTemperature;
-        Attributes::Occupancy::TypeInfo::DecodableType occupancy;
-        Attributes::AbsMinHeatSetpointLimit::TypeInfo::DecodableType absMinHeatSetpointLimit;
-        Attributes::AbsMaxHeatSetpointLimit::TypeInfo::DecodableType absMaxHeatSetpointLimit;
-        Attributes::AbsMinCoolSetpointLimit::TypeInfo::DecodableType absMinCoolSetpointLimit;
-        Attributes::AbsMaxCoolSetpointLimit::TypeInfo::DecodableType absMaxCoolSetpointLimit;
-        Attributes::PiCoolingDemand::TypeInfo::DecodableType piCoolingDemand;
-        Attributes::PiHeatingDemand::TypeInfo::DecodableType piHeatingDemand;
-        Attributes::HvacSystemTypeConfiguration::TypeInfo::DecodableType hvacSystemTypeConfiguration;
-        Attributes::LocalTemperatureCalibration::TypeInfo::DecodableType localTemperatureCalibration;
-        Attributes::OccupiedCoolingSetpoint::TypeInfo::DecodableType occupiedCoolingSetpoint;
-        Attributes::OccupiedHeatingSetpoint::TypeInfo::DecodableType occupiedHeatingSetpoint;
-        Attributes::UnoccupiedCoolingSetpoint::TypeInfo::DecodableType unoccupiedCoolingSetpoint;
-        Attributes::UnoccupiedHeatingSetpoint::TypeInfo::DecodableType unoccupiedHeatingSetpoint;
-        Attributes::MinHeatSetpointLimit::TypeInfo::DecodableType minHeatSetpointLimit;
-        Attributes::MaxHeatSetpointLimit::TypeInfo::DecodableType maxHeatSetpointLimit;
-        Attributes::MinCoolSetpointLimit::TypeInfo::DecodableType minCoolSetpointLimit;
-        Attributes::MaxCoolSetpointLimit::TypeInfo::DecodableType maxCoolSetpointLimit;
-        Attributes::MinSetpointDeadBand::TypeInfo::DecodableType minSetpointDeadBand;
-        Attributes::RemoteSensing::TypeInfo::DecodableType remoteSensing;
-        Attributes::ControlSequenceOfOperation::TypeInfo::DecodableType controlSequenceOfOperation;
-        Attributes::SystemMode::TypeInfo::DecodableType systemMode;
-        Attributes::AlarmMask::TypeInfo::DecodableType alarmMask;
-        Attributes::ThermostatRunningMode::TypeInfo::DecodableType thermostatRunningMode;
-        Attributes::StartOfWeek::TypeInfo::DecodableType startOfWeek;
-        Attributes::NumberOfWeeklyTransitions::TypeInfo::DecodableType numberOfWeeklyTransitions;
-        Attributes::NumberOfDailyTransitions::TypeInfo::DecodableType numberOfDailyTransitions;
-        Attributes::TemperatureSetpointHold::TypeInfo::DecodableType temperatureSetpointHold;
-        Attributes::TemperatureSetpointHoldDuration::TypeInfo::DecodableType temperatureSetpointHoldDuration;
-        Attributes::ThermostatProgrammingOperationMode::TypeInfo::DecodableType thermostatProgrammingOperationMode;
-        Attributes::ThermostatRunningState::TypeInfo::DecodableType thermostatRunningState;
-        Attributes::SetpointChangeSource::TypeInfo::DecodableType setpointChangeSource;
-        Attributes::SetpointChangeAmount::TypeInfo::DecodableType setpointChangeAmount;
-        Attributes::SetpointChangeSourceTimestamp::TypeInfo::DecodableType setpointChangeSourceTimestamp;
-        Attributes::AcType::TypeInfo::DecodableType acType;
-        Attributes::AcCapacity::TypeInfo::DecodableType acCapacity;
-        Attributes::AcRefrigerantType::TypeInfo::DecodableType acRefrigerantType;
-        Attributes::AcCompressor::TypeInfo::DecodableType acCompressor;
-        Attributes::AcErrorCode::TypeInfo::DecodableType acErrorCode;
-        Attributes::AcLouverPosition::TypeInfo::DecodableType acLouverPosition;
-        Attributes::AcCoilTemperature::TypeInfo::DecodableType acCoilTemperature;
-        Attributes::AcCapacityFormat::TypeInfo::DecodableType acCapacityFormat;
+        Attributes::LocalTemperature::TypeInfo::DecodableType localTemperature                       = static_cast<int16_t>(0);
+        Attributes::OutdoorTemperature::TypeInfo::DecodableType outdoorTemperature                   = static_cast<int16_t>(0);
+        Attributes::Occupancy::TypeInfo::DecodableType occupancy                                     = static_cast<uint8_t>(0);
+        Attributes::AbsMinHeatSetpointLimit::TypeInfo::DecodableType absMinHeatSetpointLimit         = static_cast<int16_t>(0);
+        Attributes::AbsMaxHeatSetpointLimit::TypeInfo::DecodableType absMaxHeatSetpointLimit         = static_cast<int16_t>(0);
+        Attributes::AbsMinCoolSetpointLimit::TypeInfo::DecodableType absMinCoolSetpointLimit         = static_cast<int16_t>(0);
+        Attributes::AbsMaxCoolSetpointLimit::TypeInfo::DecodableType absMaxCoolSetpointLimit         = static_cast<int16_t>(0);
+        Attributes::PiCoolingDemand::TypeInfo::DecodableType piCoolingDemand                         = static_cast<uint8_t>(0);
+        Attributes::PiHeatingDemand::TypeInfo::DecodableType piHeatingDemand                         = static_cast<uint8_t>(0);
+        Attributes::HvacSystemTypeConfiguration::TypeInfo::DecodableType hvacSystemTypeConfiguration = static_cast<uint8_t>(0);
+        Attributes::LocalTemperatureCalibration::TypeInfo::DecodableType localTemperatureCalibration = static_cast<int8_t>(0);
+        Attributes::OccupiedCoolingSetpoint::TypeInfo::DecodableType occupiedCoolingSetpoint         = static_cast<int16_t>(0);
+        Attributes::OccupiedHeatingSetpoint::TypeInfo::DecodableType occupiedHeatingSetpoint         = static_cast<int16_t>(0);
+        Attributes::UnoccupiedCoolingSetpoint::TypeInfo::DecodableType unoccupiedCoolingSetpoint     = static_cast<int16_t>(0);
+        Attributes::UnoccupiedHeatingSetpoint::TypeInfo::DecodableType unoccupiedHeatingSetpoint     = static_cast<int16_t>(0);
+        Attributes::MinHeatSetpointLimit::TypeInfo::DecodableType minHeatSetpointLimit               = static_cast<int16_t>(0);
+        Attributes::MaxHeatSetpointLimit::TypeInfo::DecodableType maxHeatSetpointLimit               = static_cast<int16_t>(0);
+        Attributes::MinCoolSetpointLimit::TypeInfo::DecodableType minCoolSetpointLimit               = static_cast<int16_t>(0);
+        Attributes::MaxCoolSetpointLimit::TypeInfo::DecodableType maxCoolSetpointLimit               = static_cast<int16_t>(0);
+        Attributes::MinSetpointDeadBand::TypeInfo::DecodableType minSetpointDeadBand                 = static_cast<int8_t>(0);
+        Attributes::RemoteSensing::TypeInfo::DecodableType remoteSensing                             = static_cast<uint8_t>(0);
+        Attributes::ControlSequenceOfOperation::TypeInfo::DecodableType controlSequenceOfOperation   = static_cast<uint8_t>(0);
+        Attributes::SystemMode::TypeInfo::DecodableType systemMode                                   = static_cast<uint8_t>(0);
+        Attributes::AlarmMask::TypeInfo::DecodableType alarmMask                                     = static_cast<uint8_t>(0);
+        Attributes::ThermostatRunningMode::TypeInfo::DecodableType thermostatRunningMode             = static_cast<uint8_t>(0);
+        Attributes::StartOfWeek::TypeInfo::DecodableType startOfWeek                                 = static_cast<uint8_t>(0);
+        Attributes::NumberOfWeeklyTransitions::TypeInfo::DecodableType numberOfWeeklyTransitions     = static_cast<uint8_t>(0);
+        Attributes::NumberOfDailyTransitions::TypeInfo::DecodableType numberOfDailyTransitions       = static_cast<uint8_t>(0);
+        Attributes::TemperatureSetpointHold::TypeInfo::DecodableType temperatureSetpointHold         = static_cast<uint8_t>(0);
+        Attributes::TemperatureSetpointHoldDuration::TypeInfo::DecodableType temperatureSetpointHoldDuration =
+            static_cast<uint16_t>(0);
+        Attributes::ThermostatProgrammingOperationMode::TypeInfo::DecodableType thermostatProgrammingOperationMode =
+            static_cast<uint8_t>(0);
+        Attributes::ThermostatRunningState::TypeInfo::DecodableType thermostatRunningState               = static_cast<uint16_t>(0);
+        Attributes::SetpointChangeSource::TypeInfo::DecodableType setpointChangeSource                   = static_cast<uint8_t>(0);
+        Attributes::SetpointChangeAmount::TypeInfo::DecodableType setpointChangeAmount                   = static_cast<int16_t>(0);
+        Attributes::SetpointChangeSourceTimestamp::TypeInfo::DecodableType setpointChangeSourceTimestamp = static_cast<uint32_t>(0);
+        Attributes::AcType::TypeInfo::DecodableType acType                                               = static_cast<uint8_t>(0);
+        Attributes::AcCapacity::TypeInfo::DecodableType acCapacity                                       = static_cast<uint16_t>(0);
+        Attributes::AcRefrigerantType::TypeInfo::DecodableType acRefrigerantType                         = static_cast<uint8_t>(0);
+        Attributes::AcCompressor::TypeInfo::DecodableType acCompressor                                   = static_cast<uint8_t>(0);
+        Attributes::AcErrorCode::TypeInfo::DecodableType acErrorCode                                     = static_cast<uint32_t>(0);
+        Attributes::AcLouverPosition::TypeInfo::DecodableType acLouverPosition                           = static_cast<uint8_t>(0);
+        Attributes::AcCoilTemperature::TypeInfo::DecodableType acCoilTemperature                         = static_cast<int16_t>(0);
+        Attributes::AcCapacityFormat::TypeInfo::DecodableType acCapacityFormat                           = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -22163,11 +22175,11 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::FanMode::TypeInfo::DecodableType fanMode;
-        Attributes::FanModeSequence::TypeInfo::DecodableType fanModeSequence;
+        Attributes::FanMode::TypeInfo::DecodableType fanMode                 = static_cast<uint8_t>(0);
+        Attributes::FanModeSequence::TypeInfo::DecodableType fanModeSequence = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -22317,17 +22329,17 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::RelativeHumidity::TypeInfo::DecodableType relativeHumidity;
-        Attributes::DehumidificationCooling::TypeInfo::DecodableType dehumidificationCooling;
-        Attributes::RhDehumidificationSetpoint::TypeInfo::DecodableType rhDehumidificationSetpoint;
-        Attributes::RelativeHumidityMode::TypeInfo::DecodableType relativeHumidityMode;
-        Attributes::DehumidificationLockout::TypeInfo::DecodableType dehumidificationLockout;
-        Attributes::DehumidificationHysteresis::TypeInfo::DecodableType dehumidificationHysteresis;
-        Attributes::DehumidificationMaxCool::TypeInfo::DecodableType dehumidificationMaxCool;
-        Attributes::RelativeHumidityDisplay::TypeInfo::DecodableType relativeHumidityDisplay;
+        Attributes::RelativeHumidity::TypeInfo::DecodableType relativeHumidity                     = static_cast<uint8_t>(0);
+        Attributes::DehumidificationCooling::TypeInfo::DecodableType dehumidificationCooling       = static_cast<uint8_t>(0);
+        Attributes::RhDehumidificationSetpoint::TypeInfo::DecodableType rhDehumidificationSetpoint = static_cast<uint8_t>(0);
+        Attributes::RelativeHumidityMode::TypeInfo::DecodableType relativeHumidityMode             = static_cast<uint8_t>(0);
+        Attributes::DehumidificationLockout::TypeInfo::DecodableType dehumidificationLockout       = static_cast<uint8_t>(0);
+        Attributes::DehumidificationHysteresis::TypeInfo::DecodableType dehumidificationHysteresis = static_cast<uint8_t>(0);
+        Attributes::DehumidificationMaxCool::TypeInfo::DecodableType dehumidificationMaxCool       = static_cast<uint8_t>(0);
+        Attributes::RelativeHumidityDisplay::TypeInfo::DecodableType relativeHumidityDisplay       = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -22417,12 +22429,12 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::TemperatureDisplayMode::TypeInfo::DecodableType temperatureDisplayMode;
-        Attributes::KeypadLockout::TypeInfo::DecodableType keypadLockout;
-        Attributes::ScheduleProgrammingVisibility::TypeInfo::DecodableType scheduleProgrammingVisibility;
+        Attributes::TemperatureDisplayMode::TypeInfo::DecodableType temperatureDisplayMode               = static_cast<uint8_t>(0);
+        Attributes::KeypadLockout::TypeInfo::DecodableType keypadLockout                                 = static_cast<uint8_t>(0);
+        Attributes::ScheduleProgrammingVisibility::TypeInfo::DecodableType scheduleProgrammingVisibility = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -22668,11 +22680,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t hue;
-    HueDirection direction;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t hue             = static_cast<uint8_t>(0);
+    HueDirection direction  = static_cast<HueDirection>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22687,11 +22699,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t hue;
-    HueDirection direction;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t hue             = static_cast<uint8_t>(0);
+    HueDirection direction  = static_cast<HueDirection>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToHue
@@ -22711,10 +22723,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueMoveMode moveMode;
-    uint8_t rate;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueMoveMode moveMode    = static_cast<HueMoveMode>(0);
+    uint8_t rate            = static_cast<uint8_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22729,10 +22741,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueMoveMode moveMode;
-    uint8_t rate;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueMoveMode moveMode    = static_cast<HueMoveMode>(0);
+    uint8_t rate            = static_cast<uint8_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveHue
@@ -22753,11 +22765,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueStepMode stepMode;
-    uint8_t stepSize;
-    uint8_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueStepMode stepMode    = static_cast<HueStepMode>(0);
+    uint8_t stepSize        = static_cast<uint8_t>(0);
+    uint8_t transitionTime  = static_cast<uint8_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22772,11 +22784,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueStepMode stepMode;
-    uint8_t stepSize;
-    uint8_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueStepMode stepMode    = static_cast<HueStepMode>(0);
+    uint8_t stepSize        = static_cast<uint8_t>(0);
+    uint8_t transitionTime  = static_cast<uint8_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StepHue
@@ -22796,10 +22808,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t saturation;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t saturation      = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22814,10 +22826,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t saturation;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t saturation      = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToSaturation
@@ -22837,10 +22849,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    SaturationMoveMode moveMode;
-    uint8_t rate;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    SaturationMoveMode moveMode = static_cast<SaturationMoveMode>(0);
+    uint8_t rate                = static_cast<uint8_t>(0);
+    uint8_t optionsMask         = static_cast<uint8_t>(0);
+    uint8_t optionsOverride     = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22855,10 +22867,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    SaturationMoveMode moveMode;
-    uint8_t rate;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    SaturationMoveMode moveMode = static_cast<SaturationMoveMode>(0);
+    uint8_t rate                = static_cast<uint8_t>(0);
+    uint8_t optionsMask         = static_cast<uint8_t>(0);
+    uint8_t optionsOverride     = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveSaturation
@@ -22879,11 +22891,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    SaturationStepMode stepMode;
-    uint8_t stepSize;
-    uint8_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    SaturationStepMode stepMode = static_cast<SaturationStepMode>(0);
+    uint8_t stepSize            = static_cast<uint8_t>(0);
+    uint8_t transitionTime      = static_cast<uint8_t>(0);
+    uint8_t optionsMask         = static_cast<uint8_t>(0);
+    uint8_t optionsOverride     = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22898,11 +22910,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    SaturationStepMode stepMode;
-    uint8_t stepSize;
-    uint8_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    SaturationStepMode stepMode = static_cast<SaturationStepMode>(0);
+    uint8_t stepSize            = static_cast<uint8_t>(0);
+    uint8_t transitionTime      = static_cast<uint8_t>(0);
+    uint8_t optionsMask         = static_cast<uint8_t>(0);
+    uint8_t optionsOverride     = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StepSaturation
@@ -22923,11 +22935,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToHueAndSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t hue;
-    uint8_t saturation;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t hue             = static_cast<uint8_t>(0);
+    uint8_t saturation      = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22942,11 +22954,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToHueAndSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t hue;
-    uint8_t saturation;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t hue             = static_cast<uint8_t>(0);
+    uint8_t saturation      = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToHueAndSaturation
@@ -22967,11 +22979,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToColor::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t colorX;
-    uint16_t colorY;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t colorX         = static_cast<uint16_t>(0);
+    uint16_t colorY         = static_cast<uint16_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -22986,11 +22998,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToColor::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t colorX;
-    uint16_t colorY;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t colorX         = static_cast<uint16_t>(0);
+    uint16_t colorY         = static_cast<uint16_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToColor
@@ -23010,10 +23022,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveColor::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    int16_t rateX;
-    int16_t rateY;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    int16_t rateX           = static_cast<int16_t>(0);
+    int16_t rateY           = static_cast<int16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23028,10 +23040,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveColor::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    int16_t rateX;
-    int16_t rateY;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    int16_t rateX           = static_cast<int16_t>(0);
+    int16_t rateY           = static_cast<int16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveColor
@@ -23052,11 +23064,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepColor::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    int16_t stepX;
-    int16_t stepY;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    int16_t stepX           = static_cast<int16_t>(0);
+    int16_t stepY           = static_cast<int16_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23071,11 +23083,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepColor::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    int16_t stepX;
-    int16_t stepY;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    int16_t stepX           = static_cast<int16_t>(0);
+    int16_t stepY           = static_cast<int16_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StepColor
@@ -23095,10 +23107,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToColorTemperature::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t colorTemperature;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t colorTemperature = static_cast<uint16_t>(0);
+    uint16_t transitionTime   = static_cast<uint16_t>(0);
+    uint8_t optionsMask       = static_cast<uint8_t>(0);
+    uint8_t optionsOverride   = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23113,10 +23125,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveToColorTemperature::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t colorTemperature;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t colorTemperature = static_cast<uint16_t>(0);
+    uint16_t transitionTime   = static_cast<uint16_t>(0);
+    uint8_t optionsMask       = static_cast<uint8_t>(0);
+    uint8_t optionsOverride   = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveToColorTemperature
@@ -23137,11 +23149,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t enhancedHue;
-    HueDirection direction;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t enhancedHue    = static_cast<uint16_t>(0);
+    HueDirection direction  = static_cast<HueDirection>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23156,11 +23168,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t enhancedHue;
-    HueDirection direction;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t enhancedHue    = static_cast<uint16_t>(0);
+    HueDirection direction  = static_cast<HueDirection>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnhancedMoveToHue
@@ -23180,10 +23192,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueMoveMode moveMode;
-    uint16_t rate;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueMoveMode moveMode    = static_cast<HueMoveMode>(0);
+    uint16_t rate           = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23198,10 +23210,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueMoveMode moveMode;
-    uint16_t rate;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueMoveMode moveMode    = static_cast<HueMoveMode>(0);
+    uint16_t rate           = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnhancedMoveHue
@@ -23222,11 +23234,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedStepHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueStepMode stepMode;
-    uint16_t stepSize;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueStepMode stepMode    = static_cast<HueStepMode>(0);
+    uint16_t stepSize       = static_cast<uint16_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23241,11 +23253,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedStepHue::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueStepMode stepMode;
-    uint16_t stepSize;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueStepMode stepMode    = static_cast<HueStepMode>(0);
+    uint16_t stepSize       = static_cast<uint16_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnhancedStepHue
@@ -23266,11 +23278,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHueAndSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t enhancedHue;
-    uint8_t saturation;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t enhancedHue    = static_cast<uint16_t>(0);
+    uint8_t saturation      = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23285,11 +23297,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHueAndSaturation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint16_t enhancedHue;
-    uint8_t saturation;
-    uint16_t transitionTime;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint16_t enhancedHue    = static_cast<uint16_t>(0);
+    uint8_t saturation      = static_cast<uint8_t>(0);
+    uint16_t transitionTime = static_cast<uint16_t>(0);
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnhancedMoveToHueAndSaturation
@@ -23312,13 +23324,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ColorLoopSet::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    chip::BitFlags<ColorLoopUpdateFlags> updateFlags;
-    ColorLoopAction action;
-    ColorLoopDirection direction;
-    uint16_t time;
-    uint16_t startHue;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    chip::BitFlags<ColorLoopUpdateFlags> updateFlags = static_cast<chip::BitFlags<ColorLoopUpdateFlags>>(0);
+    ColorLoopAction action                           = static_cast<ColorLoopAction>(0);
+    ColorLoopDirection direction                     = static_cast<ColorLoopDirection>(0);
+    uint16_t time                                    = static_cast<uint16_t>(0);
+    uint16_t startHue                                = static_cast<uint16_t>(0);
+    uint8_t optionsMask                              = static_cast<uint8_t>(0);
+    uint8_t optionsOverride                          = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23333,13 +23345,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ColorLoopSet::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    chip::BitFlags<ColorLoopUpdateFlags> updateFlags;
-    ColorLoopAction action;
-    ColorLoopDirection direction;
-    uint16_t time;
-    uint16_t startHue;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    chip::BitFlags<ColorLoopUpdateFlags> updateFlags = static_cast<chip::BitFlags<ColorLoopUpdateFlags>>(0);
+    ColorLoopAction action                           = static_cast<ColorLoopAction>(0);
+    ColorLoopDirection direction                     = static_cast<ColorLoopDirection>(0);
+    uint16_t time                                    = static_cast<uint16_t>(0);
+    uint16_t startHue                                = static_cast<uint16_t>(0);
+    uint8_t optionsMask                              = static_cast<uint8_t>(0);
+    uint8_t optionsOverride                          = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ColorLoopSet
@@ -23357,8 +23369,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StopMoveStep::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23373,8 +23385,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StopMoveStep::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    uint8_t optionsMask     = static_cast<uint8_t>(0);
+    uint8_t optionsOverride = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StopMoveStep
@@ -23396,12 +23408,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveColorTemperature::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueMoveMode moveMode;
-    uint16_t rate;
-    uint16_t colorTemperatureMinimum;
-    uint16_t colorTemperatureMaximum;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueMoveMode moveMode             = static_cast<HueMoveMode>(0);
+    uint16_t rate                    = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMinimum = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMaximum = static_cast<uint16_t>(0);
+    uint8_t optionsMask              = static_cast<uint8_t>(0);
+    uint8_t optionsOverride          = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23416,12 +23428,12 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MoveColorTemperature::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueMoveMode moveMode;
-    uint16_t rate;
-    uint16_t colorTemperatureMinimum;
-    uint16_t colorTemperatureMaximum;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueMoveMode moveMode             = static_cast<HueMoveMode>(0);
+    uint16_t rate                    = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMinimum = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMaximum = static_cast<uint16_t>(0);
+    uint8_t optionsMask              = static_cast<uint8_t>(0);
+    uint8_t optionsOverride          = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace MoveColorTemperature
@@ -23444,13 +23456,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepColorTemperature::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueStepMode stepMode;
-    uint16_t stepSize;
-    uint16_t transitionTime;
-    uint16_t colorTemperatureMinimum;
-    uint16_t colorTemperatureMaximum;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueStepMode stepMode             = static_cast<HueStepMode>(0);
+    uint16_t stepSize                = static_cast<uint16_t>(0);
+    uint16_t transitionTime          = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMinimum = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMaximum = static_cast<uint16_t>(0);
+    uint8_t optionsMask              = static_cast<uint8_t>(0);
+    uint8_t optionsOverride          = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -23465,13 +23477,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StepColorTemperature::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
-    HueStepMode stepMode;
-    uint16_t stepSize;
-    uint16_t transitionTime;
-    uint16_t colorTemperatureMinimum;
-    uint16_t colorTemperatureMaximum;
-    uint8_t optionsMask;
-    uint8_t optionsOverride;
+    HueStepMode stepMode             = static_cast<HueStepMode>(0);
+    uint16_t stepSize                = static_cast<uint16_t>(0);
+    uint16_t transitionTime          = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMinimum = static_cast<uint16_t>(0);
+    uint16_t colorTemperatureMaximum = static_cast<uint16_t>(0);
+    uint8_t optionsMask              = static_cast<uint8_t>(0);
+    uint8_t optionsOverride          = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StepColorTemperature
@@ -24148,61 +24160,62 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::CurrentHue::TypeInfo::DecodableType currentHue;
-        Attributes::CurrentSaturation::TypeInfo::DecodableType currentSaturation;
-        Attributes::RemainingTime::TypeInfo::DecodableType remainingTime;
-        Attributes::CurrentX::TypeInfo::DecodableType currentX;
-        Attributes::CurrentY::TypeInfo::DecodableType currentY;
-        Attributes::DriftCompensation::TypeInfo::DecodableType driftCompensation;
+        Attributes::CurrentHue::TypeInfo::DecodableType currentHue               = static_cast<uint8_t>(0);
+        Attributes::CurrentSaturation::TypeInfo::DecodableType currentSaturation = static_cast<uint8_t>(0);
+        Attributes::RemainingTime::TypeInfo::DecodableType remainingTime         = static_cast<uint16_t>(0);
+        Attributes::CurrentX::TypeInfo::DecodableType currentX                   = static_cast<uint16_t>(0);
+        Attributes::CurrentY::TypeInfo::DecodableType currentY                   = static_cast<uint16_t>(0);
+        Attributes::DriftCompensation::TypeInfo::DecodableType driftCompensation = static_cast<uint8_t>(0);
         Attributes::CompensationText::TypeInfo::DecodableType compensationText;
-        Attributes::ColorTemperature::TypeInfo::DecodableType colorTemperature;
-        Attributes::ColorMode::TypeInfo::DecodableType colorMode;
-        Attributes::ColorControlOptions::TypeInfo::DecodableType colorControlOptions;
-        Attributes::NumberOfPrimaries::TypeInfo::DecodableType numberOfPrimaries;
-        Attributes::Primary1X::TypeInfo::DecodableType primary1X;
-        Attributes::Primary1Y::TypeInfo::DecodableType primary1Y;
-        Attributes::Primary1Intensity::TypeInfo::DecodableType primary1Intensity;
-        Attributes::Primary2X::TypeInfo::DecodableType primary2X;
-        Attributes::Primary2Y::TypeInfo::DecodableType primary2Y;
-        Attributes::Primary2Intensity::TypeInfo::DecodableType primary2Intensity;
-        Attributes::Primary3X::TypeInfo::DecodableType primary3X;
-        Attributes::Primary3Y::TypeInfo::DecodableType primary3Y;
-        Attributes::Primary3Intensity::TypeInfo::DecodableType primary3Intensity;
-        Attributes::Primary4X::TypeInfo::DecodableType primary4X;
-        Attributes::Primary4Y::TypeInfo::DecodableType primary4Y;
-        Attributes::Primary4Intensity::TypeInfo::DecodableType primary4Intensity;
-        Attributes::Primary5X::TypeInfo::DecodableType primary5X;
-        Attributes::Primary5Y::TypeInfo::DecodableType primary5Y;
-        Attributes::Primary5Intensity::TypeInfo::DecodableType primary5Intensity;
-        Attributes::Primary6X::TypeInfo::DecodableType primary6X;
-        Attributes::Primary6Y::TypeInfo::DecodableType primary6Y;
-        Attributes::Primary6Intensity::TypeInfo::DecodableType primary6Intensity;
-        Attributes::WhitePointX::TypeInfo::DecodableType whitePointX;
-        Attributes::WhitePointY::TypeInfo::DecodableType whitePointY;
-        Attributes::ColorPointRX::TypeInfo::DecodableType colorPointRX;
-        Attributes::ColorPointRY::TypeInfo::DecodableType colorPointRY;
-        Attributes::ColorPointRIntensity::TypeInfo::DecodableType colorPointRIntensity;
-        Attributes::ColorPointGX::TypeInfo::DecodableType colorPointGX;
-        Attributes::ColorPointGY::TypeInfo::DecodableType colorPointGY;
-        Attributes::ColorPointGIntensity::TypeInfo::DecodableType colorPointGIntensity;
-        Attributes::ColorPointBX::TypeInfo::DecodableType colorPointBX;
-        Attributes::ColorPointBY::TypeInfo::DecodableType colorPointBY;
-        Attributes::ColorPointBIntensity::TypeInfo::DecodableType colorPointBIntensity;
-        Attributes::EnhancedCurrentHue::TypeInfo::DecodableType enhancedCurrentHue;
-        Attributes::EnhancedColorMode::TypeInfo::DecodableType enhancedColorMode;
-        Attributes::ColorLoopActive::TypeInfo::DecodableType colorLoopActive;
-        Attributes::ColorLoopDirection::TypeInfo::DecodableType colorLoopDirection;
-        Attributes::ColorLoopTime::TypeInfo::DecodableType colorLoopTime;
-        Attributes::ColorLoopStartEnhancedHue::TypeInfo::DecodableType colorLoopStartEnhancedHue;
-        Attributes::ColorLoopStoredEnhancedHue::TypeInfo::DecodableType colorLoopStoredEnhancedHue;
-        Attributes::ColorCapabilities::TypeInfo::DecodableType colorCapabilities;
-        Attributes::ColorTempPhysicalMin::TypeInfo::DecodableType colorTempPhysicalMin;
-        Attributes::ColorTempPhysicalMax::TypeInfo::DecodableType colorTempPhysicalMax;
-        Attributes::CoupleColorTempToLevelMinMireds::TypeInfo::DecodableType coupleColorTempToLevelMinMireds;
-        Attributes::StartUpColorTemperatureMireds::TypeInfo::DecodableType startUpColorTemperatureMireds;
+        Attributes::ColorTemperature::TypeInfo::DecodableType colorTemperature                     = static_cast<uint16_t>(0);
+        Attributes::ColorMode::TypeInfo::DecodableType colorMode                                   = static_cast<uint8_t>(0);
+        Attributes::ColorControlOptions::TypeInfo::DecodableType colorControlOptions               = static_cast<uint8_t>(0);
+        Attributes::NumberOfPrimaries::TypeInfo::DecodableType numberOfPrimaries                   = static_cast<uint8_t>(0);
+        Attributes::Primary1X::TypeInfo::DecodableType primary1X                                   = static_cast<uint16_t>(0);
+        Attributes::Primary1Y::TypeInfo::DecodableType primary1Y                                   = static_cast<uint16_t>(0);
+        Attributes::Primary1Intensity::TypeInfo::DecodableType primary1Intensity                   = static_cast<uint8_t>(0);
+        Attributes::Primary2X::TypeInfo::DecodableType primary2X                                   = static_cast<uint16_t>(0);
+        Attributes::Primary2Y::TypeInfo::DecodableType primary2Y                                   = static_cast<uint16_t>(0);
+        Attributes::Primary2Intensity::TypeInfo::DecodableType primary2Intensity                   = static_cast<uint8_t>(0);
+        Attributes::Primary3X::TypeInfo::DecodableType primary3X                                   = static_cast<uint16_t>(0);
+        Attributes::Primary3Y::TypeInfo::DecodableType primary3Y                                   = static_cast<uint16_t>(0);
+        Attributes::Primary3Intensity::TypeInfo::DecodableType primary3Intensity                   = static_cast<uint8_t>(0);
+        Attributes::Primary4X::TypeInfo::DecodableType primary4X                                   = static_cast<uint16_t>(0);
+        Attributes::Primary4Y::TypeInfo::DecodableType primary4Y                                   = static_cast<uint16_t>(0);
+        Attributes::Primary4Intensity::TypeInfo::DecodableType primary4Intensity                   = static_cast<uint8_t>(0);
+        Attributes::Primary5X::TypeInfo::DecodableType primary5X                                   = static_cast<uint16_t>(0);
+        Attributes::Primary5Y::TypeInfo::DecodableType primary5Y                                   = static_cast<uint16_t>(0);
+        Attributes::Primary5Intensity::TypeInfo::DecodableType primary5Intensity                   = static_cast<uint8_t>(0);
+        Attributes::Primary6X::TypeInfo::DecodableType primary6X                                   = static_cast<uint16_t>(0);
+        Attributes::Primary6Y::TypeInfo::DecodableType primary6Y                                   = static_cast<uint16_t>(0);
+        Attributes::Primary6Intensity::TypeInfo::DecodableType primary6Intensity                   = static_cast<uint8_t>(0);
+        Attributes::WhitePointX::TypeInfo::DecodableType whitePointX                               = static_cast<uint16_t>(0);
+        Attributes::WhitePointY::TypeInfo::DecodableType whitePointY                               = static_cast<uint16_t>(0);
+        Attributes::ColorPointRX::TypeInfo::DecodableType colorPointRX                             = static_cast<uint16_t>(0);
+        Attributes::ColorPointRY::TypeInfo::DecodableType colorPointRY                             = static_cast<uint16_t>(0);
+        Attributes::ColorPointRIntensity::TypeInfo::DecodableType colorPointRIntensity             = static_cast<uint8_t>(0);
+        Attributes::ColorPointGX::TypeInfo::DecodableType colorPointGX                             = static_cast<uint16_t>(0);
+        Attributes::ColorPointGY::TypeInfo::DecodableType colorPointGY                             = static_cast<uint16_t>(0);
+        Attributes::ColorPointGIntensity::TypeInfo::DecodableType colorPointGIntensity             = static_cast<uint8_t>(0);
+        Attributes::ColorPointBX::TypeInfo::DecodableType colorPointBX                             = static_cast<uint16_t>(0);
+        Attributes::ColorPointBY::TypeInfo::DecodableType colorPointBY                             = static_cast<uint16_t>(0);
+        Attributes::ColorPointBIntensity::TypeInfo::DecodableType colorPointBIntensity             = static_cast<uint8_t>(0);
+        Attributes::EnhancedCurrentHue::TypeInfo::DecodableType enhancedCurrentHue                 = static_cast<uint16_t>(0);
+        Attributes::EnhancedColorMode::TypeInfo::DecodableType enhancedColorMode                   = static_cast<uint8_t>(0);
+        Attributes::ColorLoopActive::TypeInfo::DecodableType colorLoopActive                       = static_cast<uint8_t>(0);
+        Attributes::ColorLoopDirection::TypeInfo::DecodableType colorLoopDirection                 = static_cast<uint8_t>(0);
+        Attributes::ColorLoopTime::TypeInfo::DecodableType colorLoopTime                           = static_cast<uint16_t>(0);
+        Attributes::ColorLoopStartEnhancedHue::TypeInfo::DecodableType colorLoopStartEnhancedHue   = static_cast<uint16_t>(0);
+        Attributes::ColorLoopStoredEnhancedHue::TypeInfo::DecodableType colorLoopStoredEnhancedHue = static_cast<uint16_t>(0);
+        Attributes::ColorCapabilities::TypeInfo::DecodableType colorCapabilities                   = static_cast<uint16_t>(0);
+        Attributes::ColorTempPhysicalMin::TypeInfo::DecodableType colorTempPhysicalMin             = static_cast<uint16_t>(0);
+        Attributes::ColorTempPhysicalMax::TypeInfo::DecodableType colorTempPhysicalMax             = static_cast<uint16_t>(0);
+        Attributes::CoupleColorTempToLevelMinMireds::TypeInfo::DecodableType coupleColorTempToLevelMinMireds =
+            static_cast<uint16_t>(0);
+        Attributes::StartUpColorTemperatureMireds::TypeInfo::DecodableType startUpColorTemperatureMireds = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -24448,25 +24461,25 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::PhysicalMinLevel::TypeInfo::DecodableType physicalMinLevel;
-        Attributes::PhysicalMaxLevel::TypeInfo::DecodableType physicalMaxLevel;
-        Attributes::BallastStatus::TypeInfo::DecodableType ballastStatus;
-        Attributes::MinLevel::TypeInfo::DecodableType minLevel;
-        Attributes::MaxLevel::TypeInfo::DecodableType maxLevel;
-        Attributes::PowerOnLevel::TypeInfo::DecodableType powerOnLevel;
-        Attributes::PowerOnFadeTime::TypeInfo::DecodableType powerOnFadeTime;
-        Attributes::IntrinsicBallastFactor::TypeInfo::DecodableType intrinsicBallastFactor;
-        Attributes::BallastFactorAdjustment::TypeInfo::DecodableType ballastFactorAdjustment;
-        Attributes::LampQuality::TypeInfo::DecodableType lampQuality;
+        Attributes::PhysicalMinLevel::TypeInfo::DecodableType physicalMinLevel               = static_cast<uint8_t>(0);
+        Attributes::PhysicalMaxLevel::TypeInfo::DecodableType physicalMaxLevel               = static_cast<uint8_t>(0);
+        Attributes::BallastStatus::TypeInfo::DecodableType ballastStatus                     = static_cast<uint8_t>(0);
+        Attributes::MinLevel::TypeInfo::DecodableType minLevel                               = static_cast<uint8_t>(0);
+        Attributes::MaxLevel::TypeInfo::DecodableType maxLevel                               = static_cast<uint8_t>(0);
+        Attributes::PowerOnLevel::TypeInfo::DecodableType powerOnLevel                       = static_cast<uint8_t>(0);
+        Attributes::PowerOnFadeTime::TypeInfo::DecodableType powerOnFadeTime                 = static_cast<uint16_t>(0);
+        Attributes::IntrinsicBallastFactor::TypeInfo::DecodableType intrinsicBallastFactor   = static_cast<uint8_t>(0);
+        Attributes::BallastFactorAdjustment::TypeInfo::DecodableType ballastFactorAdjustment = static_cast<uint8_t>(0);
+        Attributes::LampQuality::TypeInfo::DecodableType lampQuality                         = static_cast<uint8_t>(0);
         Attributes::LampType::TypeInfo::DecodableType lampType;
         Attributes::LampManufacturer::TypeInfo::DecodableType lampManufacturer;
-        Attributes::LampRatedHours::TypeInfo::DecodableType lampRatedHours;
-        Attributes::LampBurnHours::TypeInfo::DecodableType lampBurnHours;
-        Attributes::LampAlarmMode::TypeInfo::DecodableType lampAlarmMode;
-        Attributes::LampBurnHoursTripPoint::TypeInfo::DecodableType lampBurnHoursTripPoint;
+        Attributes::LampRatedHours::TypeInfo::DecodableType lampRatedHours                 = static_cast<uint32_t>(0);
+        Attributes::LampBurnHours::TypeInfo::DecodableType lampBurnHours                   = static_cast<uint32_t>(0);
+        Attributes::LampAlarmMode::TypeInfo::DecodableType lampAlarmMode                   = static_cast<uint8_t>(0);
+        Attributes::LampBurnHoursTripPoint::TypeInfo::DecodableType lampBurnHoursTripPoint = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -24589,11 +24602,11 @@ struct TypeInfo
         Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
         Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
         Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance = static_cast<uint16_t>(0);
         Attributes::LightSensorType::TypeInfo::DecodableType lightSensorType;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -24695,13 +24708,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<int16_t>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<int16_t>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<int16_t>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -24863,18 +24876,18 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
-        Attributes::ScaledValue::TypeInfo::DecodableType scaledValue;
-        Attributes::MinScaledValue::TypeInfo::DecodableType minScaledValue;
-        Attributes::MaxScaledValue::TypeInfo::DecodableType maxScaledValue;
-        Attributes::ScaledTolerance::TypeInfo::DecodableType scaledTolerance;
-        Attributes::Scale::TypeInfo::DecodableType scale;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<int16_t>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<int16_t>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<int16_t>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<uint16_t>(0);
+        Attributes::ScaledValue::TypeInfo::DecodableType scaledValue           = static_cast<int16_t>(0);
+        Attributes::MinScaledValue::TypeInfo::DecodableType minScaledValue     = static_cast<int16_t>(0);
+        Attributes::MaxScaledValue::TypeInfo::DecodableType maxScaledValue     = static_cast<int16_t>(0);
+        Attributes::ScaledTolerance::TypeInfo::DecodableType scaledTolerance   = static_cast<uint16_t>(0);
+        Attributes::Scale::TypeInfo::DecodableType scale                       = static_cast<int8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -24976,13 +24989,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<int16_t>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<int16_t>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<int16_t>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25084,13 +25097,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<uint16_t>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<uint16_t>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<uint16_t>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25288,22 +25301,28 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Occupancy::TypeInfo::DecodableType occupancy;
-        Attributes::OccupancySensorType::TypeInfo::DecodableType occupancySensorType;
-        Attributes::OccupancySensorTypeBitmap::TypeInfo::DecodableType occupancySensorTypeBitmap;
-        Attributes::PirOccupiedToUnoccupiedDelay::TypeInfo::DecodableType pirOccupiedToUnoccupiedDelay;
-        Attributes::PirUnoccupiedToOccupiedDelay::TypeInfo::DecodableType pirUnoccupiedToOccupiedDelay;
-        Attributes::PirUnoccupiedToOccupiedThreshold::TypeInfo::DecodableType pirUnoccupiedToOccupiedThreshold;
-        Attributes::UltrasonicOccupiedToUnoccupiedDelay::TypeInfo::DecodableType ultrasonicOccupiedToUnoccupiedDelay;
-        Attributes::UltrasonicUnoccupiedToOccupiedDelay::TypeInfo::DecodableType ultrasonicUnoccupiedToOccupiedDelay;
-        Attributes::UltrasonicUnoccupiedToOccupiedThreshold::TypeInfo::DecodableType ultrasonicUnoccupiedToOccupiedThreshold;
-        Attributes::PhysicalContactOccupiedToUnoccupiedDelay::TypeInfo::DecodableType physicalContactOccupiedToUnoccupiedDelay;
-        Attributes::PhysicalContactUnoccupiedToOccupiedDelay::TypeInfo::DecodableType physicalContactUnoccupiedToOccupiedDelay;
+        Attributes::Occupancy::TypeInfo::DecodableType occupancy                                       = static_cast<uint8_t>(0);
+        Attributes::OccupancySensorType::TypeInfo::DecodableType occupancySensorType                   = static_cast<uint8_t>(0);
+        Attributes::OccupancySensorTypeBitmap::TypeInfo::DecodableType occupancySensorTypeBitmap       = static_cast<uint8_t>(0);
+        Attributes::PirOccupiedToUnoccupiedDelay::TypeInfo::DecodableType pirOccupiedToUnoccupiedDelay = static_cast<uint16_t>(0);
+        Attributes::PirUnoccupiedToOccupiedDelay::TypeInfo::DecodableType pirUnoccupiedToOccupiedDelay = static_cast<uint16_t>(0);
+        Attributes::PirUnoccupiedToOccupiedThreshold::TypeInfo::DecodableType pirUnoccupiedToOccupiedThreshold =
+            static_cast<uint8_t>(0);
+        Attributes::UltrasonicOccupiedToUnoccupiedDelay::TypeInfo::DecodableType ultrasonicOccupiedToUnoccupiedDelay =
+            static_cast<uint16_t>(0);
+        Attributes::UltrasonicUnoccupiedToOccupiedDelay::TypeInfo::DecodableType ultrasonicUnoccupiedToOccupiedDelay =
+            static_cast<uint16_t>(0);
+        Attributes::UltrasonicUnoccupiedToOccupiedThreshold::TypeInfo::DecodableType ultrasonicUnoccupiedToOccupiedThreshold =
+            static_cast<uint8_t>(0);
+        Attributes::PhysicalContactOccupiedToUnoccupiedDelay::TypeInfo::DecodableType physicalContactOccupiedToUnoccupiedDelay =
+            static_cast<uint16_t>(0);
+        Attributes::PhysicalContactUnoccupiedToOccupiedDelay::TypeInfo::DecodableType physicalContactUnoccupiedToOccupiedDelay =
+            static_cast<uint16_t>(0);
         Attributes::PhysicalContactUnoccupiedToOccupiedThreshold::TypeInfo::DecodableType
-            physicalContactUnoccupiedToOccupiedThreshold;
+            physicalContactUnoccupiedToOccupiedThreshold = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25405,13 +25424,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25513,13 +25532,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25621,13 +25640,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25729,13 +25748,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25837,13 +25856,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -25945,13 +25964,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26053,13 +26072,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26161,13 +26180,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26269,13 +26288,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26377,13 +26396,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26485,13 +26504,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26593,13 +26612,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26701,13 +26720,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26809,13 +26828,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -26917,13 +26936,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27025,13 +27044,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27133,13 +27152,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27241,13 +27260,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27349,13 +27368,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27457,13 +27476,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27565,13 +27584,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27673,13 +27692,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27781,13 +27800,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27889,13 +27908,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -27997,13 +28016,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -28105,13 +28124,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -28213,13 +28232,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -28321,13 +28340,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -28429,13 +28448,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -28537,13 +28556,13 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue;
-        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue;
-        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue;
-        Attributes::Tolerance::TypeInfo::DecodableType tolerance;
+        Attributes::MeasuredValue::TypeInfo::DecodableType measuredValue       = static_cast<float>(0);
+        Attributes::MinMeasuredValue::TypeInfo::DecodableType minMeasuredValue = static_cast<float>(0);
+        Attributes::MaxMeasuredValue::TypeInfo::DecodableType maxMeasuredValue = static_cast<float>(0);
+        Attributes::Tolerance::TypeInfo::DecodableType tolerance               = static_cast<float>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -28660,8 +28679,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    IasEnrollResponseCode enrollResponseCode;
-    uint8_t zoneId;
+    IasEnrollResponseCode enrollResponseCode = static_cast<IasEnrollResponseCode>(0);
+    uint8_t zoneId                           = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -28676,8 +28695,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    IasEnrollResponseCode enrollResponseCode;
-    uint8_t zoneId;
+    IasEnrollResponseCode enrollResponseCode = static_cast<IasEnrollResponseCode>(0);
+    uint8_t zoneId                           = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ZoneEnrollResponse
@@ -28697,10 +28716,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChangeNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    chip::BitFlags<IasZoneStatus> zoneStatus;
-    uint8_t extendedStatus;
-    uint8_t zoneId;
-    uint16_t delay;
+    chip::BitFlags<IasZoneStatus> zoneStatus = static_cast<chip::BitFlags<IasZoneStatus>>(0);
+    uint8_t extendedStatus                   = static_cast<uint8_t>(0);
+    uint8_t zoneId                           = static_cast<uint8_t>(0);
+    uint16_t delay                           = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -28715,10 +28734,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChangeNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    chip::BitFlags<IasZoneStatus> zoneStatus;
-    uint8_t extendedStatus;
-    uint8_t zoneId;
-    uint16_t delay;
+    chip::BitFlags<IasZoneStatus> zoneStatus = static_cast<chip::BitFlags<IasZoneStatus>>(0);
+    uint8_t extendedStatus                   = static_cast<uint8_t>(0);
+    uint8_t zoneId                           = static_cast<uint8_t>(0);
+    uint16_t delay                           = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ZoneStatusChangeNotification
@@ -28764,8 +28783,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    IasZoneType zoneType;
-    uint16_t manufacturerCode;
+    IasZoneType zoneType      = static_cast<IasZoneType>(0);
+    uint16_t manufacturerCode = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -28780,8 +28799,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    IasZoneType zoneType;
-    uint16_t manufacturerCode;
+    IasZoneType zoneType      = static_cast<IasZoneType>(0);
+    uint16_t manufacturerCode = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ZoneEnrollRequest
@@ -28799,8 +28818,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::InitiateTestMode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    uint8_t testModeDuration;
-    uint8_t currentZoneSensitivityLevel;
+    uint8_t testModeDuration            = static_cast<uint8_t>(0);
+    uint8_t currentZoneSensitivityLevel = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -28815,8 +28834,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::InitiateTestMode::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
-    uint8_t testModeDuration;
-    uint8_t currentZoneSensitivityLevel;
+    uint8_t testModeDuration            = static_cast<uint8_t>(0);
+    uint8_t currentZoneSensitivityLevel = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace InitiateTestMode
@@ -29009,16 +29028,17 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::ZoneState::TypeInfo::DecodableType zoneState;
-        Attributes::ZoneType::TypeInfo::DecodableType zoneType;
-        Attributes::ZoneStatus::TypeInfo::DecodableType zoneStatus;
-        Attributes::IasCieAddress::TypeInfo::DecodableType iasCieAddress;
-        Attributes::ZoneId::TypeInfo::DecodableType zoneId;
-        Attributes::NumberOfZoneSensitivityLevelsSupported::TypeInfo::DecodableType numberOfZoneSensitivityLevelsSupported;
-        Attributes::CurrentZoneSensitivityLevel::TypeInfo::DecodableType currentZoneSensitivityLevel;
+        Attributes::ZoneState::TypeInfo::DecodableType zoneState         = static_cast<uint8_t>(0);
+        Attributes::ZoneType::TypeInfo::DecodableType zoneType           = static_cast<uint16_t>(0);
+        Attributes::ZoneStatus::TypeInfo::DecodableType zoneStatus       = static_cast<uint16_t>(0);
+        Attributes::IasCieAddress::TypeInfo::DecodableType iasCieAddress = static_cast<chip::NodeId>(0);
+        Attributes::ZoneId::TypeInfo::DecodableType zoneId               = static_cast<uint8_t>(0);
+        Attributes::NumberOfZoneSensitivityLevelsSupported::TypeInfo::DecodableType numberOfZoneSensitivityLevelsSupported =
+            static_cast<uint8_t>(0);
+        Attributes::CurrentZoneSensitivityLevel::TypeInfo::DecodableType currentZoneSensitivityLevel = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -29266,9 +29286,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Arm::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAceArmMode armMode;
+    IasAceArmMode armMode = static_cast<IasAceArmMode>(0);
     chip::CharSpan armDisarmCode;
-    uint8_t zoneId;
+    uint8_t zoneId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29283,9 +29303,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Arm::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAceArmMode armMode;
+    IasAceArmMode armMode = static_cast<IasAceArmMode>(0);
     chip::CharSpan armDisarmCode;
-    uint8_t zoneId;
+    uint8_t zoneId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Arm
@@ -29302,7 +29322,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ArmResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAceArmNotification armNotification;
+    IasAceArmNotification armNotification = static_cast<IasAceArmNotification>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29317,7 +29337,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ArmResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAceArmNotification armNotification;
+    IasAceArmNotification armNotification = static_cast<IasAceArmNotification>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ArmResponse
@@ -29336,7 +29356,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Bypass::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t numberOfZones;
+    uint8_t numberOfZones = static_cast<uint8_t>(0);
     DataModel::List<const uint8_t> zoneIds;
     chip::CharSpan armDisarmCode;
 
@@ -29353,7 +29373,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Bypass::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t numberOfZones;
+    uint8_t numberOfZones = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint8_t> zoneIds;
     chip::CharSpan armDisarmCode;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -29387,22 +29407,22 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneIdMapResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint16_t section0;
-    uint16_t section1;
-    uint16_t section2;
-    uint16_t section3;
-    uint16_t section4;
-    uint16_t section5;
-    uint16_t section6;
-    uint16_t section7;
-    uint16_t section8;
-    uint16_t section9;
-    uint16_t section10;
-    uint16_t section11;
-    uint16_t section12;
-    uint16_t section13;
-    uint16_t section14;
-    uint16_t section15;
+    uint16_t section0  = static_cast<uint16_t>(0);
+    uint16_t section1  = static_cast<uint16_t>(0);
+    uint16_t section2  = static_cast<uint16_t>(0);
+    uint16_t section3  = static_cast<uint16_t>(0);
+    uint16_t section4  = static_cast<uint16_t>(0);
+    uint16_t section5  = static_cast<uint16_t>(0);
+    uint16_t section6  = static_cast<uint16_t>(0);
+    uint16_t section7  = static_cast<uint16_t>(0);
+    uint16_t section8  = static_cast<uint16_t>(0);
+    uint16_t section9  = static_cast<uint16_t>(0);
+    uint16_t section10 = static_cast<uint16_t>(0);
+    uint16_t section11 = static_cast<uint16_t>(0);
+    uint16_t section12 = static_cast<uint16_t>(0);
+    uint16_t section13 = static_cast<uint16_t>(0);
+    uint16_t section14 = static_cast<uint16_t>(0);
+    uint16_t section15 = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29417,22 +29437,22 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneIdMapResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint16_t section0;
-    uint16_t section1;
-    uint16_t section2;
-    uint16_t section3;
-    uint16_t section4;
-    uint16_t section5;
-    uint16_t section6;
-    uint16_t section7;
-    uint16_t section8;
-    uint16_t section9;
-    uint16_t section10;
-    uint16_t section11;
-    uint16_t section12;
-    uint16_t section13;
-    uint16_t section14;
-    uint16_t section15;
+    uint16_t section0  = static_cast<uint16_t>(0);
+    uint16_t section1  = static_cast<uint16_t>(0);
+    uint16_t section2  = static_cast<uint16_t>(0);
+    uint16_t section3  = static_cast<uint16_t>(0);
+    uint16_t section4  = static_cast<uint16_t>(0);
+    uint16_t section5  = static_cast<uint16_t>(0);
+    uint16_t section6  = static_cast<uint16_t>(0);
+    uint16_t section7  = static_cast<uint16_t>(0);
+    uint16_t section8  = static_cast<uint16_t>(0);
+    uint16_t section9  = static_cast<uint16_t>(0);
+    uint16_t section10 = static_cast<uint16_t>(0);
+    uint16_t section11 = static_cast<uint16_t>(0);
+    uint16_t section12 = static_cast<uint16_t>(0);
+    uint16_t section13 = static_cast<uint16_t>(0);
+    uint16_t section14 = static_cast<uint16_t>(0);
+    uint16_t section15 = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetZoneIdMapResponse
@@ -29480,9 +29500,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneInformationResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t zoneId;
-    IasZoneType zoneType;
-    chip::NodeId ieeeAddress;
+    uint8_t zoneId           = static_cast<uint8_t>(0);
+    IasZoneType zoneType     = static_cast<IasZoneType>(0);
+    chip::NodeId ieeeAddress = static_cast<chip::NodeId>(0);
     chip::CharSpan zoneLabel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -29498,9 +29518,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneInformationResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t zoneId;
-    IasZoneType zoneType;
-    chip::NodeId ieeeAddress;
+    uint8_t zoneId           = static_cast<uint8_t>(0);
+    IasZoneType zoneType     = static_cast<IasZoneType>(0);
+    chip::NodeId ieeeAddress = static_cast<chip::NodeId>(0);
     chip::CharSpan zoneLabel;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -29549,9 +29569,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChanged::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t zoneId;
-    uint16_t zoneStatus;
-    IasAceAudibleNotification audibleNotification;
+    uint8_t zoneId                                = static_cast<uint8_t>(0);
+    uint16_t zoneStatus                           = static_cast<uint16_t>(0);
+    IasAceAudibleNotification audibleNotification = static_cast<IasAceAudibleNotification>(0);
     chip::CharSpan zoneLabel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -29567,9 +29587,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChanged::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t zoneId;
-    uint16_t zoneStatus;
-    IasAceAudibleNotification audibleNotification;
+    uint8_t zoneId                                = static_cast<uint8_t>(0);
+    uint16_t zoneStatus                           = static_cast<uint16_t>(0);
+    IasAceAudibleNotification audibleNotification = static_cast<IasAceAudibleNotification>(0);
     chip::CharSpan zoneLabel;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -29618,10 +29638,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PanelStatusChanged::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAcePanelStatus panelStatus;
-    uint8_t secondsRemaining;
-    IasAceAudibleNotification audibleNotification;
-    IasAceAlarmStatus alarmStatus;
+    IasAcePanelStatus panelStatus                 = static_cast<IasAcePanelStatus>(0);
+    uint8_t secondsRemaining                      = static_cast<uint8_t>(0);
+    IasAceAudibleNotification audibleNotification = static_cast<IasAceAudibleNotification>(0);
+    IasAceAlarmStatus alarmStatus                 = static_cast<IasAceAlarmStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29636,10 +29656,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PanelStatusChanged::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAcePanelStatus panelStatus;
-    uint8_t secondsRemaining;
-    IasAceAudibleNotification audibleNotification;
-    IasAceAlarmStatus alarmStatus;
+    IasAcePanelStatus panelStatus                 = static_cast<IasAcePanelStatus>(0);
+    uint8_t secondsRemaining                      = static_cast<uint8_t>(0);
+    IasAceAudibleNotification audibleNotification = static_cast<IasAceAudibleNotification>(0);
+    IasAceAlarmStatus alarmStatus                 = static_cast<IasAceAlarmStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PanelStatusChanged
@@ -29687,10 +29707,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPanelStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAcePanelStatus panelStatus;
-    uint8_t secondsRemaining;
-    IasAceAudibleNotification audibleNotification;
-    IasAceAlarmStatus alarmStatus;
+    IasAcePanelStatus panelStatus                 = static_cast<IasAcePanelStatus>(0);
+    uint8_t secondsRemaining                      = static_cast<uint8_t>(0);
+    IasAceAudibleNotification audibleNotification = static_cast<IasAceAudibleNotification>(0);
+    IasAceAlarmStatus alarmStatus                 = static_cast<IasAceAlarmStatus>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29705,10 +29725,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetPanelStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    IasAcePanelStatus panelStatus;
-    uint8_t secondsRemaining;
-    IasAceAudibleNotification audibleNotification;
-    IasAceAlarmStatus alarmStatus;
+    IasAcePanelStatus panelStatus                 = static_cast<IasAcePanelStatus>(0);
+    uint8_t secondsRemaining                      = static_cast<uint8_t>(0);
+    IasAceAudibleNotification audibleNotification = static_cast<IasAceAudibleNotification>(0);
+    IasAceAlarmStatus alarmStatus                 = static_cast<IasAceAlarmStatus>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPanelStatusResponse
@@ -29725,7 +29745,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneInformation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t zoneId;
+    uint8_t zoneId = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29740,7 +29760,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneInformation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t zoneId;
+    uint8_t zoneId = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetZoneInformation
@@ -29758,7 +29778,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetBypassedZoneList::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t numberOfZones;
+    uint8_t numberOfZones = static_cast<uint8_t>(0);
     DataModel::List<const uint8_t> zoneIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -29774,7 +29794,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SetBypassedZoneList::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t numberOfZones;
+    uint8_t numberOfZones = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint8_t> zoneIds;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -29821,7 +29841,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::BypassResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t numberOfZones;
+    uint8_t numberOfZones = static_cast<uint8_t>(0);
     DataModel::List<const IasAceBypassResult> bypassResult;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -29837,7 +29857,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::BypassResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t numberOfZones;
+    uint8_t numberOfZones = static_cast<uint8_t>(0);
     DataModel::DecodableList<IasAceBypassResult> bypassResult;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -29885,8 +29905,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    bool zoneStatusComplete;
-    uint8_t numberOfZones;
+    bool zoneStatusComplete = static_cast<bool>(0);
+    uint8_t numberOfZones   = static_cast<uint8_t>(0);
     DataModel::List<const Structs::IasAceZoneStatusResult::Type> zoneStatusResult;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -29902,8 +29922,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneStatusResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    bool zoneStatusComplete;
-    uint8_t numberOfZones;
+    bool zoneStatusComplete = static_cast<bool>(0);
+    uint8_t numberOfZones   = static_cast<uint8_t>(0);
     DataModel::DecodableList<Structs::IasAceZoneStatusResult::DecodableType> zoneStatusResult;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -29924,10 +29944,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneStatus::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t startingZoneId;
-    uint8_t maxNumberOfZoneIds;
-    bool zoneStatusMaskFlag;
-    uint16_t zoneStatusMask;
+    uint8_t startingZoneId     = static_cast<uint8_t>(0);
+    uint8_t maxNumberOfZoneIds = static_cast<uint8_t>(0);
+    bool zoneStatusMaskFlag    = static_cast<bool>(0);
+    uint16_t zoneStatusMask    = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -29942,10 +29962,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetZoneStatus::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
-    uint8_t startingZoneId;
-    uint8_t maxNumberOfZoneIds;
-    bool zoneStatusMaskFlag;
-    uint16_t zoneStatusMask;
+    uint8_t startingZoneId     = static_cast<uint8_t>(0);
+    uint8_t maxNumberOfZoneIds = static_cast<uint8_t>(0);
+    bool zoneStatusMaskFlag    = static_cast<bool>(0);
+    uint16_t zoneStatusMask    = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetZoneStatus
@@ -29999,8 +30019,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -30055,10 +30075,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StartWarning::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
-    chip::BitFlags<WarningInfo> warningInfo;
-    uint16_t warningDuration;
-    uint8_t strobeDutyCycle;
-    uint8_t strobeLevel;
+    chip::BitFlags<WarningInfo> warningInfo = static_cast<chip::BitFlags<WarningInfo>>(0);
+    uint16_t warningDuration                = static_cast<uint16_t>(0);
+    uint8_t strobeDutyCycle                 = static_cast<uint8_t>(0);
+    uint8_t strobeLevel                     = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -30073,10 +30093,10 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StartWarning::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
-    chip::BitFlags<WarningInfo> warningInfo;
-    uint16_t warningDuration;
-    uint8_t strobeDutyCycle;
-    uint8_t strobeLevel;
+    chip::BitFlags<WarningInfo> warningInfo = static_cast<chip::BitFlags<WarningInfo>>(0);
+    uint16_t warningDuration                = static_cast<uint16_t>(0);
+    uint8_t strobeDutyCycle                 = static_cast<uint8_t>(0);
+    uint8_t strobeLevel                     = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StartWarning
@@ -30093,7 +30113,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Squawk::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
-    chip::BitFlags<SquawkInfo> squawkInfo;
+    chip::BitFlags<SquawkInfo> squawkInfo = static_cast<chip::BitFlags<SquawkInfo>>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -30108,7 +30128,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::Squawk::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
-    chip::BitFlags<SquawkInfo> squawkInfo;
+    chip::BitFlags<SquawkInfo> squawkInfo = static_cast<chip::BitFlags<SquawkInfo>>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Squawk
@@ -30173,10 +30193,10 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MaxDuration::TypeInfo::DecodableType maxDuration;
+        Attributes::MaxDuration::TypeInfo::DecodableType maxDuration = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -30244,8 +30264,8 @@ struct TypeInfo
 
         Attributes::WakeOnLanMacAddress::TypeInfo::DecodableType wakeOnLanMacAddress;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -30389,7 +30409,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
     Structs::ChannelInfo::Type channelMatch;
-    ErrorTypeEnum errorType;
+    ErrorTypeEnum errorType = static_cast<ErrorTypeEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -30405,7 +30425,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
     Structs::ChannelInfo::DecodableType channelMatch;
-    ErrorTypeEnum errorType;
+    ErrorTypeEnum errorType = static_cast<ErrorTypeEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ChangeChannelResponse
@@ -30423,8 +30443,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeChannelByNumberRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    uint16_t majorNumber;
-    uint16_t minorNumber;
+    uint16_t majorNumber = static_cast<uint16_t>(0);
+    uint16_t minorNumber = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -30439,8 +30459,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeChannelByNumberRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    uint16_t majorNumber;
-    uint16_t minorNumber;
+    uint16_t majorNumber = static_cast<uint16_t>(0);
+    uint16_t minorNumber = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ChangeChannelByNumberRequest
@@ -30457,7 +30477,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SkipChannelRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    uint16_t count;
+    uint16_t count = static_cast<uint16_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -30472,7 +30492,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SkipChannelRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    uint16_t count;
+    uint16_t count = static_cast<uint16_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SkipChannelRequest
@@ -30566,8 +30586,8 @@ struct TypeInfo
         Attributes::ChannelLineup::TypeInfo::DecodableType channelLineup;
         Attributes::CurrentChannel::TypeInfo::DecodableType currentChannel;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -30634,7 +30654,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NavigateTargetRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
-    uint8_t target;
+    uint8_t target = static_cast<uint8_t>(0);
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -30650,7 +30670,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NavigateTargetRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
-    uint8_t target;
+    uint8_t target = static_cast<uint8_t>(0);
     chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -30669,7 +30689,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NavigateTargetResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -30685,7 +30705,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NavigateTargetResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -30766,10 +30786,10 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::TargetNavigatorList::TypeInfo::DecodableType targetNavigatorList;
-        Attributes::CurrentNavigatorTarget::TypeInfo::DecodableType currentNavigatorTarget;
+        Attributes::CurrentNavigatorTarget::TypeInfo::DecodableType currentNavigatorTarget = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -31120,7 +31140,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SkipForwardRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    uint64_t deltaPositionMilliseconds;
+    uint64_t deltaPositionMilliseconds = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31135,7 +31155,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SkipForwardRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    uint64_t deltaPositionMilliseconds;
+    uint64_t deltaPositionMilliseconds = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SkipForwardRequest
@@ -31152,7 +31172,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SkipBackwardRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    uint64_t deltaPositionMilliseconds;
+    uint64_t deltaPositionMilliseconds = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31167,7 +31187,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SkipBackwardRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    uint64_t deltaPositionMilliseconds;
+    uint64_t deltaPositionMilliseconds = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SkipBackwardRequest
@@ -31184,7 +31204,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PlaybackResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31199,7 +31219,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PlaybackResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PlaybackResponse
@@ -31216,7 +31236,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SeekRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    uint64_t position;
+    uint64_t position = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31231,7 +31251,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SeekRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    uint64_t position;
+    uint64_t position = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SeekRequest
@@ -31368,16 +31388,16 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::PlaybackState::TypeInfo::DecodableType playbackState;
-        Attributes::StartTime::TypeInfo::DecodableType startTime;
-        Attributes::Duration::TypeInfo::DecodableType duration;
+        Attributes::PlaybackState::TypeInfo::DecodableType playbackState = static_cast<PlaybackStateEnum>(0);
+        Attributes::StartTime::TypeInfo::DecodableType startTime         = static_cast<uint64_t>(0);
+        Attributes::Duration::TypeInfo::DecodableType duration           = static_cast<uint64_t>(0);
         Attributes::Position::TypeInfo::DecodableType position;
-        Attributes::PlaybackSpeed::TypeInfo::DecodableType playbackSpeed;
-        Attributes::SeekRangeEnd::TypeInfo::DecodableType seekRangeEnd;
-        Attributes::SeekRangeStart::TypeInfo::DecodableType seekRangeStart;
+        Attributes::PlaybackSpeed::TypeInfo::DecodableType playbackSpeed   = static_cast<float>(0);
+        Attributes::SeekRangeEnd::TypeInfo::DecodableType seekRangeEnd     = static_cast<uint64_t>(0);
+        Attributes::SeekRangeStart::TypeInfo::DecodableType seekRangeStart = static_cast<uint64_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -31472,7 +31492,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SelectInputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31487,7 +31507,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SelectInputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SelectInputRequest
@@ -31561,7 +31581,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RenameInputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
     chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -31577,7 +31597,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RenameInputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
     chip::CharSpan name;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -31657,10 +31677,10 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::MediaInputList::TypeInfo::DecodableType mediaInputList;
-        Attributes::CurrentMediaInput::TypeInfo::DecodableType currentMediaInput;
+        Attributes::CurrentMediaInput::TypeInfo::DecodableType currentMediaInput = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -31756,8 +31776,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -31898,7 +31918,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    CecKeyCode keyCode;
+    CecKeyCode keyCode = static_cast<CecKeyCode>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31913,7 +31933,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    CecKeyCode keyCode;
+    CecKeyCode keyCode = static_cast<CecKeyCode>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SendKeyRequest
@@ -31930,7 +31950,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31945,7 +31965,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SendKeyResponse
@@ -31999,8 +32019,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -32232,7 +32252,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchContentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    bool autoPlay;
+    bool autoPlay = static_cast<bool>(0);
     chip::CharSpan data;
     DataModel::List<const Structs::ContentSearch::Type> search;
 
@@ -32249,7 +32269,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchContentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    bool autoPlay;
+    bool autoPlay = static_cast<bool>(0);
     chip::CharSpan data;
     DataModel::DecodableList<Structs::ContentSearch::DecodableType> search;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -32307,7 +32327,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -32323,7 +32343,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -32402,10 +32422,10 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AcceptHeaderList::TypeInfo::DecodableType acceptHeaderList;
-        Attributes::SupportedStreamingProtocols::TypeInfo::DecodableType supportedStreamingProtocols;
+        Attributes::SupportedStreamingProtocols::TypeInfo::DecodableType supportedStreamingProtocols = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -32482,7 +32502,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SelectOutputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -32497,7 +32517,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SelectOutputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SelectOutputRequest
@@ -32515,7 +32535,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RenameOutputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
     chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -32531,7 +32551,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RenameOutputRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
-    uint8_t index;
+    uint8_t index = static_cast<uint8_t>(0);
     chip::CharSpan name;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -32611,10 +32631,10 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AudioOutputList::TypeInfo::DecodableType audioOutputList;
-        Attributes::CurrentAudioOutput::TypeInfo::DecodableType currentAudioOutput;
+        Attributes::CurrentAudioOutput::TypeInfo::DecodableType currentAudioOutput = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -32823,7 +32843,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LauncherResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -32839,7 +32859,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LauncherResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    StatusEnum status;
+    StatusEnum status = static_cast<StatusEnum>(0);
     chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -32920,8 +32940,8 @@ struct TypeInfo
         Attributes::ApplicationLauncherList::TypeInfo::DecodableType applicationLauncherList;
         Attributes::ApplicationLauncherApp::TypeInfo::DecodableType applicationLauncherApp;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -33103,16 +33123,16 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::VendorName::TypeInfo::DecodableType vendorName;
-        Attributes::VendorId::TypeInfo::DecodableType vendorId;
+        Attributes::VendorId::TypeInfo::DecodableType vendorId = static_cast<uint16_t>(0);
         Attributes::ApplicationName::TypeInfo::DecodableType applicationName;
-        Attributes::ProductId::TypeInfo::DecodableType productId;
+        Attributes::ProductId::TypeInfo::DecodableType productId = static_cast<uint16_t>(0);
         Attributes::ApplicationApp::TypeInfo::DecodableType applicationApp;
-        Attributes::ApplicationStatus::TypeInfo::DecodableType applicationStatus;
+        Attributes::ApplicationStatus::TypeInfo::DecodableType applicationStatus = static_cast<ApplicationStatusEnum>(0);
         Attributes::ApplicationVersion::TypeInfo::DecodableType applicationVersion;
         Attributes::AllowedVendorList::TypeInfo::DecodableType allowedVendorList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -33322,8 +33342,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -33747,7 +33767,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestSpecificResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t returnValue;
+    uint8_t returnValue = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33762,7 +33782,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestSpecificResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t returnValue;
+    uint8_t returnValue = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestSpecificResponse
@@ -33807,7 +33827,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestAddArgumentsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t returnValue;
+    uint8_t returnValue = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33822,7 +33842,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestAddArgumentsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t returnValue;
+    uint8_t returnValue = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestAddArgumentsResponse
@@ -33867,7 +33887,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool returnValue;
+    bool returnValue = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33882,7 +33902,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool returnValue;
+    bool returnValue = static_cast<bool>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestSimpleArgumentResponse
@@ -33936,8 +33956,8 @@ public:
     DataModel::List<const Structs::SimpleStruct::Type> arg2;
     DataModel::List<const SimpleEnum> arg3;
     DataModel::List<const bool> arg4;
-    SimpleEnum arg5;
-    bool arg6;
+    SimpleEnum arg5 = static_cast<SimpleEnum>(0);
+    bool arg6       = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33956,8 +33976,8 @@ public:
     DataModel::DecodableList<Structs::SimpleStruct::DecodableType> arg2;
     DataModel::DecodableList<SimpleEnum> arg3;
     DataModel::DecodableList<bool> arg4;
-    SimpleEnum arg5;
-    bool arg6;
+    SimpleEnum arg5 = static_cast<SimpleEnum>(0);
+    bool arg6       = static_cast<bool>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestStructArrayArgumentResponse
@@ -33975,8 +33995,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestAddArguments::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t arg1;
-    uint8_t arg2;
+    uint8_t arg1 = static_cast<uint8_t>(0);
+    uint8_t arg2 = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33991,8 +34011,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestAddArguments::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t arg1;
-    uint8_t arg2;
+    uint8_t arg1 = static_cast<uint8_t>(0);
+    uint8_t arg2 = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestAddArguments
@@ -34041,7 +34061,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool arg1;
+    bool arg1 = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34056,7 +34076,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool arg1;
+    bool arg1 = static_cast<bool>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestSimpleArgumentRequest
@@ -34074,8 +34094,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEnumsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    chip::VendorId arg1;
-    SimpleEnum arg2;
+    chip::VendorId arg1 = static_cast<chip::VendorId>(0);
+    SimpleEnum arg2     = static_cast<SimpleEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34090,8 +34110,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEnumsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    chip::VendorId arg1;
-    SimpleEnum arg2;
+    chip::VendorId arg1 = static_cast<chip::VendorId>(0);
+    SimpleEnum arg2     = static_cast<SimpleEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestEnumsResponse
@@ -34117,8 +34137,8 @@ public:
     DataModel::List<const Structs::SimpleStruct::Type> arg2;
     DataModel::List<const SimpleEnum> arg3;
     DataModel::List<const bool> arg4;
-    SimpleEnum arg5;
-    bool arg6;
+    SimpleEnum arg5 = static_cast<SimpleEnum>(0);
+    bool arg6       = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34137,8 +34157,8 @@ public:
     DataModel::DecodableList<Structs::SimpleStruct::DecodableType> arg2;
     DataModel::DecodableList<SimpleEnum> arg3;
     DataModel::DecodableList<bool> arg4;
-    SimpleEnum arg5;
-    bool arg6;
+    SimpleEnum arg5 = static_cast<SimpleEnum>(0);
+    bool arg6       = static_cast<bool>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestStructArrayArgumentRequest
@@ -34158,7 +34178,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestNullableOptionalResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool wasPresent;
+    bool wasPresent = static_cast<bool>(0);
     Optional<bool> wasNull;
     Optional<uint8_t> value;
     Optional<DataModel::Nullable<uint8_t>> originalValue;
@@ -34176,7 +34196,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestNullableOptionalResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool wasPresent;
+    bool wasPresent = static_cast<bool>(0);
     Optional<bool> wasNull;
     Optional<uint8_t> value;
     Optional<DataModel::Nullable<uint8_t>> originalValue;
@@ -34255,32 +34275,32 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestComplexNullableOptionalResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool nullableIntWasNull;
+    bool nullableIntWasNull = static_cast<bool>(0);
     Optional<uint16_t> nullableIntValue;
-    bool optionalIntWasPresent;
+    bool optionalIntWasPresent = static_cast<bool>(0);
     Optional<uint16_t> optionalIntValue;
-    bool nullableOptionalIntWasPresent;
+    bool nullableOptionalIntWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalIntWasNull;
     Optional<uint16_t> nullableOptionalIntValue;
-    bool nullableStringWasNull;
+    bool nullableStringWasNull = static_cast<bool>(0);
     Optional<chip::CharSpan> nullableStringValue;
-    bool optionalStringWasPresent;
+    bool optionalStringWasPresent = static_cast<bool>(0);
     Optional<chip::CharSpan> optionalStringValue;
-    bool nullableOptionalStringWasPresent;
+    bool nullableOptionalStringWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalStringWasNull;
     Optional<chip::CharSpan> nullableOptionalStringValue;
-    bool nullableStructWasNull;
+    bool nullableStructWasNull = static_cast<bool>(0);
     Optional<Structs::SimpleStruct::Type> nullableStructValue;
-    bool optionalStructWasPresent;
+    bool optionalStructWasPresent = static_cast<bool>(0);
     Optional<Structs::SimpleStruct::Type> optionalStructValue;
-    bool nullableOptionalStructWasPresent;
+    bool nullableOptionalStructWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalStructWasNull;
     Optional<Structs::SimpleStruct::Type> nullableOptionalStructValue;
-    bool nullableListWasNull;
+    bool nullableListWasNull = static_cast<bool>(0);
     Optional<DataModel::List<const SimpleEnum>> nullableListValue;
-    bool optionalListWasPresent;
+    bool optionalListWasPresent = static_cast<bool>(0);
     Optional<DataModel::List<const SimpleEnum>> optionalListValue;
-    bool nullableOptionalListWasPresent;
+    bool nullableOptionalListWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalListWasNull;
     Optional<DataModel::List<const SimpleEnum>> nullableOptionalListValue;
 
@@ -34297,32 +34317,32 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestComplexNullableOptionalResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool nullableIntWasNull;
+    bool nullableIntWasNull = static_cast<bool>(0);
     Optional<uint16_t> nullableIntValue;
-    bool optionalIntWasPresent;
+    bool optionalIntWasPresent = static_cast<bool>(0);
     Optional<uint16_t> optionalIntValue;
-    bool nullableOptionalIntWasPresent;
+    bool nullableOptionalIntWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalIntWasNull;
     Optional<uint16_t> nullableOptionalIntValue;
-    bool nullableStringWasNull;
+    bool nullableStringWasNull = static_cast<bool>(0);
     Optional<chip::CharSpan> nullableStringValue;
-    bool optionalStringWasPresent;
+    bool optionalStringWasPresent = static_cast<bool>(0);
     Optional<chip::CharSpan> optionalStringValue;
-    bool nullableOptionalStringWasPresent;
+    bool nullableOptionalStringWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalStringWasNull;
     Optional<chip::CharSpan> nullableOptionalStringValue;
-    bool nullableStructWasNull;
+    bool nullableStructWasNull = static_cast<bool>(0);
     Optional<Structs::SimpleStruct::DecodableType> nullableStructValue;
-    bool optionalStructWasPresent;
+    bool optionalStructWasPresent = static_cast<bool>(0);
     Optional<Structs::SimpleStruct::DecodableType> optionalStructValue;
-    bool nullableOptionalStructWasPresent;
+    bool nullableOptionalStructWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalStructWasNull;
     Optional<Structs::SimpleStruct::DecodableType> nullableOptionalStructValue;
-    bool nullableListWasNull;
+    bool nullableListWasNull = static_cast<bool>(0);
     Optional<DataModel::DecodableList<SimpleEnum>> nullableListValue;
-    bool optionalListWasPresent;
+    bool optionalListWasPresent = static_cast<bool>(0);
     Optional<DataModel::DecodableList<SimpleEnum>> optionalListValue;
-    bool nullableOptionalListWasPresent;
+    bool nullableOptionalListWasPresent = static_cast<bool>(0);
     Optional<bool> nullableOptionalListWasNull;
     Optional<DataModel::DecodableList<SimpleEnum>> nullableOptionalListValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -34373,7 +34393,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::BooleanResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool value;
+    bool value = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34388,7 +34408,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::BooleanResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    bool value;
+    bool value = static_cast<bool>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace BooleanResponse
@@ -34501,7 +34521,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEmitTestEventResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint64_t value;
+    uint64_t value = static_cast<uint64_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34516,7 +34536,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEmitTestEventResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint64_t value;
+    uint64_t value = static_cast<uint64_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestEmitTestEventResponse
@@ -34630,8 +34650,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEnumsRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    chip::VendorId arg1;
-    SimpleEnum arg2;
+    chip::VendorId arg1 = static_cast<chip::VendorId>(0);
+    SimpleEnum arg2     = static_cast<SimpleEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34646,8 +34666,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEnumsRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    chip::VendorId arg1;
-    SimpleEnum arg2;
+    chip::VendorId arg1 = static_cast<chip::VendorId>(0);
+    SimpleEnum arg2     = static_cast<SimpleEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestEnumsRequest
@@ -34855,9 +34875,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEmitTestEventRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t arg1;
-    SimpleEnum arg2;
-    bool arg3;
+    uint8_t arg1    = static_cast<uint8_t>(0);
+    SimpleEnum arg2 = static_cast<SimpleEnum>(0);
+    bool arg3       = static_cast<bool>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -34872,9 +34892,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::TestEmitTestEventRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t arg1;
-    SimpleEnum arg2;
-    bool arg3;
+    uint8_t arg1    = static_cast<uint8_t>(0);
+    SimpleEnum arg2 = static_cast<SimpleEnum>(0);
+    bool arg3       = static_cast<bool>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestEmitTestEventRequest
@@ -35868,31 +35888,31 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::Boolean::TypeInfo::DecodableType boolean;
-        Attributes::Bitmap8::TypeInfo::DecodableType bitmap8;
-        Attributes::Bitmap16::TypeInfo::DecodableType bitmap16;
-        Attributes::Bitmap32::TypeInfo::DecodableType bitmap32;
-        Attributes::Bitmap64::TypeInfo::DecodableType bitmap64;
-        Attributes::Int8u::TypeInfo::DecodableType int8u;
-        Attributes::Int16u::TypeInfo::DecodableType int16u;
-        Attributes::Int24u::TypeInfo::DecodableType int24u;
-        Attributes::Int32u::TypeInfo::DecodableType int32u;
-        Attributes::Int40u::TypeInfo::DecodableType int40u;
-        Attributes::Int48u::TypeInfo::DecodableType int48u;
-        Attributes::Int56u::TypeInfo::DecodableType int56u;
-        Attributes::Int64u::TypeInfo::DecodableType int64u;
-        Attributes::Int8s::TypeInfo::DecodableType int8s;
-        Attributes::Int16s::TypeInfo::DecodableType int16s;
-        Attributes::Int24s::TypeInfo::DecodableType int24s;
-        Attributes::Int32s::TypeInfo::DecodableType int32s;
-        Attributes::Int40s::TypeInfo::DecodableType int40s;
-        Attributes::Int48s::TypeInfo::DecodableType int48s;
-        Attributes::Int56s::TypeInfo::DecodableType int56s;
-        Attributes::Int64s::TypeInfo::DecodableType int64s;
-        Attributes::Enum8::TypeInfo::DecodableType enum8;
-        Attributes::Enum16::TypeInfo::DecodableType enum16;
-        Attributes::FloatSingle::TypeInfo::DecodableType floatSingle;
-        Attributes::FloatDouble::TypeInfo::DecodableType floatDouble;
+        Attributes::Boolean::TypeInfo::DecodableType boolean         = static_cast<bool>(0);
+        Attributes::Bitmap8::TypeInfo::DecodableType bitmap8         = static_cast<uint8_t>(0);
+        Attributes::Bitmap16::TypeInfo::DecodableType bitmap16       = static_cast<uint16_t>(0);
+        Attributes::Bitmap32::TypeInfo::DecodableType bitmap32       = static_cast<uint32_t>(0);
+        Attributes::Bitmap64::TypeInfo::DecodableType bitmap64       = static_cast<uint64_t>(0);
+        Attributes::Int8u::TypeInfo::DecodableType int8u             = static_cast<uint8_t>(0);
+        Attributes::Int16u::TypeInfo::DecodableType int16u           = static_cast<uint16_t>(0);
+        Attributes::Int24u::TypeInfo::DecodableType int24u           = static_cast<uint32_t>(0);
+        Attributes::Int32u::TypeInfo::DecodableType int32u           = static_cast<uint32_t>(0);
+        Attributes::Int40u::TypeInfo::DecodableType int40u           = static_cast<uint64_t>(0);
+        Attributes::Int48u::TypeInfo::DecodableType int48u           = static_cast<uint64_t>(0);
+        Attributes::Int56u::TypeInfo::DecodableType int56u           = static_cast<uint64_t>(0);
+        Attributes::Int64u::TypeInfo::DecodableType int64u           = static_cast<uint64_t>(0);
+        Attributes::Int8s::TypeInfo::DecodableType int8s             = static_cast<int8_t>(0);
+        Attributes::Int16s::TypeInfo::DecodableType int16s           = static_cast<int16_t>(0);
+        Attributes::Int24s::TypeInfo::DecodableType int24s           = static_cast<int32_t>(0);
+        Attributes::Int32s::TypeInfo::DecodableType int32s           = static_cast<int32_t>(0);
+        Attributes::Int40s::TypeInfo::DecodableType int40s           = static_cast<int64_t>(0);
+        Attributes::Int48s::TypeInfo::DecodableType int48s           = static_cast<int64_t>(0);
+        Attributes::Int56s::TypeInfo::DecodableType int56s           = static_cast<int64_t>(0);
+        Attributes::Int64s::TypeInfo::DecodableType int64s           = static_cast<int64_t>(0);
+        Attributes::Enum8::TypeInfo::DecodableType enum8             = static_cast<uint8_t>(0);
+        Attributes::Enum16::TypeInfo::DecodableType enum16           = static_cast<uint16_t>(0);
+        Attributes::FloatSingle::TypeInfo::DecodableType floatSingle = static_cast<float>(0);
+        Attributes::FloatDouble::TypeInfo::DecodableType floatDouble = static_cast<double>(0);
         Attributes::OctetString::TypeInfo::DecodableType octetString;
         Attributes::ListInt8u::TypeInfo::DecodableType listInt8u;
         Attributes::ListOctetString::TypeInfo::DecodableType listOctetString;
@@ -35900,19 +35920,19 @@ struct TypeInfo
         Attributes::LongOctetString::TypeInfo::DecodableType longOctetString;
         Attributes::CharString::TypeInfo::DecodableType charString;
         Attributes::LongCharString::TypeInfo::DecodableType longCharString;
-        Attributes::EpochUs::TypeInfo::DecodableType epochUs;
-        Attributes::EpochS::TypeInfo::DecodableType epochS;
-        Attributes::VendorId::TypeInfo::DecodableType vendorId;
+        Attributes::EpochUs::TypeInfo::DecodableType epochUs   = static_cast<uint64_t>(0);
+        Attributes::EpochS::TypeInfo::DecodableType epochS     = static_cast<uint32_t>(0);
+        Attributes::VendorId::TypeInfo::DecodableType vendorId = static_cast<chip::VendorId>(0);
         Attributes::ListNullablesAndOptionalsStruct::TypeInfo::DecodableType listNullablesAndOptionalsStruct;
-        Attributes::EnumAttr::TypeInfo::DecodableType enumAttr;
+        Attributes::EnumAttr::TypeInfo::DecodableType enumAttr = static_cast<SimpleEnum>(0);
         Attributes::StructAttr::TypeInfo::DecodableType structAttr;
-        Attributes::RangeRestrictedInt8u::TypeInfo::DecodableType rangeRestrictedInt8u;
-        Attributes::RangeRestrictedInt8s::TypeInfo::DecodableType rangeRestrictedInt8s;
-        Attributes::RangeRestrictedInt16u::TypeInfo::DecodableType rangeRestrictedInt16u;
-        Attributes::RangeRestrictedInt16s::TypeInfo::DecodableType rangeRestrictedInt16s;
+        Attributes::RangeRestrictedInt8u::TypeInfo::DecodableType rangeRestrictedInt8u   = static_cast<uint8_t>(0);
+        Attributes::RangeRestrictedInt8s::TypeInfo::DecodableType rangeRestrictedInt8s   = static_cast<int8_t>(0);
+        Attributes::RangeRestrictedInt16u::TypeInfo::DecodableType rangeRestrictedInt16u = static_cast<uint16_t>(0);
+        Attributes::RangeRestrictedInt16s::TypeInfo::DecodableType rangeRestrictedInt16s = static_cast<int16_t>(0);
         Attributes::ListLongOctetString::TypeInfo::DecodableType listLongOctetString;
-        Attributes::TimedWriteBoolean::TypeInfo::DecodableType timedWriteBoolean;
-        Attributes::Unsupported::TypeInfo::DecodableType unsupported;
+        Attributes::TimedWriteBoolean::TypeInfo::DecodableType timedWriteBoolean = static_cast<bool>(0);
+        Attributes::Unsupported::TypeInfo::DecodableType unsupported             = static_cast<bool>(0);
         Attributes::NullableBoolean::TypeInfo::DecodableType nullableBoolean;
         Attributes::NullableBitmap8::TypeInfo::DecodableType nullableBitmap8;
         Attributes::NullableBitmap16::TypeInfo::DecodableType nullableBitmap16;
@@ -35947,8 +35967,8 @@ struct TypeInfo
         Attributes::NullableRangeRestrictedInt16u::TypeInfo::DecodableType nullableRangeRestrictedInt16u;
         Attributes::NullableRangeRestrictedInt16s::TypeInfo::DecodableType nullableRangeRestrictedInt16s;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -35974,9 +35994,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t arg1;
-    SimpleEnum arg2;
-    bool arg3;
+    uint8_t arg1    = static_cast<uint8_t>(0);
+    SimpleEnum arg2 = static_cast<SimpleEnum>(0);
+    bool arg3       = static_cast<bool>(0);
     Structs::SimpleStruct::Type arg4;
     DataModel::List<const Structs::SimpleStruct::Type> arg5;
     DataModel::List<const SimpleEnum> arg6;
@@ -35991,9 +36011,9 @@ public:
     static constexpr EventId GetEventId() { return kEventId; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    uint8_t arg1;
-    SimpleEnum arg2;
-    bool arg3;
+    uint8_t arg1    = static_cast<uint8_t>(0);
+    SimpleEnum arg2 = static_cast<SimpleEnum>(0);
+    bool arg3       = static_cast<bool>(0);
     Structs::SimpleStruct::DecodableType arg4;
     DataModel::DecodableList<Structs::SimpleStruct::DecodableType> arg5;
     DataModel::DecodableList<SimpleEnum> arg6;
@@ -36199,12 +36219,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisplayMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    chip::BitFlags<MessagingControlMask> messageControl;
-    uint32_t startTime;
-    uint16_t durationInMinutes;
+    uint32_t messageId                                  = static_cast<uint32_t>(0);
+    chip::BitFlags<MessagingControlMask> messageControl = static_cast<chip::BitFlags<MessagingControlMask>>(0);
+    uint32_t startTime                                  = static_cast<uint32_t>(0);
+    uint16_t durationInMinutes                          = static_cast<uint16_t>(0);
     chip::CharSpan message;
-    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl =
+        static_cast<chip::BitFlags<MessagingExtendedControlMask>>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -36219,12 +36240,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisplayMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    chip::BitFlags<MessagingControlMask> messageControl;
-    uint32_t startTime;
-    uint16_t durationInMinutes;
+    uint32_t messageId                                  = static_cast<uint32_t>(0);
+    chip::BitFlags<MessagingControlMask> messageControl = static_cast<chip::BitFlags<MessagingControlMask>>(0);
+    uint32_t startTime                                  = static_cast<uint32_t>(0);
+    uint16_t durationInMinutes                          = static_cast<uint16_t>(0);
     chip::CharSpan message;
-    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl =
+        static_cast<chip::BitFlags<MessagingExtendedControlMask>>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace DisplayMessage
@@ -36270,8 +36292,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CancelMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    chip::BitFlags<MessagingControlMask> messageControl;
+    uint32_t messageId                                  = static_cast<uint32_t>(0);
+    chip::BitFlags<MessagingControlMask> messageControl = static_cast<chip::BitFlags<MessagingControlMask>>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -36286,8 +36308,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CancelMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    chip::BitFlags<MessagingControlMask> messageControl;
+    uint32_t messageId                                  = static_cast<uint32_t>(0);
+    chip::BitFlags<MessagingControlMask> messageControl = static_cast<chip::BitFlags<MessagingControlMask>>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CancelMessage
@@ -36307,9 +36329,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MessageConfirmation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    uint32_t confirmationTime;
-    uint8_t messageConfirmationControl;
+    uint32_t messageId                 = static_cast<uint32_t>(0);
+    uint32_t confirmationTime          = static_cast<uint32_t>(0);
+    uint8_t messageConfirmationControl = static_cast<uint8_t>(0);
     chip::ByteSpan messageResponse;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -36325,9 +36347,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::MessageConfirmation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    uint32_t confirmationTime;
-    uint8_t messageConfirmationControl;
+    uint32_t messageId                 = static_cast<uint32_t>(0);
+    uint32_t confirmationTime          = static_cast<uint32_t>(0);
+    uint8_t messageConfirmationControl = static_cast<uint8_t>(0);
     chip::ByteSpan messageResponse;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -36350,12 +36372,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisplayProtectedMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    chip::BitFlags<MessagingControlMask> messageControl;
-    uint32_t startTime;
-    uint16_t durationInMinutes;
+    uint32_t messageId                                  = static_cast<uint32_t>(0);
+    chip::BitFlags<MessagingControlMask> messageControl = static_cast<chip::BitFlags<MessagingControlMask>>(0);
+    uint32_t startTime                                  = static_cast<uint32_t>(0);
+    uint16_t durationInMinutes                          = static_cast<uint16_t>(0);
     chip::CharSpan message;
-    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl =
+        static_cast<chip::BitFlags<MessagingExtendedControlMask>>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -36370,12 +36393,13 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::DisplayProtectedMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t messageId;
-    chip::BitFlags<MessagingControlMask> messageControl;
-    uint32_t startTime;
-    uint16_t durationInMinutes;
+    uint32_t messageId                                  = static_cast<uint32_t>(0);
+    chip::BitFlags<MessagingControlMask> messageControl = static_cast<chip::BitFlags<MessagingControlMask>>(0);
+    uint32_t startTime                                  = static_cast<uint32_t>(0);
+    uint16_t durationInMinutes                          = static_cast<uint16_t>(0);
     chip::CharSpan message;
-    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl =
+        static_cast<chip::BitFlags<MessagingExtendedControlMask>>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace DisplayProtectedMessage
@@ -36392,7 +36416,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetMessageCancellation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t earliestImplementationTime;
+    uint32_t earliestImplementationTime = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -36407,7 +36431,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetMessageCancellation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t earliestImplementationTime;
+    uint32_t earliestImplementationTime = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetMessageCancellation
@@ -36424,7 +36448,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CancelAllMessages::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t implementationDateTime;
+    uint32_t implementationDateTime = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -36439,7 +36463,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::CancelAllMessages::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
-    uint32_t implementationDateTime;
+    uint32_t implementationDateTime = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CancelAllMessages
@@ -36493,8 +36517,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -36692,21 +36716,21 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::BasicIdentification::TypeInfo::DecodableType basicIdentification;
+        Attributes::BasicIdentification::TypeInfo::DecodableType basicIdentification = static_cast<uint64_t>(0);
         Attributes::CompanyName::TypeInfo::DecodableType companyName;
-        Attributes::CompanyId::TypeInfo::DecodableType companyId;
+        Attributes::CompanyId::TypeInfo::DecodableType companyId = static_cast<uint16_t>(0);
         Attributes::BrandName::TypeInfo::DecodableType brandName;
-        Attributes::BrandId::TypeInfo::DecodableType brandId;
+        Attributes::BrandId::TypeInfo::DecodableType brandId = static_cast<uint16_t>(0);
         Attributes::Model::TypeInfo::DecodableType model;
         Attributes::PartNumber::TypeInfo::DecodableType partNumber;
         Attributes::ProductRevision::TypeInfo::DecodableType productRevision;
         Attributes::SoftwareRevision::TypeInfo::DecodableType softwareRevision;
         Attributes::ProductTypeName::TypeInfo::DecodableType productTypeName;
-        Attributes::ProductTypeId::TypeInfo::DecodableType productTypeId;
-        Attributes::CecedSpecificationVersion::TypeInfo::DecodableType cecedSpecificationVersion;
+        Attributes::ProductTypeId::TypeInfo::DecodableType productTypeId                         = static_cast<uint16_t>(0);
+        Attributes::CecedSpecificationVersion::TypeInfo::DecodableType cecedSpecificationVersion = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -36905,8 +36929,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::CompanyName::TypeInfo::DecodableType companyName;
-        Attributes::MeterTypeId::TypeInfo::DecodableType meterTypeId;
-        Attributes::DataQualityId::TypeInfo::DecodableType dataQualityId;
+        Attributes::MeterTypeId::TypeInfo::DecodableType meterTypeId     = static_cast<uint16_t>(0);
+        Attributes::DataQualityId::TypeInfo::DecodableType dataQualityId = static_cast<uint16_t>(0);
         Attributes::CustomerName::TypeInfo::DecodableType customerName;
         Attributes::Model::TypeInfo::DecodableType model;
         Attributes::PartNumber::TypeInfo::DecodableType partNumber;
@@ -36914,11 +36938,11 @@ struct TypeInfo
         Attributes::SoftwareRevision::TypeInfo::DecodableType softwareRevision;
         Attributes::UtilityName::TypeInfo::DecodableType utilityName;
         Attributes::Pod::TypeInfo::DecodableType pod;
-        Attributes::AvailablePower::TypeInfo::DecodableType availablePower;
-        Attributes::PowerThreshold::TypeInfo::DecodableType powerThreshold;
+        Attributes::AvailablePower::TypeInfo::DecodableType availablePower = static_cast<int32_t>(0);
+        Attributes::PowerThreshold::TypeInfo::DecodableType powerThreshold = static_cast<int32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -37017,7 +37041,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetAlertsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
-    chip::BitFlags<AlertCount> alertsCount;
+    chip::BitFlags<AlertCount> alertsCount = static_cast<chip::BitFlags<AlertCount>>(0);
     DataModel::List<const chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37033,7 +37057,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetAlertsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
-    chip::BitFlags<AlertCount> alertsCount;
+    chip::BitFlags<AlertCount> alertsCount = static_cast<chip::BitFlags<AlertCount>>(0);
     DataModel::DecodableList<chip::BitFlags<AlertStructure>> alertStructures;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37052,7 +37076,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AlertsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
-    chip::BitFlags<AlertCount> alertsCount;
+    chip::BitFlags<AlertCount> alertsCount = static_cast<chip::BitFlags<AlertCount>>(0);
     DataModel::List<const chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37068,7 +37092,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AlertsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
-    chip::BitFlags<AlertCount> alertsCount;
+    chip::BitFlags<AlertCount> alertsCount = static_cast<chip::BitFlags<AlertCount>>(0);
     DataModel::DecodableList<chip::BitFlags<AlertStructure>> alertStructures;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37087,8 +37111,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EventsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
-    uint8_t eventHeader;
-    EventIdentification eventId;
+    uint8_t eventHeader         = static_cast<uint8_t>(0);
+    EventIdentification eventId = static_cast<EventIdentification>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -37103,8 +37127,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::EventsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
-    uint8_t eventHeader;
-    EventIdentification eventId;
+    uint8_t eventHeader         = static_cast<uint8_t>(0);
+    EventIdentification eventId = static_cast<EventIdentification>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EventsNotification
@@ -37158,8 +37182,8 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -37218,9 +37242,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint32_t timeStamp;
-    uint32_t logId;
-    uint32_t logLength;
+    uint32_t timeStamp = static_cast<uint32_t>(0);
+    uint32_t logId     = static_cast<uint32_t>(0);
+    uint32_t logLength = static_cast<uint32_t>(0);
     DataModel::List<const uint8_t> logPayload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37236,9 +37260,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogNotification::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint32_t timeStamp;
-    uint32_t logId;
-    uint32_t logLength;
+    uint32_t timeStamp = static_cast<uint32_t>(0);
+    uint32_t logId     = static_cast<uint32_t>(0);
+    uint32_t logLength = static_cast<uint32_t>(0);
     DataModel::DecodableList<uint8_t> logPayload;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37256,7 +37280,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint32_t logId;
+    uint32_t logId = static_cast<uint32_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -37271,7 +37295,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint32_t logId;
+    uint32_t logId = static_cast<uint32_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LogRequest
@@ -37291,9 +37315,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint32_t timeStamp;
-    uint32_t logId;
-    uint32_t logLength;
+    uint32_t timeStamp = static_cast<uint32_t>(0);
+    uint32_t logId     = static_cast<uint32_t>(0);
+    uint32_t logLength = static_cast<uint32_t>(0);
     DataModel::List<const uint8_t> logPayload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37309,9 +37333,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint32_t timeStamp;
-    uint32_t logId;
-    uint32_t logLength;
+    uint32_t timeStamp = static_cast<uint32_t>(0);
+    uint32_t logId     = static_cast<uint32_t>(0);
+    uint32_t logLength = static_cast<uint32_t>(0);
     DataModel::DecodableList<uint8_t> logPayload;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37358,7 +37382,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogQueueResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint8_t logQueueSize;
+    uint8_t logQueueSize = static_cast<uint8_t>(0);
     DataModel::List<const uint32_t> logIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37374,7 +37398,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LogQueueResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint8_t logQueueSize;
+    uint8_t logQueueSize = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint32_t> logIds;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37393,7 +37417,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StatisticsAvailable::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint8_t logQueueSize;
+    uint8_t logQueueSize = static_cast<uint8_t>(0);
     DataModel::List<const uint32_t> logIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37409,7 +37433,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StatisticsAvailable::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
-    uint8_t logQueueSize;
+    uint8_t logQueueSize = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint32_t> logIds;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37487,11 +37511,11 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::LogMaxSize::TypeInfo::DecodableType logMaxSize;
-        Attributes::LogQueueMaxSize::TypeInfo::DecodableType logQueueMaxSize;
+        Attributes::LogMaxSize::TypeInfo::DecodableType logMaxSize           = static_cast<uint32_t>(0);
+        Attributes::LogQueueMaxSize::TypeInfo::DecodableType logQueueMaxSize = static_cast<uint8_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes
@@ -37540,9 +37564,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetProfileInfoResponseCommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
-    uint8_t profileCount;
-    uint8_t profileIntervalPeriod;
-    uint8_t maxNumberOfIntervals;
+    uint8_t profileCount          = static_cast<uint8_t>(0);
+    uint8_t profileIntervalPeriod = static_cast<uint8_t>(0);
+    uint8_t maxNumberOfIntervals  = static_cast<uint8_t>(0);
     DataModel::List<const uint16_t> listOfAttributes;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37558,9 +37582,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetProfileInfoResponseCommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
-    uint8_t profileCount;
-    uint8_t profileIntervalPeriod;
-    uint8_t maxNumberOfIntervals;
+    uint8_t profileCount          = static_cast<uint8_t>(0);
+    uint8_t profileIntervalPeriod = static_cast<uint8_t>(0);
+    uint8_t maxNumberOfIntervals  = static_cast<uint8_t>(0);
     DataModel::DecodableList<uint16_t> listOfAttributes;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37611,11 +37635,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileResponseCommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
-    uint32_t startTime;
-    uint8_t status;
-    uint8_t profileIntervalPeriod;
-    uint8_t numberOfIntervalsDelivered;
-    uint16_t attributeId;
+    uint32_t startTime                 = static_cast<uint32_t>(0);
+    uint8_t status                     = static_cast<uint8_t>(0);
+    uint8_t profileIntervalPeriod      = static_cast<uint8_t>(0);
+    uint8_t numberOfIntervalsDelivered = static_cast<uint8_t>(0);
+    uint16_t attributeId               = static_cast<uint16_t>(0);
     DataModel::List<const uint8_t> intervals;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -37631,11 +37655,11 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileResponseCommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
-    uint32_t startTime;
-    uint8_t status;
-    uint8_t profileIntervalPeriod;
-    uint8_t numberOfIntervalsDelivered;
-    uint16_t attributeId;
+    uint32_t startTime                 = static_cast<uint32_t>(0);
+    uint8_t status                     = static_cast<uint8_t>(0);
+    uint8_t profileIntervalPeriod      = static_cast<uint8_t>(0);
+    uint8_t numberOfIntervalsDelivered = static_cast<uint8_t>(0);
+    uint16_t attributeId               = static_cast<uint16_t>(0);
     DataModel::DecodableList<uint8_t> intervals;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -37655,9 +37679,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileCommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
-    uint16_t attributeId;
-    uint32_t startTime;
-    uint8_t numberOfIntervals;
+    uint16_t attributeId      = static_cast<uint16_t>(0);
+    uint32_t startTime        = static_cast<uint32_t>(0);
+    uint8_t numberOfIntervals = static_cast<uint8_t>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -37672,9 +37696,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileCommand::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
-    uint16_t attributeId;
-    uint32_t startTime;
-    uint8_t numberOfIntervals;
+    uint16_t attributeId      = static_cast<uint16_t>(0);
+    uint32_t startTime        = static_cast<uint32_t>(0);
+    uint8_t numberOfIntervals = static_cast<uint8_t>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetMeasurementProfileCommand
@@ -39263,137 +39287,154 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::MeasurementType::TypeInfo::DecodableType measurementType;
-        Attributes::DcVoltage::TypeInfo::DecodableType dcVoltage;
-        Attributes::DcVoltageMin::TypeInfo::DecodableType dcVoltageMin;
-        Attributes::DcVoltageMax::TypeInfo::DecodableType dcVoltageMax;
-        Attributes::DcCurrent::TypeInfo::DecodableType dcCurrent;
-        Attributes::DcCurrentMin::TypeInfo::DecodableType dcCurrentMin;
-        Attributes::DcCurrentMax::TypeInfo::DecodableType dcCurrentMax;
-        Attributes::DcPower::TypeInfo::DecodableType dcPower;
-        Attributes::DcPowerMin::TypeInfo::DecodableType dcPowerMin;
-        Attributes::DcPowerMax::TypeInfo::DecodableType dcPowerMax;
-        Attributes::DcVoltageMultiplier::TypeInfo::DecodableType dcVoltageMultiplier;
-        Attributes::DcVoltageDivisor::TypeInfo::DecodableType dcVoltageDivisor;
-        Attributes::DcCurrentMultiplier::TypeInfo::DecodableType dcCurrentMultiplier;
-        Attributes::DcCurrentDivisor::TypeInfo::DecodableType dcCurrentDivisor;
-        Attributes::DcPowerMultiplier::TypeInfo::DecodableType dcPowerMultiplier;
-        Attributes::DcPowerDivisor::TypeInfo::DecodableType dcPowerDivisor;
-        Attributes::AcFrequency::TypeInfo::DecodableType acFrequency;
-        Attributes::AcFrequencyMin::TypeInfo::DecodableType acFrequencyMin;
-        Attributes::AcFrequencyMax::TypeInfo::DecodableType acFrequencyMax;
-        Attributes::NeutralCurrent::TypeInfo::DecodableType neutralCurrent;
-        Attributes::TotalActivePower::TypeInfo::DecodableType totalActivePower;
-        Attributes::TotalReactivePower::TypeInfo::DecodableType totalReactivePower;
-        Attributes::TotalApparentPower::TypeInfo::DecodableType totalApparentPower;
-        Attributes::Measured1stHarmonicCurrent::TypeInfo::DecodableType measured1stHarmonicCurrent;
-        Attributes::Measured3rdHarmonicCurrent::TypeInfo::DecodableType measured3rdHarmonicCurrent;
-        Attributes::Measured5thHarmonicCurrent::TypeInfo::DecodableType measured5thHarmonicCurrent;
-        Attributes::Measured7thHarmonicCurrent::TypeInfo::DecodableType measured7thHarmonicCurrent;
-        Attributes::Measured9thHarmonicCurrent::TypeInfo::DecodableType measured9thHarmonicCurrent;
-        Attributes::Measured11thHarmonicCurrent::TypeInfo::DecodableType measured11thHarmonicCurrent;
-        Attributes::MeasuredPhase1stHarmonicCurrent::TypeInfo::DecodableType measuredPhase1stHarmonicCurrent;
-        Attributes::MeasuredPhase3rdHarmonicCurrent::TypeInfo::DecodableType measuredPhase3rdHarmonicCurrent;
-        Attributes::MeasuredPhase5thHarmonicCurrent::TypeInfo::DecodableType measuredPhase5thHarmonicCurrent;
-        Attributes::MeasuredPhase7thHarmonicCurrent::TypeInfo::DecodableType measuredPhase7thHarmonicCurrent;
-        Attributes::MeasuredPhase9thHarmonicCurrent::TypeInfo::DecodableType measuredPhase9thHarmonicCurrent;
-        Attributes::MeasuredPhase11thHarmonicCurrent::TypeInfo::DecodableType measuredPhase11thHarmonicCurrent;
-        Attributes::AcFrequencyMultiplier::TypeInfo::DecodableType acFrequencyMultiplier;
-        Attributes::AcFrequencyDivisor::TypeInfo::DecodableType acFrequencyDivisor;
-        Attributes::PowerMultiplier::TypeInfo::DecodableType powerMultiplier;
-        Attributes::PowerDivisor::TypeInfo::DecodableType powerDivisor;
-        Attributes::HarmonicCurrentMultiplier::TypeInfo::DecodableType harmonicCurrentMultiplier;
-        Attributes::PhaseHarmonicCurrentMultiplier::TypeInfo::DecodableType phaseHarmonicCurrentMultiplier;
-        Attributes::InstantaneousVoltage::TypeInfo::DecodableType instantaneousVoltage;
-        Attributes::InstantaneousLineCurrent::TypeInfo::DecodableType instantaneousLineCurrent;
-        Attributes::InstantaneousActiveCurrent::TypeInfo::DecodableType instantaneousActiveCurrent;
-        Attributes::InstantaneousReactiveCurrent::TypeInfo::DecodableType instantaneousReactiveCurrent;
-        Attributes::InstantaneousPower::TypeInfo::DecodableType instantaneousPower;
-        Attributes::RmsVoltage::TypeInfo::DecodableType rmsVoltage;
-        Attributes::RmsVoltageMin::TypeInfo::DecodableType rmsVoltageMin;
-        Attributes::RmsVoltageMax::TypeInfo::DecodableType rmsVoltageMax;
-        Attributes::RmsCurrent::TypeInfo::DecodableType rmsCurrent;
-        Attributes::RmsCurrentMin::TypeInfo::DecodableType rmsCurrentMin;
-        Attributes::RmsCurrentMax::TypeInfo::DecodableType rmsCurrentMax;
-        Attributes::ActivePower::TypeInfo::DecodableType activePower;
-        Attributes::ActivePowerMin::TypeInfo::DecodableType activePowerMin;
-        Attributes::ActivePowerMax::TypeInfo::DecodableType activePowerMax;
-        Attributes::ReactivePower::TypeInfo::DecodableType reactivePower;
-        Attributes::ApparentPower::TypeInfo::DecodableType apparentPower;
-        Attributes::PowerFactor::TypeInfo::DecodableType powerFactor;
-        Attributes::AverageRmsVoltageMeasurementPeriod::TypeInfo::DecodableType averageRmsVoltageMeasurementPeriod;
-        Attributes::AverageRmsUnderVoltageCounter::TypeInfo::DecodableType averageRmsUnderVoltageCounter;
-        Attributes::RmsExtremeOverVoltagePeriod::TypeInfo::DecodableType rmsExtremeOverVoltagePeriod;
-        Attributes::RmsExtremeUnderVoltagePeriod::TypeInfo::DecodableType rmsExtremeUnderVoltagePeriod;
-        Attributes::RmsVoltageSagPeriod::TypeInfo::DecodableType rmsVoltageSagPeriod;
-        Attributes::RmsVoltageSwellPeriod::TypeInfo::DecodableType rmsVoltageSwellPeriod;
-        Attributes::AcVoltageMultiplier::TypeInfo::DecodableType acVoltageMultiplier;
-        Attributes::AcVoltageDivisor::TypeInfo::DecodableType acVoltageDivisor;
-        Attributes::AcCurrentMultiplier::TypeInfo::DecodableType acCurrentMultiplier;
-        Attributes::AcCurrentDivisor::TypeInfo::DecodableType acCurrentDivisor;
-        Attributes::AcPowerMultiplier::TypeInfo::DecodableType acPowerMultiplier;
-        Attributes::AcPowerDivisor::TypeInfo::DecodableType acPowerDivisor;
-        Attributes::OverloadAlarmsMask::TypeInfo::DecodableType overloadAlarmsMask;
-        Attributes::VoltageOverload::TypeInfo::DecodableType voltageOverload;
-        Attributes::CurrentOverload::TypeInfo::DecodableType currentOverload;
-        Attributes::AcOverloadAlarmsMask::TypeInfo::DecodableType acOverloadAlarmsMask;
-        Attributes::AcVoltageOverload::TypeInfo::DecodableType acVoltageOverload;
-        Attributes::AcCurrentOverload::TypeInfo::DecodableType acCurrentOverload;
-        Attributes::AcActivePowerOverload::TypeInfo::DecodableType acActivePowerOverload;
-        Attributes::AcReactivePowerOverload::TypeInfo::DecodableType acReactivePowerOverload;
-        Attributes::AverageRmsOverVoltage::TypeInfo::DecodableType averageRmsOverVoltage;
-        Attributes::AverageRmsUnderVoltage::TypeInfo::DecodableType averageRmsUnderVoltage;
-        Attributes::RmsExtremeOverVoltage::TypeInfo::DecodableType rmsExtremeOverVoltage;
-        Attributes::RmsExtremeUnderVoltage::TypeInfo::DecodableType rmsExtremeUnderVoltage;
-        Attributes::RmsVoltageSag::TypeInfo::DecodableType rmsVoltageSag;
-        Attributes::RmsVoltageSwell::TypeInfo::DecodableType rmsVoltageSwell;
-        Attributes::LineCurrentPhaseB::TypeInfo::DecodableType lineCurrentPhaseB;
-        Attributes::ActiveCurrentPhaseB::TypeInfo::DecodableType activeCurrentPhaseB;
-        Attributes::ReactiveCurrentPhaseB::TypeInfo::DecodableType reactiveCurrentPhaseB;
-        Attributes::RmsVoltagePhaseB::TypeInfo::DecodableType rmsVoltagePhaseB;
-        Attributes::RmsVoltageMinPhaseB::TypeInfo::DecodableType rmsVoltageMinPhaseB;
-        Attributes::RmsVoltageMaxPhaseB::TypeInfo::DecodableType rmsVoltageMaxPhaseB;
-        Attributes::RmsCurrentPhaseB::TypeInfo::DecodableType rmsCurrentPhaseB;
-        Attributes::RmsCurrentMinPhaseB::TypeInfo::DecodableType rmsCurrentMinPhaseB;
-        Attributes::RmsCurrentMaxPhaseB::TypeInfo::DecodableType rmsCurrentMaxPhaseB;
-        Attributes::ActivePowerPhaseB::TypeInfo::DecodableType activePowerPhaseB;
-        Attributes::ActivePowerMinPhaseB::TypeInfo::DecodableType activePowerMinPhaseB;
-        Attributes::ActivePowerMaxPhaseB::TypeInfo::DecodableType activePowerMaxPhaseB;
-        Attributes::ReactivePowerPhaseB::TypeInfo::DecodableType reactivePowerPhaseB;
-        Attributes::ApparentPowerPhaseB::TypeInfo::DecodableType apparentPowerPhaseB;
-        Attributes::PowerFactorPhaseB::TypeInfo::DecodableType powerFactorPhaseB;
-        Attributes::AverageRmsVoltageMeasurementPeriodPhaseB::TypeInfo::DecodableType averageRmsVoltageMeasurementPeriodPhaseB;
-        Attributes::AverageRmsOverVoltageCounterPhaseB::TypeInfo::DecodableType averageRmsOverVoltageCounterPhaseB;
-        Attributes::AverageRmsUnderVoltageCounterPhaseB::TypeInfo::DecodableType averageRmsUnderVoltageCounterPhaseB;
-        Attributes::RmsExtremeOverVoltagePeriodPhaseB::TypeInfo::DecodableType rmsExtremeOverVoltagePeriodPhaseB;
-        Attributes::RmsExtremeUnderVoltagePeriodPhaseB::TypeInfo::DecodableType rmsExtremeUnderVoltagePeriodPhaseB;
-        Attributes::RmsVoltageSagPeriodPhaseB::TypeInfo::DecodableType rmsVoltageSagPeriodPhaseB;
-        Attributes::RmsVoltageSwellPeriodPhaseB::TypeInfo::DecodableType rmsVoltageSwellPeriodPhaseB;
-        Attributes::LineCurrentPhaseC::TypeInfo::DecodableType lineCurrentPhaseC;
-        Attributes::ActiveCurrentPhaseC::TypeInfo::DecodableType activeCurrentPhaseC;
-        Attributes::ReactiveCurrentPhaseC::TypeInfo::DecodableType reactiveCurrentPhaseC;
-        Attributes::RmsVoltagePhaseC::TypeInfo::DecodableType rmsVoltagePhaseC;
-        Attributes::RmsVoltageMinPhaseC::TypeInfo::DecodableType rmsVoltageMinPhaseC;
-        Attributes::RmsVoltageMaxPhaseC::TypeInfo::DecodableType rmsVoltageMaxPhaseC;
-        Attributes::RmsCurrentPhaseC::TypeInfo::DecodableType rmsCurrentPhaseC;
-        Attributes::RmsCurrentMinPhaseC::TypeInfo::DecodableType rmsCurrentMinPhaseC;
-        Attributes::RmsCurrentMaxPhaseC::TypeInfo::DecodableType rmsCurrentMaxPhaseC;
-        Attributes::ActivePowerPhaseC::TypeInfo::DecodableType activePowerPhaseC;
-        Attributes::ActivePowerMinPhaseC::TypeInfo::DecodableType activePowerMinPhaseC;
-        Attributes::ActivePowerMaxPhaseC::TypeInfo::DecodableType activePowerMaxPhaseC;
-        Attributes::ReactivePowerPhaseC::TypeInfo::DecodableType reactivePowerPhaseC;
-        Attributes::ApparentPowerPhaseC::TypeInfo::DecodableType apparentPowerPhaseC;
-        Attributes::PowerFactorPhaseC::TypeInfo::DecodableType powerFactorPhaseC;
-        Attributes::AverageRmsVoltageMeasurementPeriodPhaseC::TypeInfo::DecodableType averageRmsVoltageMeasurementPeriodPhaseC;
-        Attributes::AverageRmsOverVoltageCounterPhaseC::TypeInfo::DecodableType averageRmsOverVoltageCounterPhaseC;
-        Attributes::AverageRmsUnderVoltageCounterPhaseC::TypeInfo::DecodableType averageRmsUnderVoltageCounterPhaseC;
-        Attributes::RmsExtremeOverVoltagePeriodPhaseC::TypeInfo::DecodableType rmsExtremeOverVoltagePeriodPhaseC;
-        Attributes::RmsExtremeUnderVoltagePeriodPhaseC::TypeInfo::DecodableType rmsExtremeUnderVoltagePeriodPhaseC;
-        Attributes::RmsVoltageSagPeriodPhaseC::TypeInfo::DecodableType rmsVoltageSagPeriodPhaseC;
-        Attributes::RmsVoltageSwellPeriodPhaseC::TypeInfo::DecodableType rmsVoltageSwellPeriodPhaseC;
+        Attributes::MeasurementType::TypeInfo::DecodableType measurementType                         = static_cast<uint32_t>(0);
+        Attributes::DcVoltage::TypeInfo::DecodableType dcVoltage                                     = static_cast<int16_t>(0);
+        Attributes::DcVoltageMin::TypeInfo::DecodableType dcVoltageMin                               = static_cast<int16_t>(0);
+        Attributes::DcVoltageMax::TypeInfo::DecodableType dcVoltageMax                               = static_cast<int16_t>(0);
+        Attributes::DcCurrent::TypeInfo::DecodableType dcCurrent                                     = static_cast<int16_t>(0);
+        Attributes::DcCurrentMin::TypeInfo::DecodableType dcCurrentMin                               = static_cast<int16_t>(0);
+        Attributes::DcCurrentMax::TypeInfo::DecodableType dcCurrentMax                               = static_cast<int16_t>(0);
+        Attributes::DcPower::TypeInfo::DecodableType dcPower                                         = static_cast<int16_t>(0);
+        Attributes::DcPowerMin::TypeInfo::DecodableType dcPowerMin                                   = static_cast<int16_t>(0);
+        Attributes::DcPowerMax::TypeInfo::DecodableType dcPowerMax                                   = static_cast<int16_t>(0);
+        Attributes::DcVoltageMultiplier::TypeInfo::DecodableType dcVoltageMultiplier                 = static_cast<uint16_t>(0);
+        Attributes::DcVoltageDivisor::TypeInfo::DecodableType dcVoltageDivisor                       = static_cast<uint16_t>(0);
+        Attributes::DcCurrentMultiplier::TypeInfo::DecodableType dcCurrentMultiplier                 = static_cast<uint16_t>(0);
+        Attributes::DcCurrentDivisor::TypeInfo::DecodableType dcCurrentDivisor                       = static_cast<uint16_t>(0);
+        Attributes::DcPowerMultiplier::TypeInfo::DecodableType dcPowerMultiplier                     = static_cast<uint16_t>(0);
+        Attributes::DcPowerDivisor::TypeInfo::DecodableType dcPowerDivisor                           = static_cast<uint16_t>(0);
+        Attributes::AcFrequency::TypeInfo::DecodableType acFrequency                                 = static_cast<uint16_t>(0);
+        Attributes::AcFrequencyMin::TypeInfo::DecodableType acFrequencyMin                           = static_cast<uint16_t>(0);
+        Attributes::AcFrequencyMax::TypeInfo::DecodableType acFrequencyMax                           = static_cast<uint16_t>(0);
+        Attributes::NeutralCurrent::TypeInfo::DecodableType neutralCurrent                           = static_cast<uint16_t>(0);
+        Attributes::TotalActivePower::TypeInfo::DecodableType totalActivePower                       = static_cast<int32_t>(0);
+        Attributes::TotalReactivePower::TypeInfo::DecodableType totalReactivePower                   = static_cast<int32_t>(0);
+        Attributes::TotalApparentPower::TypeInfo::DecodableType totalApparentPower                   = static_cast<uint32_t>(0);
+        Attributes::Measured1stHarmonicCurrent::TypeInfo::DecodableType measured1stHarmonicCurrent   = static_cast<int16_t>(0);
+        Attributes::Measured3rdHarmonicCurrent::TypeInfo::DecodableType measured3rdHarmonicCurrent   = static_cast<int16_t>(0);
+        Attributes::Measured5thHarmonicCurrent::TypeInfo::DecodableType measured5thHarmonicCurrent   = static_cast<int16_t>(0);
+        Attributes::Measured7thHarmonicCurrent::TypeInfo::DecodableType measured7thHarmonicCurrent   = static_cast<int16_t>(0);
+        Attributes::Measured9thHarmonicCurrent::TypeInfo::DecodableType measured9thHarmonicCurrent   = static_cast<int16_t>(0);
+        Attributes::Measured11thHarmonicCurrent::TypeInfo::DecodableType measured11thHarmonicCurrent = static_cast<int16_t>(0);
+        Attributes::MeasuredPhase1stHarmonicCurrent::TypeInfo::DecodableType measuredPhase1stHarmonicCurrent =
+            static_cast<int16_t>(0);
+        Attributes::MeasuredPhase3rdHarmonicCurrent::TypeInfo::DecodableType measuredPhase3rdHarmonicCurrent =
+            static_cast<int16_t>(0);
+        Attributes::MeasuredPhase5thHarmonicCurrent::TypeInfo::DecodableType measuredPhase5thHarmonicCurrent =
+            static_cast<int16_t>(0);
+        Attributes::MeasuredPhase7thHarmonicCurrent::TypeInfo::DecodableType measuredPhase7thHarmonicCurrent =
+            static_cast<int16_t>(0);
+        Attributes::MeasuredPhase9thHarmonicCurrent::TypeInfo::DecodableType measuredPhase9thHarmonicCurrent =
+            static_cast<int16_t>(0);
+        Attributes::MeasuredPhase11thHarmonicCurrent::TypeInfo::DecodableType measuredPhase11thHarmonicCurrent =
+            static_cast<int16_t>(0);
+        Attributes::AcFrequencyMultiplier::TypeInfo::DecodableType acFrequencyMultiplier         = static_cast<uint16_t>(0);
+        Attributes::AcFrequencyDivisor::TypeInfo::DecodableType acFrequencyDivisor               = static_cast<uint16_t>(0);
+        Attributes::PowerMultiplier::TypeInfo::DecodableType powerMultiplier                     = static_cast<uint32_t>(0);
+        Attributes::PowerDivisor::TypeInfo::DecodableType powerDivisor                           = static_cast<uint32_t>(0);
+        Attributes::HarmonicCurrentMultiplier::TypeInfo::DecodableType harmonicCurrentMultiplier = static_cast<int8_t>(0);
+        Attributes::PhaseHarmonicCurrentMultiplier::TypeInfo::DecodableType phaseHarmonicCurrentMultiplier = static_cast<int8_t>(0);
+        Attributes::InstantaneousVoltage::TypeInfo::DecodableType instantaneousVoltage                 = static_cast<int16_t>(0);
+        Attributes::InstantaneousLineCurrent::TypeInfo::DecodableType instantaneousLineCurrent         = static_cast<uint16_t>(0);
+        Attributes::InstantaneousActiveCurrent::TypeInfo::DecodableType instantaneousActiveCurrent     = static_cast<int16_t>(0);
+        Attributes::InstantaneousReactiveCurrent::TypeInfo::DecodableType instantaneousReactiveCurrent = static_cast<int16_t>(0);
+        Attributes::InstantaneousPower::TypeInfo::DecodableType instantaneousPower                     = static_cast<int16_t>(0);
+        Attributes::RmsVoltage::TypeInfo::DecodableType rmsVoltage                                     = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageMin::TypeInfo::DecodableType rmsVoltageMin                               = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageMax::TypeInfo::DecodableType rmsVoltageMax                               = static_cast<uint16_t>(0);
+        Attributes::RmsCurrent::TypeInfo::DecodableType rmsCurrent                                     = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentMin::TypeInfo::DecodableType rmsCurrentMin                               = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentMax::TypeInfo::DecodableType rmsCurrentMax                               = static_cast<uint16_t>(0);
+        Attributes::ActivePower::TypeInfo::DecodableType activePower                                   = static_cast<int16_t>(0);
+        Attributes::ActivePowerMin::TypeInfo::DecodableType activePowerMin                             = static_cast<int16_t>(0);
+        Attributes::ActivePowerMax::TypeInfo::DecodableType activePowerMax                             = static_cast<int16_t>(0);
+        Attributes::ReactivePower::TypeInfo::DecodableType reactivePower                               = static_cast<int16_t>(0);
+        Attributes::ApparentPower::TypeInfo::DecodableType apparentPower                               = static_cast<uint16_t>(0);
+        Attributes::PowerFactor::TypeInfo::DecodableType powerFactor                                   = static_cast<int8_t>(0);
+        Attributes::AverageRmsVoltageMeasurementPeriod::TypeInfo::DecodableType averageRmsVoltageMeasurementPeriod =
+            static_cast<uint16_t>(0);
+        Attributes::AverageRmsUnderVoltageCounter::TypeInfo::DecodableType averageRmsUnderVoltageCounter = static_cast<uint16_t>(0);
+        Attributes::RmsExtremeOverVoltagePeriod::TypeInfo::DecodableType rmsExtremeOverVoltagePeriod     = static_cast<uint16_t>(0);
+        Attributes::RmsExtremeUnderVoltagePeriod::TypeInfo::DecodableType rmsExtremeUnderVoltagePeriod   = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageSagPeriod::TypeInfo::DecodableType rmsVoltageSagPeriod                     = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageSwellPeriod::TypeInfo::DecodableType rmsVoltageSwellPeriod                 = static_cast<uint16_t>(0);
+        Attributes::AcVoltageMultiplier::TypeInfo::DecodableType acVoltageMultiplier                     = static_cast<uint16_t>(0);
+        Attributes::AcVoltageDivisor::TypeInfo::DecodableType acVoltageDivisor                           = static_cast<uint16_t>(0);
+        Attributes::AcCurrentMultiplier::TypeInfo::DecodableType acCurrentMultiplier                     = static_cast<uint16_t>(0);
+        Attributes::AcCurrentDivisor::TypeInfo::DecodableType acCurrentDivisor                           = static_cast<uint16_t>(0);
+        Attributes::AcPowerMultiplier::TypeInfo::DecodableType acPowerMultiplier                         = static_cast<uint16_t>(0);
+        Attributes::AcPowerDivisor::TypeInfo::DecodableType acPowerDivisor                               = static_cast<uint16_t>(0);
+        Attributes::OverloadAlarmsMask::TypeInfo::DecodableType overloadAlarmsMask                       = static_cast<uint8_t>(0);
+        Attributes::VoltageOverload::TypeInfo::DecodableType voltageOverload                             = static_cast<int16_t>(0);
+        Attributes::CurrentOverload::TypeInfo::DecodableType currentOverload                             = static_cast<int16_t>(0);
+        Attributes::AcOverloadAlarmsMask::TypeInfo::DecodableType acOverloadAlarmsMask                   = static_cast<uint16_t>(0);
+        Attributes::AcVoltageOverload::TypeInfo::DecodableType acVoltageOverload                         = static_cast<int16_t>(0);
+        Attributes::AcCurrentOverload::TypeInfo::DecodableType acCurrentOverload                         = static_cast<int16_t>(0);
+        Attributes::AcActivePowerOverload::TypeInfo::DecodableType acActivePowerOverload                 = static_cast<int16_t>(0);
+        Attributes::AcReactivePowerOverload::TypeInfo::DecodableType acReactivePowerOverload             = static_cast<int16_t>(0);
+        Attributes::AverageRmsOverVoltage::TypeInfo::DecodableType averageRmsOverVoltage                 = static_cast<int16_t>(0);
+        Attributes::AverageRmsUnderVoltage::TypeInfo::DecodableType averageRmsUnderVoltage               = static_cast<int16_t>(0);
+        Attributes::RmsExtremeOverVoltage::TypeInfo::DecodableType rmsExtremeOverVoltage                 = static_cast<int16_t>(0);
+        Attributes::RmsExtremeUnderVoltage::TypeInfo::DecodableType rmsExtremeUnderVoltage               = static_cast<int16_t>(0);
+        Attributes::RmsVoltageSag::TypeInfo::DecodableType rmsVoltageSag                                 = static_cast<int16_t>(0);
+        Attributes::RmsVoltageSwell::TypeInfo::DecodableType rmsVoltageSwell                             = static_cast<int16_t>(0);
+        Attributes::LineCurrentPhaseB::TypeInfo::DecodableType lineCurrentPhaseB                         = static_cast<uint16_t>(0);
+        Attributes::ActiveCurrentPhaseB::TypeInfo::DecodableType activeCurrentPhaseB                     = static_cast<int16_t>(0);
+        Attributes::ReactiveCurrentPhaseB::TypeInfo::DecodableType reactiveCurrentPhaseB                 = static_cast<int16_t>(0);
+        Attributes::RmsVoltagePhaseB::TypeInfo::DecodableType rmsVoltagePhaseB                           = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageMinPhaseB::TypeInfo::DecodableType rmsVoltageMinPhaseB                     = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageMaxPhaseB::TypeInfo::DecodableType rmsVoltageMaxPhaseB                     = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentPhaseB::TypeInfo::DecodableType rmsCurrentPhaseB                           = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentMinPhaseB::TypeInfo::DecodableType rmsCurrentMinPhaseB                     = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentMaxPhaseB::TypeInfo::DecodableType rmsCurrentMaxPhaseB                     = static_cast<uint16_t>(0);
+        Attributes::ActivePowerPhaseB::TypeInfo::DecodableType activePowerPhaseB                         = static_cast<int16_t>(0);
+        Attributes::ActivePowerMinPhaseB::TypeInfo::DecodableType activePowerMinPhaseB                   = static_cast<int16_t>(0);
+        Attributes::ActivePowerMaxPhaseB::TypeInfo::DecodableType activePowerMaxPhaseB                   = static_cast<int16_t>(0);
+        Attributes::ReactivePowerPhaseB::TypeInfo::DecodableType reactivePowerPhaseB                     = static_cast<int16_t>(0);
+        Attributes::ApparentPowerPhaseB::TypeInfo::DecodableType apparentPowerPhaseB                     = static_cast<uint16_t>(0);
+        Attributes::PowerFactorPhaseB::TypeInfo::DecodableType powerFactorPhaseB                         = static_cast<int8_t>(0);
+        Attributes::AverageRmsVoltageMeasurementPeriodPhaseB::TypeInfo::DecodableType averageRmsVoltageMeasurementPeriodPhaseB =
+            static_cast<uint16_t>(0);
+        Attributes::AverageRmsOverVoltageCounterPhaseB::TypeInfo::DecodableType averageRmsOverVoltageCounterPhaseB =
+            static_cast<uint16_t>(0);
+        Attributes::AverageRmsUnderVoltageCounterPhaseB::TypeInfo::DecodableType averageRmsUnderVoltageCounterPhaseB =
+            static_cast<uint16_t>(0);
+        Attributes::RmsExtremeOverVoltagePeriodPhaseB::TypeInfo::DecodableType rmsExtremeOverVoltagePeriodPhaseB =
+            static_cast<uint16_t>(0);
+        Attributes::RmsExtremeUnderVoltagePeriodPhaseB::TypeInfo::DecodableType rmsExtremeUnderVoltagePeriodPhaseB =
+            static_cast<uint16_t>(0);
+        Attributes::RmsVoltageSagPeriodPhaseB::TypeInfo::DecodableType rmsVoltageSagPeriodPhaseB     = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageSwellPeriodPhaseB::TypeInfo::DecodableType rmsVoltageSwellPeriodPhaseB = static_cast<uint16_t>(0);
+        Attributes::LineCurrentPhaseC::TypeInfo::DecodableType lineCurrentPhaseC                     = static_cast<uint16_t>(0);
+        Attributes::ActiveCurrentPhaseC::TypeInfo::DecodableType activeCurrentPhaseC                 = static_cast<int16_t>(0);
+        Attributes::ReactiveCurrentPhaseC::TypeInfo::DecodableType reactiveCurrentPhaseC             = static_cast<int16_t>(0);
+        Attributes::RmsVoltagePhaseC::TypeInfo::DecodableType rmsVoltagePhaseC                       = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageMinPhaseC::TypeInfo::DecodableType rmsVoltageMinPhaseC                 = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageMaxPhaseC::TypeInfo::DecodableType rmsVoltageMaxPhaseC                 = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentPhaseC::TypeInfo::DecodableType rmsCurrentPhaseC                       = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentMinPhaseC::TypeInfo::DecodableType rmsCurrentMinPhaseC                 = static_cast<uint16_t>(0);
+        Attributes::RmsCurrentMaxPhaseC::TypeInfo::DecodableType rmsCurrentMaxPhaseC                 = static_cast<uint16_t>(0);
+        Attributes::ActivePowerPhaseC::TypeInfo::DecodableType activePowerPhaseC                     = static_cast<int16_t>(0);
+        Attributes::ActivePowerMinPhaseC::TypeInfo::DecodableType activePowerMinPhaseC               = static_cast<int16_t>(0);
+        Attributes::ActivePowerMaxPhaseC::TypeInfo::DecodableType activePowerMaxPhaseC               = static_cast<int16_t>(0);
+        Attributes::ReactivePowerPhaseC::TypeInfo::DecodableType reactivePowerPhaseC                 = static_cast<int16_t>(0);
+        Attributes::ApparentPowerPhaseC::TypeInfo::DecodableType apparentPowerPhaseC                 = static_cast<uint16_t>(0);
+        Attributes::PowerFactorPhaseC::TypeInfo::DecodableType powerFactorPhaseC                     = static_cast<int8_t>(0);
+        Attributes::AverageRmsVoltageMeasurementPeriodPhaseC::TypeInfo::DecodableType averageRmsVoltageMeasurementPeriodPhaseC =
+            static_cast<uint16_t>(0);
+        Attributes::AverageRmsOverVoltageCounterPhaseC::TypeInfo::DecodableType averageRmsOverVoltageCounterPhaseC =
+            static_cast<uint16_t>(0);
+        Attributes::AverageRmsUnderVoltageCounterPhaseC::TypeInfo::DecodableType averageRmsUnderVoltageCounterPhaseC =
+            static_cast<uint16_t>(0);
+        Attributes::RmsExtremeOverVoltagePeriodPhaseC::TypeInfo::DecodableType rmsExtremeOverVoltagePeriodPhaseC =
+            static_cast<uint16_t>(0);
+        Attributes::RmsExtremeUnderVoltagePeriodPhaseC::TypeInfo::DecodableType rmsExtremeUnderVoltagePeriodPhaseC =
+            static_cast<uint16_t>(0);
+        Attributes::RmsVoltageSagPeriodPhaseC::TypeInfo::DecodableType rmsVoltageSagPeriodPhaseC     = static_cast<uint16_t>(0);
+        Attributes::RmsVoltageSwellPeriodPhaseC::TypeInfo::DecodableType rmsVoltageSwellPeriodPhaseC = static_cast<uint16_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
-        Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision;
+        Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
+        Attributes::ClusterRevision::TypeInfo::DecodableType clusterRevision = static_cast<uint16_t>(0);
     };
 };
 } // namespace Attributes


### PR DESCRIPTION
Otherwise we can end up reading random values from un-initialized
memory (e.g. if a mandatory command/struct/event field is not sent by
the other side).

Fixes https://github.com/project-chip/connectedhomeip/issues/10271

#### Problem
See above.

#### Change overview
Init integers/floats/enum/bitfields to 0 and decodable lists to empty list.

#### Testing
No behavior changes on well-behaved clients, which are the only kind we have so far.