### PR TITLE
[chip-tool] Add read-event support to chip-tool

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -554,6 +554,21 @@ const char * Command::GetAttribute(void) const
     return nullptr;
 }
 
+const char * Command::GetEvent(void) const
+{
+    size_t argsCount = mArgs.size();
+    for (size_t i = 0; i < argsCount; i++)
+    {
+        Argument arg = mArgs.at(i);
+        if (arg.type == ArgumentType::Attribute)
+        {
+            return reinterpret_cast<const char *>(arg.value);
+        }
+    }
+
+    return nullptr;
+}
+
 size_t Command::AddArgumentToList(Argument && argument)
 {
     if (argument.isOptional() || mArgs.empty() || !mArgs.back().isOptional())

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -105,6 +105,7 @@ public:
 
     const char * GetName(void) const { return mName; }
     const char * GetAttribute(void) const;
+    const char * GetEvent(void) const;
     const char * GetArgumentName(size_t index) const;
     bool GetArgumentIsOptional(size_t index) const { return mArgs[index].isOptional(); }
     size_t GetArgumentsCount(void) const { return mArgs.size(); }

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -90,6 +90,23 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
     }
+    else if (IsEventCommand(argv[2]))
+    {
+        if (argc <= 3)
+        {
+            ChipLogError(chipTool, "Missing event name");
+            ShowClusterEvents(argv[0], argv[1], argv[2], cluster->second);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+
+        command = GetGlobalCommand(cluster->second, argv[2], argv[3]);
+        if (command == nullptr)
+        {
+            ChipLogError(chipTool, "Unknown event: %s", argv[3]);
+            ShowClusterEvents(argv[0], argv[1], argv[2], cluster->second);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+    }
     else
     {
         if (argc <= 3)
@@ -158,9 +175,19 @@ Command * Commands::GetGlobalCommand(CommandsVector & commands, std::string comm
     return nullptr;
 }
 
-bool Commands::IsGlobalCommand(std::string commandName) const
+bool Commands::IsAttributeCommand(std::string commandName) const
 {
     return commandName.compare("read") == 0 || commandName.compare("write") == 0 || commandName.compare("report") == 0;
+}
+
+bool Commands::IsEventCommand(std::string commandName) const
+{
+    return commandName.compare("read-event") == 0;
+}
+
+bool Commands::IsGlobalCommand(std::string commandName) const
+{
+    return IsAttributeCommand(commandName) || IsEventCommand(commandName);
 }
 
 void Commands::ShowClusters(std::string executable)
@@ -189,9 +216,10 @@ void Commands::ShowCluster(std::string executable, std::string clusterName, Comm
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | Commands:                                                                           |\n");
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
-    bool readCommand   = false;
-    bool writeCommand  = false;
-    bool reportCommand = false;
+    bool readCommand      = false;
+    bool writeCommand     = false;
+    bool reportCommand    = false;
+    bool readEventCommand = false;
     for (auto & command : commands)
     {
         bool shouldPrint = true;
@@ -209,6 +237,10 @@ void Commands::ShowCluster(std::string executable, std::string clusterName, Comm
             else if (strcmp(command->GetName(), "report") == 0 && reportCommand == false)
             {
                 reportCommand = true;
+            }
+            else if (strcmp(command->GetName(), "read-event") == 0 && readEventCommand == false)
+            {
+                readEventCommand = true;
             }
             else
             {
@@ -239,6 +271,25 @@ void Commands::ShowClusterAttributes(std::string executable, std::string cluster
         if (commandName.compare(command->GetName()) == 0)
         {
             fprintf(stderr, "  | * %-82s|\n", command->GetAttribute());
+        }
+    }
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+}
+
+void Commands::ShowClusterEvents(std::string executable, std::string clusterName, std::string commandName,
+                                 CommandsVector & commands)
+{
+    fprintf(stderr, "Usage:\n");
+    fprintf(stderr, "  %s %s %s event-name [param1 param2 ...]\n", executable.c_str(), clusterName.c_str(), commandName.c_str());
+    fprintf(stderr, "\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    fprintf(stderr, "  | Events:                                                                             |\n");
+    fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
+    for (auto & command : commands)
+    {
+        if (commandName.compare(command->GetName()) == 0)
+        {
+            fprintf(stderr, "  | * %-82s|\n", command->GetEvent());
         }
     }
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -36,11 +36,14 @@ private:
     std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);
     Command * GetGlobalCommand(CommandsVector & commands, std::string commandName, std::string attributeName);
+    bool IsAttributeCommand(std::string commandName) const;
+    bool IsEventCommand(std::string commandName) const;
     bool IsGlobalCommand(std::string commandName) const;
 
     void ShowClusters(std::string executable);
     void ShowCluster(std::string executable, std::string clusterName, CommandsVector & commands);
     void ShowClusterAttributes(std::string executable, std::string clusterName, std::string commandName, CommandsVector & commands);
+    void ShowClusterEvents(std::string executable, std::string clusterName, std::string commandName, CommandsVector & commands);
     void ShowCommand(std::string executable, std::string clusterName, Command * command);
 
     std::map<std::string, CommandsVector> mClusters;

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -36,6 +36,14 @@ CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClust
 {{/zcl_structs}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#zcl_events}}
+{{#unless has_more_than_one_cluster}}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::{{asUpperCamelCase parent.name}}::Events::{{asUpperCamelCase name}}::DecodableType value);
+{{/unless}}
+{{/zcl_events}}
+{{/zcl_clusters}}
+
 #if CHIP_PROGRESS_LOGGING
 std::string IndentStr(size_t indent)
 {
@@ -168,6 +176,18 @@ CHIP_ERROR LogValue(const char * label, size_t indent, const chip::Optional<T> &
 {{/zcl_clusters}}
 #pragma GCC diagnostic pop
 
+// We output helpers for all events here, including ones we might not actually
+// be logging.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+{{#zcl_clusters}}
+{{#zcl_events}}
+{{#unless has_more_than_one_cluster}}
+{{> log_event_value ns=parent.name}}
+{{/unless}}
+{{/zcl_events}}
+{{/zcl_clusters}}
+#pragma GCC diagnostic pop
 } // anonymous namespace
 
 static void OnDefaultSuccessResponseWithoutExit(void * context)
@@ -197,7 +217,7 @@ static void OnDefaultSuccess(void * context, const chip::app::DataModel::NullObj
 };
 
 template <typename T>
-static void OnGeneralAttributeResponse(void * context, const char * label, T value)
+static void OnGeneralAttributeEventResponse(void * context, const char * label, T value)
 {
     CHIP_ERROR err = LogValue(label, 0, value);
 
@@ -278,6 +298,41 @@ private:
 
 {{/chip_cluster_commands}}
 
+{{#chip_server_cluster_events}}
+/*
+ * Event {{asUpperCamelCase name}}
+ */
+class Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
+{
+public:
+    Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("read-event")
+    {
+        AddArgument("event-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
+        ModelCommand::AddArguments();
+    }
+
+    ~Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
+    {
+    }
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::{{asUpperCamelCase parent.name}}::Events::{{asUpperCamelCase name}}::DecodableType>(this,
+          OnEventResponse,
+          OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::{{asUpperCamelCase parent.name}}::Events::{{asUpperCamelCase name}}::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response", value);
+    }
+};
+{{/chip_server_cluster_events}}
+
 {{#chip_server_cluster_attributes}}
 {{! TODO: Various types (floats, structs) not supported here. }}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
@@ -299,7 +354,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
@@ -310,7 +365,7 @@ public:
 
     static void OnAttributeResponse(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} value)
     {
-        OnGeneralAttributeResponse(context, "{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response", value);
+        OnGeneralAttributeEventResponse(context, "{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response", value);
     }
 };
 
@@ -342,7 +397,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
@@ -374,7 +429,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
@@ -434,6 +489,9 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         {{/if}}
         {{/unless}}
         {{/chip_server_cluster_attributes}}
+        {{#chip_server_cluster_events}}
+        make_unique<Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
+        {{/chip_server_cluster_events}}
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/templates/partials/log_event_value.zapt
+++ b/examples/chip-tool/templates/partials/log_event_value.zapt
@@ -1,0 +1,16 @@
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::{{asUpperCamelCase parent.name}}::Events::{{asUpperCamelCase name}}::DecodableType value)
+{
+  ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+{{#zcl_event_fields}}
+  {
+      CHIP_ERROR err = LogValue("{{asUpperCamelCase name}}", indent + 1, value.{{asLowerCamelCase name}});
+      if (err != CHIP_NO_ERROR)
+      {
+          ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for '{{asUpperCamelCase name}}'", IndentStr(indent + 1).c_str());
+          return err;
+      }
+  }
+{{/zcl_event_fields}}
+  ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+  return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/templates/templates.json
+++ b/examples/chip-tool/templates/templates.json
@@ -39,6 +39,10 @@
         {
             "name": "log_struct_value",
             "path": "partials/log_struct_value.zapt"
+        },
+        {
+            "name": "log_event_value",
+            "path": "partials/log_event_value.zapt"
         }
     ],
     "templates": [

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -21,6 +21,7 @@ const queryConfig       = require(zapPath + 'db/query-config.js')
 const queryCommand      = require(zapPath + 'db/query-command.js')
 const queryEndpoint     = require(zapPath + 'db/query-endpoint.js')
 const queryEndpointType = require(zapPath + 'db/query-endpoint-type.js')
+const queryEvent        = require(zapPath + 'db/query-event.js')
 const templateUtil      = require(zapPath + 'generator/template-util.js')
 const zclHelper         = require(zapPath + 'generator/helper-zcl.js')
 const zclQuery          = require(zapPath + 'db/query-zcl.js')
@@ -146,6 +147,26 @@ function loadAttributes(packageId)
       .then(attributes => attributes.filter(attribute => attribute.isIncluded))
       .then(attributes => attributes.sort((a, b) => a.code - b.code));
   //.then(attributes => Promise.all(attributes.map(attribute => types.typeSizeAttribute(db, packageId, attribute))
+}
+
+function loadEvents(packageId)
+{
+  const { db, sessionId } = this.global;
+  return queryEvent.selectAllEvents(db, packageId)
+      .then(events => { return queryEndpointType.selectEndpointTypeIds(db, sessionId)
+                    .then(endpointTypes => Promise.all(
+                              endpointTypes.map(({ endpointTypeId }) => queryEndpoint.selectEndpointClusters(db, endpointTypeId))))
+                    .then(clusters => clusters.flat(3))
+                    .then(clusters => {
+                      events.forEach(event => {
+                        const cluster = clusters.find(cluster => cluster.code == event.clusterCode && cluster.side == 'client');
+                        if (cluster) {
+                          event.clusterId   = cluster.clusterId;
+                          event.clusterName = cluster.name;
+                        }
+                      });
+                      return events.filter(event => clusters.find(cluster => cluster.code == event.clusterCode));
+                    }) })
 }
 
 function loadGlobalAttributes(packageId)
@@ -463,12 +484,14 @@ Clusters.init = async function(context) {
     loadCommands.call(context, packageId),
     loadAttributes.call(context, packageId),
     loadGlobalAttributes.call(context, packageId),
+    loadEvents.call(context, packageId),
   ];
 
-  return Promise.all(promises).then(([types, clusters, commands, attributes, globalAttributes]) => {
+  return Promise.all(promises).then(([types, clusters, commands, attributes, globalAttributes, events]) => {
     this._clusters = clusters;
     this._commands = enhancedCommands(commands, types);
     this._attributes = enhancedAttributes(attributes, globalAttributes, types);
+    this._events = events;
 
     return this.ready.resolve();
   }, err => this.ready.reject(err));
@@ -524,6 +547,11 @@ Clusters.getAttributes = function()
     return this.ensureReady().then(() => this._attributes);
 }
 
+Clusters.getEvents = function()
+{
+    return this.ensureReady().then(() => this._events);
+}
+
 //
 // Helpers: Get by Cluster Name
 //
@@ -548,6 +576,11 @@ Clusters.getAttributesByClusterName = function(name)
     });
 }
 
+Clusters.getEventsByClusterName = function(name)
+{
+    return this.getEvents().then(items => items.filter(kNameFilter.bind(null, name)));
+}
+
 //
 // Helpers: Get by Cluster Side
 //
@@ -568,6 +601,12 @@ Clusters.getAttributesByClusterSide = function(side)
 {
     return this.getAttributes().then(items => items.filter(kSideFilter.bind(null, side)));
 }
+
+Clusters.getEventsByClusterSide = function(side)
+{
+    return this.getEvents().then(items => items.filter(kSideFilter.bind(null, side)));
+}
+
 
 //
 // Helpers: Client
@@ -594,6 +633,11 @@ Clusters.getClientAttributes = function(name)
     return this.getAttributesByClusterName(name).then(items => items.filter(kClientSideFilter));
 }
 
+Clusters.getClientEvents = function(name)
+{
+    return this.getEventsByClusterName(name).then(items => items.filter(kClientSideFilter));
+}
+
 //
 // Helpers: Server
 //
@@ -617,6 +661,11 @@ Clusters.getServerResponses = function(name)
 Clusters.getServerAttributes = function(name)
 {
     return this.getAttributesByClusterName(name).then(items => items.filter(kServerSideFilter));
+}
+
+Clusters.getServerEvents = function(name)
+{
+    return this.getEventsByClusterName(name).then(items => items.filter(kServerSideFilter));
 }
 
 //

--- a/src/app/zap-templates/partials/cluster_header.zapt
+++ b/src/app/zap-templates/partials/cluster_header.zapt
@@ -10,4 +10,9 @@
 {{#chip_server_cluster_attributes}}
 {{pad (concat "| * " (asUpperCamelCase name)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
 {{/chip_server_cluster_attributes}}
+{{pad "|" 79 '-'}}|
+{{pad "| Events: " 70 ' '}}{{pad "| " 9 ' '}}|
+{{#chip_server_cluster_events}}
+{{pad (concat "| * " (asUpperCamelCase name)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
+{{/chip_server_cluster_events}}
 {{pad '\*' 78 '-'}}*/

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -347,6 +347,23 @@ function chip_server_cluster_attributes(options)
   return asBlocks.call(this, attributes, options);
 }
 
+/**
+ * Creates block iterator over the server side cluster attributes
+ * for a given cluster.
+ *
+ * This function is meant to be used inside a {{#chip_server_clusters}}
+ * block. It will throw otherwise.
+ *
+ * @param {*} options
+ */
+function chip_server_cluster_events(options)
+{
+  const { clusterName } = checkIsInsideClusterBlock(this, 'chip_server_cluster_events');
+  const events          = ensureClusters(this).getServerEvents(clusterName);
+
+  return asBlocks.call(this, events, options);
+}
+
 function chip_attribute_list_entryTypes(options)
 {
   checkIsInsideAttributeBlock(this, 'chip_attribute_list_entry_types');
@@ -412,6 +429,7 @@ exports.chip_cluster_responses                               = chip_cluster_resp
 exports.chip_cluster_response_arguments                      = chip_cluster_response_arguments
 exports.chip_attribute_list_entryTypes                       = chip_attribute_list_entryTypes;
 exports.chip_server_cluster_attributes                       = chip_server_cluster_attributes;
+exports.chip_server_cluster_events                           = chip_server_cluster_events;
 exports.chip_server_has_list_attributes                      = chip_server_has_list_attributes;
 exports.chip_available_cluster_commands                      = chip_available_cluster_commands;
 exports.if_chip_enum                                         = if_chip_enum;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -264,6 +264,34 @@ public:
             onFailureCb, minIntervalFloorSeconds, maxIntervalCeilingSeconds, onSubscriptionEstablishedCb);
     }
 
+    /**
+     * Read an event and get a type-safe callback with the event data.
+     */
+    template <typename DecodableType>
+    CHIP_ERROR ReadEvent(void * context, ReadResponseSuccessCallback<DecodableType> successCb,
+                         ReadResponseFailureCallback failureCb)
+    {
+        VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        auto onSuccessCb = [context, successCb](const app::EventHeader & eventHeader, const DecodableType & aData) {
+            if (successCb != nullptr)
+            {
+                successCb(context, aData);
+            }
+        };
+
+        auto onFailureCb = [context, failureCb](const app::EventHeader * eventHeader, Protocols::InteractionModel::Status status,
+                                                CHIP_ERROR error) {
+            if (failureCb != nullptr)
+            {
+                failureCb(context, app::ToEmberAfStatus(status));
+            }
+        };
+
+        return Controller::ReadEvent<DecodableType>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
+                                                    onSuccessCb, onFailureCb);
+    }
+
 protected:
     ClusterBase(uint16_t cluster) : mClusterId(cluster) {}
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -148,6 +148,89 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType & value);
 
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::BridgedActions::Events::ActionFailed::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::StartUp::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::ShutDown::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::Leave::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::ReachableChanged::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::StateTransition::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::VersionApplied::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::DownloadError::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::HardwareFaultChange::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::RadioFaultChange::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::NetworkFaultChange::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::BootReason::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::ThreadNetworkDiagnostics::Events::ConnectionStatus::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::WiFiNetworkDiagnostics::Events::Disconnection::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::WiFiNetworkDiagnostics::Events::AssociationFailure::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::WiFiNetworkDiagnostics::Events::ConnectionStatus::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::SwitchLatched::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::InitialPress::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::LongPress::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::ShortRelease::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::LongRelease::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::MultiPressOngoing::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::Switch::Events::MultiPressComplete::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::BooleanState::Events::StateChange::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::DoorLockAlarm::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::DoorStateChange::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::LockOperation::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::DoorLock::Events::LockOperationError::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::LockUserChange::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageLow::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageHigh::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PowerMissingPhase::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureLow::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureHigh::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::DryRunning::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::MotorTemperatureHigh::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PumpMotorFatalFailure::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicTemperatureHigh::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PumpBlocked::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SensorFailure::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicNonFatalFailure::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicFatalFailure::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::GeneralFault::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::Leakage::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::AirDetection::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::TurbineOperation::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::TestCluster::Events::TestEvent::DecodableType value);
+
 #if CHIP_PROGRESS_LOGGING
 std::string IndentStr(size_t indent)
 {
@@ -2456,6 +2539,917 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
 }
 #pragma GCC diagnostic pop
 
+// We output helpers for all events here, including ones we might not actually
+// be logging.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ActionID", indent + 1, value.actionID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ActionID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("InvokeID", indent + 1, value.invokeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'InvokeID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NewState", indent + 1, value.newState);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewState'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::BridgedActions::Events::ActionFailed::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ActionID", indent + 1, value.actionID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ActionID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("InvokeID", indent + 1, value.invokeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'InvokeID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NewState", indent + 1, value.newState);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewState'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Error", indent + 1, value.error);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Error'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::StartUp::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("SoftwareVersion", indent + 1, value.softwareVersion);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SoftwareVersion'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::ShutDown::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::Leave::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Basic::Events::ReachableChanged::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ReachableNewValue", indent + 1, value.reachableNewValue);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ReachableNewValue'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::StateTransition::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("PreviousState", indent + 1, value.previousState);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'PreviousState'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NewState", indent + 1, value.newState);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewState'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Reason", indent + 1, value.reason);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Reason'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("TargetSoftwareVersion", indent + 1, value.targetSoftwareVersion);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'TargetSoftwareVersion'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::VersionApplied::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("SoftwareVersion", indent + 1, value.softwareVersion);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SoftwareVersion'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ProductID", indent + 1, value.productID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ProductID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::DownloadError::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("SoftwareVersion", indent + 1, value.softwareVersion);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SoftwareVersion'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("BytesDownloaded", indent + 1, value.bytesDownloaded);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'BytesDownloaded'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ProgressPercent", indent + 1, value.progressPercent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ProgressPercent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PlatformCode", indent + 1, value.platformCode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'PlatformCode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::HardwareFaultChange::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Current", indent + 1, value.current);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Current'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Previous", indent + 1, value.previous);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Previous'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::RadioFaultChange::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Current", indent + 1, value.current);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Current'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Previous", indent + 1, value.previous);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Previous'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::NetworkFaultChange::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Current", indent + 1, value.current);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Current'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Previous", indent + 1, value.previous);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Previous'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::GeneralDiagnostics::Events::BootReason::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("BootReason", indent + 1, value.bootReason);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'BootReason'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("SoftwareFault", indent + 1, value.softwareFault);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SoftwareFault'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::ThreadNetworkDiagnostics::Events::ConnectionStatus::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ConnectionStatus", indent + 1, value.connectionStatus);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ConnectionStatus'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::WiFiNetworkDiagnostics::Events::Disconnection::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ReasonCode", indent + 1, value.reasonCode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ReasonCode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::WiFiNetworkDiagnostics::Events::AssociationFailure::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("AssociationFailure", indent + 1, value.associationFailure);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AssociationFailure'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Status", indent + 1, value.status);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Status'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::WiFiNetworkDiagnostics::Events::ConnectionStatus::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ConnectionStatus", indent + 1, value.connectionStatus);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ConnectionStatus'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::SwitchLatched::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("NewPosition", indent + 1, value.newPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewPosition'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::InitialPress::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("NewPosition", indent + 1, value.newPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewPosition'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::LongPress::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("NewPosition", indent + 1, value.newPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewPosition'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::ShortRelease::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("PreviousPosition", indent + 1, value.previousPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'PreviousPosition'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::LongRelease::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("PreviousPosition", indent + 1, value.previousPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'PreviousPosition'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::MultiPressOngoing::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("NewPosition", indent + 1, value.newPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewPosition'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("CurrentNumberOfPressesCounted", indent + 1, value.currentNumberOfPressesCounted);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'CurrentNumberOfPressesCounted'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::Switch::Events::MultiPressComplete::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("NewPosition", indent + 1, value.newPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'NewPosition'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("TotalNumberOfPressesCounted", indent + 1, value.totalNumberOfPressesCounted);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'TotalNumberOfPressesCounted'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::BooleanState::Events::StateChange::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("StateValue", indent + 1, value.stateValue);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'StateValue'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::DoorLockAlarm::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("AlarmCode", indent + 1, value.alarmCode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AlarmCode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::DoorStateChange::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("DoorState", indent + 1, value.doorState);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'DoorState'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::LockOperation::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("LockOperationType", indent + 1, value.lockOperationType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'LockOperationType'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OperationSource", indent + 1, value.operationSource);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'OperationSource'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("UserIndex", indent + 1, value.userIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'UserIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FabricIndex", indent + 1, value.fabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'FabricIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("SourceNode", indent + 1, value.sourceNode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SourceNode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Credentials", indent + 1, value.credentials);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Credentials'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::DoorLock::Events::LockOperationError::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("LockOperationType", indent + 1, value.lockOperationType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'LockOperationType'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OperationSource", indent + 1, value.operationSource);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'OperationSource'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OperationError", indent + 1, value.operationError);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'OperationError'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("UserIndex", indent + 1, value.userIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'UserIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FabricIndex", indent + 1, value.fabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'FabricIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("SourceNode", indent + 1, value.sourceNode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SourceNode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Credentials", indent + 1, value.credentials);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Credentials'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::DoorLock::Events::LockUserChange::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("LockDataType", indent + 1, value.lockDataType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'LockDataType'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("DataOperationType", indent + 1, value.dataOperationType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'DataOperationType'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OperationSource", indent + 1, value.operationSource);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'OperationSource'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("UserIndex", indent + 1, value.userIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'UserIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FabricIndex", indent + 1, value.fabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'FabricIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("SourceNode", indent + 1, value.sourceNode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'SourceNode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("DataIndex", indent + 1, value.dataIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'DataIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageLow::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageHigh::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PowerMissingPhase::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureLow::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureHigh::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::DryRunning::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::MotorTemperatureHigh::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PumpMotorFatalFailure::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicTemperatureHigh::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PumpBlocked::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::SensorFailure::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicNonFatalFailure::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicFatalFailure::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::GeneralFault::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::Leakage::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::AirDetection::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::TurbineOperation::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::app::Clusters::TestCluster::Events::TestEvent::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Arg1", indent + 1, value.arg1);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Arg1'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Arg2", indent + 1, value.arg2);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Arg2'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Arg3", indent + 1, value.arg3);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Arg3'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Arg4", indent + 1, value.arg4);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Arg4'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Arg5", indent + 1, value.arg5);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Arg5'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Arg6", indent + 1, value.arg6);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'Arg6'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+#pragma GCC diagnostic pop
 } // anonymous namespace
 
 static void OnDefaultSuccessResponseWithoutExit(void * context)
@@ -2485,7 +3479,7 @@ static void OnDefaultSuccess(void * context, const chip::app::DataModel::NullObj
 };
 
 template <typename T>
-static void OnGeneralAttributeResponse(void * context, const char * label, T value)
+static void OnGeneralAttributeEventResponse(void * context, const char * label, T value)
 {
     CHIP_ERROR err = LogValue(label, 0, value);
 
@@ -3520,6 +4514,8 @@ static void OnThermostatGetWeeklyScheduleResponseSuccess(
 | * Extension                                                         | 0x0001 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -3538,7 +4534,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3551,7 +4547,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "AccessControl.Acl response", value);
+        OnGeneralAttributeEventResponse(context, "AccessControl.Acl response", value);
     }
 };
 
@@ -3571,7 +4567,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3616,7 +4612,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3629,7 +4625,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::ExtensionEntry::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "AccessControl.Extension response", value);
+        OnGeneralAttributeEventResponse(context, "AccessControl.Extension response", value);
     }
 };
 
@@ -3649,7 +4645,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3694,7 +4690,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3704,7 +4700,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "AccessControl.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "AccessControl.AttributeList response", value);
     }
 };
 
@@ -3724,7 +4720,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccessControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3734,7 +4730,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "AccessControl.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "AccessControl.ClusterRevision response", value);
     }
 };
 
@@ -3749,6 +4745,8 @@ public:
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -3836,7 +4834,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccountLoginCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3846,7 +4844,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "AccountLogin.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "AccountLogin.AttributeList response", value);
     }
 };
 
@@ -3866,7 +4864,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccountLoginCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3876,7 +4874,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "AccountLogin.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "AccountLogin.ClusterRevision response", value);
     }
 };
 
@@ -3896,7 +4894,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AccountLoginCluster cluster;
         cluster.Associate(device, endpointId);
@@ -3933,6 +4931,8 @@ private:
 | * AdminVendorId                                                     | 0x0002 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -4024,7 +5024,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4034,7 +5034,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "AdministratorCommissioning.WindowStatus response", value);
+        OnGeneralAttributeEventResponse(context, "AdministratorCommissioning.WindowStatus response", value);
     }
 };
 
@@ -4054,7 +5054,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4064,7 +5064,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::FabricIndex value)
     {
-        OnGeneralAttributeResponse(context, "AdministratorCommissioning.AdminFabricIndex response", value);
+        OnGeneralAttributeEventResponse(context, "AdministratorCommissioning.AdminFabricIndex response", value);
     }
 };
 
@@ -4084,7 +5084,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4094,7 +5094,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "AdministratorCommissioning.AdminVendorId response", value);
+        OnGeneralAttributeEventResponse(context, "AdministratorCommissioning.AdminVendorId response", value);
     }
 };
 
@@ -4114,7 +5114,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4124,7 +5124,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "AdministratorCommissioning.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "AdministratorCommissioning.AttributeList response", value);
     }
 };
 
@@ -4144,7 +5144,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4154,7 +5154,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "AdministratorCommissioning.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "AdministratorCommissioning.ClusterRevision response", value);
     }
 };
 
