### PR TITLE
[Android] Make cluster id a constant instead of a method

### DIFF
--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -83,12 +83,10 @@ public class ChipClusters {
 
   {{#chip_client_clusters}}
   public static class {{asUpperCamelCase name}}Cluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = {{code}}L;
+
     public {{asUpperCamelCase name}}Cluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("{{code}}");
     }
 
     @Override

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -113,12 +113,10 @@ public class ChipClusters {
   }
 
   public static class AccessControlCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 31L;
+
     public AccessControlCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("31");
     }
 
     @Override
@@ -231,12 +229,10 @@ public class ChipClusters {
   }
 
   public static class AccountLoginCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1294L;
+
     public AccountLoginCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1294");
     }
 
     @Override
@@ -305,12 +301,10 @@ public class ChipClusters {
   }
 
   public static class AdministratorCommissioningCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 60L;
+
     public AdministratorCommissioningCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("60");
     }
 
     @Override
@@ -420,12 +414,10 @@ public class ChipClusters {
   }
 
   public static class ApplicationBasicCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1293L;
+
     public ApplicationBasicCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1293");
     }
 
     @Override
@@ -577,12 +569,10 @@ public class ChipClusters {
   }
 
   public static class ApplicationLauncherCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1292L;
+
     public ApplicationLauncherCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1292");
     }
 
     @Override
@@ -679,12 +669,10 @@ public class ChipClusters {
   }
 
   public static class AudioOutputCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1291L;
+
     public AudioOutputCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1291");
     }
 
     @Override
@@ -796,12 +784,10 @@ public class ChipClusters {
   }
 
   public static class BarrierControlCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 259L;
+
     public BarrierControlCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("259");
     }
 
     @Override
@@ -912,12 +898,10 @@ public class ChipClusters {
   }
 
   public static class BasicCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 40L;
+
     public BasicCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("40");
     }
 
     @Override
@@ -1300,12 +1284,10 @@ public class ChipClusters {
   }
 
   public static class BinaryInputBasicCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 15L;
+
     public BinaryInputBasicCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("15");
     }
 
     @Override
@@ -1402,12 +1384,10 @@ public class ChipClusters {
   }
 
   public static class BindingCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 30L;
+
     public BindingCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("30");
     }
 
     @Override
@@ -1479,12 +1459,10 @@ public class ChipClusters {
   }
 
   public static class BooleanStateCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 69L;
+
     public BooleanStateCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("69");
     }
 
     @Override
@@ -1537,12 +1515,10 @@ public class ChipClusters {
   }
 
   public static class BridgedActionsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 37L;
+
     public BridgedActionsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("37");
     }
 
     @Override
@@ -1852,12 +1828,10 @@ public class ChipClusters {
   }
 
   public static class BridgedDeviceBasicCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 57L;
+
     public BridgedDeviceBasicCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("57");
     }
 
     @Override
@@ -1895,12 +1869,10 @@ public class ChipClusters {
   }
 
   public static class ChannelCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1284L;
+
     public ChannelCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1284");
     }
 
     @Override
@@ -2033,12 +2005,10 @@ public class ChipClusters {
   }
 
   public static class ColorControlCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 768L;
+
     public ColorControlCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("768");
     }
 
     @Override
@@ -3373,12 +3343,10 @@ public class ChipClusters {
   }
 
   public static class ContentLauncherCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1290L;
+
     public ContentLauncherCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1290");
     }
 
     @Override
@@ -3484,12 +3452,10 @@ public class ChipClusters {
   }
 
   public static class DescriptorCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 29L;
+
     public DescriptorCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("29");
     }
 
     @Override
@@ -3611,12 +3577,10 @@ public class ChipClusters {
   }
 
   public static class DiagnosticLogsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 50L;
+
     public DiagnosticLogsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("50");
     }
 
     @Override
@@ -3661,12 +3625,10 @@ public class ChipClusters {
   }
 
   public static class DoorLockCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 257L;
+
     public DoorLockCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("257");
     }
 
     @Override
@@ -4120,12 +4082,10 @@ public class ChipClusters {
   }
 
   public static class ElectricalMeasurementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 2820L;
+
     public ElectricalMeasurementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("2820");
     }
 
     @Override
@@ -4328,12 +4288,10 @@ public class ChipClusters {
   }
 
   public static class EthernetNetworkDiagnosticsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 55L;
