### PR TITLE
Add support for HourFormat & CalendarType in ConfigurationMgr

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -102,6 +102,8 @@ public:
     virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)    = 0;
     virtual CHIP_ERROR GetActiveLocale(char * buf, size_t bufSize, size_t & codeLen)   = 0;
     virtual CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb)                            = 0;
+    virtual CHIP_ERROR GetHourFormat(uint8_t & format)                                 = 0;
+    virtual CHIP_ERROR GetCalendarType(uint8_t & type)                                 = 0;
     virtual CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen)  = 0;
     virtual CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf)                 = 0;
     virtual CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf)               = 0;
@@ -113,6 +115,8 @@ public:
     virtual CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen)             = 0;
     virtual CHIP_ERROR StoreActiveLocale(const char * code, size_t codeLen)            = 0;
     virtual CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb)                            = 0;
+    virtual CHIP_ERROR StoreHourFormat(uint8_t format)                                 = 0;
+    virtual CHIP_ERROR StoreCalendarType(uint8_t type)                                 = 0;
     virtual CHIP_ERROR GetRebootCount(uint32_t & rebootCount)                          = 0;
     virtual CHIP_ERROR StoreRebootCount(uint32_t rebootCount)                          = 0;
     virtual CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours)      = 0;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -322,6 +322,52 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreRegulatoryLocation
 }
 
 template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetHourFormat(uint8_t & format)
