### PR TITLE
Update OTA Requestor Server cluster attributes

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -543,12 +543,10 @@ static void InitOTARequestor(void)
 {
 #if CONFIG_ENABLE_OTA_REQUESTOR
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.SetServerInstance(&Server::GetInstance());
-    gRequestorCore.SetOtaRequestorDriver(&gRequestorUser);
+    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
-    gRequestorCore.SetBDXDownloader(&gDownloader);
 #endif
 }
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -147,9 +147,7 @@ void AppTask::InitOTARequestor()
     sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
-    sOTARequestor.SetOtaRequestorDriver(&sOTARequestorDriver);
-    sOTARequestor.SetBDXDownloader(&sBDXDownloader);
-    sOTARequestor.SetServerInstance(&chip::Server::GetInstance());
+    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif
 }

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -124,12 +124,7 @@ CHIP_ERROR AppTask::Init()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    // Set server instance used for session establishment
-    chip::Server * server = &(chip::Server::GetInstance());
-    gRequestorCore.SetServerInstance(server);
-
-    // Connect the Requestor and Requestor Driver objects
-    gRequestorCore.SetOtaRequestorDriver(&gRequestorUser);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
@@ -143,8 +138,6 @@ CHIP_ERROR AppTask::Init()
 
     // Connect the gDownloader and Image Processor objects
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
-
-    gRequestorCore.SetBDXDownloader(&gDownloader);
     // Initialize and interconnect the Requestor and Image Processor objects -- END
 
     // QR code will be used with CHIP Tool

--- a/examples/ota-requestor-app/efr32/src/main.cpp
+++ b/examples/ota-requestor-app/efr32/src/main.cpp
@@ -172,12 +172,7 @@ int main(void)
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    // Set server instance used for session establishment
-    chip::Server * server = &(chip::Server::GetInstance());
-    gRequestorCore.SetServerInstance(server);
-
-    // Connect the Requestor and Requestor Driver objects
-    gRequestorCore.SetOtaRequestorDriver(&gRequestorUser);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
 
     OTAImageProcessorParams ipParams;
     ipParams.imageFile = CharSpan("test.txt");
@@ -186,8 +181,6 @@ int main(void)
 
     // Connect the Downloader and Image Processor objects
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
-
-    gRequestorCore.SetBDXDownloader(&gDownloader);
     // Initialize and interconnect the Requestor and Image Processor objects -- END
 
     EFR32_LOG("Starting Platform Manager Event Loop");

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -142,14 +142,8 @@ extern "C" void app_main()
 
     ESPInitConsole();
     SetRequestorInstance(&gRequestorCore);
-
-    Server * server = &(Server::GetInstance());
-    gRequestorCore.SetServerInstance(server);
-    gRequestorCore.SetOtaRequestorDriver(&gRequestorUser);
-
+    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
-
-    gRequestorCore.SetBDXDownloader(&gDownloader);
 }

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -175,14 +175,13 @@ CHIP_ERROR BDXDownloader::HandleBdxEvent(const chip::bdx::TransferSession::Outpu
         {
             // BDX transfer is not complete until BlockAckEOF has been sent
             SetState(State::kComplete);
-
-            // TODO: how/when to reset the BDXDownloader to be ready to handle another download
         }
         break;
     }
     case TransferSession::OutputEventType::kBlockReceived: {
         chip::ByteSpan blockData(outEvent.blockdata.Data, outEvent.blockdata.Length);
         ReturnErrorOnFailure(mImageProcessor->ProcessBlock(blockData));
+        mStateDelegate->OnUpdateProgressChanged(mImageProcessor->GetPercentComplete());
 
         // TODO: this will cause problems if Finalize() is not guaranteed to do its work after ProcessBlock().
         if (outEvent.blockdata.IsEof)

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -48,8 +48,11 @@ public:
     class StateDelegate
     {
     public:
+        // Handle download state change
         virtual void OnDownloadStateChanged(State state) = 0;
-        virtual ~StateDelegate()                         = default;
+        // Handle update progress change
+        virtual void OnUpdateProgressChanged(uint8_t percent) = 0;
+        virtual ~StateDelegate()                              = default;
     };
 
     // To be called when there is an incoming message to handle (of any protocol type)

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -20,7 +20,6 @@
  * OTA Requestor logic is contained in this class.
  */
 
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <lib/core/CHIPEncoding.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OTAImageProcessor.h>
@@ -90,12 +89,12 @@ static void LogApplyUpdateResponse(const ApplyUpdateResponse::DecodableType & re
 
 static void SetUpdateStateAttribute(OTAUpdateStateEnum state)
 {
-    OtaRequestorServer::GetInstance().SetUpdateState(state);
+    OtaRequestorServerSetUpdateState(state);
 
     // The UpdateStateProgress attribute only applies to the querying state
     if (state != OTAUpdateStateEnum::kQuerying)
     {
-        OtaRequestorServer::GetInstance().SetUpdateStateProgress(0);
+        OtaRequestorServerSetUpdateStateProgress(0);
     }
 }
 
@@ -302,6 +301,7 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
         {
             ChipLogError(SoftwareUpdate, "Failed to start download: %" CHIP_ERROR_FORMAT, err.Format());
             requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kDownloading, err);
+            SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
             return;
         }
 
@@ -315,6 +315,7 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
         {
             ChipLogError(SoftwareUpdate, "Failed to send ApplyUpdate command: %" CHIP_ERROR_FORMAT, err.Format());
             requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kApplying, err);
+            SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
             return;
         }
 
