### PR TITLE
Increase test cluster time

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <zap-generated/tests/CHIPClustersTest.h>
 
-constexpr uint16_t kTimeoutInSeconds = 30;
+constexpr uint16_t kTimeoutInSeconds = 90;
 
 class TestCommand : public CHIPCommand
 {

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -610,6 +610,11 @@ bool emberAfTestClusterClusterTestListInt8UReverseRequestCallback(
     {
         auto iter = commandData.arg1.begin();
         Commands::TestListInt8UReverseResponse::Type responseData;
+        if (count == 0)
+        {
+            SuccessOrExit(commandObj->AddResponseData(commandPath, responseData));
+            return true;
+        }
         size_t cur = count;
         Platform::ScopedMemoryBuffer<uint8_t> responseBuf;
         VerifyOrExit(responseBuf.Calloc(count), );


### PR DESCRIPTION
#### Problem
Fixes TestCluster tests on M5.
1) timeout is way too short - this is the timeout for the entire test suite. There's 471 separate tests.
2) Fixes test 161 to early return if the list is empty - previously this was failing on M5 on the calloc and returning an error rather than an empty list.

#### Change overview
Increases test timeout, fixes test 161 to early return if the input list is empty.
Remaining test failures are tracked #13434, #13435

#### Testing
chip-tool tests TestCluster <node-id> (checks on 174 and 353 disabled)
Linux controller, M5 all clusters app as device.