+{
+    uint32_t value = 0;
+
+    CHIP_ERROR err = ReadConfigValue(ConfigClass::kConfigKey_HourFormat, value);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(value <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        format = static_cast<uint8_t>(value);
+    }
+
+    return err;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreHourFormat(uint8_t format)
+{
+    uint32_t value = format;
+    return WriteConfigValue(ConfigClass::kConfigKey_HourFormat, value);
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCalendarType(uint8_t & type)
+{
+    uint32_t value = 0;
+
+    CHIP_ERROR err = ReadConfigValue(ConfigClass::kConfigKey_CalendarType, value);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(value <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        type = static_cast<uint8_t>(value);
+    }
+
+    return err;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::StoreCalendarType(uint8_t type)
+{
+    uint32_t value = type;
+    return WriteConfigValue(ConfigClass::kConfigKey_CalendarType, value);
+}
+
+template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
 {
     return ReadConfigValueStr(ConfigClass::kConfigKey_CountryCode, buf, bufSize, codeLen);

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -110,6 +110,10 @@ public:
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override;
     CHIP_ERROR GetReachable(bool & reachable) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetHourFormat(uint8_t & format) override;
+    CHIP_ERROR StoreHourFormat(uint8_t format) override;
+    CHIP_ERROR GetCalendarType(uint8_t & type) override;
+    CHIP_ERROR StoreCalendarType(uint8_t type) override;
     CHIP_ERROR RunUnitTests(void) override;
     bool IsFullyProvisioned() override;
     void InitiateFactoryReset() override;

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -74,6 +74,8 @@ const AmebaConfig::Key AmebaConfig::kConfigKey_RegulatoryLocation          = { k
 const AmebaConfig::Key AmebaConfig::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_ActiveLocale                = { kConfigNamespace_ChipConfig, "active-locale" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_Breadcrumb                  = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const AmebaConfig::Key AmebaConfig::kConfigKey_HourFormat                  = { kConfigNamespace_ChipConfig, "hour-format" };
+const AmebaConfig::Key AmebaConfig::kConfigKey_CalendarType                = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Keys stored in the Chip-counters namespace
 const AmebaConfig::Key AmebaConfig::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -68,6 +68,10 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
+
+    // Counter keys
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -67,6 +67,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_ActiveLocale       = { kConfigNamespace_ChipConfig, "active-locale" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const PosixConfig::Key PosixConfig::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
+const PosixConfig::Key PosixConfig::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -74,6 +74,8 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -94,9 +94,11 @@ public:
     static constexpr Key kConfigKey_RegulatoryLocation = EFR32ConfigKey(kChipConfig_KeyBase, 0x09);
     static constexpr Key kConfigKey_CountryCode        = EFR32ConfigKey(kChipConfig_KeyBase, 0x0A);
     static constexpr Key kConfigKey_Breadcrumb         = EFR32ConfigKey(kChipConfig_KeyBase, 0x0B);
-    static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_ActiveLocale       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0D);
-    static constexpr Key kConfigKey_GroupKeyMax = EFR32ConfigKey(kChipConfig_KeyBase, 0x1B); // Allows 16 Group Keys to be created.
+    static constexpr Key kConfigKey_ActiveLocale       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0C);
+    static constexpr Key kConfigKey_HourFormat         = EFR32ConfigKey(kChipConfig_KeyBase, 0x0D);
+    static constexpr Key kConfigKey_CalendarType       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
+    static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0F);
+    static constexpr Key kConfigKey_GroupKeyMax = EFR32ConfigKey(kChipConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.
 
     // CHIP Counter Keys
     static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x00);

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -73,6 +73,8 @@ const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_ActiveLocale       = { kConfigNamespace_ChipConfig, "active-locale" };
 const ESP32Config::Key ESP32Config::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const ESP32Config::Key ESP32Config::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
+const ESP32Config::Key ESP32Config::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Keys stored in the Chip-counters namespace
 const ESP32Config::Key ESP32Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -75,6 +75,10 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
+
+    // CHIP Counter keys
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -73,6 +73,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_ActiveLocale       = { kConfigNamespace_ChipConfig, "active-locale" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 const PosixConfig::Key PosixConfig::kConfigKey_LocationCapability = { kConfigNamespace_ChipConfig, "location-capability" };
+const PosixConfig::Key PosixConfig::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
+const PosixConfig::Key PosixConfig::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Keys stored in the Chip-counters namespace
 const PosixConfig::Key PosixConfig::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -77,6 +77,8 @@ public:
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
     static const Key kConfigKey_LocationCapability;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
 
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;

--- a/src/platform/P6/P6Config.cpp
+++ b/src/platform/P6/P6Config.cpp
@@ -57,10 +57,6 @@ const P6Config::Key P6Config::kConfigKey_HardwareVersion     = { kConfigNamespac
 const P6Config::Key P6Config::kConfigKey_ManufacturingDate   = { kConfigNamespace_ChipFactory, "mfg-date" };
 const P6Config::Key P6Config::kConfigKey_SetupPinCode        = { kConfigNamespace_ChipFactory, "pin-code" };
 const P6Config::Key P6Config::kConfigKey_SetupDiscriminator  = { kConfigNamespace_ChipFactory, "discriminator" };
-const P6Config::Key P6Config::kConfigKey_RegulatoryLocation  = { kConfigNamespace_ChipConfig, "regulatory-location" };
-const P6Config::Key P6Config::kConfigKey_CountryCode         = { kConfigNamespace_ChipConfig, "country-code" };
-const P6Config::Key P6Config::kConfigKey_ActiveLocale        = { kConfigNamespace_ChipConfig, "active-locale" };
-const P6Config::Key P6Config::kConfigKey_Breadcrumb          = { kConfigNamespace_ChipConfig, "breadcrumb" };
 
 // Keys stored in the chip-config namespace
 const P6Config::Key P6Config::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
@@ -71,6 +67,12 @@ const P6Config::Key P6Config::kConfigKey_GroupKeyIndex      = { kConfigNamespace
 const P6Config::Key P6Config::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const P6Config::Key P6Config::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const P6Config::Key P6Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
+const P6Config::Key P6Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
+const P6Config::Key P6Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
+const P6Config::Key P6Config::kConfigKey_ActiveLocale       = { kConfigNamespace_ChipConfig, "active-locale" };
+const P6Config::Key P6Config::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const P6Config::Key P6Config::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
+const P6Config::Key P6Config::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Keys stored in the Chip-counters namespace
 const P6Config::Key P6Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/P6/P6Config.h
+++ b/src/platform/P6/P6Config.h
@@ -76,6 +76,10 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
+
+    // CHIP Counter keys
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -68,6 +68,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 const PosixConfig::Key PosixConfig::kConfigKey_ActiveLocale       = { kConfigNamespace_ChipConfig, "active-locale" };
+const PosixConfig::Key PosixConfig::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
+const PosixConfig::Key PosixConfig::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/Tizen/PosixConfig.h
+++ b/src/platform/Tizen/PosixConfig.h
@@ -74,6 +74,8 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
     static const Key kConfigKey_ActiveLocale;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -72,6 +72,8 @@ const ZephyrConfig::Key ZephyrConfig::kConfigKey_RegulatoryLocation = CONFIG_KEY
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_CountryCode        = CONFIG_KEY(NAMESPACE_CONFIG "country-code");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_ActiveLocale       = CONFIG_KEY(NAMESPACE_CONFIG "active-locale");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_Breadcrumb         = CONFIG_KEY(NAMESPACE_CONFIG "breadcrumb");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_HourFormat         = CONFIG_KEY(NAMESPACE_CONFIG "hour-format");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_CalendarType       = CONFIG_KEY(NAMESPACE_CONFIG "calendar-type");
 
 // Keys stored in the counters namespace
 const ZephyrConfig::Key ZephyrConfig::kCounterKey_RebootCount           = CONFIG_KEY(NAMESPACE_COUNTERS "reboot-count");
@@ -86,7 +88,8 @@ constexpr const char * sAllResettableConfigKeys[] = {
     ZephyrConfig::kConfigKey_FabricSecret,       ZephyrConfig::kConfigKey_GroupKeyIndex,
     ZephyrConfig::kConfigKey_LastUsedEpochKeyId, ZephyrConfig::kConfigKey_FailSafeArmed,
     ZephyrConfig::kConfigKey_RegulatoryLocation, ZephyrConfig::kConfigKey_CountryCode,
-    ZephyrConfig::kConfigKey_ActiveLocale,       ZephyrConfig::kConfigKey_Breadcrumb
+    ZephyrConfig::kConfigKey_ActiveLocale,       ZephyrConfig::kConfigKey_Breadcrumb,
+    ZephyrConfig::kConfigKey_HourFormat,         ZephyrConfig::kConfigKey_CalendarType,
 };
 
 // Data structure to be passed as a parameter of Zephyr's settings_load_subtree_direct() function

--- a/src/platform/Zephyr/ZephyrConfig.h
+++ b/src/platform/Zephyr/ZephyrConfig.h
@@ -64,6 +64,9 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
+
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_BootReason;
     static const Key kCounterKey_TotalOperationalHours;

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -93,6 +93,8 @@ const AndroidConfig::Key AndroidConfig::kConfigKey_RegulatoryLocation = { kConfi
 const AndroidConfig::Key AndroidConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_ActiveLocale       = { kConfigNamespace_ChipConfig, "active-locale" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
+const AndroidConfig::Key AndroidConfig::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char AndroidConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -76,6 +76,8 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
     static const Key kConfigKey_ProductId;
     static const Key kConfigKey_ProductName;
     static const Key kConfigKey_SoftwareVersion;

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -61,6 +61,8 @@ public interface ConfigurationManager {
   String kConfigKey_CountryCode = "country-code";
   String kConfigKey_ActiveLocale = "active-locale";
   String kConfigKey_Breadcrumb = "breadcrumb";
+  String kConfigKey_HourFormat = "hour-format";
+  String kConfigKey_CalendarType = "calendar-type";
 
   // Prefix used for NVS keys that contain Chip group encryption keys.
   String kGroupKeyNamePrefix = "gk-";

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
@@ -89,12 +89,16 @@ const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_Breadcrumb         = 
                                                                             .itemID   = 0x001c } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_ActiveLocale       = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
                                                                               .itemID   = 0x001d } };
+const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_HourFormat         = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
+                                                                            .itemID   = 0x001e } };
+const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_CalendarType       = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
+                                                                              .itemID   = 0x001f } };
 
 /* Internal for the KVS interface. */
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_KVS_key   = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
-                                                                         .itemID   = 0x001e } };
+                                                                         .itemID   = 0x0020 } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_KVS_value = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
-                                                                           .itemID   = 0x001f } };
+                                                                           .itemID   = 0x0021 } };
 
 /* Static local variables */
 static NVINTF_nvFuncts_t sNvoctpFps = { 0 };

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
@@ -67,6 +67,8 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
     static const Key kConfigKey_KVS_key;   // special key for KVS system, key storage
     static const Key kConfigKey_KVS_value; // special key for KVS system, value storage
 

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -97,6 +97,10 @@ private:
     CHIP_ERROR GetLocalConfigDisabled(bool & disabled) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetReachable(bool & reachable) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetHourFormat(uint8_t & format) override { return CHIP_ERROR_NOT_IMPLEMENTED; };