@@ -394,7 +395,7 @@ void OTARequestor::OnDownloadStateChanged(OTADownloader::State state)
 
 void OTARequestor::OnUpdateProgressChanged(uint8_t percent)
 {
-    OtaRequestorServer::GetInstance().SetUpdateStateProgress(percent);
+    OtaRequestorServerSetUpdateStateProgress(percent);
 }
 
 CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -88,6 +88,17 @@ static void LogApplyUpdateResponse(const ApplyUpdateResponse::DecodableType & re
     ChipLogDetail(SoftwareUpdate, "  delayedActionTime: %" PRIu32 " seconds", response.delayedActionTime);
 }
 
+static void SetUpdateStateAttribute(OTAUpdateStateEnum state)
+{
+    OtaRequestorServer::GetInstance().SetUpdateState(state);
+
+    // The UpdateStateProgress attribute only applies to the querying state
+    if (state != OTAUpdateStateEnum::kQuerying)
+    {
+        OtaRequestorServer::GetInstance().SetUpdateStateProgress(0);
+    }
+}
+
 void StartDelayTimerHandler(System::Layer * systemLayer, void * appState)
 {
     VerifyOrReturn(appState != nullptr);
@@ -135,13 +146,16 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
     case OTAQueryStatus::kBusy:
         requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::Busy,
                                                            System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kDelayedOnQuery);
         break;
     case OTAQueryStatus::kNotAvailable:
         requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::NotAvailable,
                                                            System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
         break;
     default:
         requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kQuerying, CHIP_ERROR_BAD_REQUEST);
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
         break;
     }
 }
@@ -153,6 +167,7 @@ void OTARequestor::OnQueryImageFailure(void * context, EmberAfStatus status)
 
     ChipLogDetail(SoftwareUpdate, "QueryImage failure response %" PRIu8, status);
     requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kQuerying, CHIP_ERROR_BAD_REQUEST);
+    SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
 }
 
 void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateResponse::DecodableType & response)
@@ -169,9 +184,11 @@ void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateRespon
         break;
     case OTAApplyUpdateAction::kAwaitNextAction:
         requestorCore->mOtaRequestorDriver->UpdateSuspended(System::Clock::Seconds32(response.delayedActionTime));
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kDelayedOnApply);
         break;
     case OTAApplyUpdateAction::kDiscontinue:
         requestorCore->mOtaRequestorDriver->UpdateDiscontinued();
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
         break;
     }
 }
@@ -183,6 +200,7 @@ void OTARequestor::OnApplyUpdateFailure(void * context, EmberAfStatus status)
 
     ChipLogDetail(SoftwareUpdate, "ApplyUpdate failure response %" PRIu8, status);
     requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kApplying, CHIP_ERROR_BAD_REQUEST);
