### PR TITLE
Split global dirty set into dedicated pool

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -144,9 +144,6 @@ public:
 
     void ReleaseClusterInfoList(ClusterInfo *& aClusterInfo);
     CHIP_ERROR PushFront(ClusterInfo *& aClusterInfoLisst, ClusterInfo & aClusterInfo);
-    // Merges aAttributePath inside apAttributePathList if current path is overlapped with existing path in apAttributePathList
-    // Overlap means the path is superset or subset of another path
-    bool MergeOverlappedAttributePath(ClusterInfo * apAttributePathList, ClusterInfo & aAttributePath);
     bool IsOverlappedAttributePath(ClusterInfo & aAttributePath);
 
     CHIP_ERROR RegisterCommandHandler(CommandHandlerInterface * handler);
@@ -267,8 +264,7 @@ private:
     WriteClient mWriteClients[CHIP_IM_MAX_NUM_WRITE_CLIENT];
     WriteHandler mWriteHandlers[CHIP_IM_MAX_NUM_WRITE_HANDLER];
     reporting::Engine mReportingEngine;
-    ClusterInfo mClusterInfoPool[CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS];
-    ClusterInfo * mpNextAvailableClusterInfo = nullptr;
+    BitMapObjectPool<ClusterInfo, CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS> mClusterInfoPool;
 
     ReadClient * mpActiveReadClientList = nullptr;
 

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -136,6 +136,14 @@ private:
     void GetMinEventLogPosition(uint32_t & aMinLogPosition);
 
     /**
+     * If the provided path is a superset of our of our existing paths, update that existing path to match the
+     * provided path.
+     *
+     * Return whether one of our paths is now a superset of the provided path.
+     */
+    bool MergeOverlappedAttributePath(ClusterInfo & aAttributePath);
+
+    /**
      * Boolean to indicate if ScheduleRun is pending. This flag is used to prevent calling ScheduleRun multiple times
      * within the same execution context to avoid applying too much pressure on platforms that use small, fixed size event queues.
      *
@@ -155,13 +163,10 @@ private:
     uint32_t mCurReadHandlerIdx = 0;
 
     /**
-     *  mpGlobalDirtySet is used to track the dirty cluster info application modified for attributes during
-     *  post-subscription via SetDirty API, and further form the report. This reporting engine acquires this global dirty
-     *  set from mClusterInfoPool managed by InteractionModelEngine, where all active read handlers also acquire the interested
-     *  cluster Info list from mClusterInfoPool.
+     *  mGlobalDirtySet is used to track the set of attribute/event paths marked dirty for reporting purposes.
      *
      */
-    ClusterInfo * mpGlobalDirtySet = nullptr;
+    BitMapObjectPool<ClusterInfo, CHIP_IM_SERVER_MAX_NUM_DIRTY_SET> mGlobalDirtySet;
 
 #if CONFIG_IM_BUILD_FOR_UNIT_TEST
     uint32_t mReservedSize = 0;

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -44,7 +44,6 @@ class TestInteractionModelEngine
 {
 public:
     static void TestClusterInfoPushRelease(nlTestSuite * apSuite, void * apContext);
-    static void TestMergeOverlappedAttributePath(nlTestSuite * apSuite, void * apContext);
     static int GetClusterInfoListLength(ClusterInfo * apClusterInfoList);
 };
 
@@ -90,37 +89,6 @@ void TestInteractionModelEngine::TestClusterInfoPushRelease(nlTestSuite * apSuit
     InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(clusterInfoList);
     NL_TEST_ASSERT(apSuite, GetClusterInfoListLength(clusterInfoList) == 0);
 }