@@ -4174,7 +5174,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003C) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003C) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AdministratorCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4216,6 +5216,8 @@ private:
 | * AllowedVendorList                                                 | 0x0007 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -4234,7 +5236,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4244,7 +5246,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.VendorName response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.VendorName response", value);
     }
 };
 
@@ -4264,7 +5266,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4303,7 +5305,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4313,7 +5315,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.VendorId response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.VendorId response", value);
     }
 };
 
@@ -4333,7 +5335,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4372,7 +5374,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4382,7 +5384,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.ApplicationName response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.ApplicationName response", value);
     }
 };
 
@@ -4402,7 +5404,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4444,7 +5446,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4454,7 +5456,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.ProductId response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.ProductId response", value);
     }
 };
 
@@ -4474,7 +5476,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4513,7 +5515,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4523,7 +5525,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.ApplicationStatus response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.ApplicationStatus response", value);
     }
 };
 
@@ -4543,7 +5545,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4585,7 +5587,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4595,7 +5597,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.ApplicationVersion response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.ApplicationVersion response", value);
     }
 };
 
@@ -4615,7 +5617,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4657,7 +5659,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4667,7 +5669,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::VendorId> & value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.AllowedVendorList response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.AllowedVendorList response", value);
     }
 };
 
@@ -4687,7 +5689,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4697,7 +5699,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.AttributeList response", value);
     }
 };
 
@@ -4717,7 +5719,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4727,7 +5729,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationBasic.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationBasic.ClusterRevision response", value);
     }
 };
 
@@ -4747,7 +5749,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4782,6 +5784,8 @@ private:
 | * ApplicationLauncherList                                           | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -4873,7 +5877,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4883,7 +5887,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationLauncher.ApplicationLauncherList response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationLauncher.ApplicationLauncherList response", value);
     }
 };
 
@@ -4903,7 +5907,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050C) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050C) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4945,7 +5949,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4955,7 +5959,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationLauncher.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationLauncher.AttributeList response", value);
     }
 };
 
@@ -4975,7 +5979,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050C) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050C) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -4985,7 +5989,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ApplicationLauncher.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ApplicationLauncher.ClusterRevision response", value);
     }
 };
 
@@ -5005,7 +6009,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050C) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050C) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5040,6 +6044,8 @@ private:
 | * CurrentAudioOutput                                                | 0x0001 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -5107,7 +6113,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5119,7 +6125,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::OutputInfo::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "AudioOutput.AudioOutputList response", value);
+        OnGeneralAttributeEventResponse(context, "AudioOutput.AudioOutputList response", value);
     }
 };
 
@@ -5139,7 +6145,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5183,7 +6189,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5193,7 +6199,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "AudioOutput.CurrentAudioOutput response", value);
+        OnGeneralAttributeEventResponse(context, "AudioOutput.CurrentAudioOutput response", value);
     }
 };
 
@@ -5213,7 +6219,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5252,7 +6258,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5262,7 +6268,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "AudioOutput.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "AudioOutput.AttributeList response", value);
     }
 };
 
@@ -5282,7 +6288,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5292,7 +6298,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "AudioOutput.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "AudioOutput.ClusterRevision response", value);
     }
 };
 
@@ -5312,7 +6318,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5349,6 +6355,8 @@ private:
 | * BarrierPosition                                                   | 0x000A |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -5411,7 +6419,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5421,7 +6429,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "BarrierControl.BarrierMovingState response", value);
+        OnGeneralAttributeEventResponse(context, "BarrierControl.BarrierMovingState response", value);
     }
 };
 
@@ -5441,7 +6449,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5480,7 +6488,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5490,7 +6498,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "BarrierControl.BarrierSafetyStatus response", value);
+        OnGeneralAttributeEventResponse(context, "BarrierControl.BarrierSafetyStatus response", value);
     }
 };
 
@@ -5510,7 +6518,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5549,7 +6557,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5559,7 +6567,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "BarrierControl.BarrierCapabilities response", value);
+        OnGeneralAttributeEventResponse(context, "BarrierControl.BarrierCapabilities response", value);
     }
 };
 
@@ -5579,7 +6587,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5618,7 +6626,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5628,7 +6636,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "BarrierControl.BarrierPosition response", value);
+        OnGeneralAttributeEventResponse(context, "BarrierControl.BarrierPosition response", value);
     }
 };
 
@@ -5648,7 +6656,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5687,7 +6695,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5697,7 +6705,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "BarrierControl.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "BarrierControl.AttributeList response", value);
     }
 };
 
@@ -5717,7 +6725,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5727,7 +6735,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "BarrierControl.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "BarrierControl.ClusterRevision response", value);
     }
 };
 
@@ -5747,7 +6755,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0103) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0103) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BarrierControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5798,6 +6806,12 @@ private:
 | * UniqueID                                                          | 0x0012 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * StartUp                                                           | 0x0000 |
+| * ShutDown                                                          | 0x0001 |
+| * Leave                                                             | 0x0002 |
+| * ReachableChanged                                                  | 0x0003 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -5821,6 +6835,122 @@ private:
 };
 
 /*
+ * Event StartUp
+ */
+class ReadBasicStartUp : public ModelCommand
+{
+public:
+    ReadBasicStartUp() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "start-up");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBasicStartUp() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BasicCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Basic::Events::StartUp::DecodableType>(this, OnEventResponse,
+                                                                                             OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Basic::Events::StartUp::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Basic.StartUp response", value);
+    }
+};
+/*
+ * Event ShutDown
+ */
+class ReadBasicShutDown : public ModelCommand
+{
+public:
+    ReadBasicShutDown() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "shut-down");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBasicShutDown() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BasicCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Basic::Events::ShutDown::DecodableType>(this, OnEventResponse,
+                                                                                              OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Basic::Events::ShutDown::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Basic.ShutDown response", value);
+    }
+};
+/*
+ * Event Leave
+ */
+class ReadBasicLeave : public ModelCommand
+{
+public:
+    ReadBasicLeave() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "leave");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBasicLeave() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BasicCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Basic::Events::Leave::DecodableType>(this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Basic::Events::Leave::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Basic.Leave response", value);
+    }
+};
+/*
+ * Event ReachableChanged
+ */
+class ReadBasicReachableChanged : public ModelCommand
+{
+public:
+    ReadBasicReachableChanged() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "reachable-changed");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBasicReachableChanged() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BasicCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Basic::Events::ReachableChanged::DecodableType>(this, OnEventResponse,
+                                                                                                      OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Basic::Events::ReachableChanged::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Basic.ReachableChanged response", value);
+    }
+};
+
+/*
  * Attribute InteractionModelVersion
  */
 class ReadBasicInteractionModelVersion : public ModelCommand
@@ -5836,7 +6966,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5846,7 +6976,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Basic.InteractionModelVersion response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.InteractionModelVersion response", value);
     }
 };
 
@@ -5866,7 +6996,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5905,7 +7035,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5915,7 +7045,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.VendorName response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.VendorName response", value);
     }
 };
 
@@ -5935,7 +7065,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5974,7 +7104,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -5984,7 +7114,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::VendorId value)
     {
-        OnGeneralAttributeResponse(context, "Basic.VendorID response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.VendorID response", value);
     }
 };
 
@@ -6004,7 +7134,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6043,7 +7173,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6053,7 +7183,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.ProductName response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.ProductName response", value);
     }
 };
 
@@ -6073,7 +7203,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6112,7 +7242,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6122,7 +7252,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Basic.ProductID response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.ProductID response", value);
     }
 };
 
@@ -6142,7 +7272,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6181,7 +7311,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6191,7 +7321,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.NodeLabel response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.NodeLabel response", value);
     }
 };
 
@@ -6209,7 +7339,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6237,7 +7367,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6276,7 +7406,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6286,7 +7416,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.Location response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.Location response", value);
     }
 };
 
@@ -6304,7 +7434,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6332,7 +7462,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6371,7 +7501,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6381,7 +7511,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Basic.HardwareVersion response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.HardwareVersion response", value);
     }
 };
 
@@ -6401,7 +7531,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6440,7 +7570,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6450,7 +7580,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.HardwareVersionString response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.HardwareVersionString response", value);
     }
 };
 
@@ -6470,7 +7600,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6509,7 +7639,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6519,7 +7649,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "Basic.SoftwareVersion response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.SoftwareVersion response", value);
     }
 };
 
@@ -6539,7 +7669,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6578,7 +7708,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6588,7 +7718,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.SoftwareVersionString response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.SoftwareVersionString response", value);
     }
 };
 
@@ -6608,7 +7738,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6647,7 +7777,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6657,7 +7787,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.ManufacturingDate response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.ManufacturingDate response", value);
     }
 };
 
@@ -6677,7 +7807,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6716,7 +7846,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6726,7 +7856,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.PartNumber response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.PartNumber response", value);
     }
 };
 
@@ -6746,7 +7876,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6785,7 +7915,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6795,7 +7925,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.ProductURL response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.ProductURL response", value);
     }
 };
 
@@ -6815,7 +7945,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6854,7 +7984,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6864,7 +7994,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.ProductLabel response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.ProductLabel response", value);
     }
 };
 
@@ -6884,7 +8014,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6923,7 +8053,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6933,7 +8063,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.SerialNumber response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.SerialNumber response", value);
     }
 };
 
@@ -6953,7 +8083,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -6992,7 +8122,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7002,7 +8132,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "Basic.LocalConfigDisabled response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.LocalConfigDisabled response", value);
     }
 };
 
@@ -7020,7 +8150,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7048,7 +8178,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7087,7 +8217,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7097,7 +8227,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "Basic.Reachable response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.Reachable response", value);
     }
 };
 
@@ -7117,7 +8247,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7156,7 +8286,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7166,7 +8296,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "Basic.UniqueID response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.UniqueID response", value);
     }
 };
 
@@ -7186,7 +8316,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7196,7 +8326,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Basic.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.AttributeList response", value);
     }
 };
 
@@ -7216,7 +8346,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7226,7 +8356,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Basic.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Basic.ClusterRevision response", value);
     }
 };
 
@@ -7246,7 +8376,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0028) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0028) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7280,6 +8410,8 @@ private:
 | * StatusFlags                                                       | 0x006F |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -7298,7 +8430,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7308,7 +8440,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "BinaryInputBasic.OutOfService response", value);
+        OnGeneralAttributeEventResponse(context, "BinaryInputBasic.OutOfService response", value);
     }
 };
 
@@ -7326,7 +8458,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7354,7 +8486,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7393,7 +8525,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7403,7 +8535,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "BinaryInputBasic.PresentValue response", value);
+        OnGeneralAttributeEventResponse(context, "BinaryInputBasic.PresentValue response", value);
     }
 };
 
@@ -7421,7 +8553,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7449,7 +8581,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7488,7 +8620,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7498,7 +8630,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "BinaryInputBasic.StatusFlags response", value);
+        OnGeneralAttributeEventResponse(context, "BinaryInputBasic.StatusFlags response", value);
     }
 };
 
@@ -7518,7 +8650,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7557,7 +8689,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7567,7 +8699,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "BinaryInputBasic.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "BinaryInputBasic.AttributeList response", value);
     }
 };
 
@@ -7587,7 +8719,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7597,7 +8729,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "BinaryInputBasic.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "BinaryInputBasic.ClusterRevision response", value);
     }
 };
 
@@ -7617,7 +8749,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x000F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x000F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BinaryInputBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7650,6 +8782,8 @@ private:
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -7722,7 +8856,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BindingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7732,7 +8866,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Binding.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Binding.AttributeList response", value);
     }
 };
 
@@ -7752,7 +8886,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BindingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7762,7 +8896,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Binding.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Binding.ClusterRevision response", value);
     }
 };
 
@@ -7782,7 +8916,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BindingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7814,7 +8948,40 @@ private:
 | * StateValue                                                        | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * StateChange                                                       | 0x0000 |
 \*----------------------------------------------------------------------------*/
+
+/*
+ * Event StateChange
+ */
+class ReadBooleanStateStateChange : public ModelCommand
+{
+public:
+    ReadBooleanStateStateChange() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "state-change");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBooleanStateStateChange() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0045) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BooleanStateCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::BooleanState::Events::StateChange::DecodableType>(this, OnEventResponse,
+                                                                                                        OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::BooleanState::Events::StateChange::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "BooleanState.StateChange response", value);
+    }
+};
 
 /*
  * Attribute StateValue
@@ -7832,7 +8999,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0045) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0045) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7842,7 +9009,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "BooleanState.StateValue response", value);
+        OnGeneralAttributeEventResponse(context, "BooleanState.StateValue response", value);
     }
 };
 
@@ -7862,7 +9029,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0045) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0045) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7901,7 +9068,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0045) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0045) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7911,7 +9078,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "BooleanState.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "BooleanState.AttributeList response", value);
     }
 };
 
@@ -7931,7 +9098,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0045) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0045) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
@@ -7941,7 +9108,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "BooleanState.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "BooleanState.ClusterRevision response", value);
     }
 };
 
@@ -7961,7 +9128,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0045) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0045) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BooleanStateCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8007,6 +9174,10 @@ private:
 | * SetupUrl                                                          | 0x0002 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * StateChanged                                                      | 0x0000 |
+| * ActionFailed                                                      | 0x0001 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -8315,6 +9486,65 @@ private:
 };
 
 /*
+ * Event StateChanged
+ */
+class ReadBridgedActionsStateChanged : public ModelCommand
+{
+public:
+    ReadBridgedActionsStateChanged() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "state-changed");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBridgedActionsStateChanged() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BridgedActionsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType>(this, OnEventResponse,
+                                                                                                           OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "BridgedActions.StateChanged response", value);
+    }
+};
+/*
+ * Event ActionFailed
+ */
+class ReadBridgedActionsActionFailed : public ModelCommand
+{
+public:
+    ReadBridgedActionsActionFailed() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "action-failed");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadBridgedActionsActionFailed() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::BridgedActionsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::BridgedActions::Events::ActionFailed::DecodableType>(this, OnEventResponse,
+                                                                                                           OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::BridgedActions::Events::ActionFailed::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "BridgedActions.ActionFailed response", value);
+    }
+};
+
+/*
  * Attribute ActionList
  */
 class ReadBridgedActionsActionList : public ModelCommand
@@ -8330,7 +9560,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8343,7 +9573,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "BridgedActions.ActionList response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedActions.ActionList response", value);
     }
 };
 
@@ -8363,7 +9593,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8408,7 +9638,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8421,7 +9651,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "BridgedActions.EndpointList response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedActions.EndpointList response", value);
     }
 };
 
@@ -8441,7 +9671,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8486,7 +9716,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8496,7 +9726,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "BridgedActions.SetupUrl response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedActions.SetupUrl response", value);
     }
 };
 
@@ -8516,7 +9746,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8555,7 +9785,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8565,7 +9795,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "BridgedActions.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedActions.AttributeList response", value);
     }
 };
 
@@ -8585,7 +9815,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8595,7 +9825,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "BridgedActions.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedActions.ClusterRevision response", value);
     }
 };
 
@@ -8615,7 +9845,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0025) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0025) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedActionsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8646,6 +9876,8 @@ private:
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -8664,7 +9896,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0039) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0039) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedDeviceBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8674,7 +9906,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "BridgedDeviceBasic.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedDeviceBasic.AttributeList response", value);
     }
 };
 
@@ -8694,7 +9926,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0039) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0039) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedDeviceBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8704,7 +9936,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "BridgedDeviceBasic.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "BridgedDeviceBasic.ClusterRevision response", value);
     }
 };
 
@@ -8724,7 +9956,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0039) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0039) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::BridgedDeviceBasicCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8759,6 +9991,8 @@ private:
 | * ChannelList                                                       | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -8850,7 +10084,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0504) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0504) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ChannelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8862,7 +10096,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "Channel.ChannelList response", value);
+        OnGeneralAttributeEventResponse(context, "Channel.ChannelList response", value);
     }
 };
 
@@ -8882,7 +10116,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0504) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0504) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ChannelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8926,7 +10160,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0504) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0504) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ChannelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8936,7 +10170,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Channel.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Channel.AttributeList response", value);
     }
 };
 
@@ -8956,7 +10190,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0504) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0504) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ChannelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -8966,7 +10200,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Channel.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Channel.ClusterRevision response", value);
     }
 };
 
@@ -8986,7 +10220,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0504) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0504) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ChannelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9088,6 +10322,8 @@ private:
 | * StartUpColorTemperatureMireds                                     | 0x4010 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -9648,7 +10884,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9658,7 +10894,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.CurrentHue response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.CurrentHue response", value);
     }
 };
 
@@ -9678,7 +10914,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9717,7 +10953,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9727,7 +10963,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.CurrentSaturation response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.CurrentSaturation response", value);
     }
 };
 
@@ -9747,7 +10983,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9786,7 +11022,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9796,7 +11032,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.RemainingTime response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.RemainingTime response", value);
     }
 };
 
@@ -9816,7 +11052,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9855,7 +11091,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9865,7 +11101,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.CurrentX response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.CurrentX response", value);
     }
 };
 
@@ -9885,7 +11121,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9924,7 +11160,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9934,7 +11170,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.CurrentY response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.CurrentY response", value);
     }
 };
 
@@ -9954,7 +11190,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -9993,7 +11229,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10003,7 +11239,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.DriftCompensation response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.DriftCompensation response", value);
     }
 };
 
@@ -10023,7 +11259,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10062,7 +11298,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10072,7 +11308,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.CompensationText response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.CompensationText response", value);
     }
 };
 
@@ -10092,7 +11328,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10131,7 +11367,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10141,7 +11377,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorTemperature response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorTemperature response", value);
     }
 };
 
@@ -10161,7 +11397,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10200,7 +11436,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10210,7 +11446,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorMode response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorMode response", value);
     }
 };
 