+    SetUpdateStateAttribute(OTAUpdateStateEnum::kIdle);
 }
 
 EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * commandObj,
@@ -271,8 +289,10 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
         {
             ChipLogError(SoftwareUpdate, "Failed to send QueryImage command: %" CHIP_ERROR_FORMAT, err.Format());
             requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kQuerying, err);
+            return;
         }
 
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kQuerying);
         break;
     }
     case kStartBDX: {
@@ -282,8 +302,10 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
         {
             ChipLogError(SoftwareUpdate, "Failed to start download: %" CHIP_ERROR_FORMAT, err.Format());
             requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kDownloading, err);
+            return;
         }
 
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kDownloading);
         break;
     }
     case kApplyUpdate: {
@@ -293,27 +315,14 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
         {
             ChipLogError(SoftwareUpdate, "Failed to send ApplyUpdate command: %" CHIP_ERROR_FORMAT, err.Format());
             requestorCore->mOtaRequestorDriver->HandleError(OTAUpdateStateEnum::kApplying, err);
+            return;
         }
 
+        SetUpdateStateAttribute(OTAUpdateStateEnum::kApplying);
         break;
     }
     default:
         break;
-    }
-}
-
-OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
-{
-
-    if (mProviderNodeId != kUndefinedNodeId)
-    {
-        ConnectToProvider(kQueryImage);
-        return kTriggerSuccessful;
-    }
-    else
-    {
-        ChipLogError(SoftwareUpdate, "No OTA Providers available");
-        return kNoProviderKnown;
     }
 }
 
@@ -342,6 +351,20 @@ void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR
     }
 }
 
+OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
+{
+    if (mProviderNodeId != kUndefinedNodeId)
+    {
+        ConnectToProvider(kQueryImage);
+        return kTriggerSuccessful;
+    }
+    else
+    {
+        ChipLogError(SoftwareUpdate, "No OTA Providers available");
+        return kNoProviderKnown;
+    }
+}
+
 void OTARequestor::DownloadUpdate()
 {
     ConnectToProvider(kStartBDX);
@@ -367,6 +390,11 @@ void OTARequestor::OnDownloadStateChanged(OTADownloader::State state)
     default:
         break;
     }
+}
+
+void OTARequestor::OnUpdateProgressChanged(uint8_t percent)
+{
+    OtaRequestorServer::GetInstance().SetUpdateStateProgress(percent);
 }
 
 CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <app/CASESessionManager.h>
+#include <app/clusters/ota-requestor/ota-requestor-server.h>
 #include <app/server/Server.h>
 #include <platform/OTARequestorDriver.h>
 #include <platform/OTARequestorInterface.h>
@@ -46,7 +47,10 @@ public:
 
     OTARequestor() : mOnConnectedCallback(OnConnected, this), mOnConnectionFailureCallback(OnConnectionFailure, this) {}
 
-    // Application interface declarations -- start
+    //////////// OTARequestorInterface Implementation ///////////////
+    EmberAfStatus HandleAnnounceOTAProvider(
+        app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
+        const app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData) override;
 
     // Application directs the Requestor to start the Image Query process
     // and download the new image if available
@@ -58,53 +62,26 @@ public:
     // Send ApplyImage
     void ApplyUpdate() override;
 
-    // Handle download state change
+    //////////// BDXDownloader::StateDelegate Implementation ///////////////
     void OnDownloadStateChanged(OTADownloader::State state) override;
+    void OnUpdateProgressChanged(uint8_t percent) override;
 
