### PR TITLE
[Darwin] Avoid duplicate block typedef

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -22,8 +22,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SubscriptionEstablishedHandler)(void);
-
 @interface CHIPDevice : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -40,7 +38,7 @@ typedef void (^SubscriptionEstablishedHandler)(void);
  *
  * The array passed to reportHandler will contain CHIPAttributeReport instances.
  *
- * subscriptionEstablishedHandler, if not nil, will be called once the
+ * subscriptionEstablished block, if not nil, will be called once the
  * subscription is established.  This will be _after_ the first (priming) call
  * to reportHandler.
  *
@@ -50,7 +48,7 @@ typedef void (^SubscriptionEstablishedHandler)(void);
                 minInterval:(uint16_t)minInterval
                 maxInterval:(uint16_t)maxInterval
               reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
-    subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler;
+    subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler;
 @end
 
 @interface CHIPAttributePath : NSObject

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -27,6 +27,8 @@
 #include <app/ReadClient.h>
 #include <app/util/error-mapping.h>
 
+typedef void (^SubscriptionEstablishedHandler)(void);
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::Protocols::InteractionModel;
@@ -138,7 +140,7 @@ private:
                 minInterval:(uint16_t)minInterval
                 maxInterval:(uint16_t)maxInterval
               reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
-    subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
+    subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler
 {
     DeviceProxy * device = [self internalDevice];
     if (!device) {


### PR DESCRIPTION
#### Problem
The SubscriptionEstablishedHandler typedef doesn't need to be public and can cause duplicate definition errors based on the project settings

#### Change overview
Remove unnecessary public declaration of SubscriptionEstablishedHandler 

#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not?
Minor refactor, compile should be  sufficient. 