@@ -10230,7 +11466,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10269,7 +11505,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10279,7 +11515,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorControlOptions response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorControlOptions response", value);
     }
 };
 
@@ -10297,7 +11533,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10325,7 +11561,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10364,7 +11600,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10374,7 +11610,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.NumberOfPrimaries response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.NumberOfPrimaries response", value);
     }
 };
 
@@ -10394,7 +11630,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10433,7 +11669,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10443,7 +11679,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary1X response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary1X response", value);
     }
 };
 
@@ -10463,7 +11699,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10502,7 +11738,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10512,7 +11748,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary1Y response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary1Y response", value);
     }
 };
 
@@ -10532,7 +11768,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10571,7 +11807,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10581,7 +11817,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary1Intensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary1Intensity response", value);
     }
 };
 
@@ -10601,7 +11837,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10640,7 +11876,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10650,7 +11886,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary2X response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary2X response", value);
     }
 };
 
@@ -10670,7 +11906,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10709,7 +11945,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10719,7 +11955,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary2Y response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary2Y response", value);
     }
 };
 
@@ -10739,7 +11975,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10778,7 +12014,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10788,7 +12024,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary2Intensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary2Intensity response", value);
     }
 };
 
@@ -10808,7 +12044,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10847,7 +12083,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10857,7 +12093,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary3X response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary3X response", value);
     }
 };
 
@@ -10877,7 +12113,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10916,7 +12152,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10926,7 +12162,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary3Y response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary3Y response", value);
     }
 };
 
@@ -10946,7 +12182,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10985,7 +12221,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -10995,7 +12231,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary3Intensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary3Intensity response", value);
     }
 };
 
@@ -11015,7 +12251,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11054,7 +12290,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11064,7 +12300,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary4X response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary4X response", value);
     }
 };
 
@@ -11084,7 +12320,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11123,7 +12359,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11133,7 +12369,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary4Y response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary4Y response", value);
     }
 };
 
@@ -11153,7 +12389,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11192,7 +12428,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11202,7 +12438,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary4Intensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary4Intensity response", value);
     }
 };
 
@@ -11222,7 +12458,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11261,7 +12497,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11271,7 +12507,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary5X response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary5X response", value);
     }
 };
 
@@ -11291,7 +12527,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11330,7 +12566,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11340,7 +12576,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary5Y response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary5Y response", value);
     }
 };
 
@@ -11360,7 +12596,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11399,7 +12635,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11409,7 +12645,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary5Intensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary5Intensity response", value);
     }
 };
 
@@ -11429,7 +12665,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11468,7 +12704,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11478,7 +12714,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary6X response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary6X response", value);
     }
 };
 
@@ -11498,7 +12734,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11537,7 +12773,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11547,7 +12783,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary6Y response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary6Y response", value);
     }
 };
 
@@ -11567,7 +12803,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11606,7 +12842,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11616,7 +12852,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.Primary6Intensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.Primary6Intensity response", value);
     }
 };
 
@@ -11636,7 +12872,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11675,7 +12911,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11685,7 +12921,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.WhitePointX response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.WhitePointX response", value);
     }
 };
 
@@ -11703,7 +12939,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11731,7 +12967,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11770,7 +13006,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11780,7 +13016,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.WhitePointY response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.WhitePointY response", value);
     }
 };
 
@@ -11798,7 +13034,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11826,7 +13062,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11865,7 +13101,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11875,7 +13111,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointRX response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointRX response", value);
     }
 };
 
@@ -11893,7 +13129,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11921,7 +13157,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11960,7 +13196,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -11970,7 +13206,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointRY response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointRY response", value);
     }
 };
 
@@ -11988,7 +13224,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12016,7 +13252,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12055,7 +13291,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12065,7 +13301,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointRIntensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointRIntensity response", value);
     }
 };
 
@@ -12083,7 +13319,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12111,7 +13347,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12150,7 +13386,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12160,7 +13396,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointGX response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointGX response", value);
     }
 };
 
@@ -12178,7 +13414,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12206,7 +13442,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12245,7 +13481,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12255,7 +13491,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointGY response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointGY response", value);
     }
 };
 
@@ -12273,7 +13509,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12301,7 +13537,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12340,7 +13576,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12350,7 +13586,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointGIntensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointGIntensity response", value);
     }
 };
 
@@ -12368,7 +13604,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12396,7 +13632,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12435,7 +13671,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12445,7 +13681,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointBX response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointBX response", value);
     }
 };
 
@@ -12463,7 +13699,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12491,7 +13727,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12530,7 +13766,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12540,7 +13776,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointBY response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointBY response", value);
     }
 };
 
@@ -12558,7 +13794,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12586,7 +13822,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12625,7 +13861,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12635,7 +13871,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorPointBIntensity response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorPointBIntensity response", value);
     }
 };
 
@@ -12653,7 +13889,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12681,7 +13917,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12720,7 +13956,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12730,7 +13966,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.EnhancedCurrentHue response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.EnhancedCurrentHue response", value);
     }
 };
 
@@ -12750,7 +13986,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12789,7 +14025,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12799,7 +14035,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.EnhancedColorMode response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.EnhancedColorMode response", value);
     }
 };
 
@@ -12819,7 +14055,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12858,7 +14094,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12868,7 +14104,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopActive response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorLoopActive response", value);
     }
 };
 
@@ -12888,7 +14124,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12927,7 +14163,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12937,7 +14173,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopDirection response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorLoopDirection response", value);
     }
 };
 
@@ -12957,7 +14193,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -12996,7 +14232,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13006,7 +14242,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopTime response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorLoopTime response", value);
     }
 };
 
@@ -13026,7 +14262,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13065,7 +14301,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13075,7 +14311,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopStartEnhancedHue response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorLoopStartEnhancedHue response", value);
     }
 };
 
@@ -13095,7 +14331,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13137,7 +14373,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13147,7 +14383,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorLoopStoredEnhancedHue response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorLoopStoredEnhancedHue response", value);
     }
 };
 
@@ -13167,7 +14403,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13209,7 +14445,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13219,7 +14455,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorCapabilities response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorCapabilities response", value);
     }
 };
 
@@ -13239,7 +14475,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13278,7 +14514,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13288,7 +14524,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorTempPhysicalMin response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorTempPhysicalMin response", value);
     }
 };
 
@@ -13308,7 +14544,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13347,7 +14583,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13357,7 +14593,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ColorTempPhysicalMax response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ColorTempPhysicalMax response", value);
     }
 };
 
@@ -13377,7 +14613,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13416,7 +14652,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13426,7 +14662,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.CoupleColorTempToLevelMinMireds response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.CoupleColorTempToLevelMinMireds response", value);
     }
 };
 
@@ -13446,7 +14682,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13488,7 +14724,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13498,7 +14734,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.StartUpColorTemperatureMireds response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.StartUpColorTemperatureMireds response", value);
     }
 };
 
@@ -13516,7 +14752,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13544,7 +14780,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13586,7 +14822,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13596,7 +14832,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.AttributeList response", value);
     }
 };
 
@@ -13616,7 +14852,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13626,7 +14862,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ColorControl.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ColorControl.ClusterRevision response", value);
     }
 };
 
@@ -13646,7 +14882,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0300) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0300) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13681,6 +14917,8 @@ private:
 | * SupportedStreamingProtocols                                       | 0x0001 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -13751,7 +14989,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13761,7 +14999,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "ContentLauncher.AcceptHeaderList response", value);
+        OnGeneralAttributeEventResponse(context, "ContentLauncher.AcceptHeaderList response", value);
     }
 };
 
@@ -13781,7 +15019,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13823,7 +15061,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13833,7 +15071,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ContentLauncher.SupportedStreamingProtocols response", value);
+        OnGeneralAttributeEventResponse(context, "ContentLauncher.SupportedStreamingProtocols response", value);
     }
 };
 
@@ -13851,7 +15089,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13879,7 +15117,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13921,7 +15159,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13931,7 +15169,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ContentLauncher.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ContentLauncher.AttributeList response", value);
     }
 };
 
@@ -13951,7 +15189,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -13961,7 +15199,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ContentLauncher.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ContentLauncher.ClusterRevision response", value);
     }
 };
 
@@ -13981,7 +15219,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14016,6 +15254,8 @@ private:
 | * PartsList                                                         | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -14034,7 +15274,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14046,7 +15286,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "Descriptor.DeviceList response", value);
+        OnGeneralAttributeEventResponse(context, "Descriptor.DeviceList response", value);
     }
 };
 
@@ -14066,7 +15306,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14110,7 +15350,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14120,7 +15360,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & value)
     {
-        OnGeneralAttributeResponse(context, "Descriptor.ServerList response", value);
+        OnGeneralAttributeEventResponse(context, "Descriptor.ServerList response", value);
     }
 };
 
@@ -14140,7 +15380,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14182,7 +15422,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14192,7 +15432,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & value)
     {
-        OnGeneralAttributeResponse(context, "Descriptor.ClientList response", value);
+        OnGeneralAttributeEventResponse(context, "Descriptor.ClientList response", value);
     }
 };
 
@@ -14212,7 +15452,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14254,7 +15494,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14264,7 +15504,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & value)
     {
-        OnGeneralAttributeResponse(context, "Descriptor.PartsList response", value);
+        OnGeneralAttributeEventResponse(context, "Descriptor.PartsList response", value);
     }
 };
 
@@ -14284,7 +15524,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14326,7 +15566,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14336,7 +15576,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Descriptor.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Descriptor.AttributeList response", value);
     }
 };
 
@@ -14356,7 +15596,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14366,7 +15606,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Descriptor.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Descriptor.ClusterRevision response", value);
     }
 };
 
@@ -14386,7 +15626,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x001D) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x001D) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DescriptorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14417,6 +15657,8 @@ private:
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -14463,7 +15705,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0032) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0032) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DiagnosticLogsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14473,7 +15715,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "DiagnosticLogs.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "DiagnosticLogs.AttributeList response", value);
     }
 };
 
@@ -14509,6 +15751,13 @@ public:
 | * WrongCodeEntryLimit                                               | 0x0030 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * DoorLockAlarm                                                     | 0x0000 |
+| * DoorStateChange                                                   | 0x0001 |
+| * LockOperation                                                     | 0x0002 |
+| * LockOperationError                                                | 0x0003 |
+| * LockUserChange                                                    | 0x0004 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -14720,6 +15969,152 @@ private:
 };
 
 /*
+ * Event DoorLockAlarm
+ */
+class ReadDoorLockDoorLockAlarm : public ModelCommand
+{
+public:
+    ReadDoorLockDoorLockAlarm() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "door-lock-alarm");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadDoorLockDoorLockAlarm() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::DoorLockCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::DoorLock::Events::DoorLockAlarm::DecodableType>(this, OnEventResponse,
+                                                                                                      OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::DoorLock::Events::DoorLockAlarm::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "DoorLock.DoorLockAlarm response", value);
+    }
+};
+/*
+ * Event DoorStateChange
+ */
+class ReadDoorLockDoorStateChange : public ModelCommand
+{
+public:
+    ReadDoorLockDoorStateChange() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "door-state-change");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadDoorLockDoorStateChange() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::DoorLockCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::DoorLock::Events::DoorStateChange::DecodableType>(this, OnEventResponse,
+                                                                                                        OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::DoorLock::Events::DoorStateChange::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "DoorLock.DoorStateChange response", value);
+    }
+};
+/*
+ * Event LockOperation
+ */
+class ReadDoorLockLockOperation : public ModelCommand
+{
+public:
+    ReadDoorLockLockOperation() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "lock-operation");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadDoorLockLockOperation() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::DoorLockCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::DoorLock::Events::LockOperation::DecodableType>(this, OnEventResponse,
+                                                                                                      OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::DoorLock::Events::LockOperation::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "DoorLock.LockOperation response", value);
+    }
+};
+/*
+ * Event LockOperationError
+ */
+class ReadDoorLockLockOperationError : public ModelCommand
+{
+public:
+    ReadDoorLockLockOperationError() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "lock-operation-error");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadDoorLockLockOperationError() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::DoorLockCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::DoorLock::Events::LockOperationError::DecodableType>(this, OnEventResponse,
+                                                                                                           OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::DoorLock::Events::LockOperationError::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "DoorLock.LockOperationError response", value);
+    }
+};
+/*
+ * Event LockUserChange
+ */
+class ReadDoorLockLockUserChange : public ModelCommand
+{
+public:
+    ReadDoorLockLockUserChange() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "lock-user-change");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadDoorLockLockUserChange() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::DoorLockCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::DoorLock::Events::LockUserChange::DecodableType>(this, OnEventResponse,
+                                                                                                       OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::DoorLock::Events::LockUserChange::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "DoorLock.LockUserChange response", value);
+    }
+};
+
+/*
  * Attribute LockState
  */
 class ReadDoorLockLockState : public ModelCommand
@@ -14735,7 +16130,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14746,7 +16141,7 @@ public:
     static void OnAttributeResponse(void * context,
                                     const chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> & value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.LockState response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.LockState response", value);
     }
 };
 
@@ -14766,7 +16161,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14809,7 +16204,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14819,7 +16214,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::DoorLock::DlLockType value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.LockType response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.LockType response", value);
     }
 };
 
@@ -14839,7 +16234,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14881,7 +16276,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14891,7 +16286,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.ActuatorEnabled response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.ActuatorEnabled response", value);
     }
 };
 
@@ -14911,7 +16306,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14950,7 +16345,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -14961,7 +16356,7 @@ public:
     static void OnAttributeResponse(void * context,
                                     const chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlDoorState> & value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.DoorState response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.DoorState response", value);
     }
 };
 
@@ -14981,7 +16376,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15024,7 +16419,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15034,7 +16429,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.NumberOfTotalUsersSupported response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.NumberOfTotalUsersSupported response", value);
     }
 };
 
@@ -15054,7 +16449,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15064,7 +16459,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.NumberOfPINUsersSupported response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.NumberOfPINUsersSupported response", value);
     }
 };
 
@@ -15084,7 +16479,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15094,7 +16489,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.MaxPINCodeLength response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.MaxPINCodeLength response", value);
     }
 };
 
@@ -15114,7 +16509,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15124,7 +16519,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.MinPINCodeLength response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.MinPINCodeLength response", value);
     }
 };
 
@@ -15144,7 +16539,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15154,7 +16549,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.Language response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.Language response", value);
     }
 };
 
@@ -15172,7 +16567,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15200,7 +16595,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15239,7 +16634,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15249,7 +16644,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.AutoRelockTime response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.AutoRelockTime response", value);
     }
 };
 
@@ -15267,7 +16662,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15295,7 +16690,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15334,7 +16729,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15344,7 +16739,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.SoundVolume response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.SoundVolume response", value);
     }
 };
 
@@ -15362,7 +16757,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15390,7 +16785,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15429,7 +16824,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15439,7 +16834,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::DoorLock::DlOperatingMode value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.OperatingMode response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.OperatingMode response", value);
     }
 };
 
@@ -15457,7 +16852,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15485,7 +16880,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15527,7 +16922,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15537,7 +16932,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.SupportedOperatingModes response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.SupportedOperatingModes response", value);
     }
 };
 
@@ -15557,7 +16952,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15567,7 +16962,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.EnableOneTouchLocking response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.EnableOneTouchLocking response", value);
     }
 };
 
@@ -15585,7 +16980,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15613,7 +17008,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15652,7 +17047,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15662,7 +17057,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.EnablePrivacyModeButton response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.EnablePrivacyModeButton response", value);
     }
 };
 
@@ -15680,7 +17075,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15708,7 +17103,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15747,7 +17142,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15757,7 +17152,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.WrongCodeEntryLimit response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.WrongCodeEntryLimit response", value);
     }
 };
 
@@ -15775,7 +17170,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15803,7 +17198,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15842,7 +17237,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15852,7 +17247,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.AttributeList response", value);
     }
 };
 
@@ -15872,7 +17267,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15882,7 +17277,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "DoorLock.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "DoorLock.ClusterRevision response", value);
     }
 };
 
@@ -15902,7 +17297,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0101) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0101) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15944,6 +17339,8 @@ private:
 | * ActivePowerMax                                                    | 0x050D |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -15962,7 +17359,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -15972,7 +17369,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.MeasurementType response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.MeasurementType response", value);
     }
 };
 
@@ -15992,7 +17389,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16034,7 +17431,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16044,7 +17441,7 @@ public:
 
     static void OnAttributeResponse(void * context, int32_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.TotalActivePower response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.TotalActivePower response", value);
     }
 };
 
@@ -16064,7 +17461,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16106,7 +17503,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16116,7 +17513,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsVoltage response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.RmsVoltage response", value);
     }
 };
 
@@ -16136,7 +17533,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16175,7 +17572,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16185,7 +17582,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsVoltageMin response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.RmsVoltageMin response", value);
     }
 };
 
@@ -16205,7 +17602,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16244,7 +17641,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16254,7 +17651,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsVoltageMax response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.RmsVoltageMax response", value);
     }
 };
 
@@ -16274,7 +17671,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16313,7 +17710,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16323,7 +17720,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsCurrent response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.RmsCurrent response", value);
     }
 };
 
@@ -16343,7 +17740,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16382,7 +17779,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16392,7 +17789,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsCurrentMin response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.RmsCurrentMin response", value);
     }
 };
 
@@ -16412,7 +17809,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16451,7 +17848,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16461,7 +17858,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.RmsCurrentMax response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.RmsCurrentMax response", value);
     }
 };
 
@@ -16481,7 +17878,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16520,7 +17917,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16530,7 +17927,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ActivePower response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.ActivePower response", value);
     }
 };
 
@@ -16550,7 +17947,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16589,7 +17986,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16599,7 +17996,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ActivePowerMin response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.ActivePowerMin response", value);
     }
 };
 
@@ -16619,7 +18016,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16658,7 +18055,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16668,7 +18065,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ActivePowerMax response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.ActivePowerMax response", value);
     }
 };
 
@@ -16688,7 +18085,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16727,7 +18124,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16737,7 +18134,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.AttributeList response", value);
     }
 };
 
@@ -16757,7 +18154,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16767,7 +18164,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ElectricalMeasurement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ElectricalMeasurement.ClusterRevision response", value);
     }
 };
 
@@ -16787,7 +18184,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0B04) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0B04) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ElectricalMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16832,6 +18229,8 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -16870,7 +18269,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16880,7 +18279,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.PHYRate response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.PHYRate response", value);
     }
 };
 
@@ -16900,7 +18299,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16939,7 +18338,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -16949,7 +18348,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.FullDuplex response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.FullDuplex response", value);
     }
 };
 
@@ -16969,7 +18368,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17008,7 +18407,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17018,7 +18417,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.PacketRxCount response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.PacketRxCount response", value);
     }
 };
 
@@ -17038,7 +18437,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17080,7 +18479,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17090,7 +18489,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.PacketTxCount response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.PacketTxCount response", value);
     }
 };
 
@@ -17110,7 +18509,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17152,7 +18551,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17162,7 +18561,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.TxErrCount response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.TxErrCount response", value);
     }
 };
 
@@ -17182,7 +18581,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17224,7 +18623,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17234,7 +18633,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.CollisionCount response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.CollisionCount response", value);
     }
 };
 
@@ -17254,7 +18653,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17296,7 +18695,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17306,7 +18705,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.OverrunCount response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.OverrunCount response", value);
     }
 };
 
@@ -17326,7 +18725,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17368,7 +18767,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17378,7 +18777,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.CarrierDetect response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.CarrierDetect response", value);
     }
 };
 
@@ -17398,7 +18797,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17437,7 +18836,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17447,7 +18846,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.TimeSinceReset response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.TimeSinceReset response", value);
     }
 };
 
@@ -17467,7 +18866,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17509,7 +18908,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17519,7 +18918,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.AttributeList response", value);
     }
 };
 
@@ -17539,7 +18938,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17549,7 +18948,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.FeatureMap response", value);
     }
 };
 
@@ -17569,7 +18968,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17579,7 +18978,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "EthernetNetworkDiagnostics.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "EthernetNetworkDiagnostics.ClusterRevision response", value);
     }
 };
 
@@ -17599,7 +18998,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0037) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0037) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17634,6 +19033,8 @@ private:
 | * LabelList                                                         | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -17652,7 +19053,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0040) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0040) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17664,7 +19065,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "FixedLabel.LabelList response", value);
+        OnGeneralAttributeEventResponse(context, "FixedLabel.LabelList response", value);
     }
 };
 
@@ -17684,7 +19085,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0040) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0040) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17728,7 +19129,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0040) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0040) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17738,7 +19139,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "FixedLabel.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "FixedLabel.AttributeList response", value);
     }
 };
 
@@ -17758,7 +19159,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0040) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0040) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17768,7 +19169,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "FixedLabel.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "FixedLabel.ClusterRevision response", value);
     }
 };
 
@@ -17788,7 +19189,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0040) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0040) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FixedLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17823,6 +19224,8 @@ private:
 | * Tolerance                                                         | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -17841,7 +19244,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17851,7 +19254,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "FlowMeasurement.MeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "FlowMeasurement.MeasuredValue response", value);
     }
 };
 
@@ -17871,7 +19274,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17910,7 +19313,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17920,7 +19323,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "FlowMeasurement.MinMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "FlowMeasurement.MinMeasuredValue response", value);
     }
 };
 
@@ -17940,7 +19343,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17979,7 +19382,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -17989,7 +19392,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "FlowMeasurement.MaxMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "FlowMeasurement.MaxMeasuredValue response", value);
     }
 };
 
@@ -18009,7 +19412,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18048,7 +19451,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18058,7 +19461,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "FlowMeasurement.Tolerance response", value);
+        OnGeneralAttributeEventResponse(context, "FlowMeasurement.Tolerance response", value);
     }
 };
 
@@ -18078,7 +19481,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18117,7 +19520,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18127,7 +19530,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "FlowMeasurement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "FlowMeasurement.AttributeList response", value);
     }
 };
 
@@ -18147,7 +19550,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18157,7 +19560,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "FlowMeasurement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "FlowMeasurement.ClusterRevision response", value);
     }
 };
 
@@ -18177,7 +19580,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0404) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0404) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::FlowMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18215,6 +19618,8 @@ private:
 | * LocationCapability                                                | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -18307,7 +19712,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18317,7 +19722,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralCommissioning.Breadcrumb response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralCommissioning.Breadcrumb response", value);
     }
 };
 