-    // A setter for the delegate class pointer
-    void SetOtaRequestorDriver(OTARequestorDriver * driver) { mOtaRequestorDriver = driver; }
-
-    // TODO: this should really be OTADownloader, but right now OTARequestor has information that we need to initialize a
-    // BDXDownloader specifically.
-    // The BDXDownloader instance should already have the ImageProcessingDelegate set.
-    void SetBDXDownloader(chip::BDXDownloader * downloader) { mBdxDownloader = downloader; }
-
-    // Application directs the Requestor to abort the download in progress. All the Requestor state (such
-    // as the QueryImageResponse content) is preserved
-    void AbortImageUpdate();
-
-    // Application directs the Requestor to abort the download in progress. All the Requestor state is
-    // cleared, UploadState is reset to Idle
-    void AbortAndResetState();
-
-    // Application notifies the Requestor on the user consent action, TRUE if consent is given,
-    // FALSE otherwise
-    void OnUserConsent(bool result);
-
-    /* Commented out until the API is supported
-    // Application directs the Requestor to download the image using the suppiled parameter and without
-    // issuing QueryImage
-    OTATriggerResult ResumeImageDownload(const BdxDownloadParameters & bdxParameters){ return kTriggerSuccessful;}
-    */
-
-    // Application interface declarations -- end
-
-    // Virtual functions from OTARequestorInterface -- start
-
-    // Handler for the AnnounceOTAProvider command
-    EmberAfStatus HandleAnnounceOTAProvider(
-        app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-        const app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData) override;
-
-    // Virtual functions from OTARequestorInterface -- end
     /**
-     * Called to set the server instance which used to get access to the system resources necessary to open CASE sessions and drive
-     * BDX transfers
+     * Called to perform some initialization including:
+     *   - Set server instance used to get access to the system resources necessary to open CASE sessions and drive
+     *     BDX transfers
+     *   - Set the OTA requestor driver instance used to communicate download progress and errors
+     *   - Set the BDX downloader instance used for initiating BDX downloads
      */
-    void SetServerInstance(Server * server)
+    void Init(Server * server, OTARequestorDriver * driver, BDXDownloader * downloader)
     {
         mServer             = server;
         mCASESessionManager = server->GetCASESessionManager();
+        mOtaRequestorDriver = driver;
+        mBdxDownloader      = downloader;
+
+        OtaRequestorServer::GetInstance().SetUpdateState(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum::kIdle);
+        OtaRequestorServer::GetInstance().SetUpdateStateProgress(0);
     }
 
     /**
@@ -125,6 +102,18 @@ public:
         mProviderFabricIndex = fabIndex;
         mProviderEndpointId  = endpointId;
     }
+
+    // Application directs the Requestor to abort the download in progress. All the Requestor state (such
+    // as the QueryImageResponse content) is preserved
+    void AbortImageUpdate();
+
+    // Application directs the Requestor to abort the download in progress. All the Requestor state is
+    // cleared, UploadState is reset to Idle
+    void AbortAndResetState();
+
+    // Application notifies the Requestor on the user consent action, TRUE if consent is given,
+    // FALSE otherwise
+    void OnUserConsent(bool result);
 
 private:
     using QueryImageResponseDecodableType  = app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -80,8 +80,8 @@ public:
         mOtaRequestorDriver = driver;
         mBdxDownloader      = downloader;
 
-        OtaRequestorServer::GetInstance().SetUpdateState(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum::kIdle);
-        OtaRequestorServer::GetInstance().SetUpdateStateProgress(0);
+        OtaRequestorServerSetUpdateState(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum::kIdle);
+        OtaRequestorServerSetUpdateStateProgress(0);
     }
 
     /**

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -20,10 +20,8 @@
  * to the OTA Requestor object that handles them
  */
 
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/clusters/ota-requestor/ota-requestor-server.h>
-#include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <platform/OTARequestorInterface.h>
 
@@ -81,19 +79,9 @@ CHIP_ERROR OtaSoftwareUpdateRequestorAttrAccess::Write(const ConcreteDataAttribu
 
 } // namespace
 
-namespace chip {
-
 // -----------------------------------------------------------------------------
-// OtaRequestorServer implementation
-
-static OtaRequestorServer sInstance;
-
-OtaRequestorServer & OtaRequestorServer::GetInstance(void)
-{
-    return sInstance;
-}
-
-EmberAfStatus OtaRequestorServer::SetUpdateState(OTAUpdateStateEnum value)
+// Global functions
+EmberAfStatus OtaRequestorServerSetUpdateState(OTAUpdateStateEnum value)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
@@ -114,7 +102,7 @@ EmberAfStatus OtaRequestorServer::SetUpdateState(OTAUpdateStateEnum value)
     return status;
 }
 
