### PR TITLE
Fix the issue of BLE notification not being received from the device

### DIFF
--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1660,8 +1660,6 @@ static void SubscribeCharacteristicDone(GObject * aObject, GAsyncResult * aResul
 
     VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: BluezSubscribeCharacteristic : %s", error->message));
 
-    // Get notifications on the TX characteristic change (e.g. indication is received)
-    g_signal_connect(c2, "g-properties-changed", G_CALLBACK(OnCharacteristicChanged), apConnection);
     BLEManagerImpl::HandleSubscribeOpComplete(static_cast<BLE_CONNECTION_OBJECT>(apConnection), true);
 
 exit:
@@ -1671,9 +1669,13 @@ exit:
 
 static gboolean SubscribeCharacteristicImpl(BluezConnection * connection)
 {
+    BluezGattCharacteristic1 * c2 = nullptr;
     VerifyOrExit(connection != nullptr, ChipLogError(DeviceLayer, "BluezConnection is NULL in %s", __func__));
     VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
+    c2 = BLUEZ_GATT_CHARACTERISTIC1(connection->mpC2);
 
+    // Get notifications on the TX characteristic change (e.g. indication is received)
+    g_signal_connect(c2, "g-properties-changed", G_CALLBACK(OnCharacteristicChanged), connection);
     bluez_gatt_characteristic1_call_start_notify(connection->mpC2, nullptr, SubscribeCharacteristicDone, connection);
 
 exit:


### PR DESCRIPTION
Fix the issue of BLE notification not being received from the device (BLE peripheral) to chiptool

#### Problem
When the console prints are reduced on ESP32 (change debug level from info to error only) the commissioning doesn't go through. Actually, it doesn't even begin. The BLE connection is done, GATT database discovery is done, first BLE write is received from chiptool, then the chiptool subscribes to a characteristic and then nothing happens. The chip-tool waits on receiving notification from the device and that never happens.

Debugged the problem to find out that, on the chip-tool side, handling notification callback is registered after the subscribe request is done. So, it misses the notification when sent very quickly (as the console logs are less) by the device. And the chip-tool thinks that the notification isn't received.

#### Change overview
* Moved the code to register the notification callback before sending the subscribe request

#### Testing
* Tested that with the change, the notification is received by chip-tool and commissioning completes successfully