@@ -18335,7 +19740,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18363,7 +19768,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18402,7 +19807,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18415,7 +19820,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfoType::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralCommissioning.BasicCommissioningInfoList response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralCommissioning.BasicCommissioningInfoList response", value);
     }
 };
 
@@ -18435,7 +19840,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18481,7 +19886,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18491,7 +19896,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralCommissioning.RegulatoryConfig response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralCommissioning.RegulatoryConfig response", value);
     }
 };
 
@@ -18511,7 +19916,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18521,7 +19926,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralCommissioning.LocationCapability response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralCommissioning.LocationCapability response", value);
     }
 };
 
@@ -18541,7 +19946,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18551,7 +19956,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralCommissioning.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralCommissioning.AttributeList response", value);
     }
 };
 
@@ -18571,7 +19976,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18581,7 +19986,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralCommissioning.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralCommissioning.ClusterRevision response", value);
     }
 };
 
@@ -18601,7 +20006,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0030) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0030) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18640,7 +20045,133 @@ private:
 | * ActiveNetworkFaults                                               | 0x0007 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * HardwareFaultChange                                               | 0x0000 |
+| * RadioFaultChange                                                  | 0x0001 |
+| * NetworkFaultChange                                                | 0x0002 |
+| * BootReason                                                        | 0x0003 |
 \*----------------------------------------------------------------------------*/
+
+/*
+ * Event HardwareFaultChange
+ */
+class ReadGeneralDiagnosticsHardwareFaultChange : public ModelCommand
+{
+public:
+    ReadGeneralDiagnosticsHardwareFaultChange() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "hardware-fault-change");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadGeneralDiagnosticsHardwareFaultChange() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::GeneralDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::GeneralDiagnostics::Events::HardwareFaultChange::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::GeneralDiagnostics::Events::HardwareFaultChange::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.HardwareFaultChange response", value);
+    }
+};
+/*
+ * Event RadioFaultChange
+ */
+class ReadGeneralDiagnosticsRadioFaultChange : public ModelCommand
+{
+public:
+    ReadGeneralDiagnosticsRadioFaultChange() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "radio-fault-change");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadGeneralDiagnosticsRadioFaultChange() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::GeneralDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::GeneralDiagnostics::Events::RadioFaultChange::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::GeneralDiagnostics::Events::RadioFaultChange::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.RadioFaultChange response", value);
+    }
+};
+/*
+ * Event NetworkFaultChange
+ */
+class ReadGeneralDiagnosticsNetworkFaultChange : public ModelCommand
+{
+public:
+    ReadGeneralDiagnosticsNetworkFaultChange() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "network-fault-change");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadGeneralDiagnosticsNetworkFaultChange() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::GeneralDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::GeneralDiagnostics::Events::NetworkFaultChange::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::GeneralDiagnostics::Events::NetworkFaultChange::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.NetworkFaultChange response", value);
+    }
+};
+/*
+ * Event BootReason
+ */
+class ReadGeneralDiagnosticsBootReason : public ModelCommand
+{
+public:
+    ReadGeneralDiagnosticsBootReason() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "boot-reason");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadGeneralDiagnosticsBootReason() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::GeneralDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::GeneralDiagnostics::Events::BootReason::DecodableType>(this, OnEventResponse,
+                                                                                                             OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::GeneralDiagnostics::Events::BootReason::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.BootReason response", value);
+    }
+};
 
 /*
  * Attribute NetworkInterfaces
@@ -18658,7 +20189,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18671,7 +20202,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.NetworkInterfaces response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.NetworkInterfaces response", value);
     }
 };
 
@@ -18691,7 +20222,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18735,7 +20266,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18745,7 +20276,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.RebootCount response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.RebootCount response", value);
     }
 };
 
@@ -18765,7 +20296,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18804,7 +20335,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18814,7 +20345,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.UpTime response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.UpTime response", value);
     }
 };
 
@@ -18834,7 +20365,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18873,7 +20404,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18883,7 +20414,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.TotalOperationalHours response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.TotalOperationalHours response", value);
     }
 };
 
@@ -18903,7 +20434,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18945,7 +20476,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -18955,7 +20486,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.BootReasons response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.BootReasons response", value);
     }
 };
 
@@ -18975,7 +20506,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19014,7 +20545,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19024,7 +20555,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ActiveHardwareFaults response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.ActiveHardwareFaults response", value);
     }
 };
 
@@ -19044,7 +20575,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19086,7 +20617,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19096,7 +20627,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ActiveRadioFaults response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.ActiveRadioFaults response", value);
     }
 };
 
@@ -19116,7 +20647,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19158,7 +20689,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19168,7 +20699,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ActiveNetworkFaults response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.ActiveNetworkFaults response", value);
     }
 };
 
@@ -19188,7 +20719,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19230,7 +20761,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19240,7 +20771,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.AttributeList response", value);
     }
 };
 
@@ -19260,7 +20791,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19270,7 +20801,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "GeneralDiagnostics.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "GeneralDiagnostics.ClusterRevision response", value);
     }
 };
 
@@ -19290,7 +20821,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0033) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0033) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GeneralDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19329,6 +20860,8 @@ private:
 | * MaxGroupKeysPerFabric                                             | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -19443,7 +20976,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19456,7 +20989,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "GroupKeyManagement.GroupKeyMap response", value);
+        OnGeneralAttributeEventResponse(context, "GroupKeyManagement.GroupKeyMap response", value);
     }
 };
 
@@ -19476,7 +21009,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19521,7 +21054,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19534,7 +21067,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupInfo::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "GroupKeyManagement.GroupTable response", value);
+        OnGeneralAttributeEventResponse(context, "GroupKeyManagement.GroupTable response", value);
     }
 };
 
@@ -19554,7 +21087,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19599,7 +21132,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19609,7 +21142,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "GroupKeyManagement.MaxGroupsPerFabric response", value);
+        OnGeneralAttributeEventResponse(context, "GroupKeyManagement.MaxGroupsPerFabric response", value);
     }
 };
 
@@ -19629,7 +21162,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19639,7 +21172,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "GroupKeyManagement.MaxGroupKeysPerFabric response", value);
+        OnGeneralAttributeEventResponse(context, "GroupKeyManagement.MaxGroupKeysPerFabric response", value);
     }
 };
 
@@ -19659,7 +21192,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19669,7 +21202,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "GroupKeyManagement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "GroupKeyManagement.AttributeList response", value);
     }
 };
 
@@ -19689,7 +21222,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19699,7 +21232,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "GroupKeyManagement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "GroupKeyManagement.ClusterRevision response", value);
     }
 };
 
@@ -19719,7 +21252,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupKeyManagementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19757,6 +21290,8 @@ private:
 | * NameSupport                                                       | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -19917,7 +21452,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0004) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0004) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19927,7 +21462,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Groups.NameSupport response", value);
+        OnGeneralAttributeEventResponse(context, "Groups.NameSupport response", value);
     }
 };
 
@@ -19947,7 +21482,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0004) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0004) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19986,7 +21521,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0004) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0004) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -19996,7 +21531,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Groups.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Groups.AttributeList response", value);
     }
 };
 
@@ -20016,7 +21551,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0004) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0004) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20026,7 +21561,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Groups.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Groups.ClusterRevision response", value);
     }
 };
 
@@ -20046,7 +21581,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0004) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0004) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20082,6 +21617,8 @@ private:
 | * IdentifyType                                                      | 0x0001 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -20171,7 +21708,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20181,7 +21718,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Identify.IdentifyTime response", value);
+        OnGeneralAttributeEventResponse(context, "Identify.IdentifyTime response", value);
     }
 };
 
@@ -20199,7 +21736,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20227,7 +21764,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20266,7 +21803,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20276,7 +21813,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Identify.IdentifyType response", value);
+        OnGeneralAttributeEventResponse(context, "Identify.IdentifyType response", value);
     }
 };
 
@@ -20296,7 +21833,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20335,7 +21872,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20345,7 +21882,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Identify.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Identify.AttributeList response", value);
     }
 };
 
@@ -20365,7 +21902,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20375,7 +21912,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Identify.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Identify.ClusterRevision response", value);
     }
 };
 
@@ -20395,7 +21932,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0003) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0003) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IdentifyCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20431,6 +21968,8 @@ private:
 | * LightSensorType                                                   | 0x0004 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -20449,7 +21988,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20459,7 +21998,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.MeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.MeasuredValue response", value);
     }
 };
 
@@ -20479,7 +22018,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20521,7 +22060,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20531,7 +22070,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.MinMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.MinMeasuredValue response", value);
     }
 };
 
@@ -20551,7 +22090,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20593,7 +22132,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20603,7 +22142,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.MaxMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.MaxMeasuredValue response", value);
     }
 };
 
@@ -20623,7 +22162,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20665,7 +22204,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20675,7 +22214,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.Tolerance response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.Tolerance response", value);
     }
 };
 
@@ -20695,7 +22234,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20734,7 +22273,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20744,7 +22283,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.LightSensorType response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.LightSensorType response", value);
     }
 };
 
@@ -20764,7 +22303,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20806,7 +22345,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20816,7 +22355,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.AttributeList response", value);
     }
 };
 
@@ -20836,7 +22375,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20846,7 +22385,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "IlluminanceMeasurement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "IlluminanceMeasurement.ClusterRevision response", value);
     }
 };
 
@@ -20866,7 +22405,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0400) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0400) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::IlluminanceMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20901,6 +22440,8 @@ private:
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -20944,7 +22485,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0509) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0509) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::KeypadInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20954,7 +22495,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "KeypadInput.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "KeypadInput.AttributeList response", value);
     }
 };
 
@@ -20974,7 +22515,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0509) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0509) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::KeypadInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -20984,7 +22525,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "KeypadInput.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "KeypadInput.ClusterRevision response", value);
     }
 };
 
@@ -21004,7 +22545,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0509) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0509) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::KeypadInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21057,6 +22598,8 @@ private:
 | * StartUpCurrentLevel                                               | 0x4000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -21282,7 +22825,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21292,7 +22835,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.CurrentLevel response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.CurrentLevel response", value);
     }
 };
 
@@ -21312,7 +22855,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21351,7 +22894,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21361,7 +22904,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.RemainingTime response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.RemainingTime response", value);
     }
 };
 
@@ -21381,7 +22924,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21420,7 +22963,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21430,7 +22973,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.MinLevel response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.MinLevel response", value);
     }
 };
 
@@ -21450,7 +22993,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21489,7 +23032,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21499,7 +23042,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.MaxLevel response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.MaxLevel response", value);
     }
 };
 
@@ -21519,7 +23062,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21558,7 +23101,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21568,7 +23111,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.CurrentFrequency response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.CurrentFrequency response", value);
     }
 };
 
@@ -21588,7 +23131,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21627,7 +23170,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21637,7 +23180,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.MinFrequency response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.MinFrequency response", value);
     }
 };
 
@@ -21657,7 +23200,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21696,7 +23239,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21706,7 +23249,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.MaxFrequency response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.MaxFrequency response", value);
     }
 };
 
@@ -21726,7 +23269,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21765,7 +23308,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21775,7 +23318,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.Options response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.Options response", value);
     }
 };
 
@@ -21793,7 +23336,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21821,7 +23364,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21860,7 +23403,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21870,7 +23413,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.OnOffTransitionTime response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.OnOffTransitionTime response", value);
     }
 };
 
@@ -21888,7 +23431,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21916,7 +23459,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21955,7 +23498,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -21965,7 +23508,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.OnLevel response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.OnLevel response", value);
     }
 };
 
@@ -21983,7 +23526,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22011,7 +23554,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22053,7 +23596,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22063,7 +23606,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.OnTransitionTime response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.OnTransitionTime response", value);
     }
 };
 
@@ -22081,7 +23624,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22109,7 +23652,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22151,7 +23694,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22161,7 +23704,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.OffTransitionTime response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.OffTransitionTime response", value);
     }
 };
 
@@ -22179,7 +23722,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22207,7 +23750,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22249,7 +23792,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22259,7 +23802,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.DefaultMoveRate response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.DefaultMoveRate response", value);
     }
 };
 
@@ -22277,7 +23820,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22305,7 +23848,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22347,7 +23890,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22357,7 +23900,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.StartUpCurrentLevel response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.StartUpCurrentLevel response", value);
     }
 };
 
@@ -22375,7 +23918,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22403,7 +23946,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22442,7 +23985,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22452,7 +23995,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.AttributeList response", value);
     }
 };
 
@@ -22472,7 +24015,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22482,7 +24025,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LevelControl.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "LevelControl.ClusterRevision response", value);
     }
 };
 
@@ -22502,7 +24045,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0008) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0008) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LevelControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22533,6 +24076,8 @@ private:
 | Attributes:                                                         |        |
 | * ActiveLocale                                                      | 0x0001 |
 | * SupportedLocales                                                  | 0x0002 |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -22551,7 +24096,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LocalizationConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22561,7 +24106,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "LocalizationConfiguration.ActiveLocale response", value);
+        OnGeneralAttributeEventResponse(context, "LocalizationConfiguration.ActiveLocale response", value);
     }
 };
 
@@ -22579,7 +24124,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002B) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002B) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LocalizationConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22607,7 +24152,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LocalizationConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22617,7 +24162,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "LocalizationConfiguration.SupportedLocales response", value);
+        OnGeneralAttributeEventResponse(context, "LocalizationConfiguration.SupportedLocales response", value);
     }
 };
 
@@ -22630,6 +24175,8 @@ public:
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -22668,7 +24215,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0508) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0508) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LowPowerCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22678,7 +24225,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "LowPower.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "LowPower.AttributeList response", value);
     }
 };
 
@@ -22698,7 +24245,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0508) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0508) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LowPowerCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22708,7 +24255,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "LowPower.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "LowPower.ClusterRevision response", value);
     }
 };
 
@@ -22728,7 +24275,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0508) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0508) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::LowPowerCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22765,6 +24312,8 @@ private:
 | * CurrentMediaInput                                                 | 0x0001 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -22872,7 +24421,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22884,7 +24433,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::InputInfo::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "MediaInput.MediaInputList response", value);
+        OnGeneralAttributeEventResponse(context, "MediaInput.MediaInputList response", value);
     }
 };
 
@@ -22904,7 +24453,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22948,7 +24497,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -22958,7 +24507,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaInput.CurrentMediaInput response", value);
+        OnGeneralAttributeEventResponse(context, "MediaInput.CurrentMediaInput response", value);
     }
 };
 
@@ -22978,7 +24527,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23017,7 +24566,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23027,7 +24576,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "MediaInput.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "MediaInput.AttributeList response", value);
     }
 };
 
@@ -23047,7 +24596,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23057,7 +24606,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaInput.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "MediaInput.ClusterRevision response", value);
     }
 };
 
@@ -23077,7 +24626,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0507) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0507) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23125,6 +24674,8 @@ private:
 | * SeekRangeStart                                                    | 0x0006 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -23375,7 +24926,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23385,7 +24936,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::MediaPlayback::PlaybackStateEnum value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.PlaybackState response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.PlaybackState response", value);
     }
 };
 
@@ -23405,7 +24956,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23447,7 +24998,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23457,7 +25008,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.StartTime response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.StartTime response", value);
     }
 };
 
@@ -23477,7 +25028,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23516,7 +25067,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23526,7 +25077,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.Duration response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.Duration response", value);
     }
 };
 
@@ -23546,7 +25097,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23585,7 +25136,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23595,7 +25146,7 @@ public:
 
     static void OnAttributeResponse(void * context, float value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.PlaybackSpeed response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.PlaybackSpeed response", value);
     }
 };
 
@@ -23615,7 +25166,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23625,7 +25176,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.SeekRangeEnd response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.SeekRangeEnd response", value);
     }
 };
 
@@ -23645,7 +25196,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23684,7 +25235,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23694,7 +25245,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.SeekRangeStart response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.SeekRangeStart response", value);
     }
 };
 
@@ -23714,7 +25265,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23753,7 +25304,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23763,7 +25314,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.AttributeList response", value);
     }
 };
 
@@ -23783,7 +25334,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23793,7 +25344,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "MediaPlayback.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "MediaPlayback.ClusterRevision response", value);
     }
 };
 
@@ -23813,7 +25364,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0506) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0506) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::MediaPlaybackCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23850,6 +25401,8 @@ private:
 | * Description                                                       | 0x0004 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -23892,7 +25445,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23902,7 +25455,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.CurrentMode response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.CurrentMode response", value);
     }
 };
 
@@ -23922,7 +25475,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23961,7 +25514,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -23974,7 +25527,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.SupportedModes response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.SupportedModes response", value);
     }
 };
 
@@ -23994,7 +25547,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24039,7 +25592,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24049,7 +25602,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.OnMode response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.OnMode response", value);
     }
 };
 
@@ -24067,7 +25620,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24095,7 +25648,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24134,7 +25687,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24144,7 +25697,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.StartUpMode response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.StartUpMode response", value);
     }
 };
 
@@ -24164,7 +25717,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24203,7 +25756,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24213,7 +25766,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.Description response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.Description response", value);
     }
 };
 
@@ -24233,7 +25786,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24272,7 +25825,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24282,7 +25835,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.AttributeList response", value);
     }
 };
 
@@ -24302,7 +25855,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24312,7 +25865,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ModeSelect.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ModeSelect.ClusterRevision response", value);
     }
 };
 
@@ -24332,7 +25885,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0050) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0050) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ModeSelectCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24377,6 +25930,8 @@ private:
 | * LastConnectErrorValue                                             | 0x0007 |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -24547,7 +26102,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24557,7 +26112,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.MaxNetworks response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.MaxNetworks response", value);
     }
 };
 
@@ -24577,7 +26132,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24590,7 +26145,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::NetworkCommissioning::Structs::NetworkInfo::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.Networks response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.Networks response", value);
     }
 };
 
@@ -24610,7 +26165,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24620,7 +26175,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.ScanMaxTimeSeconds response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.ScanMaxTimeSeconds response", value);
     }
 };
 
@@ -24640,7 +26195,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24650,7 +26205,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.ConnectMaxTimeSeconds response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.ConnectMaxTimeSeconds response", value);
     }
 };
 
@@ -24670,7 +26225,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24680,7 +26235,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.InterfaceEnabled response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.InterfaceEnabled response", value);
     }
 };
 
@@ -24698,7 +26253,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24726,7 +26281,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24736,7 +26291,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatus value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.LastNetworkingStatus response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.LastNetworkingStatus response", value);
     }
 };
 
@@ -24756,7 +26311,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24766,7 +26321,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.LastNetworkID response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.LastNetworkID response", value);
     }
 };
 
@@ -24786,7 +26341,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24796,7 +26351,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.LastConnectErrorValue response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.LastConnectErrorValue response", value);
     }
 };
 
@@ -24816,7 +26371,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24826,7 +26381,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.FeatureMap response", value);
     }
 };
 
@@ -24846,7 +26401,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24885,7 +26440,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24895,7 +26450,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "NetworkCommissioning.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "NetworkCommissioning.ClusterRevision response", value);
     }
 };
 
@@ -24915,7 +26470,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0031) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
@@ -24949,6 +26504,8 @@ private:
 | Attributes:                                                         |        |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -25048,7 +26605,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0029) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0029) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25058,7 +26615,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateProvider.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateProvider.AttributeList response", value);
     }
 };
 
@@ -25078,7 +26635,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0029) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0029) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25088,7 +26645,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateProvider.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateProvider.ClusterRevision response", value);
     }
 };
 
@@ -25108,7 +26665,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0029) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0029) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25147,6 +26704,11 @@ private:
 | * UpdateStateProgress                                               | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * StateTransition                                                   | 0x0000 |
+| * VersionApplied                                                    | 0x0001 |
+| * DownloadError                                                     | 0x0002 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -25180,6 +26742,97 @@ private:
 };
 
 /*
+ * Event StateTransition
+ */
+class ReadOtaSoftwareUpdateRequestorStateTransition : public ModelCommand
+{
+public:
+    ReadOtaSoftwareUpdateRequestorStateTransition() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "state-transition");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadOtaSoftwareUpdateRequestorStateTransition() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::StateTransition::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::StateTransition::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.StateTransition response", value);
+    }
+};
+/*
+ * Event VersionApplied
+ */
+class ReadOtaSoftwareUpdateRequestorVersionApplied : public ModelCommand
+{
+public:
+    ReadOtaSoftwareUpdateRequestorVersionApplied() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "version-applied");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadOtaSoftwareUpdateRequestorVersionApplied() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::VersionApplied::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::VersionApplied::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.VersionApplied response", value);
+    }
+};
+/*
+ * Event DownloadError
+ */
+class ReadOtaSoftwareUpdateRequestorDownloadError : public ModelCommand
+{
+public:
+    ReadOtaSoftwareUpdateRequestorDownloadError() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "download-error");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadOtaSoftwareUpdateRequestorDownloadError() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::DownloadError::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::DownloadError::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.DownloadError response", value);
+    }
+};
+
+/*
  * Attribute DefaultOtaProviders
  */
 class ReadOtaSoftwareUpdateRequestorDefaultOtaProviders : public ModelCommand
@@ -25195,7 +26848,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25208,7 +26861,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.DefaultOtaProviders response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.DefaultOtaProviders response", value);
     }
 };
 
@@ -25228,7 +26881,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25274,7 +26927,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25284,7 +26937,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.UpdatePossible response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.UpdatePossible response", value);
     }
 };
 
@@ -25304,7 +26957,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25346,7 +26999,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25356,7 +27009,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.UpdateState response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.UpdateState response", value);
     }
 };
 
@@ -25376,7 +27029,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25418,7 +27071,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25428,7 +27081,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.UpdateStateProgress response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.UpdateStateProgress response", value);
     }
 };
 
@@ -25448,7 +27101,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25491,7 +27144,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25501,7 +27154,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.AttributeList response", value);
     }
 };
 
@@ -25521,7 +27174,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25531,7 +27184,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OtaSoftwareUpdateRequestor.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "OtaSoftwareUpdateRequestor.ClusterRevision response", value);
     }
 };
 
@@ -25551,7 +27204,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002A) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002A) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25588,6 +27241,8 @@ private:
 | * OccupancySensorTypeBitmap                                         | 0x0002 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -25606,7 +27261,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25616,7 +27271,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OccupancySensing.Occupancy response", value);
+        OnGeneralAttributeEventResponse(context, "OccupancySensing.Occupancy response", value);
     }
 };
 
@@ -25636,7 +27291,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25675,7 +27330,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25685,7 +27340,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OccupancySensing.OccupancySensorType response", value);
+        OnGeneralAttributeEventResponse(context, "OccupancySensing.OccupancySensorType response", value);
     }
 };
 