-EmberAfStatus OtaRequestorServer::SetUpdateStateProgress(uint8_t value)
+EmberAfStatus OtaRequestorServerSetUpdateStateProgress(uint8_t value)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
@@ -124,20 +112,15 @@ EmberAfStatus OtaRequestorServer::SetUpdateStateProgress(uint8_t value)
         app::DataModel::Nullable<uint8_t> currentValue;
         status = Attributes::UpdateStateProgress::Get(endpoint, currentValue);
         VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
-        if (!currentValue.IsNull())
+        if (currentValue.IsNull() || currentValue.Value() != value)
         {
-            if (currentValue.Value() != value)
-            {
-                status = Attributes::UpdateStateProgress::Set(endpoint, value);
-                VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
-            }
+            status = Attributes::UpdateStateProgress::Set(endpoint, value);
+            VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
         }
     }
 
     return status;
 }
-
-} // namespace chip
 
 // -----------------------------------------------------------------------------
 // Callbacks implementation

--- a/src/app/clusters/ota-requestor/ota-requestor-server.h
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.h
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+namespace chip {
+
+class OtaRequestorServer
+{
+public:
+    static OtaRequestorServer & GetInstance(void);
+
+    EmberAfStatus SetUpdateState(chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value);
+    EmberAfStatus SetUpdateStateProgress(uint8_t value);
+};
+
+} // namespace chip

--- a/src/app/clusters/ota-requestor/ota-requestor-server.h
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.h
@@ -16,15 +16,9 @@
  *    limitations under the License.
  */
 
-namespace chip {
+#pragma once
 
-class OtaRequestorServer
-{
-public:
-    static OtaRequestorServer & GetInstance(void);
+#include <app-common/zap-generated/attributes/Accessors.h>
 
-    EmberAfStatus SetUpdateState(chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value);
-    EmberAfStatus SetUpdateStateProgress(uint8_t value);
-};
-
-} // namespace chip
+EmberAfStatus OtaRequestorServerSetUpdateState(chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value);
+EmberAfStatus OtaRequestorServerSetUpdateStateProgress(uint8_t value);

--- a/src/include/platform/OTAImageProcessor.h
+++ b/src/include/platform/OTAImageProcessor.h
@@ -28,8 +28,8 @@ namespace chip {
 struct OTAImageProcessorParams
 {
     CharSpan imageFile;
-    uint64_t downloadedBytes;
-    uint64_t totalFileBytes;
+    uint64_t downloadedBytes = 0;
+    uint64_t totalFileBytes  = 0;
 };
 
 /**

--- a/src/platform/GenericOTARequestorDriver.h
+++ b/src/platform/GenericOTARequestorDriver.h
@@ -31,6 +31,11 @@ namespace DeviceLayer {
 class GenericOTARequestorDriver : public OTARequestorDriver
 {
 public:
+    /**
+     * Called to perform some initialization including:
+     *   - Set the OTA requestor instance used to direct download progress
+     *   - Set the OTA image processor instance used to apply/abort the downloaded image
+     */
     void Init(OTARequestorInterface * requestor, OTAImageProcessorInterface * processor)
     {
         mRequestor      = requestor;


### PR DESCRIPTION
#### Problem
Currently, the OTA Requestor Server cluster attributes for `UpdateState` and `UpdateStateProgress` are not updated to reflect the current state of the OTA Requestor.

Fixes: https://github.com/project-chip/connectedhomeip/issues/13169

#### Change overview
- Set the `UpdateState` and `UpdateStateProgress` attributes as the OTA Requestor progresses through an OTA download/apply
- On boot, the `UpdateState` should be set to idle (default value is unknown). The idle value should be set in OTA Requestor ctor. However, since OTA Requestor core is a global object in all applications and is likely created before the data model is initialized, use an explicit Init() to be called after the object is created to set the attribute
-- This affects all applications that initialize an `OTARequestor` instance
- Add `OnUpdateProgressChanged` to OTARequestor class to be called by BDXDownloader each time a block of data has been processed to ensure that `UpdateStateProgress` attribute is updated

#### Testing
Manual testing using Linux requestor/provider
