### PR TITLE
Ameba Build Issue

### DIFF
--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -245,8 +245,8 @@ namespace {
 float BitCastToFloat(const uint64_t elemLenOrVal)
 {
     float f;
-    auto u32 = static_cast<uint32_t>(elemLenOrVal);
-    memcpy(&f, &u32, sizeof(f));
+    auto unsigned32 = static_cast<uint32_t>(elemLenOrVal);
+    memcpy(&f, &unsigned32, sizeof(f));
     return f;
 }
 } // namespace


### PR DESCRIPTION
Problem:
amebaD sdk uses u32 as a typedef.  CHIPTLVReader.cpp uses u32 in a function as an identifier.  This causes a build failure

Solution:
Renamed "u32" to "unsigned32" in CHIPTLVReader.cpp
Change limited only to name change within a single function
Testing:
Verified builds gn_build.sh
Verified all clusters app for amebad
