### PR TITLE
Improve the CommandResponseHelper API a bit.

### DIFF
--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -174,12 +174,12 @@ bool emberAfChannelClusterChangeChannelRequestCallback(app::CommandHandler * com
 
     auto & match = commandData.match;
 
-    app::CommandResponseHelper<Commands::ChangeChannelResponse::Type> responser(command, commandPath);
+    app::CommandResponseHelper<Commands::ChangeChannelResponse::Type> responder(command, commandPath);
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
     {
-        delegate->HandleChangeChannel(match, responser);
+        delegate->HandleChangeChannel(match, responder);
     }
 
 exit:
@@ -188,8 +188,8 @@ exit:
         ChipLogError(Zcl, "emberAfChannelClusterChangeChannelRequestCallback error: %s", err.AsString());
     }
 
-    // If isDelegateNull, no one will call responser, so IsResponsed will be false
-    if (!responser.IsResponsed())
+    // If isDelegateNull, no one will call responder, so HasSentResponse will be false
+    if (!responder.HasSentResponse())
     {
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -177,12 +177,12 @@ bool emberAfContentLauncherClusterLaunchContentRequestCallback(
     // auto searchIterator = commandData.search.begin();
     std::list<Parameter> parameterList;
 
-    app::CommandResponseHelper<Commands::LaunchResponse::Type> responser(commandObj, commandPath);
+    app::CommandResponseHelper<Commands::LaunchResponse::Type> responder(commandObj, commandPath);
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
     {
-        delegate->HandleLaunchContent(parameterList, autoplay, data, responser);
+        delegate->HandleLaunchContent(parameterList, autoplay, data, responder);
     }
 
 exit:
@@ -191,8 +191,8 @@ exit:
         ChipLogError(Zcl, "emberAfContentLauncherClusterLaunchContentRequestCallback error: %s", err.AsString());
     }
 
-    // If isDelegateNull, no one will call responser, so IsResponsed will be false
-    if (!responser.IsResponsed())
+    // If isDelegateNull, no one will call responder, so HasSentResponse will be false
+    if (!responder.HasSentResponse())
     {
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }
@@ -213,12 +213,12 @@ bool emberAfContentLauncherClusterLaunchURLRequestCallback(
     // auto brandingInformationIterator = commandData.brandingInformation.begin();
     std::list<BrandingInformation> brandingInformationList;
 
-    app::CommandResponseHelper<Commands::LaunchResponse::Type> responser(commandObj, commandPath);
+    app::CommandResponseHelper<Commands::LaunchResponse::Type> responder(commandObj, commandPath);
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
     {
-        delegate->HandleLaunchUrl(contentUrl, displayString, brandingInformationList, responser);
+        delegate->HandleLaunchUrl(contentUrl, displayString, brandingInformationList, responder);
     }
 
 exit:
@@ -227,8 +227,8 @@ exit:
         ChipLogError(Zcl, "emberAfContentLauncherClusterLaunchURLCallback error: %s", err.AsString());
     }
 
-    // If isDelegateNull, no one will call responser, so IsResponsed will be false
-    if (!responser.IsResponsed())
+    // If isDelegateNull, no one will call responder, so HasSentResponse will be false
+    if (!responder.HasSentResponse())
     {
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }


### PR DESCRIPTION
Fix some grammar/style issues, stop using the deprecated
emberAfSendImmediateDefaultResponse API.

#### Problem
"responsed" is not a verb, and we should not be doing emberAfSendImmediateDefaultResponse.

#### Change overview
Make the CommandResponseHelper APIs match what we want people to actually be doing.

#### Testing
No behavior changes.