+
     public EthernetNetworkDiagnosticsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("55");
     }
 
     @Override
@@ -4519,12 +4477,10 @@ public class ChipClusters {
   }
 
   public static class FixedLabelCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 64L;
+
     public FixedLabelCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("64");
     }
 
     @Override
@@ -4601,12 +4557,10 @@ public class ChipClusters {
   }
 
   public static class FlowMeasurementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1028L;
+
     public FlowMeasurementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1028");
     }
 
     @Override
@@ -4704,12 +4658,10 @@ public class ChipClusters {
   }
 
   public static class GeneralCommissioningCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 48L;
+
     public GeneralCommissioningCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("48");
     }
 
     @Override
@@ -4874,12 +4826,10 @@ public class ChipClusters {
   }
 
   public static class GeneralDiagnosticsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 51L;
+
     public GeneralDiagnosticsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("51");
     }
 
     @Override
@@ -5090,12 +5040,10 @@ public class ChipClusters {
   }
 
   public static class GroupKeyManagementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 63L;
+
     public GroupKeyManagementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("63");
     }
 
     @Override
@@ -5310,12 +5258,10 @@ public class ChipClusters {
   }
 
   public static class GroupsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 4L;
+
     public GroupsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("4");
     }
 
     @Override
@@ -5437,12 +5383,10 @@ public class ChipClusters {
   }
 
   public static class IdentifyCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 3L;
+
     public IdentifyCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("3");
     }
 
     @Override
@@ -5547,12 +5491,10 @@ public class ChipClusters {
   }
 
   public static class IlluminanceMeasurementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1024L;
+
     public IlluminanceMeasurementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1024");
     }
 
     @Override
@@ -5709,12 +5651,10 @@ public class ChipClusters {
   }
 
   public static class KeypadInputCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1289L;
+
     public KeypadInputCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1289");
     }
 
     @Override
@@ -5765,12 +5705,10 @@ public class ChipClusters {
   }
 
   public static class LevelControlCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 8L;
+
     public LevelControlCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("8");
     }
 
     @Override
@@ -6214,12 +6152,10 @@ public class ChipClusters {
   }
 
   public static class LocalizationConfigurationCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 43L;
+
     public LocalizationConfigurationCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("43");
     }
 
     @Override
@@ -6256,12 +6192,10 @@ public class ChipClusters {
   }
 
   public static class LowPowerCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1288L;
+
     public LowPowerCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1288");
     }
 
     @Override
@@ -6305,12 +6239,10 @@ public class ChipClusters {
   }
 
   public static class MediaInputCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1287L;
+
     public MediaInputCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1287");
     }
 
     @Override
@@ -6443,12 +6375,10 @@ public class ChipClusters {
   }
 
   public static class MediaPlaybackCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1286L;
+
     public MediaPlaybackCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1286");
     }
 
     @Override
@@ -6643,12 +6573,10 @@ public class ChipClusters {
   }
 
   public static class ModeSelectCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 80L;
+
     public ModeSelectCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("80");
     }
 
     @Override
@@ -6807,12 +6735,10 @@ public class ChipClusters {
   }
 
   public static class NetworkCommissioningCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 49L;
+
     public NetworkCommissioningCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("49");
     }
 
     @Override
@@ -7035,12 +6961,10 @@ public class ChipClusters {
   }
 
   public static class OtaSoftwareUpdateProviderCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 41L;
+
     public OtaSoftwareUpdateProviderCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("41");
     }
 
     @Override
@@ -7155,12 +7079,10 @@ public class ChipClusters {
   }
 
   public static class OtaSoftwareUpdateRequestorCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 42L;
+
     public OtaSoftwareUpdateRequestorCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("42");
     }
 
     @Override
@@ -7326,12 +7248,10 @@ public class ChipClusters {
   }
 
   public static class OccupancySensingCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1030L;
+
     public OccupancySensingCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1030");
     }
 
     @Override
@@ -7415,12 +7335,10 @@ public class ChipClusters {
   }
 
   public static class OnOffCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 6L;
+
     public OnOffCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("6");
     }
 
     @Override
@@ -7618,12 +7536,10 @@ public class ChipClusters {
   }
 
   public static class OnOffSwitchConfigurationCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 7L;
+
     public OnOffSwitchConfigurationCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("7");
     }
 
     @Override
