### PR TITLE
CommissioneeDeviceProxy fix.

### DIFF
--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -138,11 +138,12 @@ CHIP_ERROR CommissioneeDeviceProxy::SetConnected()
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
+    mState = ConnectionState::SecureConnected;
     bool _didLoad;
     CHIP_ERROR err = LoadSecureSessionParametersIfNeeded(_didLoad);
-    if (err == CHIP_NO_ERROR)
+    if (err != CHIP_NO_ERROR)
     {
-        mState = ConnectionState::SecureConnected;
+        mState = ConnectionState::NotConnected;
     }
     return err;
 }


### PR DESCRIPTION
#### Problem
Added a review comment fix, but the logic is not correct due to an
early exit on the load function. This didn't show up when testing
because the python tool caches the proxy and doesn't need to re-look
up the pairing.

#### Change overview
move state change back to earlier in the function so the load parameters call doesn't bail early.

#### Testing
Tested by Kevin C using java impl - pase then command