### PR TITLE
fix memory issue in MediaInputMgr

### DIFF
--- a/examples/tv-app/android/java/MediaInputManager.cpp
+++ b/examples/tv-app/android/java/MediaInputManager.cpp
@@ -223,6 +223,7 @@ exit:
 
 bool MediaInputManager::HandleRenameInput(const uint8_t index, const chip::CharSpan & name)
 {
+    std::string inputname(name.data(), name.size());
     jboolean ret = JNI_FALSE;
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
 
@@ -232,7 +233,7 @@ bool MediaInputManager::HandleRenameInput(const uint8_t index, const chip::CharS
     VerifyOrExit(env != NULL, ChipLogError(Zcl, "env null"));
 
     {
-        UtfString jniInputname(env, name.data());
+        UtfString jniInputname(env, inputname.data());
         env->ExceptionClear();
         ret =
             env->CallBooleanMethod(mMediaInputManagerObject, mRenameInputMethod, static_cast<jint>(index), jniInputname.jniValue());


### PR DESCRIPTION
#### Problem
* MediaInputManager::HandleRenameInput has memroy issue

#### Change overview
The name get from frame is not end with \0,  so UtfString jniInputname(env, name.data()); can not get a strings.

#### Testing
How was this tested? (at least one bullet point required)
* chip-toop mediainput renameinput