@@ -25705,7 +27360,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25744,7 +27399,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25754,7 +27409,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OccupancySensing.OccupancySensorTypeBitmap response", value);
+        OnGeneralAttributeEventResponse(context, "OccupancySensing.OccupancySensorTypeBitmap response", value);
     }
 };
 
@@ -25774,7 +27429,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25816,7 +27471,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25826,7 +27481,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "OccupancySensing.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "OccupancySensing.AttributeList response", value);
     }
 };
 
@@ -25846,7 +27501,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25856,7 +27511,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OccupancySensing.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "OccupancySensing.ClusterRevision response", value);
     }
 };
 
@@ -25876,7 +27531,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0406) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0406) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OccupancySensingCluster cluster;
         cluster.Associate(device, endpointId);
@@ -25919,6 +27574,8 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -26071,7 +27728,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26081,7 +27738,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.OnOff response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.OnOff response", value);
     }
 };
 
@@ -26101,7 +27758,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26140,7 +27797,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26150,7 +27807,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.GlobalSceneControl response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.GlobalSceneControl response", value);
     }
 };
 
@@ -26170,7 +27827,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26209,7 +27866,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26219,7 +27876,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.OnTime response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.OnTime response", value);
     }
 };
 
@@ -26237,7 +27894,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26265,7 +27922,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26304,7 +27961,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26314,7 +27971,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.OffWaitTime response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.OffWaitTime response", value);
     }
 };
 
@@ -26332,7 +27989,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26360,7 +28017,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26399,7 +28056,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26409,7 +28066,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.StartUpOnOff response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.StartUpOnOff response", value);
     }
 };
 
@@ -26427,7 +28084,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26455,7 +28112,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26494,7 +28151,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26504,7 +28161,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.AttributeList response", value);
     }
 };
 
@@ -26524,7 +28181,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26534,7 +28191,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.FeatureMap response", value);
     }
 };
 
@@ -26554,7 +28211,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26593,7 +28250,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26603,7 +28260,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOff.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "OnOff.ClusterRevision response", value);
     }
 };
 
@@ -26623,7 +28280,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0006) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0006) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26656,6 +28313,8 @@ private:
 | * SwitchActions                                                     | 0x0010 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -26674,7 +28333,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26684,7 +28343,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.SwitchType response", value);
+        OnGeneralAttributeEventResponse(context, "OnOffSwitchConfiguration.SwitchType response", value);
     }
 };
 
@@ -26704,7 +28363,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26743,7 +28402,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26753,7 +28412,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.SwitchActions response", value);
+        OnGeneralAttributeEventResponse(context, "OnOffSwitchConfiguration.SwitchActions response", value);
     }
 };
 
@@ -26771,7 +28430,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26799,7 +28458,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26841,7 +28500,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26851,7 +28510,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "OnOffSwitchConfiguration.AttributeList response", value);
     }
 };
 
@@ -26871,7 +28530,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26881,7 +28540,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OnOffSwitchConfiguration.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "OnOffSwitchConfiguration.ClusterRevision response", value);
     }
 };
 
@@ -26901,7 +28560,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0007) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0007) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OnOffSwitchConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -26949,6 +28608,8 @@ private:
 | * CurrentFabricIndex                                                | 0x0005 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -27188,7 +28849,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27201,7 +28862,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.FabricsList response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.FabricsList response", value);
     }
 };
 
@@ -27221,7 +28882,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27265,7 +28926,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27275,7 +28936,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.SupportedFabrics response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.SupportedFabrics response", value);
     }
 };
 
@@ -27295,7 +28956,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27337,7 +28998,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27347,7 +29008,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.CommissionedFabrics response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.CommissionedFabrics response", value);
     }
 };
 
@@ -27367,7 +29028,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27409,7 +29070,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27419,7 +29080,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.TrustedRootCertificates response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.TrustedRootCertificates response", value);
     }
 };
 
@@ -27439,7 +29100,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27482,7 +29143,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27492,7 +29153,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::FabricIndex value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.CurrentFabricIndex response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.CurrentFabricIndex response", value);
     }
 };
 
@@ -27512,7 +29173,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27554,7 +29215,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27564,7 +29225,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.AttributeList response", value);
     }
 };
 
@@ -27584,7 +29245,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27594,7 +29255,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "OperationalCredentials.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "OperationalCredentials.ClusterRevision response", value);
     }
 };
 
@@ -27614,7 +29275,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003E) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003E) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27658,6 +29319,8 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -27676,7 +29339,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27686,7 +29349,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.Status response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.Status response", value);
     }
 };
 
@@ -27706,7 +29369,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27745,7 +29408,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27755,7 +29418,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.Order response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.Order response", value);
     }
 };
 
@@ -27775,7 +29438,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27814,7 +29477,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27824,7 +29487,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.Description response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.Description response", value);
     }
 };
 
@@ -27844,7 +29507,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27883,7 +29546,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27893,7 +29556,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.BatteryVoltage response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.BatteryVoltage response", value);
     }
 };
 
@@ -27913,7 +29576,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27952,7 +29615,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -27962,7 +29625,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.BatteryPercentRemaining response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.BatteryPercentRemaining response", value);
     }
 };
 
@@ -27982,7 +29645,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28021,7 +29684,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28031,7 +29694,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.BatteryTimeRemaining response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.BatteryTimeRemaining response", value);
     }
 };
 
@@ -28051,7 +29714,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28090,7 +29753,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28100,7 +29763,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.BatteryChargeLevel response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.BatteryChargeLevel response", value);
     }
 };
 
@@ -28120,7 +29783,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28159,7 +29822,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28169,7 +29832,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.ActiveBatteryFaults response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.ActiveBatteryFaults response", value);
     }
 };
 
@@ -28189,7 +29852,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28231,7 +29894,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28241,7 +29904,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.BatteryChargeState response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.BatteryChargeState response", value);
     }
 };
 
@@ -28261,7 +29924,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28300,7 +29963,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28310,7 +29973,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.AttributeList response", value);
     }
 };
 
@@ -28330,7 +29993,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28340,7 +30003,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.FeatureMap response", value);
     }
 };
 
@@ -28360,7 +30023,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28399,7 +30062,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28409,7 +30072,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSource.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSource.ClusterRevision response", value);
     }
 };
 
@@ -28429,7 +30092,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28461,6 +30124,8 @@ private:
 | * Sources                                                           | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -28479,7 +30144,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28489,7 +30154,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "PowerSourceConfiguration.Sources response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSourceConfiguration.Sources response", value);
     }
 };
 
@@ -28509,7 +30174,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28519,7 +30184,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "PowerSourceConfiguration.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSourceConfiguration.AttributeList response", value);
     }
 };
 
@@ -28539,7 +30204,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x002E) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x002E) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PowerSourceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28549,7 +30214,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PowerSourceConfiguration.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "PowerSourceConfiguration.ClusterRevision response", value);
     }
 };
 
@@ -28564,6 +30229,8 @@ public:
 | * MaxMeasuredValue                                                  | 0x0002 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -28582,7 +30249,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28592,7 +30259,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PressureMeasurement.MeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "PressureMeasurement.MeasuredValue response", value);
     }
 };
 
@@ -28612,7 +30279,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28651,7 +30318,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28661,7 +30328,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PressureMeasurement.MinMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "PressureMeasurement.MinMeasuredValue response", value);
     }
 };
 
@@ -28681,7 +30348,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28720,7 +30387,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28730,7 +30397,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PressureMeasurement.MaxMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "PressureMeasurement.MaxMeasuredValue response", value);
     }
 };
 
@@ -28750,7 +30417,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28789,7 +30456,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28799,7 +30466,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "PressureMeasurement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "PressureMeasurement.AttributeList response", value);
     }
 };
 
@@ -28819,7 +30486,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28829,7 +30496,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PressureMeasurement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "PressureMeasurement.ClusterRevision response", value);
     }
 };
 
@@ -28849,7 +30516,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0403) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0403) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PressureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28905,7 +30572,543 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * SupplyVoltageLow                                                  | 0x0000 |
+| * SupplyVoltageHigh                                                 | 0x0001 |
+| * PowerMissingPhase                                                 | 0x0002 |
+| * SystemPressureLow                                                 | 0x0003 |
+| * SystemPressureHigh                                                | 0x0004 |
+| * DryRunning                                                        | 0x0005 |
+| * MotorTemperatureHigh                                              | 0x0006 |
+| * PumpMotorFatalFailure                                             | 0x0007 |
+| * ElectronicTemperatureHigh                                         | 0x0008 |
+| * PumpBlocked                                                       | 0x0009 |
+| * SensorFailure                                                     | 0x000A |
+| * ElectronicNonFatalFailure                                         | 0x000B |
+| * ElectronicFatalFailure                                            | 0x000C |
+| * GeneralFault                                                      | 0x000D |
+| * Leakage                                                           | 0x000E |
+| * AirDetection                                                      | 0x000F |
+| * TurbineOperation                                                  | 0x0010 |
 \*----------------------------------------------------------------------------*/
+
+/*
+ * Event SupplyVoltageLow
+ */
+class ReadPumpConfigurationAndControlSupplyVoltageLow : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlSupplyVoltageLow() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "supply-voltage-low");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlSupplyVoltageLow() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageLow::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageLow::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.SupplyVoltageLow response", value);
+    }
+};
+/*
+ * Event SupplyVoltageHigh
+ */
+class ReadPumpConfigurationAndControlSupplyVoltageHigh : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlSupplyVoltageHigh() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "supply-voltage-high");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlSupplyVoltageHigh() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageHigh::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageHigh::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.SupplyVoltageHigh response", value);
+    }
+};
+/*
+ * Event PowerMissingPhase
+ */
+class ReadPumpConfigurationAndControlPowerMissingPhase : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlPowerMissingPhase() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "power-missing-phase");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlPowerMissingPhase() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::PowerMissingPhase::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::PowerMissingPhase::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.PowerMissingPhase response", value);
+    }
+};
+/*
+ * Event SystemPressureLow
+ */
+class ReadPumpConfigurationAndControlSystemPressureLow : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlSystemPressureLow() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "system-pressure-low");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlSystemPressureLow() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureLow::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureLow::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.SystemPressureLow response", value);
+    }
+};
+/*
+ * Event SystemPressureHigh
+ */
+class ReadPumpConfigurationAndControlSystemPressureHigh : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlSystemPressureHigh() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "system-pressure-high");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlSystemPressureHigh() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureHigh::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureHigh::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.SystemPressureHigh response", value);
+    }
+};
+/*
+ * Event DryRunning
+ */
+class ReadPumpConfigurationAndControlDryRunning : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlDryRunning() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "dry-running");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlDryRunning() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::DryRunning::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::DryRunning::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.DryRunning response", value);
+    }
+};
+/*
+ * Event MotorTemperatureHigh
+ */
+class ReadPumpConfigurationAndControlMotorTemperatureHigh : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlMotorTemperatureHigh() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "motor-temperature-high");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlMotorTemperatureHigh() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::MotorTemperatureHigh::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::MotorTemperatureHigh::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MotorTemperatureHigh response", value);
+    }
+};
+/*
+ * Event PumpMotorFatalFailure
+ */
+class ReadPumpConfigurationAndControlPumpMotorFatalFailure : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlPumpMotorFatalFailure() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "pump-motor-fatal-failure");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlPumpMotorFatalFailure() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::PumpMotorFatalFailure::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void
+    OnEventResponse(void * context,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::PumpMotorFatalFailure::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.PumpMotorFatalFailure response", value);
+    }
+};
+/*
+ * Event ElectronicTemperatureHigh
+ */
+class ReadPumpConfigurationAndControlElectronicTemperatureHigh : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlElectronicTemperatureHigh() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "electronic-temperature-high");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlElectronicTemperatureHigh() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster
+            .ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicTemperatureHigh::DecodableType>(
+                this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void
+    OnEventResponse(void * context,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicTemperatureHigh::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.ElectronicTemperatureHigh response", value);
+    }
+};
+/*
+ * Event PumpBlocked
+ */
+class ReadPumpConfigurationAndControlPumpBlocked : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlPumpBlocked() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "pump-blocked");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlPumpBlocked() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::PumpBlocked::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::PumpBlocked::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.PumpBlocked response", value);
+    }
+};
+/*
+ * Event SensorFailure
+ */
+class ReadPumpConfigurationAndControlSensorFailure : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlSensorFailure() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "sensor-failure");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlSensorFailure() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::SensorFailure::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::SensorFailure::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.SensorFailure response", value);
+    }
+};
+/*
+ * Event ElectronicNonFatalFailure
+ */
+class ReadPumpConfigurationAndControlElectronicNonFatalFailure : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlElectronicNonFatalFailure() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "electronic-non-fatal-failure");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlElectronicNonFatalFailure() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster
+            .ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicNonFatalFailure::DecodableType>(
+                this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void
+    OnEventResponse(void * context,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicNonFatalFailure::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.ElectronicNonFatalFailure response", value);
+    }
+};
+/*
+ * Event ElectronicFatalFailure
+ */
+class ReadPumpConfigurationAndControlElectronicFatalFailure : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlElectronicFatalFailure() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "electronic-fatal-failure");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlElectronicFatalFailure() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicFatalFailure::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void
+    OnEventResponse(void * context,
+                    chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicFatalFailure::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.ElectronicFatalFailure response", value);
+    }
+};
+/*
+ * Event GeneralFault
+ */
+class ReadPumpConfigurationAndControlGeneralFault : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlGeneralFault() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "general-fault");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlGeneralFault() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::GeneralFault::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::GeneralFault::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.GeneralFault response", value);
+    }
+};
+/*
+ * Event Leakage
+ */
+class ReadPumpConfigurationAndControlLeakage : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlLeakage() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "leakage");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlLeakage() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::Leakage::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::Leakage::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.Leakage response", value);
+    }
+};
+/*
+ * Event AirDetection
+ */
+class ReadPumpConfigurationAndControlAirDetection : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlAirDetection() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "air-detection");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlAirDetection() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::AirDetection::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::AirDetection::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.AirDetection response", value);
+    }
+};
+/*
+ * Event TurbineOperation
+ */
+class ReadPumpConfigurationAndControlTurbineOperation : public ModelCommand
+{
+public:
+    ReadPumpConfigurationAndControlTurbineOperation() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "turbine-operation");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadPumpConfigurationAndControlTurbineOperation() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::PumpConfigurationAndControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::PumpConfigurationAndControl::Events::TurbineOperation::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::PumpConfigurationAndControl::Events::TurbineOperation::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.TurbineOperation response", value);
+    }
+};
 
 /*
  * Attribute MaxPressure
@@ -28923,7 +31126,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28933,7 +31136,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxPressure response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxPressure response", value);
     }
 };
 
@@ -28953,7 +31156,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -28995,7 +31198,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29005,7 +31208,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxSpeed response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxSpeed response", value);
     }
 };
 
@@ -29025,7 +31228,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29064,7 +31267,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29074,7 +31277,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxFlow response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxFlow response", value);
     }
 };
 
@@ -29094,7 +31297,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29133,7 +31336,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29143,7 +31346,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstPressure response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MinConstPressure response", value);
     }
 };
 
@@ -29163,7 +31366,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29205,7 +31408,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29215,7 +31418,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstPressure response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxConstPressure response", value);
     }
 };
 
@@ -29235,7 +31438,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29277,7 +31480,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29287,7 +31490,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinCompPressure response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MinCompPressure response", value);
     }
 };
 
@@ -29307,7 +31510,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29349,7 +31552,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29359,7 +31562,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxCompPressure response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxCompPressure response", value);
     }
 };
 
@@ -29379,7 +31582,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29421,7 +31624,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29431,7 +31634,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstSpeed response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MinConstSpeed response", value);
     }
 };
 
@@ -29451,7 +31654,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29493,7 +31696,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29503,7 +31706,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstSpeed response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxConstSpeed response", value);
     }
 };
 
@@ -29523,7 +31726,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29565,7 +31768,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29575,7 +31778,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstFlow response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MinConstFlow response", value);
     }
 };
 
@@ -29595,7 +31798,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29637,7 +31840,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29647,7 +31850,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstFlow response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxConstFlow response", value);
     }
 };
 
@@ -29667,7 +31870,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29709,7 +31912,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29719,7 +31922,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MinConstTemp response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MinConstTemp response", value);
     }
 };
 
@@ -29739,7 +31942,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29781,7 +31984,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29791,7 +31994,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.MaxConstTemp response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.MaxConstTemp response", value);
     }
 };
 
@@ -29811,7 +32014,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29853,7 +32056,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29863,7 +32066,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.PumpStatus response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.PumpStatus response", value);
     }
 };
 
@@ -29883,7 +32086,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29925,7 +32128,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29936,7 +32139,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.EffectiveOperationMode response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.EffectiveOperationMode response", value);
     }
 };
 
@@ -29956,7 +32159,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -29999,7 +32202,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30009,7 +32212,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.EffectiveControlMode response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.EffectiveControlMode response", value);
     }
 };
 
@@ -30029,7 +32232,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30072,7 +32275,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30082,7 +32285,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.Capacity response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.Capacity response", value);
     }
 };
 
@@ -30102,7 +32305,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30141,7 +32344,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30151,7 +32354,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.Speed response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.Speed response", value);
     }
 };
 
@@ -30171,7 +32374,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30210,7 +32413,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30220,7 +32423,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.LifetimeRunningHours response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.LifetimeRunningHours response", value);
     }
 };
 
@@ -30238,7 +32441,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30266,7 +32469,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30309,7 +32512,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30319,7 +32522,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.Power response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.Power response", value);
     }
 };
 
@@ -30339,7 +32542,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30378,7 +32581,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30389,7 +32592,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.LifetimeEnergyConsumed response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.LifetimeEnergyConsumed response", value);
     }
 };
 
@@ -30407,7 +32610,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30436,7 +32639,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30479,7 +32682,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30489,7 +32692,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.OperationMode response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.OperationMode response", value);
     }
 };
 
@@ -30507,7 +32710,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30535,7 +32738,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30577,7 +32780,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30587,7 +32790,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.ControlMode response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.ControlMode response", value);
     }
 };
 
@@ -30605,7 +32808,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30633,7 +32836,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30675,7 +32878,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30685,7 +32888,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.AlarmMask response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.AlarmMask response", value);
     }
 };
 
@@ -30705,7 +32908,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30747,7 +32950,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30757,7 +32960,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.AttributeList response", value);
     }
 };
 
@@ -30777,7 +32980,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30787,7 +32990,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.FeatureMap response", value);
     }
 };
 
@@ -30807,7 +33010,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30849,7 +33052,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30859,7 +33062,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "PumpConfigurationAndControl.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "PumpConfigurationAndControl.ClusterRevision response", value);
     }
 };
 
@@ -30879,7 +33082,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0200) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0200) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::PumpConfigurationAndControlCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30917,6 +33120,8 @@ private:
 | * Tolerance                                                         | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -30935,7 +33140,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -30945,7 +33150,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.MeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "RelativeHumidityMeasurement.MeasuredValue response", value);
     }
 };
 
@@ -30965,7 +33170,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31007,7 +33212,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31017,7 +33222,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.MinMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "RelativeHumidityMeasurement.MinMeasuredValue response", value);
     }
 };
 
@@ -31037,7 +33242,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31079,7 +33284,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31089,7 +33294,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.MaxMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "RelativeHumidityMeasurement.MaxMeasuredValue response", value);
     }
 };
 
@@ -31109,7 +33314,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31151,7 +33356,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31161,7 +33366,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.Tolerance response", value);
+        OnGeneralAttributeEventResponse(context, "RelativeHumidityMeasurement.Tolerance response", value);
     }
 };
 
@@ -31181,7 +33386,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31223,7 +33428,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31233,7 +33438,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "RelativeHumidityMeasurement.AttributeList response", value);
     }
 };
 
@@ -31253,7 +33458,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31263,7 +33468,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "RelativeHumidityMeasurement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "RelativeHumidityMeasurement.ClusterRevision response", value);
     }
 };
 
@@ -31283,7 +33488,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0405) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0405) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::RelativeHumidityMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31329,6 +33534,8 @@ private:
 | * NameSupport                                                       | 0x0004 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -31524,7 +33731,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31534,7 +33741,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.SceneCount response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.SceneCount response", value);
     }
 };
 
@@ -31554,7 +33761,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31593,7 +33800,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31603,7 +33810,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.CurrentScene response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.CurrentScene response", value);
     }
 };
 
@@ -31623,7 +33830,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31662,7 +33869,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31672,7 +33879,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.CurrentGroup response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.CurrentGroup response", value);
     }
 };
 
@@ -31692,7 +33899,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31731,7 +33938,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31741,7 +33948,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.SceneValid response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.SceneValid response", value);
     }
 };
 
@@ -31761,7 +33968,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31800,7 +34007,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31810,7 +34017,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.NameSupport response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.NameSupport response", value);
     }
 };
 
@@ -31830,7 +34037,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31869,7 +34076,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31879,7 +34086,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.AttributeList response", value);
     }
 };
 
@@ -31899,7 +34106,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31909,7 +34116,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Scenes.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Scenes.ClusterRevision response", value);
     }
 };
 
@@ -31929,7 +34136,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0005) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0005) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
@@ -31966,6 +34173,9 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * SoftwareFault                                                     | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -31989,6 +34199,37 @@ private:
 };
 
 /*
+ * Event SoftwareFault
+ */
+class ReadSoftwareDiagnosticsSoftwareFault : public ModelCommand
+{
+public:
+    ReadSoftwareDiagnosticsSoftwareFault() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "software-fault");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSoftwareDiagnosticsSoftwareFault() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SoftwareDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.SoftwareFault response", value);
+    }
+};
+
+/*
  * Attribute ThreadMetrics
  */
 class ReadSoftwareDiagnosticsThreadMetrics : public ModelCommand
@@ -32004,7 +34245,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32017,7 +34258,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.ThreadMetrics response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.ThreadMetrics response", value);
     }
 };
 
@@ -32037,7 +34278,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32082,7 +34323,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32092,7 +34333,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.CurrentHeapFree response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.CurrentHeapFree response", value);
     }
 };
 
@@ -32112,7 +34353,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32151,7 +34392,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32161,7 +34402,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.CurrentHeapUsed response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.CurrentHeapUsed response", value);
     }
 };
 
@@ -32181,7 +34422,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32220,7 +34461,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32230,7 +34471,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.CurrentHeapHighWatermark response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.CurrentHeapHighWatermark response", value);
     }
 };
 
@@ -32250,7 +34491,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32292,7 +34533,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32302,7 +34543,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.AttributeList response", value);
     }
 };
 