@@ -7698,12 +7614,10 @@ public class ChipClusters {
   }
 
   public static class OperationalCredentialsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 62L;
+
     public OperationalCredentialsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("62");
     }
 
     @Override
@@ -7987,12 +7901,10 @@ public class ChipClusters {
   }
 
   public static class PowerSourceCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 47L;
+
     public PowerSourceCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("47");
     }
 
     @Override
@@ -8181,12 +8093,10 @@ public class ChipClusters {
   }
 
   public static class PowerSourceConfigurationCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 46L;
+
     public PowerSourceConfigurationCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("46");
     }
 
     @Override
@@ -8231,12 +8141,10 @@ public class ChipClusters {
   }
 
   public static class PressureMeasurementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1027L;
+
     public PressureMeasurementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1027");
     }
 
     @Override
@@ -8319,12 +8227,10 @@ public class ChipClusters {
   }
 
   public static class PumpConfigurationAndControlCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 512L;
+
     public PumpConfigurationAndControlCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("512");
     }
 
     @Override
@@ -8788,12 +8694,10 @@ public class ChipClusters {
   }
 
   public static class RelativeHumidityMeasurementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1029L;
+
     public RelativeHumidityMeasurementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1029");
     }
 
     @Override
@@ -8891,12 +8795,10 @@ public class ChipClusters {
   }
 
   public static class ScenesCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 5L;
+
     public ScenesCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("5");
     }
 
     @Override
@@ -9135,12 +9037,10 @@ public class ChipClusters {
   }
 
   public static class SoftwareDiagnosticsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 52L;
+
     public SoftwareDiagnosticsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("52");
     }
 
     @Override
@@ -9295,12 +9195,10 @@ public class ChipClusters {
   }
 
   public static class SwitchCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 59L;
+
     public SwitchCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("59");
     }
 
     @Override
@@ -9398,12 +9296,10 @@ public class ChipClusters {
   }
 
   public static class TargetNavigatorCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1285L;
+
     public TargetNavigatorCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1285");
     }
 
     @Override
@@ -9509,12 +9405,10 @@ public class ChipClusters {
   }
 
   public static class TemperatureMeasurementCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1026L;
+
     public TemperatureMeasurementCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1026");
     }
 
     @Override
@@ -9612,12 +9506,10 @@ public class ChipClusters {
   }
 
   public static class TestClusterCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1295L;
+
     public TestClusterCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1295");
     }
 
     @Override
@@ -11970,12 +11862,10 @@ public class ChipClusters {
   }
 
   public static class ThermostatCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 513L;
+
     public ThermostatCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("513");
     }
 
     @Override
@@ -12430,12 +12320,10 @@ public class ChipClusters {
   }
 
   public static class ThermostatUserInterfaceConfigurationCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 516L;
+
     public ThermostatUserInterfaceConfigurationCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("516");
     }
 
     @Override
@@ -12542,12 +12430,10 @@ public class ChipClusters {
   }
 
   public static class ThreadNetworkDiagnosticsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 53L;
+
     public ThreadNetworkDiagnosticsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("53");
     }
 
     @Override
@@ -13869,12 +13755,10 @@ public class ChipClusters {
   }
 
   public static class UserLabelCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 65L;
+
     public UserLabelCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("65");
     }
 
     @Override
@@ -13928,12 +13812,10 @@ public class ChipClusters {
   }
 
   public static class WakeOnLanCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 1283L;
+
     public WakeOnLanCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("1283");
     }
 
     @Override
@@ -13989,12 +13871,10 @@ public class ChipClusters {
   }
 
   public static class WiFiNetworkDiagnosticsCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 54L;
+
     public WiFiNetworkDiagnosticsCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("54");
     }
 
     @Override
@@ -14242,12 +14122,10 @@ public class ChipClusters {
   }
 
   public static class WindowCoveringCluster extends BaseChipCluster {
+    public static final long CLUSTER_ID = 258L;
+
     public WindowCoveringCluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
-    }
-
-    public static long clusterId() {
-      return Long.parseUnsignedLong("258");
     }
 
     @Override


### PR DESCRIPTION
#### Problem
* In Java clusters code, generated `clusterId()` can be a constant instead

#### Change overview
* Change method to final long
#### Testing
* Compiles (cluster id is not used by Android CHIPTool)
