### PR TITLE
Removed optional tag

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
@@ -53,6 +53,7 @@ tests:
           value: 1
 
     #issue #11053 disabled steps below Global attributes missing from YAML framework
+    #disabled due to issue #13442
     - label: "Read the global attribute: AttributeList"
       disabled: true
       command: "readAttribute"
@@ -95,7 +96,6 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
@@ -103,9 +103,9 @@ tests:
           value: 0
 
     #Issue #11142 Disabled all optional attribute checks
+    #disabled due to issue #13442
     - label: "Read optional non-global attribute: ActiveText"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "active text"
       response:
@@ -113,7 +113,6 @@ tests:
 
     - label: "Read optional non-global attribute constraints: ActiveText"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "active text"
       response:
@@ -123,7 +122,6 @@ tests:
     - label:
           "Write the default values to optional non-global attribute: ActiveText"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "active text"
       arguments:
@@ -131,7 +129,6 @@ tests:
 
     - label: "Reads back the optional non-global attribute: ActiveText"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "active text"
       response:
@@ -139,7 +136,6 @@ tests:
 
     - label: "Read optional non-global attribute: Description"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "description"
       response:
@@ -147,7 +143,6 @@ tests:
 
     - label: "Read optional non-global attribute constraints: Description"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "description"
       response:
@@ -158,7 +153,6 @@ tests:
           "Write the default values to optional non-global attribute:
           Description"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "description"
       arguments:
@@ -166,7 +160,6 @@ tests:
 
     - label: "Reads back the optional non-global attribute: Description"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "description"
       response:
@@ -174,7 +167,6 @@ tests:
 
     - label: "Read optional non-global attribute: InactiveText"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "inactive text"
       response:
@@ -182,7 +174,6 @@ tests:
 
     - label: "Read optional non-global attribute constraints: InactiveText"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "inactive text"
       response:
@@ -193,7 +184,6 @@ tests:
           "Write the default values to optional non-global attribute:
           InactiveText"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "inactive text"
       arguments:
@@ -201,7 +191,6 @@ tests:
 
     - label: "Reads back the optional non-global attribute: InactiveText"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "inactive text"
       response:
@@ -209,7 +198,6 @@ tests:
 
     - label: "Read optional non-global attribute: Polarity"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "polarity"
       response:
@@ -217,7 +205,6 @@ tests:
 
     - label: "Read optional non-global attribute constraints: Polarity"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "polarity"
       response:
@@ -227,7 +214,6 @@ tests:
     - label:
           "Write the default values to optional non-global attribute: Polarity"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "polarity"
       arguments:
@@ -237,7 +223,6 @@ tests:
 
     - label: "Reads back the optional non-global attribute: Polarity"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "polarity"
       response:
@@ -245,7 +230,6 @@ tests:
 
     - label: "Read optional non-global attribute: Reliability"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "reliability"
       response:
@@ -253,7 +237,6 @@ tests:
 
     - label: "Read optional non-global attribute constraints: Reliability"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "reliability"
       response:
@@ -264,7 +247,6 @@ tests:
           "Write the default values to optional non-global attribute:
           Reliability"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "reliability"
       arguments:
@@ -272,7 +254,6 @@ tests:
 
     - label: "Reads back the optional non-global attribute: Reliability"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "reliability"
       response:
@@ -280,7 +261,6 @@ tests:
 
     - label: "Read optional non-global attribute constraints: ApplicationType"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "application type"
       response:
@@ -293,7 +273,6 @@ tests:
           "Write the default values to optional non-global attribute:
           ApplicationType"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "application type"
       arguments:
@@ -303,7 +282,6 @@ tests:
 
     - label: "Reads back the optional non-global attribute: ApplicationType"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "application type"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
@@ -53,6 +53,7 @@ tests:
           value: 1
 
     #issue #11053 disabled steps below Global attributes missing from YAML framework
+    #disabled due to issue #13442
     - label: "Read the global attribute: AttributeList"
       disabled: true
       command: "readAttribute"
@@ -95,7 +96,6 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
@@ -55,6 +55,7 @@ tests:
           value: 4
 
     #issue #11053 disabled steps below Global attributes missing from YAML framework
+    #disabled due to issue #13442
     - label: "Read the global attribute: AttributeList"
       disabled: true
       command: "readAttribute"
@@ -124,7 +125,6 @@ tests:
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
@@ -56,6 +56,7 @@ tests:
           value: 2
 
     #issue #11053 disabled steps below Global attributes missing from YAML framework
+    #disabled due to issue #13442
     - label: "Read the global attribute: AttributeList"
       disabled: true
       command: "readAttribute"
@@ -98,7 +99,6 @@ tests:
 
     - label: "Read the optional global attribute : FeatureMap"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "FeatureMap"
       response:

--- a/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
@@ -86,9 +86,9 @@ tests:
       response:
           value: 0
 
+    #disabled due to issue #13442
     - label: "Read the optional attribute: Tolerance"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
@@ -96,7 +96,6 @@ tests:
 
     - label: "Write the default values to optional attribute: Tolerance"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "Tolerance"
       arguments:
@@ -106,7 +105,6 @@ tests:
 
     - label: "Reads back optional attribute: Tolerance"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "Tolerance"
       response:
@@ -115,7 +113,6 @@ tests:
     #Following attributes are based on the value of the extended feature in the cluster feature map
     - label: "Read the optional attribute: ScaledValue"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "ScaledValue"
       response:
@@ -123,7 +120,6 @@ tests:
 
     - label: "Write the default values to optional attribute: ScaledValue"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "ScaledValue"
       arguments:
@@ -133,7 +129,6 @@ tests:
 
     - label: "Reads back optional attribute: ScaledValue"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "ScaledValue"
       response:
@@ -141,7 +136,6 @@ tests:
 
     - label: "Read the optional attribute: MinScaledValue"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "MinScaledValue"
       response:
@@ -149,7 +143,6 @@ tests:
 
     - label: "Write the default values to optional attribute: MinScaledValue"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "MinScaledValue"
       arguments:
@@ -159,7 +152,6 @@ tests:
 
     - label: "Reads back optional attribute: MinScaledValue"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "MinScaledValue"
       response:
@@ -167,7 +159,6 @@ tests:
 
     - label: "Read the optional attribute: MaxScaledValue"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "MaxScaledValue"
       response:
@@ -175,7 +166,6 @@ tests:
 
     - label: "Write the default values to optional attribute: MaxScaledValue"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "MaxScaledValue"
       arguments:
@@ -185,7 +175,6 @@ tests:
 
     - label: "Reads back optional attribute: MaxScaledValue"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "MaxScaledValue"
       response:
@@ -193,7 +182,6 @@ tests:
 
     - label: "Read the optional attribute: ScaledTolerance"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "ScaledTolerance"
       response:
@@ -201,7 +189,6 @@ tests:
 
     - label: "Write the default values to optional attribute: ScaledTolerance"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "ScaledTolerance"
       arguments:
@@ -211,7 +198,6 @@ tests:
 
     - label: "Reads back optional attribute: ScaledTolerance"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "ScaledTolerance"
       response:
@@ -219,7 +205,6 @@ tests:
 
     - label: "Read the optional attribute: Scale"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "Scale"
       response:
@@ -227,7 +212,6 @@ tests:
 
     - label: "Write the default values to optional attribute: Scale"
       disabled: true
-      optional: true
       command: "writeAttribute"
       attribute: "Scale"
       arguments:
@@ -237,7 +221,6 @@ tests:
 
     - label: "Reads back optional attribute: Scale"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "Scale"
       response:

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_1_1.yaml
@@ -24,10 +24,10 @@ tests:
       command: "WaitForCommissionee"
 
     #Issue #11185 Disabled as ThreadMetrics attribute missing
+    #disabled due to issue  #13441
     - label:
           "Reads a list of ThreadMetrics struct non-global attribute from DUT."
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "ThreadMetrics"
       PICS: A_THREADMETRICS

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_2_1.yaml
@@ -22,7 +22,6 @@ tests:
     #issue #11725 Reading the List is not implemented in YAML framework
     - label: "Reads a list of SoftwareFault struct from DUT"
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "SoftwareFault"
       PICS: E_SOFTWAREFAULT

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
@@ -24,15 +24,14 @@ tests:
       command: "WaitForCommissionee"
 
     #issue #11578 ResetWatermarks command is Failing
+    #disabled due to issue  #13441
     - label: "Sends ResetWatermarks to DUT"
       disabled: true
-      optional: true
       command: "ResetWatermarks"
       PICS: CR_RESETWATERMARKS
 
     - label: "Reads a list of ThreadMetrics struct attribute from DUT."
       disabled: true
-      optional: true
       command: "readAttribute"
       attribute: "ThreadMetrics"
       PICS: A_THREADMETRICS


### PR DESCRIPTION
Removed "optional:true" tag for following testscripts:
1.TC-BI-1.1 
2.TC-BI-2.1 
3.TC-BOOL-1.1 
4.TC-CC-1.1
5.TC-FLW-1.1 
6.TC-SWDIAG-3.1
7.TC-SWDIAG-1.1
8.TC-SWDIAG-2.1
9.TC-PRS-2.1

Executed all YAML test scripts, attached logs for reference:  
[test-execution-logs.zip](https://github.com/project-chip/connectedhomeip/files/7846092/test-execution-logs.zip)