@@ -32322,7 +34563,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32332,7 +34573,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.FeatureMap response", value);
     }
 };
 
@@ -32352,7 +34593,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32362,7 +34603,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "SoftwareDiagnostics.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "SoftwareDiagnostics.ClusterRevision response", value);
     }
 };
 
@@ -32382,7 +34623,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0034) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0034) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SoftwareDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32417,7 +34658,220 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * SwitchLatched                                                     | 0x0000 |
+| * InitialPress                                                      | 0x0001 |
+| * LongPress                                                         | 0x0002 |
+| * ShortRelease                                                      | 0x0003 |
+| * LongRelease                                                       | 0x0004 |
+| * MultiPressOngoing                                                 | 0x0005 |
+| * MultiPressComplete                                                | 0x0006 |
 \*----------------------------------------------------------------------------*/
+
+/*
+ * Event SwitchLatched
+ */
+class ReadSwitchSwitchLatched : public ModelCommand
+{
+public:
+    ReadSwitchSwitchLatched() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "switch-latched");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchSwitchLatched() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::SwitchLatched::DecodableType>(this, OnEventResponse,
+                                                                                                    OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::SwitchLatched::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.SwitchLatched response", value);
+    }
+};
+/*
+ * Event InitialPress
+ */
+class ReadSwitchInitialPress : public ModelCommand
+{
+public:
+    ReadSwitchInitialPress() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "initial-press");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchInitialPress() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::InitialPress::DecodableType>(this, OnEventResponse,
+                                                                                                   OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::InitialPress::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.InitialPress response", value);
+    }
+};
+/*
+ * Event LongPress
+ */
+class ReadSwitchLongPress : public ModelCommand
+{
+public:
+    ReadSwitchLongPress() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "long-press");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchLongPress() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::LongPress::DecodableType>(this, OnEventResponse,
+                                                                                                OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::LongPress::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.LongPress response", value);
+    }
+};
+/*
+ * Event ShortRelease
+ */
+class ReadSwitchShortRelease : public ModelCommand
+{
+public:
+    ReadSwitchShortRelease() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "short-release");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchShortRelease() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::ShortRelease::DecodableType>(this, OnEventResponse,
+                                                                                                   OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::ShortRelease::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.ShortRelease response", value);
+    }
+};
+/*
+ * Event LongRelease
+ */
+class ReadSwitchLongRelease : public ModelCommand
+{
+public:
+    ReadSwitchLongRelease() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "long-release");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchLongRelease() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::LongRelease::DecodableType>(this, OnEventResponse,
+                                                                                                  OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::LongRelease::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.LongRelease response", value);
+    }
+};
+/*
+ * Event MultiPressOngoing
+ */
+class ReadSwitchMultiPressOngoing : public ModelCommand
+{
+public:
+    ReadSwitchMultiPressOngoing() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "multi-press-ongoing");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchMultiPressOngoing() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::MultiPressOngoing::DecodableType>(this, OnEventResponse,
+                                                                                                        OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::MultiPressOngoing::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.MultiPressOngoing response", value);
+    }
+};
+/*
+ * Event MultiPressComplete
+ */
+class ReadSwitchMultiPressComplete : public ModelCommand
+{
+public:
+    ReadSwitchMultiPressComplete() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "multi-press-complete");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadSwitchMultiPressComplete() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::SwitchCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::Switch::Events::MultiPressComplete::DecodableType>(this, OnEventResponse,
+                                                                                                         OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::Switch::Events::MultiPressComplete::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "Switch.MultiPressComplete response", value);
+    }
+};
 
 /*
  * Attribute NumberOfPositions
@@ -32435,7 +34889,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32445,7 +34899,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Switch.NumberOfPositions response", value);
+        OnGeneralAttributeEventResponse(context, "Switch.NumberOfPositions response", value);
     }
 };
 
@@ -32465,7 +34919,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32504,7 +34958,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32514,7 +34968,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Switch.CurrentPosition response", value);
+        OnGeneralAttributeEventResponse(context, "Switch.CurrentPosition response", value);
     }
 };
 
@@ -32534,7 +34988,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32573,7 +35027,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32583,7 +35037,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Switch.MultiPressMax response", value);
+        OnGeneralAttributeEventResponse(context, "Switch.MultiPressMax response", value);
     }
 };
 
@@ -32603,7 +35057,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32642,7 +35096,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32652,7 +35106,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Switch.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Switch.AttributeList response", value);
     }
 };
 
@@ -32672,7 +35126,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32682,7 +35136,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "Switch.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "Switch.FeatureMap response", value);
     }
 };
 
@@ -32702,7 +35156,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32741,7 +35195,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32751,7 +35205,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Switch.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Switch.ClusterRevision response", value);
     }
 };
 
@@ -32771,7 +35225,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x003B) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x003B) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::SwitchCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32805,6 +35259,8 @@ private:
 | * CurrentNavigatorTarget                                            | 0x0001 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -32848,7 +35304,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32860,7 +35316,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TargetNavigator::Structs::TargetInfo::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "TargetNavigator.TargetNavigatorList response", value);
+        OnGeneralAttributeEventResponse(context, "TargetNavigator.TargetNavigatorList response", value);
     }
 };
 
@@ -32880,7 +35336,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32924,7 +35380,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32934,7 +35390,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "TargetNavigator.CurrentNavigatorTarget response", value);
+        OnGeneralAttributeEventResponse(context, "TargetNavigator.CurrentNavigatorTarget response", value);
     }
 };
 
@@ -32954,7 +35410,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -32996,7 +35452,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33006,7 +35462,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "TargetNavigator.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "TargetNavigator.AttributeList response", value);
     }
 };
 
@@ -33026,7 +35482,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33036,7 +35492,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TargetNavigator.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "TargetNavigator.ClusterRevision response", value);
     }
 };
 
@@ -33056,7 +35512,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0505) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0505) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33091,6 +35547,8 @@ private:
 | * Tolerance                                                         | 0x0003 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -33109,7 +35567,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33119,7 +35577,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "TemperatureMeasurement.MeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "TemperatureMeasurement.MeasuredValue response", value);
     }
 };
 
@@ -33139,7 +35597,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33178,7 +35636,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33188,7 +35646,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "TemperatureMeasurement.MinMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "TemperatureMeasurement.MinMeasuredValue response", value);
     }
 };
 
@@ -33208,7 +35666,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33250,7 +35708,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33260,7 +35718,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "TemperatureMeasurement.MaxMeasuredValue response", value);
+        OnGeneralAttributeEventResponse(context, "TemperatureMeasurement.MaxMeasuredValue response", value);
     }
 };
 
@@ -33280,7 +35738,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33322,7 +35780,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33332,7 +35790,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TemperatureMeasurement.Tolerance response", value);
+        OnGeneralAttributeEventResponse(context, "TemperatureMeasurement.Tolerance response", value);
     }
 };
 
@@ -33352,7 +35810,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33391,7 +35849,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33401,7 +35859,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "TemperatureMeasurement.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "TemperatureMeasurement.AttributeList response", value);
     }
 };
 
@@ -33421,7 +35879,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33431,7 +35889,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TemperatureMeasurement.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "TemperatureMeasurement.ClusterRevision response", value);
     }
 };
 
@@ -33451,7 +35909,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0402) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0402) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TemperatureMeasurementCluster cluster;
         cluster.Associate(device, endpointId);
@@ -33581,6 +36039,9 @@ private:
 | * NullableRangeRestrictedInt16s                                     | 0x8029 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * TestEvent                                                         | 0x0001 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -34000,6 +36461,36 @@ private:
 };
 
 /*
+ * Event TestEvent
+ */
+class ReadTestClusterTestEvent : public ModelCommand
+{
+public:
+    ReadTestClusterTestEvent() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "test-event");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadTestClusterTestEvent() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::TestClusterCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::TestCluster::Events::TestEvent::DecodableType>(this, OnEventResponse,
+                                                                                                     OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context, chip::app::Clusters::TestCluster::Events::TestEvent::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "TestCluster.TestEvent response", value);
+    }
+};
+
+/*
  * Attribute Boolean
  */
 class ReadTestClusterBoolean : public ModelCommand
@@ -34015,7 +36506,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34025,7 +36516,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Boolean response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Boolean response", value);
     }
 };
 
@@ -34043,7 +36534,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34071,7 +36562,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34110,7 +36601,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34120,7 +36611,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Bitmap8 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Bitmap8 response", value);
     }
 };
 
@@ -34138,7 +36629,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34166,7 +36657,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34205,7 +36696,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34215,7 +36706,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Bitmap16 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Bitmap16 response", value);
     }
 };
 
@@ -34233,7 +36724,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34261,7 +36752,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34300,7 +36791,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34310,7 +36801,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Bitmap32 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Bitmap32 response", value);
     }
 };
 
@@ -34328,7 +36819,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34356,7 +36847,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34395,7 +36886,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34405,7 +36896,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Bitmap64 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Bitmap64 response", value);
     }
 };
 
@@ -34423,7 +36914,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34451,7 +36942,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34490,7 +36981,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34500,7 +36991,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int8u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int8u response", value);
     }
 };
 
@@ -34518,7 +37009,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34546,7 +37037,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34585,7 +37076,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34595,7 +37086,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int16u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int16u response", value);
     }
 };
 
@@ -34613,7 +37104,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34641,7 +37132,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34680,7 +37171,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34690,7 +37181,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int24u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int24u response", value);
     }
 };
 
@@ -34708,7 +37199,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34736,7 +37227,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34775,7 +37266,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34785,7 +37276,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int32u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int32u response", value);
     }
 };
 
@@ -34803,7 +37294,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34831,7 +37322,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34870,7 +37361,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34880,7 +37371,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int40u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int40u response", value);
     }
 };
 
@@ -34898,7 +37389,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34926,7 +37417,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34965,7 +37456,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -34975,7 +37466,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int48u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int48u response", value);
     }
 };
 
@@ -34993,7 +37484,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35021,7 +37512,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35060,7 +37551,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35070,7 +37561,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int56u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int56u response", value);
     }
 };
 
@@ -35088,7 +37579,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35116,7 +37607,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35155,7 +37646,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35165,7 +37656,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int64u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int64u response", value);
     }
 };
 
@@ -35183,7 +37674,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35211,7 +37702,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35250,7 +37741,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35260,7 +37751,7 @@ public:
 
     static void OnAttributeResponse(void * context, int8_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int8s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int8s response", value);
     }
 };
 
@@ -35278,7 +37769,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35306,7 +37797,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35345,7 +37836,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35355,7 +37846,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int16s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int16s response", value);
     }
 };
 
@@ -35373,7 +37864,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35401,7 +37892,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35440,7 +37931,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35450,7 +37941,7 @@ public:
 
     static void OnAttributeResponse(void * context, int32_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int24s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int24s response", value);
     }
 };
 
@@ -35468,7 +37959,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35496,7 +37987,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35535,7 +38026,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35545,7 +38036,7 @@ public:
 
     static void OnAttributeResponse(void * context, int32_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int32s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int32s response", value);
     }
 };
 
@@ -35563,7 +38054,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35591,7 +38082,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35630,7 +38121,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35640,7 +38131,7 @@ public:
 
     static void OnAttributeResponse(void * context, int64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int40s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int40s response", value);
     }
 };
 
@@ -35658,7 +38149,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35686,7 +38177,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35725,7 +38216,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35735,7 +38226,7 @@ public:
 
     static void OnAttributeResponse(void * context, int64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int48s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int48s response", value);
     }
 };
 
@@ -35753,7 +38244,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35781,7 +38272,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35820,7 +38311,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35830,7 +38321,7 @@ public:
 
     static void OnAttributeResponse(void * context, int64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int56s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int56s response", value);
     }
 };
 
@@ -35848,7 +38339,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35876,7 +38367,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35915,7 +38406,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35925,7 +38416,7 @@ public:
 
     static void OnAttributeResponse(void * context, int64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Int64s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Int64s response", value);
     }
 };
 
@@ -35943,7 +38434,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -35971,7 +38462,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36010,7 +38501,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36020,7 +38511,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Enum8 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Enum8 response", value);
     }
 };
 
@@ -36038,7 +38529,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36066,7 +38557,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36105,7 +38596,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36115,7 +38606,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Enum16 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Enum16 response", value);
     }
 };
 
@@ -36133,7 +38624,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36161,7 +38652,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36200,7 +38691,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36210,7 +38701,7 @@ public:
 
     static void OnAttributeResponse(void * context, float value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.FloatSingle response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.FloatSingle response", value);
     }
 };
 
@@ -36228,7 +38719,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36256,7 +38747,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36295,7 +38786,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36305,7 +38796,7 @@ public:
 
     static void OnAttributeResponse(void * context, double value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.FloatDouble response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.FloatDouble response", value);
     }
 };
 
@@ -36323,7 +38814,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36351,7 +38842,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36390,7 +38881,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36400,7 +38891,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.OctetString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.OctetString response", value);
     }
 };
 
@@ -36418,7 +38909,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36446,7 +38937,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36485,7 +38976,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36495,7 +38986,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.ListInt8u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.ListInt8u response", value);
     }
 };
 
@@ -36515,7 +39006,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36557,7 +39048,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36567,7 +39058,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.ListOctetString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.ListOctetString response", value);
     }
 };
 
@@ -36587,7 +39078,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36629,7 +39120,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36642,7 +39133,7 @@ public:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
             value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.ListStructOctetString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.ListStructOctetString response", value);
     }
 };
 
@@ -36662,7 +39153,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36707,7 +39198,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36717,7 +39208,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.LongOctetString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.LongOctetString response", value);
     }
 };
 
@@ -36735,7 +39226,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36763,7 +39254,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36802,7 +39293,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36812,7 +39303,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.CharString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.CharString response", value);
     }
 };
 
@@ -36830,7 +39321,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36858,7 +39349,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36897,7 +39388,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36907,7 +39398,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.LongCharString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.LongCharString response", value);
     }
 };
 
@@ -36925,7 +39416,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36953,7 +39444,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -36992,7 +39483,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37002,7 +39493,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.EpochUs response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.EpochUs response", value);
     }
 };
 
@@ -37020,7 +39511,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37048,7 +39539,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37087,7 +39578,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37097,7 +39588,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.EpochS response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.EpochS response", value);
     }
 };
 
@@ -37115,7 +39606,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37143,7 +39634,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37182,7 +39673,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37192,7 +39683,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::VendorId value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.VendorId response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.VendorId response", value);
     }
 };
 
@@ -37210,7 +39701,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37238,7 +39729,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37277,7 +39768,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37290,7 +39781,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.ListNullablesAndOptionalsStruct response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.ListNullablesAndOptionalsStruct response", value);
     }
 };
 
@@ -37310,7 +39801,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37354,7 +39845,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37364,7 +39855,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::app::Clusters::TestCluster::SimpleEnum value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.EnumAttr response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.EnumAttr response", value);
     }
 };
 
@@ -37382,7 +39873,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37410,7 +39901,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37452,7 +39943,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37462,7 +39953,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt8u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.RangeRestrictedInt8u response", value);
     }
 };
 
@@ -37480,7 +39971,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37508,7 +39999,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37547,7 +40038,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37557,7 +40048,7 @@ public:
 
     static void OnAttributeResponse(void * context, int8_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt8s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.RangeRestrictedInt8s response", value);
     }
 };
 
@@ -37575,7 +40066,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37603,7 +40094,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37642,7 +40133,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37652,7 +40143,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt16u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.RangeRestrictedInt16u response", value);
     }
 };
 
@@ -37670,7 +40161,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37698,7 +40189,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37737,7 +40228,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37747,7 +40238,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.RangeRestrictedInt16s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.RangeRestrictedInt16s response", value);
     }
 };
 
@@ -37765,7 +40256,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37793,7 +40284,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37832,7 +40323,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37842,7 +40333,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.ListLongOctetString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.ListLongOctetString response", value);
     }
 };
 
@@ -37862,7 +40353,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37872,7 +40363,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.TimedWriteBoolean response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.TimedWriteBoolean response", value);
     }
 };
 
@@ -37890,7 +40381,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37918,7 +40409,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37928,7 +40419,7 @@ public:
 
     static void OnAttributeResponse(void * context, bool value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.Unsupported response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.Unsupported response", value);
     }
 };
 
@@ -37946,7 +40437,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -37974,7 +40465,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38013,7 +40504,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38023,7 +40514,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<bool> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableBoolean response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableBoolean response", value);
     }
 };
 
@@ -38041,7 +40532,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38069,7 +40560,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38111,7 +40602,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38121,7 +40612,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap8 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableBitmap8 response", value);
     }
 };
 
@@ -38139,7 +40630,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38167,7 +40658,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38209,7 +40700,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38219,7 +40710,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap16 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableBitmap16 response", value);
     }
 };
 
@@ -38237,7 +40728,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38265,7 +40756,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38307,7 +40798,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38317,7 +40808,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap32 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableBitmap32 response", value);
     }
 };
 
@@ -38335,7 +40826,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38363,7 +40854,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38405,7 +40896,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38415,7 +40906,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableBitmap64 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableBitmap64 response", value);
     }
 };
 
@@ -38433,7 +40924,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38461,7 +40952,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38503,7 +40994,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38513,7 +41004,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt8u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt8u response", value);
     }
 };
 
@@ -38531,7 +41022,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38559,7 +41050,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38601,7 +41092,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38611,7 +41102,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt16u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt16u response", value);
     }
 };
 
@@ -38629,7 +41120,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38657,7 +41148,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38699,7 +41190,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38709,7 +41200,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt24u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt24u response", value);
     }
 };
 
@@ -38727,7 +41218,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38755,7 +41246,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38797,7 +41288,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38807,7 +41298,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt32u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt32u response", value);
     }
 };
 
@@ -38825,7 +41316,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38853,7 +41344,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38895,7 +41386,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38905,7 +41396,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt40u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt40u response", value);
     }
 };
 
@@ -38923,7 +41414,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38951,7 +41442,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -38993,7 +41484,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39003,7 +41494,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt48u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt48u response", value);
     }
 };
 
@@ -39021,7 +41512,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39049,7 +41540,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39091,7 +41582,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39101,7 +41592,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt56u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt56u response", value);
     }
 };
 
@@ -39119,7 +41610,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39147,7 +41638,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39189,7 +41680,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39199,7 +41690,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt64u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt64u response", value);
     }
 };
 
@@ -39217,7 +41708,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39245,7 +41736,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39287,7 +41778,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39297,7 +41788,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt8s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt8s response", value);
     }
 };
 
@@ -39315,7 +41806,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39343,7 +41834,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39385,7 +41876,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39395,7 +41886,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt16s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt16s response", value);
     }
 };
 
@@ -39413,7 +41904,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39441,7 +41932,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39483,7 +41974,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39493,7 +41984,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt24s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt24s response", value);
     }
 };
 
@@ -39511,7 +42002,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39539,7 +42030,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39581,7 +42072,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39591,7 +42082,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int32_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt32s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt32s response", value);
     }
 };
 
@@ -39609,7 +42100,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39637,7 +42128,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39679,7 +42170,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39689,7 +42180,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt40s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt40s response", value);
     }
 };
 
@@ -39707,7 +42198,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39735,7 +42226,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39777,7 +42268,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39787,7 +42278,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt48s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt48s response", value);
     }
 };
 
@@ -39805,7 +42296,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39833,7 +42324,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39875,7 +42366,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39885,7 +42376,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt56s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt56s response", value);
     }
 };
 
@@ -39903,7 +42394,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39931,7 +42422,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39973,7 +42464,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -39983,7 +42474,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int64_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableInt64s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableInt64s response", value);
     }
 };
 
@@ -40001,7 +42492,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40029,7 +42520,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40071,7 +42562,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40081,7 +42572,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableEnum8 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableEnum8 response", value);
     }
 };
 
@@ -40099,7 +42590,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40127,7 +42618,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40169,7 +42660,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40179,7 +42670,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableEnum16 response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableEnum16 response", value);
     }
 };
 
@@ -40197,7 +42688,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40225,7 +42716,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40267,7 +42758,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40277,7 +42768,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<float> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableFloatSingle response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableFloatSingle response", value);
     }
 };
 
@@ -40295,7 +42786,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40323,7 +42814,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40365,7 +42856,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40375,7 +42866,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<double> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableFloatDouble response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableFloatDouble response", value);
     }
 };
 
@@ -40393,7 +42884,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40421,7 +42912,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40463,7 +42954,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40473,7 +42964,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableOctetString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableOctetString response", value);
     }
 };
 
@@ -40491,7 +42982,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40519,7 +43010,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40561,7 +43052,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40571,7 +43062,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableCharString response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableCharString response", value);
     }
 };
 
@@ -40589,7 +43080,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40617,7 +43108,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40659,7 +43150,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40670,7 +43161,7 @@ public:
     static void OnAttributeResponse(void * context,
                                     const chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableEnumAttr response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableEnumAttr response", value);
     }
 };
 
@@ -40688,7 +43179,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40716,7 +43207,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40759,7 +43250,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40769,7 +43260,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt8u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableRangeRestrictedInt8u response", value);
     }
 };
 
@@ -40787,7 +43278,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40815,7 +43306,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40857,7 +43348,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40867,7 +43358,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int8_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt8s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableRangeRestrictedInt8s response", value);
     }
 };
 
@@ -40885,7 +43376,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40913,7 +43404,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40955,7 +43446,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -40965,7 +43456,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt16u response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableRangeRestrictedInt16u response", value);
     }
 };
 
@@ -40983,7 +43474,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41011,7 +43502,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41053,7 +43544,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41063,7 +43554,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<int16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.NullableRangeRestrictedInt16s response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.NullableRangeRestrictedInt16s response", value);
     }
 };
 
@@ -41081,7 +43572,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41109,7 +43600,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41151,7 +43642,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41161,7 +43652,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.AttributeList response", value);
     }
 };
 
@@ -41181,7 +43672,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41191,7 +43682,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "TestCluster.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "TestCluster.ClusterRevision response", value);
     }
 };
 
@@ -41211,7 +43702,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x050F) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x050F) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41265,6 +43756,8 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -41407,7 +43900,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41417,7 +43910,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.LocalTemperature response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.LocalTemperature response", value);
     }
 };
 
@@ -41437,7 +43930,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41476,7 +43969,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41486,7 +43979,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.AbsMinHeatSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.AbsMinHeatSetpointLimit response", value);
     }
 };
 
@@ -41506,7 +43999,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41545,7 +44038,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41555,7 +44048,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.AbsMaxHeatSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.AbsMaxHeatSetpointLimit response", value);
     }
 };
 
