### PR TITLE
Fix CommissioneeDeviceProxy state

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -976,9 +976,7 @@ void DeviceCommissioner::OnSessionEstablished()
     // TODO: the session should know which peer we are trying to connect to when started
     pairing->SetPeerNodeId(mDeviceBeingCommissioned->GetDeviceId());
 
-    CHIP_ERROR err = mSystemState->SessionMgr()->NewPairing(
-        mDeviceBeingCommissioned->GetSecureSessionHolder(), Optional<Transport::PeerAddress>::Value(pairing->GetPeerAddress()),
-        pairing->GetPeerNodeId(), pairing, CryptoContext::SessionRole::kInitiator, mFabricIndex);
+    CHIP_ERROR err = mDeviceBeingCommissioned->SetConnected();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -132,6 +132,13 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR CommissioneeDeviceProxy::SetConnected()
+{
+    mState = ConnectionState::SecureConnected;
+    bool didLoad;
+    return LoadSecureSessionParametersIfNeeded(didLoad);
+}
+
 void CommissioneeDeviceProxy::Reset()
 {
     SetActive(false);

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -134,9 +134,17 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 
 CHIP_ERROR CommissioneeDeviceProxy::SetConnected()
 {
-    mState = ConnectionState::SecureConnected;
-    bool didLoad;
-    return LoadSecureSessionParametersIfNeeded(didLoad);
+    if (mState != ConnectionState::Connecting)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    bool _didLoad;
+    CHIP_ERROR err = LoadSecureSessionParametersIfNeeded(_didLoad);
+    if (err == CHIP_NO_ERROR)
+    {
+        mState = ConnectionState::SecureConnected;
+    }
+    return err;
 }
 
 void CommissioneeDeviceProxy::Reset()

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -196,6 +196,14 @@ public:
 
     void SetActive(bool active) { mActive = active; }
 
+    /**
+     * @brief
+     * Should be called when the pairing completes.
+     *
+     * This causes the secure session parameters to be loaded and stores the session details in the session manager.
+     */
+    CHIP_ERROR SetConnected();
+
     bool IsSecureConnected() const override { return IsActive() && mState == ConnectionState::SecureConnected; }
 
     bool IsSessionSetupInProgress() const { return IsActive() && mState == ConnectionState::Connecting; }

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -198,7 +198,7 @@ public:
 
     /**
      * @brief
-     * Should be called when the pairing completes.
+     * Called to indicate this proxy has been paired successfully.
      *
      * This causes the secure session parameters to be loaded and stores the session details in the session manager.
      */


### PR DESCRIPTION
#### Problem
The pairing call was moved to external so the commissionee
device proxy never gets set to connected. LoadSecureSessionParameters
takes care of setting up the pairing in the session manager anyway, so it makes sense to call through the DeviceProxy.
Fixes #13431 

#### Change overview
Added a new function that gets called when the pairing is complete
to set the state and setup the pairing in the session manager.

#### Testing
paseonly then commission in chip-device-ctrl