### PR TITLE
Use current time during CASE session handshake

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1298,20 +1298,39 @@ CHIP_ERROR CASESession::RetrieveIPK(FabricId fabricId, MutableByteSpan & ipk)
     return CHIP_NO_ERROR;
 }
 
-// TODO: Remove this and replace with system method to retrieve current time
-CHIP_ERROR CASESession::SetEffectiveTime(void)
+CHIP_ERROR CASESession::GetHardcodedTime()
 {
     using namespace ASN1;
     ASN1UniversalTime effectiveTime;
 
-    effectiveTime.Year   = 2021;
-    effectiveTime.Month  = 2;
-    effectiveTime.Day    = 12;
+    effectiveTime.Year   = 2022;
+    effectiveTime.Month  = 1;
+    effectiveTime.Day    = 1;
     effectiveTime.Hour   = 10;
     effectiveTime.Minute = 10;
     effectiveTime.Second = 10;
 
     return ASN1ToChipEpochTime(effectiveTime, mValidContext.mEffectiveTime);
+}
+
+CHIP_ERROR CASESession::SetEffectiveTime()
+{
+    System::Clock::Milliseconds64 currentTimeMS;
+    CHIP_ERROR err = System::SystemClock().GetClock_RealTimeMS(currentTimeMS);
+    if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    {
+        ChipLogError(
+            SecureChannel,
+            "The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.");
+        // TODO: Remove use of hardcoded time during CASE setup
+        return GetHardcodedTime();
+    }
+    ReturnErrorOnFailure(err);
+
+    System::Clock::Seconds32 currentTime = std::chrono::duration_cast<System::Clock::Seconds32>(currentTimeMS);
+    VerifyOrReturnError(UnixEpochToChipEpochTime(currentTime.count(), mValidContext.mEffectiveTime), CHIP_ERROR_INVALID_TIME);
+
+    return CHIP_NO_ERROR;
 }
 
 void CASESession::OnSuccessStatusReport()

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -226,8 +226,9 @@ private:
      */
     void DiscardExchange();
 
-    // TODO: Remove this and replace with system method to retrieve current time
-    CHIP_ERROR SetEffectiveTime(void);
+    CHIP_ERROR GetHardcodedTime();
+
+    CHIP_ERROR SetEffectiveTime();
 
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                        System::PacketBufferHandle & msg);


### PR DESCRIPTION
#### Problem
* Fixes #5871

#### Change overview
Use `SystemClock` to get the current time. If the API is not supported for the platform, it'll currently print an error log, but use the hardcoded time.

#### Testing
Ran `TestCASESession` to ensure the CASE session setup continues to work.