-
-void TestInteractionModelEngine::TestMergeOverlappedAttributePath(nlTestSuite * apSuite, void * apContext)
-{
-    TestContext & ctx = *static_cast<TestContext *>(apContext);
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    err               = InteractionModelEngine::GetInstance()->Init(&ctx.GetExchangeManager(), nullptr);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    ClusterInfo clusterInfoList[2];
-
-    clusterInfoList[0].mAttributeId = 1;
-    clusterInfoList[1].mAttributeId = 2;
-
-    {
-        chip::app::ClusterInfo testClusterInfo;
-        testClusterInfo.mAttributeId = 3;
-        NL_TEST_ASSERT(apSuite,
-                       !InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    }
-    {
-        chip::app::ClusterInfo testClusterInfo;
-        NL_TEST_ASSERT(apSuite,
-                       InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    }
-    {
-        chip::app::ClusterInfo testClusterInfo;
-        testClusterInfo.mAttributeId = 1;
-        testClusterInfo.mListIndex   = 2;
-        NL_TEST_ASSERT(apSuite,
-                       InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    }
-}
 } // namespace app
 } // namespace chip
 
@@ -130,7 +98,6 @@ namespace {
 const nlTest sTests[] =
         {
                 NL_TEST_DEF("TestClusterInfoPushRelease", chip::app::TestInteractionModelEngine::TestClusterInfoPushRelease),
-                NL_TEST_DEF("TestMergeOverlappedAttributePath", chip::app::TestInteractionModelEngine::TestMergeOverlappedAttributePath),
                 NL_TEST_SENTINEL()
         };
 // clang-format on

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -52,6 +52,7 @@ class TestReportingEngine
 {
 public:
     static void TestBuildAndSendSingleReportData(nlTestSuite * apSuite, void * apContext);
+    static void TestMergeOverlappedAttributePath(nlTestSuite * apSuite, void * apContext);
 };
 
 class TestExchangeDelegate : public Messaging::ExchangeDelegate
@@ -107,6 +108,33 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     readHandler.Shutdown(app::ReadHandler::ShutdownOptions::AbortCurrentExchange);
 }
 
+void TestReportingEngine::TestMergeOverlappedAttributePath(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    err               = InteractionModelEngine::GetInstance()->Init(&ctx.GetExchangeManager(), nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    ClusterInfo * clusterInfo = InteractionModelEngine::GetInstance()->GetReportingEngine().mGlobalDirtySet.CreateObject();
+    clusterInfo->mAttributeId = 1;
+
+    {
+        chip::app::ClusterInfo testClusterInfo;
+        testClusterInfo.mAttributeId = 3;
+        NL_TEST_ASSERT(apSuite,
+                       !InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
+    }
+    {
+        chip::app::ClusterInfo testClusterInfo;
+        testClusterInfo.mAttributeId = 1;
+        testClusterInfo.mListIndex   = 2;
+        NL_TEST_ASSERT(apSuite,
+                       InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
+    }
+
+    InteractionModelEngine::GetInstance()->GetReportingEngine().Shutdown();
+}
+
 } // namespace reporting
 } // namespace app
 } // namespace chip
@@ -116,6 +144,7 @@ namespace {
 const nlTest sTests[] =
 {
     NL_TEST_DEF("CheckBuildAndSendSingleReportData", chip::app::reporting::TestReportingEngine::TestBuildAndSendSingleReportData),
+    NL_TEST_DEF("TestMergeOverlappedAttributePath", chip::app::reporting::TestReportingEngine::TestMergeOverlappedAttributePath),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2434,6 +2434,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  *      * #CHIP_IM_MAX_NUM_READ_CLIENT
  *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
  *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *      * #CHIP_IM_SERVER_MAX_NUM_DIRTY_SET
  *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
  *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
  *      * #CHIP_IM_MAX_NUM_TIMED_HANDLER
@@ -2484,6 +2485,15 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  */
 #ifndef CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
 #define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 8
+#endif
+
+/**
+ * @def CHIP_IM_SERVER_MAX_NUM_DIRTY_SET
+ *
+ * @brief Defines the maximum number of dirty set, limits the number of attributes being read or subscribed at the same time.
+ */
+#ifndef CHIP_IM_SERVER_MAX_NUM_DIRTY_SET
+#define CHIP_IM_SERVER_MAX_NUM_DIRTY_SET 8
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
Currently clusterInfo pool are created in array pool, we should use bitmap objects so that it can be allocated in heap in real products.

In addition, interested attribute/event paths from read/subscribe interaction are sharing the cluster info pool with dirty path used when attribute change happens. It is better to split dirty set path into dedicated pool so that it's easier to adjust the number of dirty paths using chip configuration parameter  

#### Change overview

-- Split global dirty set into dedicated bitmap object pool
-- Update the clusterInfo pool with bitmap object pool

#### Testing
The exiting test covers