@@ -41575,7 +44068,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41614,7 +44107,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41624,7 +44117,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.AbsMinCoolSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.AbsMinCoolSetpointLimit response", value);
     }
 };
 
@@ -41644,7 +44137,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41683,7 +44176,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41693,7 +44186,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.AbsMaxCoolSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.AbsMaxCoolSetpointLimit response", value);
     }
 };
 
@@ -41713,7 +44206,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41752,7 +44245,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41762,7 +44255,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.OccupiedCoolingSetpoint response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.OccupiedCoolingSetpoint response", value);
     }
 };
 
@@ -41780,7 +44273,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41808,7 +44301,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41847,7 +44340,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41857,7 +44350,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.OccupiedHeatingSetpoint response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.OccupiedHeatingSetpoint response", value);
     }
 };
 
@@ -41875,7 +44368,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41903,7 +44396,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41942,7 +44435,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41952,7 +44445,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.MinHeatSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.MinHeatSetpointLimit response", value);
     }
 };
 
@@ -41970,7 +44463,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -41998,7 +44491,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42037,7 +44530,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42047,7 +44540,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.MaxHeatSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.MaxHeatSetpointLimit response", value);
     }
 };
 
@@ -42065,7 +44558,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42093,7 +44586,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42132,7 +44625,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42142,7 +44635,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.MinCoolSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.MinCoolSetpointLimit response", value);
     }
 };
 
@@ -42160,7 +44653,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42188,7 +44681,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42227,7 +44720,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42237,7 +44730,7 @@ public:
 
     static void OnAttributeResponse(void * context, int16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.MaxCoolSetpointLimit response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.MaxCoolSetpointLimit response", value);
     }
 };
 
@@ -42255,7 +44748,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42283,7 +44776,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42322,7 +44815,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42332,7 +44825,7 @@ public:
 
     static void OnAttributeResponse(void * context, int8_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.MinSetpointDeadBand response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.MinSetpointDeadBand response", value);
     }
 };
 
@@ -42350,7 +44843,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42378,7 +44871,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42417,7 +44910,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42427,7 +44920,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.ControlSequenceOfOperation response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.ControlSequenceOfOperation response", value);
     }
 };
 
@@ -42445,7 +44938,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42473,7 +44966,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42512,7 +45005,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42522,7 +45015,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.SystemMode response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.SystemMode response", value);
     }
 };
 
@@ -42540,7 +45033,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42568,7 +45061,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42607,7 +45100,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42617,7 +45110,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.StartOfWeek response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.StartOfWeek response", value);
     }
 };
 
@@ -42637,7 +45130,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42676,7 +45169,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42686,7 +45179,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.NumberOfWeeklyTransitions response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.NumberOfWeeklyTransitions response", value);
     }
 };
 
@@ -42706,7 +45199,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42745,7 +45238,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42755,7 +45248,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.NumberOfDailyTransitions response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.NumberOfDailyTransitions response", value);
     }
 };
 
@@ -42775,7 +45268,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42814,7 +45307,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42824,7 +45317,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.AttributeList response", value);
     }
 };
 
@@ -42844,7 +45337,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42854,7 +45347,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.FeatureMap response", value);
     }
 };
 
@@ -42874,7 +45367,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42913,7 +45406,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42923,7 +45416,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "Thermostat.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "Thermostat.ClusterRevision response", value);
     }
 };
 
@@ -42943,7 +45436,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0201) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0201) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatCluster cluster;
         cluster.Associate(device, endpointId);
@@ -42977,6 +45470,8 @@ private:
 | * ScheduleProgrammingVisibility                                     | 0x0002 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -42995,7 +45490,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43006,7 +45501,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.TemperatureDisplayMode response", value);
+        OnGeneralAttributeEventResponse(context, "ThermostatUserInterfaceConfiguration.TemperatureDisplayMode response", value);
     }
 };
 
@@ -43024,7 +45519,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43053,7 +45548,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43096,7 +45591,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43107,7 +45602,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.KeypadLockout response", value);
+        OnGeneralAttributeEventResponse(context, "ThermostatUserInterfaceConfiguration.KeypadLockout response", value);
     }
 };
 
@@ -43125,7 +45620,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43154,7 +45649,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43197,7 +45692,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43208,7 +45703,8 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.ScheduleProgrammingVisibility response", value);
+        OnGeneralAttributeEventResponse(context, "ThermostatUserInterfaceConfiguration.ScheduleProgrammingVisibility response",
+                                        value);
     }
 };
 
@@ -43226,7 +45722,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43255,7 +45751,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43298,7 +45794,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43309,7 +45805,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ThermostatUserInterfaceConfiguration.AttributeList response", value);
     }
 };
 
@@ -43329,7 +45825,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43340,7 +45836,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThermostatUserInterfaceConfiguration.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ThermostatUserInterfaceConfiguration.ClusterRevision response", value);
     }
 };
 
@@ -43360,7 +45856,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0204) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0204) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43460,6 +45956,9 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * ConnectionStatus                                                  | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -43483,6 +45982,37 @@ private:
 };
 
 /*
+ * Event ConnectionStatus
+ */
+class ReadThreadNetworkDiagnosticsConnectionStatus : public ModelCommand
+{
+public:
+    ReadThreadNetworkDiagnosticsConnectionStatus() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "connection-status");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadThreadNetworkDiagnosticsConnectionStatus() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::ThreadNetworkDiagnostics::Events::ConnectionStatus::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::ThreadNetworkDiagnostics::Events::ConnectionStatus::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ConnectionStatus response", value);
+    }
+};
+
+/*
  * Attribute Channel
  */
 class ReadThreadNetworkDiagnosticsChannel : public ModelCommand
@@ -43498,7 +46028,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43508,7 +46038,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.Channel response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.Channel response", value);
     }
 };
 
@@ -43528,7 +46058,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43567,7 +46097,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43577,7 +46107,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RoutingRole response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RoutingRole response", value);
     }
 };
 
@@ -43597,7 +46127,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43636,7 +46166,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43646,7 +46176,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.NetworkName response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.NetworkName response", value);
     }
 };
 
@@ -43666,7 +46196,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43708,7 +46238,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43718,7 +46248,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PanId response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.PanId response", value);
     }
 };
 
@@ -43738,7 +46268,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43777,7 +46307,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43787,7 +46317,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ExtendedPanId response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ExtendedPanId response", value);
     }
 };
 
@@ -43807,7 +46337,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43849,7 +46379,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43859,7 +46389,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.MeshLocalPrefix response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.MeshLocalPrefix response", value);
     }
 };
 
@@ -43879,7 +46409,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43921,7 +46451,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43931,7 +46461,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.OverrunCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.OverrunCount response", value);
     }
 };
 
@@ -43951,7 +46481,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -43993,7 +46523,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44006,7 +46536,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.NeighborTableList response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.NeighborTableList response", value);
     }
 };
 
@@ -44026,7 +46556,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44070,7 +46600,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44082,7 +46612,7 @@ public:
                                     const chip::app::DataModel::DecodableList<
                                         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RouteTableList response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RouteTableList response", value);
     }
 };
 
@@ -44102,7 +46632,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44146,7 +46676,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44156,7 +46686,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PartitionId response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.PartitionId response", value);
     }
 };
 
@@ -44176,7 +46706,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44215,7 +46745,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44225,7 +46755,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.Weighting response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.Weighting response", value);
     }
 };
 
@@ -44245,7 +46775,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44284,7 +46814,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44294,7 +46824,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.DataVersion response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.DataVersion response", value);
     }
 };
 
@@ -44314,7 +46844,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44353,7 +46883,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44363,7 +46893,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.StableDataVersion response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.StableDataVersion response", value);
     }
 };
 
@@ -44383,7 +46913,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44425,7 +46955,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44435,7 +46965,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.LeaderRouterId response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.LeaderRouterId response", value);
     }
 };
 
@@ -44455,7 +46985,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44497,7 +47027,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44507,7 +47037,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.DetachedRoleCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.DetachedRoleCount response", value);
     }
 };
 
@@ -44527,7 +47057,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44569,7 +47099,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44579,7 +47109,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ChildRoleCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ChildRoleCount response", value);
     }
 };
 
@@ -44599,7 +47129,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44641,7 +47171,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44651,7 +47181,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RouterRoleCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RouterRoleCount response", value);
     }
 };
 
@@ -44671,7 +47201,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44713,7 +47243,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44723,7 +47253,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.LeaderRoleCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.LeaderRoleCount response", value);
     }
 };
 
@@ -44743,7 +47273,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44785,7 +47315,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44795,7 +47325,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.AttachAttemptCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.AttachAttemptCount response", value);
     }
 };
 
@@ -44815,7 +47345,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44857,7 +47387,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44867,7 +47397,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PartitionIdChangeCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.PartitionIdChangeCount response", value);
     }
 };
 
@@ -44887,7 +47417,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44930,7 +47460,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -44941,7 +47471,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.BetterPartitionAttachAttemptCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.BetterPartitionAttachAttemptCount response", value);
     }
 };
 
@@ -44961,7 +47491,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45004,7 +47534,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45014,7 +47544,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ParentChangeCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ParentChangeCount response", value);
     }
 };
 
@@ -45034,7 +47564,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45076,7 +47606,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45086,7 +47616,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxTotalCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxTotalCount response", value);
     }
 };
 
@@ -45106,7 +47636,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45148,7 +47678,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45158,7 +47688,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxUnicastCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxUnicastCount response", value);
     }
 };
 
@@ -45178,7 +47708,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45220,7 +47750,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45230,7 +47760,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxBroadcastCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxBroadcastCount response", value);
     }
 };
 
@@ -45250,7 +47780,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45292,7 +47822,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45302,7 +47832,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxAckRequestedCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxAckRequestedCount response", value);
     }
 };
 
@@ -45322,7 +47852,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45364,7 +47894,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45374,7 +47904,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxAckedCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxAckedCount response", value);
     }
 };
 
@@ -45394,7 +47924,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45436,7 +47966,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45446,7 +47976,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxNoAckRequestedCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxNoAckRequestedCount response", value);
     }
 };
 
@@ -45466,7 +47996,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45509,7 +48039,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45519,7 +48049,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxDataCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxDataCount response", value);
     }
 };
 
@@ -45539,7 +48069,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45578,7 +48108,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45588,7 +48118,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxDataPollCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxDataPollCount response", value);
     }
 };
 
@@ -45608,7 +48138,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45650,7 +48180,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45660,7 +48190,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxBeaconCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxBeaconCount response", value);
     }
 };
 
@@ -45680,7 +48210,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45722,7 +48252,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45732,7 +48262,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxBeaconRequestCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxBeaconRequestCount response", value);
     }
 };
 
@@ -45752,7 +48282,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45795,7 +48325,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45805,7 +48335,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxOtherCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxOtherCount response", value);
     }
 };
 
@@ -45825,7 +48355,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45867,7 +48397,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45877,7 +48407,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxRetryCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxRetryCount response", value);
     }
 };
 
@@ -45897,7 +48427,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45939,7 +48469,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -45950,7 +48480,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxDirectMaxRetryExpiryCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxDirectMaxRetryExpiryCount response", value);
     }
 };
 
@@ -45970,7 +48500,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46013,7 +48543,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46024,7 +48554,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxIndirectMaxRetryExpiryCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxIndirectMaxRetryExpiryCount response", value);
     }
 };
 
@@ -46044,7 +48574,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46087,7 +48617,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46097,7 +48627,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxErrCcaCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxErrCcaCount response", value);
     }
 };
 
@@ -46117,7 +48647,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46159,7 +48689,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46169,7 +48699,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxErrAbortCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxErrAbortCount response", value);
     }
 };
 
@@ -46189,7 +48719,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46231,7 +48761,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46241,7 +48771,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.TxErrBusyChannelCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.TxErrBusyChannelCount response", value);
     }
 };
 
@@ -46261,7 +48791,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46304,7 +48834,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46314,7 +48844,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxTotalCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxTotalCount response", value);
     }
 };
 
@@ -46334,7 +48864,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46376,7 +48906,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46386,7 +48916,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxUnicastCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxUnicastCount response", value);
     }
 };
 
@@ -46406,7 +48936,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46448,7 +48978,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46458,7 +48988,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxBroadcastCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxBroadcastCount response", value);
     }
 };
 
@@ -46478,7 +49008,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46520,7 +49050,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46530,7 +49060,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDataCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxDataCount response", value);
     }
 };
 
@@ -46550,7 +49080,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46589,7 +49119,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46599,7 +49129,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDataPollCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxDataPollCount response", value);
     }
 };
 
@@ -46619,7 +49149,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46661,7 +49191,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46671,7 +49201,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxBeaconCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxBeaconCount response", value);
     }
 };
 
@@ -46691,7 +49221,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46733,7 +49263,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46743,7 +49273,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxBeaconRequestCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxBeaconRequestCount response", value);
     }
 };
 
@@ -46763,7 +49293,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46806,7 +49336,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46816,7 +49346,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxOtherCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxOtherCount response", value);
     }
 };
 
@@ -46836,7 +49366,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46878,7 +49408,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46888,7 +49418,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxAddressFilteredCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxAddressFilteredCount response", value);
     }
 };
 
@@ -46908,7 +49438,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46951,7 +49481,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -46961,7 +49491,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDestAddrFilteredCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxDestAddrFilteredCount response", value);
     }
 };
 
@@ -46981,7 +49511,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47024,7 +49554,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47034,7 +49564,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxDuplicatedCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxDuplicatedCount response", value);
     }
 };
 
@@ -47054,7 +49584,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47096,7 +49626,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47106,7 +49636,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrNoFrameCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxErrNoFrameCount response", value);
     }
 };
 
@@ -47126,7 +49656,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47168,7 +49698,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47179,7 +49709,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrUnknownNeighborCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxErrUnknownNeighborCount response", value);
     }
 };
 
@@ -47199,7 +49729,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47242,7 +49772,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47252,7 +49782,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrInvalidSrcAddrCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxErrInvalidSrcAddrCount response", value);
     }
 };
 
@@ -47272,7 +49802,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47315,7 +49845,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47325,7 +49855,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrSecCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxErrSecCount response", value);
     }
 };
 
@@ -47345,7 +49875,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47387,7 +49917,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47397,7 +49927,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrFcsCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxErrFcsCount response", value);
     }
 };
 
@@ -47417,7 +49947,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47459,7 +49989,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47469,7 +49999,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.RxErrOtherCount response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.RxErrOtherCount response", value);
     }
 };
 
@@ -47489,7 +50019,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47531,7 +50061,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47541,7 +50071,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ActiveTimestamp response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ActiveTimestamp response", value);
     }
 };
 
@@ -47561,7 +50091,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47603,7 +50133,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47613,7 +50143,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.PendingTimestamp response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.PendingTimestamp response", value);
     }
 };
 
@@ -47633,7 +50163,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47675,7 +50205,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47685,7 +50215,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.Delay response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.Delay response", value);
     }
 };
 
@@ -47705,7 +50235,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47744,7 +50274,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47757,7 +50287,7 @@ public:
                         const chip::app::DataModel::DecodableList<
                             chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.SecurityPolicy response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.SecurityPolicy response", value);
     }
 };
 
@@ -47777,7 +50307,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47821,7 +50351,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47831,7 +50361,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ChannelMask response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ChannelMask response", value);
     }
 };
 
@@ -47851,7 +50381,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47893,7 +50423,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47907,7 +50437,7 @@ public:
         const chip::app::DataModel::DecodableList<
             chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.OperationalDatasetComponents response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.OperationalDatasetComponents response", value);
     }
 };
 
@@ -47927,7 +50457,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47973,7 +50503,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -47985,7 +50515,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFault> & value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ActiveNetworkFaultsList response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ActiveNetworkFaultsList response", value);
     }
 };
 
@@ -48005,7 +50535,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48050,7 +50580,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48060,7 +50590,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.AttributeList response", value);
     }
 };
 
@@ -48080,7 +50610,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48090,7 +50620,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.FeatureMap response", value);
     }
 };
 
@@ -48110,7 +50640,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48120,7 +50650,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "ThreadNetworkDiagnostics.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "ThreadNetworkDiagnostics.ClusterRevision response", value);
     }
 };
 
@@ -48140,7 +50670,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0035) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0035) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48174,6 +50704,8 @@ private:
 | Attributes:                                                         |        |
 | * LabelList                                                         | 0x0000 |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -48192,7 +50724,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0041) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0041) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::UserLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48204,7 +50736,7 @@ public:
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::UserLabel::Structs::LabelStruct::DecodableType> & value)
     {
-        OnGeneralAttributeResponse(context, "UserLabel.LabelList response", value);
+        OnGeneralAttributeEventResponse(context, "UserLabel.LabelList response", value);
     }
 };
 
@@ -48224,7 +50756,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0041) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0041) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::UserLabelCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48234,7 +50766,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "UserLabel.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "UserLabel.ClusterRevision response", value);
     }
 };
 
@@ -48247,6 +50779,8 @@ public:
 | * WakeOnLanMacAddress                                               | 0x0000 |
 | * AttributeList                                                     | 0xFFFB |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -48265,7 +50799,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0503) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0503) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48275,7 +50809,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::CharSpan value)
     {
-        OnGeneralAttributeResponse(context, "WakeOnLan.WakeOnLanMacAddress response", value);
+        OnGeneralAttributeEventResponse(context, "WakeOnLan.WakeOnLanMacAddress response", value);
     }
 };
 
@@ -48295,7 +50829,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0503) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0503) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48334,7 +50868,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0503) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0503) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48344,7 +50878,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "WakeOnLan.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "WakeOnLan.AttributeList response", value);
     }
 };
 
@@ -48364,7 +50898,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0503) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0503) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48374,7 +50908,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WakeOnLan.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "WakeOnLan.ClusterRevision response", value);
     }
 };
 
@@ -48394,7 +50928,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0503) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0503) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WakeOnLanCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48440,6 +50974,11 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
+| * Disconnection                                                     | 0x0000 |
+| * AssociationFailure                                                | 0x0001 |
+| * ConnectionStatus                                                  | 0x0002 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -48463,6 +51002,97 @@ private:
 };
 
 /*
+ * Event Disconnection
+ */
+class ReadWiFiNetworkDiagnosticsDisconnection : public ModelCommand
+{
+public:
+    ReadWiFiNetworkDiagnosticsDisconnection() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "disconnection");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadWiFiNetworkDiagnosticsDisconnection() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::WiFiNetworkDiagnostics::Events::Disconnection::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::WiFiNetworkDiagnostics::Events::Disconnection::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.Disconnection response", value);
+    }
+};
+/*
+ * Event AssociationFailure
+ */
+class ReadWiFiNetworkDiagnosticsAssociationFailure : public ModelCommand
+{
+public:
+    ReadWiFiNetworkDiagnosticsAssociationFailure() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "association-failure");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadWiFiNetworkDiagnosticsAssociationFailure() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::WiFiNetworkDiagnostics::Events::AssociationFailure::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::WiFiNetworkDiagnostics::Events::AssociationFailure::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.AssociationFailure response", value);
+    }
+};
+/*
+ * Event ConnectionStatus
+ */
+class ReadWiFiNetworkDiagnosticsConnectionStatus : public ModelCommand
+{
+public:
+    ReadWiFiNetworkDiagnosticsConnectionStatus() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "connection-status");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadWiFiNetworkDiagnosticsConnectionStatus() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::WiFiNetworkDiagnostics::Events::ConnectionStatus::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::WiFiNetworkDiagnostics::Events::ConnectionStatus::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.ConnectionStatus response", value);
+    }
+};
+
+/*
  * Attribute Bssid
  */
 class ReadWiFiNetworkDiagnosticsBssid : public ModelCommand
@@ -48478,7 +51108,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48488,7 +51118,7 @@ public:
 
     static void OnAttributeResponse(void * context, chip::ByteSpan value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.Bssid response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.Bssid response", value);
     }
 };
 
@@ -48508,7 +51138,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48547,7 +51177,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48557,7 +51187,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.SecurityType response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.SecurityType response", value);
     }
 };
 
@@ -48577,7 +51207,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48616,7 +51246,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48626,7 +51256,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.WiFiVersion response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.WiFiVersion response", value);
     }
 };
 
@@ -48646,7 +51276,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48685,7 +51315,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48695,7 +51325,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.ChannelNumber response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.ChannelNumber response", value);
     }
 };
 
@@ -48715,7 +51345,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48754,7 +51384,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48764,7 +51394,7 @@ public:
 
     static void OnAttributeResponse(void * context, int8_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.Rssi response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.Rssi response", value);
     }
 };
 
@@ -48784,7 +51414,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48823,7 +51453,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48833,7 +51463,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.BeaconLostCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.BeaconLostCount response", value);
     }
 };
 
@@ -48853,7 +51483,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48895,7 +51525,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48905,7 +51535,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.BeaconRxCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.BeaconRxCount response", value);
     }
 };
 
@@ -48925,7 +51555,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48964,7 +51594,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -48974,7 +51604,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketMulticastRxCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.PacketMulticastRxCount response", value);
     }
 };
 
@@ -48994,7 +51624,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49037,7 +51667,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49047,7 +51677,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketMulticastTxCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.PacketMulticastTxCount response", value);
     }
 };
 
@@ -49067,7 +51697,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49110,7 +51740,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49120,7 +51750,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketUnicastRxCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.PacketUnicastRxCount response", value);
     }
 };
 
@@ -49140,7 +51770,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49182,7 +51812,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49192,7 +51822,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.PacketUnicastTxCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.PacketUnicastTxCount response", value);
     }
 };
 
@@ -49212,7 +51842,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49254,7 +51884,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49264,7 +51894,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.CurrentMaxRate response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.CurrentMaxRate response", value);
     }
 };
 
@@ -49284,7 +51914,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49326,7 +51956,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49336,7 +51966,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint64_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.OverrunCount response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.OverrunCount response", value);
     }
 };
 
@@ -49356,7 +51986,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49395,7 +52025,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49405,7 +52035,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.AttributeList response", value);
     }
 };
 
@@ -49425,7 +52055,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49435,7 +52065,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.FeatureMap response", value);
     }
 };
 
@@ -49455,7 +52085,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49465,7 +52095,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WiFiNetworkDiagnostics.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "WiFiNetworkDiagnostics.ClusterRevision response", value);
     }
 };
 
@@ -49485,7 +52115,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0036) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0036) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49545,6 +52175,8 @@ private:
 | * AttributeList                                                     | 0xFFFB |
 | * FeatureMap                                                        | 0xFFFC |
 | * ClusterRevision                                                   | 0xFFFD |