+    CHIP_ERROR StoreHourFormat(uint8_t format) override { return CHIP_ERROR_NOT_IMPLEMENTED; };
+    CHIP_ERROR GetCalendarType(uint8_t & type) override { return CHIP_ERROR_NOT_IMPLEMENTED; };
+    CHIP_ERROR StoreCalendarType(uint8_t type) override { return CHIP_ERROR_NOT_IMPLEMENTED; };
 #if !defined(NDEBUG)
     CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -82,6 +82,8 @@ const MbedConfig::Key MbedConfig::kConfigKey_RegulatoryLocation = { CONFIG_KEY("
 const MbedConfig::Key MbedConfig::kConfigKey_CountryCode        = { CONFIG_KEY("country-code") };
 const MbedConfig::Key MbedConfig::kConfigKey_ActiveLocale       = { CONFIG_KEY("active-locale") };
 const MbedConfig::Key MbedConfig::kConfigKey_Breadcrumb         = { CONFIG_KEY("breadcrumb") };
+const MbedConfig::Key MbedConfig::kConfigKey_HourFormat         = { CONFIG_KEY("hour-format") };
+const MbedConfig::Key MbedConfig::kConfigKey_CalendarType       = { CONFIG_KEY("calendar-type") };
 
 CHIP_ERROR MbedConfig::ReadConfigValue(Key key, bool & val)
 {

--- a/src/platform/mbed/MbedConfig.h
+++ b/src/platform/mbed/MbedConfig.h
@@ -73,6 +73,8 @@ public:
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_ActiveLocale;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_HourFormat;
+    static const Key kConfigKey_CalendarType;
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.h
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.h
@@ -89,6 +89,8 @@ public:
     static constexpr Key kConfigKey_CountryCode        = K32WConfigKey(kPDMId_ChipConfig, 0x08);
     static constexpr Key kConfigKey_Breadcrumb         = K32WConfigKey(kPDMId_ChipConfig, 0x09);
     static constexpr Key kConfigKey_ActiveLocale       = K32WConfigKey(kPDMId_ChipConfig, 0x0A);
+    static constexpr Key kConfigKey_HourFormat         = K32WConfigKey(kPDMId_ChipConfig, 0x0B);
+    static constexpr Key kConfigKey_CalendarType       = K32WConfigKey(kPDMId_ChipConfig, 0x0C);
 
     // CHIP Counter Keys
     static constexpr Key kCounterKey_RebootCount           = K32WConfigKey(kPDMId_ChipCounter, 0x00);

--- a/src/platform/qpg/qpgConfig.h
+++ b/src/platform/qpg/qpgConfig.h
@@ -86,9 +86,11 @@ public:
     static constexpr Key kConfigKey_CountryCode        = QorvoConfigKey(kFileId_ChipConfig, 0x0A);
     static constexpr Key kConfigKey_Breadcrumb         = QorvoConfigKey(kFileId_ChipConfig, 0x0B);
     static constexpr Key kConfigKey_ActiveLocale       = QorvoConfigKey(kFileId_ChipConfig, 0x0C);
+    static constexpr Key kConfigKey_HourFormat         = QorvoConfigKey(kFileId_ChipConfig, 0x0D);
+    static constexpr Key kConfigKey_CalendarType       = QorvoConfigKey(kFileId_ChipConfig, 0x0E);
 
-    static constexpr Key kConfigKey_GroupKeyBase = QorvoConfigKey(kFileId_ChipConfig, 0x0D);
-    static constexpr Key kConfigKey_GroupKeyMax  = QorvoConfigKey(kFileId_ChipConfig, 0x1C); // Allows 16 Group Keys to be created.
+    static constexpr Key kConfigKey_GroupKeyBase = QorvoConfigKey(kFileId_ChipConfig, 0x0F);
+    static constexpr Key kConfigKey_GroupKeyMax  = QorvoConfigKey(kFileId_ChipConfig, 0x1E); // Allows 16 Group Keys to be created.
 
     static constexpr Key kConfigKey_CounterKeyBase = QorvoConfigKey(kFileId_ChipCounter, 0x00);
     static constexpr Key kConfigKey_CounterKeyMax =

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -245,6 +245,34 @@ static void TestConfigurationMgr_ActiveLocale(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, strcmp(buf, activeLocale) == 0);
 }
 
+static void TestConfigurationMgr_HourFormat(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t format = 0;
+
+    err = ConfigurationMgr().StoreHourFormat(3);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetHourFormat(format);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, format == 3);
+}
+
+static void TestConfigurationMgr_CalendarType(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t type   = 0;
+
+    err = ConfigurationMgr().StoreCalendarType(3);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetCalendarType(type);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, type == 3);
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -263,6 +291,8 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test ConfigurationMgr::Breadcrumb", TestConfigurationMgr_Breadcrumb),
     NL_TEST_DEF("Test ConfigurationMgr::GetPrimaryMACAddress", TestConfigurationMgr_GetPrimaryMACAddress),
     NL_TEST_DEF("Test ConfigurationMgr::ActiveLocale", TestConfigurationMgr_ActiveLocale),
+    NL_TEST_DEF("Test ConfigurationMgr::HourFormat", TestConfigurationMgr_HourFormat),
+    NL_TEST_DEF("Test ConfigurationMgr::CalendarType", TestConfigurationMgr_CalendarType),
     NL_TEST_SENTINEL()
 };
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Need new config key HourFormat & CalendarType for TimeFormat cluster.

#### Change overview
Add support for HourFormat & CalendarType in ConfigurationMgr

#### Testing
How was this tested? (at least one bullet point required)
* Covered by the new added unit test case 'TestConfigurationMgr_HourFormat' and 'TestConfigurationMgr_CalendarType'
