### PR TITLE
ESP32:Fix CaseSession fail on ESP32, Add InitClock_ReadTime function

### DIFF
--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -20,7 +20,6 @@ assert(chip_device_platform == "esp32")
 
 static_library("ESP32") {
   sources = [
-    "../FreeRTOS/SystemTimeSupport.cpp",
     "../SingletonConfigurationManager.cpp",
     "BLEManagerImpl.h",
     "CHIPDevicePlatformConfig.h",
@@ -45,6 +44,7 @@ static_library("ESP32") {
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
     "SystemTimeSupport.cpp",
+    "SystemTimeSupport.h",
     "bluedroid/BLEManagerImpl.cpp",
     "nimble/BLEManagerImpl.cpp",
   ]

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -29,6 +29,7 @@
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/ESP32/DiagnosticDataProviderImpl.h>
 #include <platform/ESP32/ESP32Utils.h>
+#include <platform/ESP32/SystemTimeSupport.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp>
 
@@ -123,6 +124,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // to finish the initialization process.
     ReturnErrorOnFailure(Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_InitChipStack());
 
+    ReturnErrorOnFailure(System::Clock::InitClock_RealTime());
 exit:
     return chip::DeviceLayer::Internal::ESP32Utils::MapError(err);
 }

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -25,8 +25,8 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <lib/support/TimeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/ESP32/SystemTimeSupport.h>
 
 #include <esp_timer.h>
 
@@ -110,6 +110,15 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR InitClock_RealTime()
+{
+    Clock::Microseconds64 curTime =
+        Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
+    // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
+    // Then the RealTime obtained from GetClock_RealTime will be always valid.
+    return System::SystemClock().SetClock_RealTime(curTime);
 }
 
 } // namespace Clock

--- a/src/platform/ESP32/SystemTimeSupport.h
+++ b/src/platform/ESP32/SystemTimeSupport.h
@@ -20,10 +20,9 @@
 namespace chip {
 namespace System {
 namespace Clock {
-    
+
 CHIP_ERROR InitClock_RealTime();
 
 } // namespace Clock
 } // namespace System
 } // namespace chip
-

--- a/src/platform/ESP32/SystemTimeSupport.h
+++ b/src/platform/ESP32/SystemTimeSupport.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/support/TimeUtils.h>
+
+namespace chip {
+namespace System {
+namespace Clock {
+    
+CHIP_ERROR InitClock_RealTime();
+
+} // namespace Clock
+} // namespace System
+} // namespace chip
+


### PR DESCRIPTION
#### Problem
CaseSession fails on ESP32 platform because GetClock_RealTimeMS returns CHIP_ERROR_REAL_TIME_NOT_SYNCED #13490

#### Change overview
Add `InitClock_RealTime` function so that the GetClock_RealTimeMS will not return errors.

#### Testing
Test  all-clusters-app on ESP32&ESP32C3 manually