+|------------------------------------------------------------------------------|
+| Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -49721,7 +52353,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49731,7 +52363,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.Type response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.Type response", value);
     }
 };
 
@@ -49751,7 +52383,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49790,7 +52422,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49800,7 +52432,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionLift response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.CurrentPositionLift response", value);
     }
 };
 
@@ -49820,7 +52452,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49862,7 +52494,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49872,7 +52504,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<uint16_t> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionTilt response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.CurrentPositionTilt response", value);
     }
 };
 
@@ -49892,7 +52524,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49934,7 +52566,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -49944,7 +52576,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.ConfigStatus response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.ConfigStatus response", value);
     }
 };
 
@@ -49964,7 +52596,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50003,7 +52635,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50013,7 +52645,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::Percent> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionLiftPercentage response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.CurrentPositionLiftPercentage response", value);
     }
 };
 
@@ -50033,7 +52665,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50075,7 +52707,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50085,7 +52717,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::Percent> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionTiltPercentage response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.CurrentPositionTiltPercentage response", value);
     }
 };
 
@@ -50105,7 +52737,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50147,7 +52779,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50157,7 +52789,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.OperationalStatus response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.OperationalStatus response", value);
     }
 };
 
@@ -50177,7 +52809,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50216,7 +52848,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50226,7 +52858,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.TargetPositionLiftPercent100ths response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.TargetPositionLiftPercent100ths response", value);
     }
 };
 
@@ -50246,7 +52878,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50289,7 +52921,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50299,7 +52931,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.TargetPositionTiltPercent100ths response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.TargetPositionTiltPercent100ths response", value);
     }
 };
 
@@ -50319,7 +52951,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50362,7 +52994,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50372,7 +53004,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.EndProductType response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.EndProductType response", value);
     }
 };
 
@@ -50392,7 +53024,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50431,7 +53063,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50441,7 +53073,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionLiftPercent100ths response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.CurrentPositionLiftPercent100ths response", value);
     }
 };
 
@@ -50461,7 +53093,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50504,7 +53136,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50514,7 +53146,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::Nullable<chip::Percent100ths> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.CurrentPositionTiltPercent100ths response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.CurrentPositionTiltPercent100ths response", value);
     }
 };
 
@@ -50534,7 +53166,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50577,7 +53209,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50587,7 +53219,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.InstalledOpenLimitLift response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.InstalledOpenLimitLift response", value);
     }
 };
 
@@ -50607,7 +53239,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50649,7 +53281,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50659,7 +53291,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.InstalledClosedLimitLift response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.InstalledClosedLimitLift response", value);
     }
 };
 
@@ -50679,7 +53311,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50721,7 +53353,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50731,7 +53363,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.InstalledOpenLimitTilt response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.InstalledOpenLimitTilt response", value);
     }
 };
 
@@ -50751,7 +53383,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50793,7 +53425,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50803,7 +53435,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.InstalledClosedLimitTilt response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.InstalledClosedLimitTilt response", value);
     }
 };
 
@@ -50823,7 +53455,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50865,7 +53497,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50875,7 +53507,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint8_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.Mode response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.Mode response", value);
     }
 };
 
@@ -50893,7 +53525,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x01) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) WriteAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50921,7 +53553,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50960,7 +53592,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -50970,7 +53602,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.SafetyStatus response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.SafetyStatus response", value);
     }
 };
 
@@ -50990,7 +53622,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -51029,7 +53661,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -51039,7 +53671,7 @@ public:
 
     static void OnAttributeResponse(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.AttributeList response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.AttributeList response", value);
     }
 };
 
@@ -51059,7 +53691,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -51069,7 +53701,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint32_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.FeatureMap response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.FeatureMap response", value);
     }
 };
 
@@ -51089,7 +53721,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -51128,7 +53760,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x00) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReadAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -51138,7 +53770,7 @@ public:
 
     static void OnAttributeResponse(void * context, uint16_t value)
     {
-        OnGeneralAttributeResponse(context, "WindowCovering.ClusterRevision response", value);
+        OnGeneralAttributeEventResponse(context, "WindowCovering.ClusterRevision response", value);
     }
 };
 
@@ -51158,7 +53790,7 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        ChipLogProgress(chipTool, "Sending cluster (0x0102) command (0x06) on endpoint %" PRIu8, endpointId);
+        ChipLogProgress(chipTool, "Sending cluster (0x0102) ReportAttribute on endpoint %" PRIu8, endpointId);
 
         chip::Controller::WindowCoveringCluster cluster;
         cluster.Associate(device, endpointId);
@@ -51359,6 +53991,10 @@ void registerClusterBasic(Commands & commands)
         make_unique<ReadBasicAttributeList>(),             //
         make_unique<ReadBasicClusterRevision>(),           //
         make_unique<ReportBasicClusterRevision>(),         //
+        make_unique<ReadBasicStartUp>(),                   //
+        make_unique<ReadBasicShutDown>(),                  //
+        make_unique<ReadBasicLeave>(),                     //
+        make_unique<ReadBasicReachableChanged>(),          //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -51407,6 +54043,7 @@ void registerClusterBooleanState(Commands & commands)
         make_unique<ReadBooleanStateAttributeList>(),     //
         make_unique<ReadBooleanStateClusterRevision>(),   //
         make_unique<ReportBooleanStateClusterRevision>(), //
+        make_unique<ReadBooleanStateStateChange>(),       //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -51435,6 +54072,8 @@ void registerClusterBridgedActions(Commands & commands)
         make_unique<ReadBridgedActionsAttributeList>(),           //
         make_unique<ReadBridgedActionsClusterRevision>(),         //
         make_unique<ReportBridgedActionsClusterRevision>(),       //
+        make_unique<ReadBridgedActionsStateChanged>(),            //
+        make_unique<ReadBridgedActionsActionFailed>(),            //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -51710,6 +54349,11 @@ void registerClusterDoorLock(Commands & commands)
         make_unique<ReadDoorLockAttributeList>(),               //
         make_unique<ReadDoorLockClusterRevision>(),             //
         make_unique<ReportDoorLockClusterRevision>(),           //
+        make_unique<ReadDoorLockDoorLockAlarm>(),               //
+        make_unique<ReadDoorLockDoorStateChange>(),             //
+        make_unique<ReadDoorLockLockOperation>(),               //
+        make_unique<ReadDoorLockLockOperationError>(),          //
+        make_unique<ReadDoorLockLockUserChange>(),              //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -51854,6 +54498,10 @@ void registerClusterGeneralDiagnostics(Commands & commands)
         make_unique<ReadGeneralDiagnosticsAttributeList>(),           //
         make_unique<ReadGeneralDiagnosticsClusterRevision>(),         //
         make_unique<ReportGeneralDiagnosticsClusterRevision>(),       //
+        make_unique<ReadGeneralDiagnosticsHardwareFaultChange>(),     //
+        make_unique<ReadGeneralDiagnosticsRadioFaultChange>(),        //
+        make_unique<ReadGeneralDiagnosticsNetworkFaultChange>(),      //
+        make_unique<ReadGeneralDiagnosticsBootReason>(),              //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -52168,6 +54816,9 @@ void registerClusterOtaSoftwareUpdateRequestor(Commands & commands)
         make_unique<ReadOtaSoftwareUpdateRequestorAttributeList>(),         //
         make_unique<ReadOtaSoftwareUpdateRequestorClusterRevision>(),       //
         make_unique<ReportOtaSoftwareUpdateRequestorClusterRevision>(),     //
+        make_unique<ReadOtaSoftwareUpdateRequestorStateTransition>(),       //
+        make_unique<ReadOtaSoftwareUpdateRequestorVersionApplied>(),        //
+        make_unique<ReadOtaSoftwareUpdateRequestorDownloadError>(),         //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -52335,63 +54986,80 @@ void registerClusterPumpConfigurationAndControl(Commands & commands)
     const char * clusterName = "PumpConfigurationAndControl";
 
     commands_list clusterCommands = {
-        make_unique<ReadPumpConfigurationAndControlMaxPressure>(),              //
-        make_unique<ReportPumpConfigurationAndControlMaxPressure>(),            //
-        make_unique<ReadPumpConfigurationAndControlMaxSpeed>(),                 //
-        make_unique<ReportPumpConfigurationAndControlMaxSpeed>(),               //
-        make_unique<ReadPumpConfigurationAndControlMaxFlow>(),                  //
-        make_unique<ReportPumpConfigurationAndControlMaxFlow>(),                //
-        make_unique<ReadPumpConfigurationAndControlMinConstPressure>(),         //
-        make_unique<ReportPumpConfigurationAndControlMinConstPressure>(),       //
-        make_unique<ReadPumpConfigurationAndControlMaxConstPressure>(),         //
-        make_unique<ReportPumpConfigurationAndControlMaxConstPressure>(),       //
-        make_unique<ReadPumpConfigurationAndControlMinCompPressure>(),          //
-        make_unique<ReportPumpConfigurationAndControlMinCompPressure>(),        //
-        make_unique<ReadPumpConfigurationAndControlMaxCompPressure>(),          //
-        make_unique<ReportPumpConfigurationAndControlMaxCompPressure>(),        //
-        make_unique<ReadPumpConfigurationAndControlMinConstSpeed>(),            //
-        make_unique<ReportPumpConfigurationAndControlMinConstSpeed>(),          //
-        make_unique<ReadPumpConfigurationAndControlMaxConstSpeed>(),            //
-        make_unique<ReportPumpConfigurationAndControlMaxConstSpeed>(),          //
-        make_unique<ReadPumpConfigurationAndControlMinConstFlow>(),             //
-        make_unique<ReportPumpConfigurationAndControlMinConstFlow>(),           //
-        make_unique<ReadPumpConfigurationAndControlMaxConstFlow>(),             //
-        make_unique<ReportPumpConfigurationAndControlMaxConstFlow>(),           //
-        make_unique<ReadPumpConfigurationAndControlMinConstTemp>(),             //
-        make_unique<ReportPumpConfigurationAndControlMinConstTemp>(),           //
-        make_unique<ReadPumpConfigurationAndControlMaxConstTemp>(),             //
-        make_unique<ReportPumpConfigurationAndControlMaxConstTemp>(),           //
-        make_unique<ReadPumpConfigurationAndControlPumpStatus>(),               //
-        make_unique<ReportPumpConfigurationAndControlPumpStatus>(),             //
-        make_unique<ReadPumpConfigurationAndControlEffectiveOperationMode>(),   //
-        make_unique<ReportPumpConfigurationAndControlEffectiveOperationMode>(), //
-        make_unique<ReadPumpConfigurationAndControlEffectiveControlMode>(),     //
-        make_unique<ReportPumpConfigurationAndControlEffectiveControlMode>(),   //
-        make_unique<ReadPumpConfigurationAndControlCapacity>(),                 //
-        make_unique<ReportPumpConfigurationAndControlCapacity>(),               //
-        make_unique<ReadPumpConfigurationAndControlSpeed>(),                    //
-        make_unique<ReportPumpConfigurationAndControlSpeed>(),                  //
-        make_unique<ReadPumpConfigurationAndControlLifetimeRunningHours>(),     //
-        make_unique<WritePumpConfigurationAndControlLifetimeRunningHours>(),    //
-        make_unique<ReportPumpConfigurationAndControlLifetimeRunningHours>(),   //
-        make_unique<ReadPumpConfigurationAndControlPower>(),                    //
-        make_unique<ReportPumpConfigurationAndControlPower>(),                  //
-        make_unique<ReadPumpConfigurationAndControlLifetimeEnergyConsumed>(),   //
-        make_unique<WritePumpConfigurationAndControlLifetimeEnergyConsumed>(),  //
-        make_unique<ReportPumpConfigurationAndControlLifetimeEnergyConsumed>(), //
-        make_unique<ReadPumpConfigurationAndControlOperationMode>(),            //
-        make_unique<WritePumpConfigurationAndControlOperationMode>(),           //
-        make_unique<ReportPumpConfigurationAndControlOperationMode>(),          //
-        make_unique<ReadPumpConfigurationAndControlControlMode>(),              //
-        make_unique<WritePumpConfigurationAndControlControlMode>(),             //
-        make_unique<ReportPumpConfigurationAndControlControlMode>(),            //
-        make_unique<ReadPumpConfigurationAndControlAlarmMask>(),                //
-        make_unique<ReportPumpConfigurationAndControlAlarmMask>(),              //
-        make_unique<ReadPumpConfigurationAndControlAttributeList>(),            //
-        make_unique<ReadPumpConfigurationAndControlFeatureMap>(),               //
-        make_unique<ReportPumpConfigurationAndControlFeatureMap>(),             //
-        make_unique<ReadPumpConfigurationAndControlClusterRevision>(),          //
-        make_unique<ReportPumpConfigurationAndControlClusterRevision>(),        //
+        make_unique<ReadPumpConfigurationAndControlMaxPressure>(),               //
+        make_unique<ReportPumpConfigurationAndControlMaxPressure>(),             //
+        make_unique<ReadPumpConfigurationAndControlMaxSpeed>(),                  //
+        make_unique<ReportPumpConfigurationAndControlMaxSpeed>(),                //
+        make_unique<ReadPumpConfigurationAndControlMaxFlow>(),                   //
+        make_unique<ReportPumpConfigurationAndControlMaxFlow>(),                 //
+        make_unique<ReadPumpConfigurationAndControlMinConstPressure>(),          //
+        make_unique<ReportPumpConfigurationAndControlMinConstPressure>(),        //
+        make_unique<ReadPumpConfigurationAndControlMaxConstPressure>(),          //
+        make_unique<ReportPumpConfigurationAndControlMaxConstPressure>(),        //
+        make_unique<ReadPumpConfigurationAndControlMinCompPressure>(),           //
+        make_unique<ReportPumpConfigurationAndControlMinCompPressure>(),         //
+        make_unique<ReadPumpConfigurationAndControlMaxCompPressure>(),           //
+        make_unique<ReportPumpConfigurationAndControlMaxCompPressure>(),         //
+        make_unique<ReadPumpConfigurationAndControlMinConstSpeed>(),             //
+        make_unique<ReportPumpConfigurationAndControlMinConstSpeed>(),           //
+        make_unique<ReadPumpConfigurationAndControlMaxConstSpeed>(),             //
+        make_unique<ReportPumpConfigurationAndControlMaxConstSpeed>(),           //
+        make_unique<ReadPumpConfigurationAndControlMinConstFlow>(),              //
+        make_unique<ReportPumpConfigurationAndControlMinConstFlow>(),            //
+        make_unique<ReadPumpConfigurationAndControlMaxConstFlow>(),              //
+        make_unique<ReportPumpConfigurationAndControlMaxConstFlow>(),            //
+        make_unique<ReadPumpConfigurationAndControlMinConstTemp>(),              //
+        make_unique<ReportPumpConfigurationAndControlMinConstTemp>(),            //
+        make_unique<ReadPumpConfigurationAndControlMaxConstTemp>(),              //
+        make_unique<ReportPumpConfigurationAndControlMaxConstTemp>(),            //
+        make_unique<ReadPumpConfigurationAndControlPumpStatus>(),                //
+        make_unique<ReportPumpConfigurationAndControlPumpStatus>(),              //
+        make_unique<ReadPumpConfigurationAndControlEffectiveOperationMode>(),    //
+        make_unique<ReportPumpConfigurationAndControlEffectiveOperationMode>(),  //
+        make_unique<ReadPumpConfigurationAndControlEffectiveControlMode>(),      //
+        make_unique<ReportPumpConfigurationAndControlEffectiveControlMode>(),    //
+        make_unique<ReadPumpConfigurationAndControlCapacity>(),                  //
+        make_unique<ReportPumpConfigurationAndControlCapacity>(),                //
+        make_unique<ReadPumpConfigurationAndControlSpeed>(),                     //
+        make_unique<ReportPumpConfigurationAndControlSpeed>(),                   //
+        make_unique<ReadPumpConfigurationAndControlLifetimeRunningHours>(),      //
+        make_unique<WritePumpConfigurationAndControlLifetimeRunningHours>(),     //
+        make_unique<ReportPumpConfigurationAndControlLifetimeRunningHours>(),    //
+        make_unique<ReadPumpConfigurationAndControlPower>(),                     //
+        make_unique<ReportPumpConfigurationAndControlPower>(),                   //
+        make_unique<ReadPumpConfigurationAndControlLifetimeEnergyConsumed>(),    //
+        make_unique<WritePumpConfigurationAndControlLifetimeEnergyConsumed>(),   //
+        make_unique<ReportPumpConfigurationAndControlLifetimeEnergyConsumed>(),  //
+        make_unique<ReadPumpConfigurationAndControlOperationMode>(),             //
+        make_unique<WritePumpConfigurationAndControlOperationMode>(),            //
+        make_unique<ReportPumpConfigurationAndControlOperationMode>(),           //
+        make_unique<ReadPumpConfigurationAndControlControlMode>(),               //
+        make_unique<WritePumpConfigurationAndControlControlMode>(),              //
+        make_unique<ReportPumpConfigurationAndControlControlMode>(),             //
+        make_unique<ReadPumpConfigurationAndControlAlarmMask>(),                 //
+        make_unique<ReportPumpConfigurationAndControlAlarmMask>(),               //
+        make_unique<ReadPumpConfigurationAndControlAttributeList>(),             //
+        make_unique<ReadPumpConfigurationAndControlFeatureMap>(),                //
+        make_unique<ReportPumpConfigurationAndControlFeatureMap>(),              //
+        make_unique<ReadPumpConfigurationAndControlClusterRevision>(),           //
+        make_unique<ReportPumpConfigurationAndControlClusterRevision>(),         //
+        make_unique<ReadPumpConfigurationAndControlSupplyVoltageLow>(),          //
+        make_unique<ReadPumpConfigurationAndControlSupplyVoltageHigh>(),         //
+        make_unique<ReadPumpConfigurationAndControlPowerMissingPhase>(),         //
+        make_unique<ReadPumpConfigurationAndControlSystemPressureLow>(),         //
+        make_unique<ReadPumpConfigurationAndControlSystemPressureHigh>(),        //
+        make_unique<ReadPumpConfigurationAndControlDryRunning>(),                //
+        make_unique<ReadPumpConfigurationAndControlMotorTemperatureHigh>(),      //
+        make_unique<ReadPumpConfigurationAndControlPumpMotorFatalFailure>(),     //
+        make_unique<ReadPumpConfigurationAndControlElectronicTemperatureHigh>(), //
+        make_unique<ReadPumpConfigurationAndControlPumpBlocked>(),               //
+        make_unique<ReadPumpConfigurationAndControlSensorFailure>(),             //
+        make_unique<ReadPumpConfigurationAndControlElectronicNonFatalFailure>(), //
+        make_unique<ReadPumpConfigurationAndControlElectronicFatalFailure>(),    //
+        make_unique<ReadPumpConfigurationAndControlGeneralFault>(),              //
+        make_unique<ReadPumpConfigurationAndControlLeakage>(),                   //
+        make_unique<ReadPumpConfigurationAndControlAirDetection>(),              //
+        make_unique<ReadPumpConfigurationAndControlTurbineOperation>(),          //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -52462,6 +55130,7 @@ void registerClusterSoftwareDiagnostics(Commands & commands)
         make_unique<ReadSoftwareDiagnosticsFeatureMap>(),                 //
         make_unique<ReadSoftwareDiagnosticsClusterRevision>(),            //
         make_unique<ReportSoftwareDiagnosticsClusterRevision>(),          //
+        make_unique<ReadSoftwareDiagnosticsSoftwareFault>(),              //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -52482,6 +55151,13 @@ void registerClusterSwitch(Commands & commands)
         make_unique<ReportSwitchFeatureMap>(),        //
         make_unique<ReadSwitchClusterRevision>(),     //
         make_unique<ReportSwitchClusterRevision>(),   //
+        make_unique<ReadSwitchSwitchLatched>(),       //
+        make_unique<ReadSwitchInitialPress>(),        //
+        make_unique<ReadSwitchLongPress>(),           //
+        make_unique<ReadSwitchShortRelease>(),        //
+        make_unique<ReadSwitchLongRelease>(),         //
+        make_unique<ReadSwitchMultiPressOngoing>(),   //
+        make_unique<ReadSwitchMultiPressComplete>(),  //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -52765,6 +55441,7 @@ void registerClusterTestCluster(Commands & commands)
         make_unique<ReadTestClusterAttributeList>(),                       //
         make_unique<ReadTestClusterClusterRevision>(),                     //
         make_unique<ReportTestClusterClusterRevision>(),                   //
+        make_unique<ReadTestClusterTestEvent>(),                           //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -52983,6 +55660,7 @@ void registerClusterThreadNetworkDiagnostics(Commands & commands)
         make_unique<ReadThreadNetworkDiagnosticsFeatureMap>(),                          //
         make_unique<ReadThreadNetworkDiagnosticsClusterRevision>(),                     //
         make_unique<ReportThreadNetworkDiagnosticsClusterRevision>(),                   //
+        make_unique<ReadThreadNetworkDiagnosticsConnectionStatus>(),                    //
     };
 
     commands.Register(clusterName, clusterCommands);
@@ -53048,6 +55726,9 @@ void registerClusterWiFiNetworkDiagnostics(Commands & commands)
         make_unique<ReadWiFiNetworkDiagnosticsFeatureMap>(),               //
         make_unique<ReadWiFiNetworkDiagnosticsClusterRevision>(),          //
         make_unique<ReportWiFiNetworkDiagnosticsClusterRevision>(),        //
+        make_unique<ReadWiFiNetworkDiagnosticsDisconnection>(),            //
+        make_unique<ReadWiFiNetworkDiagnosticsAssociationFailure>(),       //
+        make_unique<ReadWiFiNetworkDiagnosticsConnectionStatus>(),         //
     };
 
     commands.Register(clusterName, clusterCommands);


### PR DESCRIPTION
#### Problem
 `chip-tool` does not have any command to read events


#### Change overview
 * Add `read-event` command to chip-tool
 * Update `ClusterHelper.js` to return a list of events and creates zap iterators for those
 * Update `examples/chip-tool/templates/commands.zapt` to generate `read-event` commands

#### Testing
 I have manually added an event to the all-clusters-app using:
```
$ ./out/debug/standalone/chip-tool testcluster test-emit-test-event-request 11 22 1 0x12345 1
$ ./out/debug/standalone/chip-tool testcluster test-emit-test-event-request 111 222 1 0x12345 1
$ ./out/debug/standalone/chip-tool testcluster read-event test-event 0x12345 1
```

Next step will be to add `events` support to YAML...