### PR TITLE
Rename duplicate Application struct

### DIFF
--- a/examples/tv-app/android/include/application-basic/ApplicationBasicManager.cpp
+++ b/examples/tv-app/android/include/application-basic/ApplicationBasicManager.cpp
@@ -41,9 +41,9 @@ uint16_t ApplicationBasicManager::HandleGetProductId()
     return 1;
 }
 
-chip::app::Clusters::ApplicationBasic::Structs::Application::Type ApplicationBasicManager::HandleGetApplication()
+chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type ApplicationBasicManager::HandleGetApplication()
 {
-    chip::app::Clusters::ApplicationBasic::Structs::Application::Type application;
+    chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type application;
     application.catalogVendorId = 123;
     application.applicationId   = chip::CharSpan("applicationId", strlen("applicationId"));
     return application;

--- a/examples/tv-app/android/include/application-basic/ApplicationBasicManager.h
+++ b/examples/tv-app/android/include/application-basic/ApplicationBasicManager.h
@@ -27,7 +27,7 @@ public:
     uint16_t HandleGetVendorId() override;
     chip::CharSpan HandleGetApplicationName() override;
     uint16_t HandleGetProductId() override;
-    chip::app::Clusters::ApplicationBasic::Structs::Application::Type HandleGetApplication() override;
+    chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type HandleGetApplication() override;
     chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum HandleGetStatus() override;
     chip::CharSpan HandleGetApplicationVersion() override;
     std::list<uint16_t> HandleGetAllowedVendorList() override;

--- a/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
@@ -36,7 +36,8 @@ std::list<uint16_t> ApplicationLauncherManager::HandleGetCatalogList()
 }
 
 Commands::LauncherResponse::Type ApplicationLauncherManager::HandleLaunchApp(
-    const chip::CharSpan & data, const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application)
+    const chip::CharSpan & data,
+    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application)
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
@@ -45,8 +46,8 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleLaunchApp(
     return response;
 }
 
-Commands::LauncherResponse::Type
-ApplicationLauncherManager::HandleStopApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application)
+Commands::LauncherResponse::Type ApplicationLauncherManager::HandleStopApp(
+    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application)
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
@@ -55,8 +56,8 @@ ApplicationLauncherManager::HandleStopApp(const chip::app::Clusters::Application
     return response;
 }
 
-Commands::LauncherResponse::Type
-ApplicationLauncherManager::HandleHideApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application)
+Commands::LauncherResponse::Type ApplicationLauncherManager::HandleHideApp(
+    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application)
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;

--- a/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.h
+++ b/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.h
@@ -27,11 +27,11 @@ public:
     chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type HandleGetCurrentApp() override;
     std::list<uint16_t> HandleGetCatalogList() override;
 
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-    HandleLaunchApp(const chip::CharSpan & data,
-                    const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) override;
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-    HandleStopApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) override;
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-    HandleHideApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) override;
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type HandleLaunchApp(
+        const chip::CharSpan & data,
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) override;
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type HandleStopApp(
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) override;
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type HandleHideApp(
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) override;
 };

--- a/examples/tv-app/linux/AppImpl.cpp
+++ b/examples/tv-app/linux/AppImpl.cpp
@@ -191,7 +191,7 @@ uint32_t AccountLoginImpl::GetSetupPIN(const char * tempAccountId)
 }
 
 chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-ApplicationLauncherImpl::LaunchApp(Application application, std::string data)
+ApplicationLauncherImpl::LaunchApp(ApplicationLauncherApplication application, std::string data)
 {
     std::string appId(application.applicationId.data(), application.applicationId.size());
     ChipLogProgress(DeviceLayer,
@@ -239,7 +239,7 @@ ContentApp * ContentAppFactoryImpl::LoadContentAppByVendorId(uint16_t vendorId)
     return nullptr;
 }
 
-ContentApp * ContentAppFactoryImpl::LoadContentAppByAppId(Application application)
+ContentApp * ContentAppFactoryImpl::LoadContentAppByAppId(ApplicationLauncherApplication application)
 {
     std::string appId(application.applicationId.data(), application.applicationId.size());
     ChipLogProgress(DeviceLayer,

--- a/examples/tv-app/linux/AppImpl.h
+++ b/examples/tv-app/linux/AppImpl.h
@@ -98,7 +98,7 @@ class DLL_EXPORT ApplicationLauncherImpl : public ApplicationLauncher
 public:
     virtual ~ApplicationLauncherImpl() {}
 
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type LaunchApp(Application application,
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type LaunchApp(ApplicationLauncherApplication application,
                                                                                          std::string data) override;
 
 protected:
@@ -175,7 +175,7 @@ public:
     virtual ~ContentAppFactoryImpl() {}
 
     ContentApp * LoadContentAppByVendorId(uint16_t vendorId);
-    ContentApp * LoadContentAppByAppId(Application application);
+    ContentApp * LoadContentAppByAppId(ApplicationLauncherApplication application);
 
 protected:
     ContentAppImpl mContentApps[APP_LIBRARY_SIZE] = { ContentAppImpl("Vendor1", 1, "App1", 11, "Version1"),

--- a/examples/tv-app/linux/include/application-basic/ApplicationBasicManager.cpp
+++ b/examples/tv-app/linux/include/application-basic/ApplicationBasicManager.cpp
@@ -41,9 +41,9 @@ uint16_t ApplicationBasicManager::HandleGetProductId()
     return 1;
 }
 
-chip::app::Clusters::ApplicationBasic::Structs::Application::Type ApplicationBasicManager::HandleGetApplication()
+chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type ApplicationBasicManager::HandleGetApplication()
 {
-    chip::app::Clusters::ApplicationBasic::Structs::Application::Type application;
+    chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type application;
     application.catalogVendorId = 123;
     application.applicationId   = chip::CharSpan("applicationId", strlen("applicationId"));
     return application;

--- a/examples/tv-app/linux/include/application-basic/ApplicationBasicManager.h
+++ b/examples/tv-app/linux/include/application-basic/ApplicationBasicManager.h
@@ -27,7 +27,7 @@ public:
     uint16_t HandleGetVendorId() override;
     chip::CharSpan HandleGetApplicationName() override;
     uint16_t HandleGetProductId() override;
-    chip::app::Clusters::ApplicationBasic::Structs::Application::Type HandleGetApplication() override;
+    chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type HandleGetApplication() override;
     chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum HandleGetStatus() override;
     chip::CharSpan HandleGetApplicationVersion() override;
     std::list<uint16_t> HandleGetAllowedVendorList() override;

--- a/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.cpp
@@ -36,7 +36,8 @@ std::list<uint16_t> ApplicationLauncherManager::HandleGetCatalogList()
 }
 
 Commands::LauncherResponse::Type ApplicationLauncherManager::HandleLaunchApp(
-    const chip::CharSpan & data, const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application)
+    const chip::CharSpan & data,
+    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application)
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
@@ -45,8 +46,8 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleLaunchApp(
     return response;
 }
 
-Commands::LauncherResponse::Type
-ApplicationLauncherManager::HandleStopApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application)
+Commands::LauncherResponse::Type ApplicationLauncherManager::HandleStopApp(
+    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application)
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
@@ -55,8 +56,8 @@ ApplicationLauncherManager::HandleStopApp(const chip::app::Clusters::Application
     return response;
 }
 
-Commands::LauncherResponse::Type
-ApplicationLauncherManager::HandleHideApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application)
+Commands::LauncherResponse::Type ApplicationLauncherManager::HandleHideApp(
+    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application)
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;

--- a/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.h
+++ b/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.h
@@ -27,11 +27,11 @@ public:
     chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type HandleGetCurrentApp() override;
     std::list<uint16_t> HandleGetCatalogList() override;
 
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-    HandleLaunchApp(const chip::CharSpan & data,
-                    const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) override;
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-    HandleStopApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) override;
-    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
-    HandleHideApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) override;
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type HandleLaunchApp(
+        const chip::CharSpan & data,
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) override;
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type HandleStopApp(
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) override;
+    chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type HandleHideApp(
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) override;
 };

--- a/src/app/clusters/application-basic-server/application-basic-delegate.h
+++ b/src/app/clusters/application-basic-server/application-basic-delegate.h
@@ -34,14 +34,14 @@ namespace ApplicationBasic {
 class Delegate
 {
 public:
-    virtual chip::CharSpan HandleGetVendorName()                                                     = 0;
-    virtual uint16_t HandleGetVendorId()                                                             = 0;
-    virtual chip::CharSpan HandleGetApplicationName()                                                = 0;
-    virtual uint16_t HandleGetProductId()                                                            = 0;
-    virtual chip::app::Clusters::ApplicationBasic::Structs::Application::Type HandleGetApplication() = 0;
-    virtual ApplicationStatusEnum HandleGetStatus()                                                  = 0;
-    virtual chip::CharSpan HandleGetApplicationVersion()                                             = 0;
-    virtual std::list<uint16_t> HandleGetAllowedVendorList()                                         = 0;
+    virtual chip::CharSpan HandleGetVendorName()                                                                     = 0;
+    virtual uint16_t HandleGetVendorId()                                                                             = 0;
+    virtual chip::CharSpan HandleGetApplicationName()                                                                = 0;
+    virtual uint16_t HandleGetProductId()                                                                            = 0;
+    virtual chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type HandleGetApplication() = 0;
+    virtual ApplicationStatusEnum HandleGetStatus()                                                                  = 0;
+    virtual chip::CharSpan HandleGetApplicationVersion()                                                             = 0;
+    virtual std::list<uint16_t> HandleGetAllowedVendorList()                                                         = 0;
 
     virtual ~Delegate() = default;
 };

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -179,7 +179,7 @@ CHIP_ERROR ApplicationBasicAttrAccess::ReadProductIdAttribute(app::AttributeValu
 
 CHIP_ERROR ApplicationBasicAttrAccess::ReadApplicationAttribute(app::AttributeValueEncoder & aEncoder, Delegate * delegate)
 {
-    Structs::Application::Type application = delegate->HandleGetApplication();
+    Structs::ApplicationBasicApplication::Type application = delegate->HandleGetApplication();
     return aEncoder.Encode(application);
 }
 

--- a/src/app/clusters/application-launcher-server/application-launcher-delegate.h
+++ b/src/app/clusters/application-launcher-server/application-launcher-delegate.h
@@ -37,13 +37,13 @@ public:
     virtual chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type HandleGetCurrentApp() = 0;
     virtual std::list<uint16_t> HandleGetCatalogList()                                                   = 0;
 
+    virtual Commands::LauncherResponse::Type HandleLaunchApp(
+        const chip::CharSpan & data,
+        const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) = 0;
     virtual Commands::LauncherResponse::Type
-    HandleLaunchApp(const chip::CharSpan & data,
-                    const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) = 0;
+    HandleStopApp(const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) = 0;
     virtual Commands::LauncherResponse::Type
-    HandleStopApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) = 0;
-    virtual Commands::LauncherResponse::Type
-    HandleHideApp(const chip::app::Clusters::ApplicationLauncher::Structs::Application::Type & application) = 0;
+    HandleHideApp(const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type & application) = 0;
 
     virtual ~Delegate() = default;
 };

--- a/src/app/util/ContentApp.h
+++ b/src/app/util/ContentApp.h
@@ -91,8 +91,8 @@ class DLL_EXPORT ApplicationLauncher : public ContentAppCluster
 public:
     virtual ~ApplicationLauncher() = default;
 
-    virtual app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type LaunchApp(Application application,
-                                                                                           std::string data) = 0;
+    virtual app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type
+    LaunchApp(ApplicationLauncherApplication application, std::string data) = 0;
 
     EmberAfStatus HandleReadAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength) override;
     EmberAfStatus HandleWriteAttribute(chip::AttributeId attributeId, uint8_t * buffer) override;

--- a/src/app/util/ContentAppPlatform.cpp
+++ b/src/app/util/ContentAppPlatform.cpp
@@ -235,7 +235,7 @@ ContentApp * AppPlatform::GetLoadContentAppByVendorId(uint16_t vendorId)
     return NULL;
 }
 
-ContentApp * AppPlatform::GetLoadContentAppByAppId(Application application)
+ContentApp * AppPlatform::GetLoadContentAppByAppId(ApplicationLauncherApplication application)
 {
     ChipLogProgress(DeviceLayer, "GetLoadContentAppByAppId()");
     if (mContentAppFactory != NULL)

--- a/src/app/util/ContentAppPlatform.h
+++ b/src/app/util/ContentAppPlatform.h
@@ -37,9 +37,9 @@ namespace AppPlatform {
 class DLL_EXPORT ContentAppFactory
 {
 public:
-    virtual ~ContentAppFactory()                                        = default;
-    virtual ContentApp * LoadContentAppByVendorId(uint16_t vendorId)    = 0;
-    virtual ContentApp * LoadContentAppByAppId(Application application) = 0;
+    virtual ~ContentAppFactory()                                                           = default;
+    virtual ContentApp * LoadContentAppByVendorId(uint16_t vendorId)                       = 0;
+    virtual ContentApp * LoadContentAppByAppId(ApplicationLauncherApplication application) = 0;
 };
 
 class DLL_EXPORT AppPlatform
@@ -63,7 +63,7 @@ public:
     // load and unload by vendor id
     void UnloadContentAppByVendorId(uint16_t vendorId);
     ContentApp * GetLoadContentAppByVendorId(uint16_t vendorId);
-    ContentApp * GetLoadContentAppByAppId(Application application);
+    ContentApp * GetLoadContentAppByAppId(ApplicationLauncherApplication application);
 
     // helpful method to get a Content App by endpoint in order to perform attribute or command ops
     ContentApp * GetContentAppByEndpointId(chip::EndpointId id);

--- a/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
@@ -28,13 +28,13 @@ limitations under the License.
     <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">vendor id</attribute>
     <attribute side="server" code="0x0002" define="APPLICATION_NAME" type="CHAR_STRING" length="32" writable="false" optional="false">application name</attribute>
     <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">product id</attribute>
-    <attribute side="server" code="0x0004" define="APPLICATION_APP" type="Application" writable="true" optional="false">application app</attribute>
+    <attribute side="server" code="0x0004" define="APPLICATION_APP" type="ApplicationBasicApplication" writable="true" optional="false">application app</attribute>
     <attribute side="server" code="0x0005" define="APPLICATION_STATUS" type="ApplicationStatusEnum" min="0x00" max="0xFF" default="0x01" writable="false" optional="false">application status</attribute>
     <attribute side="server" code="0x0006" define="APPLICATION_VERSION" type="CHAR_STRING" length="32" writable="false" optional="false">application version</attribute>
     <attribute side="server" code="0x0007" define="APPLICATION_ALLOWED_VENDOR_LIST" type="ARRAY" entryType="vendor_id" length="32" writable="false" optional="false">allowed vendor list</attribute>
   </cluster>
 
-  <struct name="Application">
+  <struct name="ApplicationBasicApplication">
     <cluster code="0x050d"/>
     <item name="catalogVendorId" type="INT16U"/>
     <item name="applicationId" type="CHAR_STRING"/>

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -31,17 +31,17 @@ limitations under the License.
     <command source="client" code="0x00" name="LaunchAppRequest" response="LauncherResponse" optional="false">
       <description>Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns a Launch Response.</description>
       <arg name="data" type="CHAR_STRING"/>
-      <arg name="application" type="Application"/>
+      <arg name="application" type="ApplicationLauncherApplication"/>
     </command>
 
     <command source="client" code="0x01" name="StopAppRequest" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.</description>
-      <arg name="application" type="Application"/>
+      <arg name="application" type="ApplicationLauncherApplication"/>
     </command>
 
     <command source="client" code="0x02" name="HideAppRequest" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.</description>
-      <arg name="application" type="Application"/>
+      <arg name="application" type="ApplicationLauncherApplication"/>
     </command>
 
     <command source="server" code="0x03" name="LauncherResponse" optional="false">
@@ -54,11 +54,11 @@ limitations under the License.
 
   <struct name="ApplicationEP">
     <cluster code="0x050c"/>
-    <item name="application" type="Application"/>
+    <item name="application" type="ApplicationLauncherApplication"/>
     <item name="endpoint" type="CHAR_STRING"/>
   </struct>
       
-  <struct name="Application">
+  <struct name="ApplicationLauncherApplication">
     <cluster code="0x050c"/>
     <item name="catalogVendorId" type="INT16U"/>
     <item name="applicationId" type="CHAR_STRING"/>

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -675,7 +675,7 @@ JNI_METHOD(void, ApplicationLauncherCluster, hideAppRequest)
 
     chip::app::Clusters::ApplicationLauncher::Commands::HideAppRequest::Type request;
 
-    request.application = chip::app::Clusters::ApplicationLauncher::Structs::Application::Type();
+    request.application = chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type();
 
     std::unique_ptr<CHIPApplicationLauncherClusterLauncherResponseCallback,
                     void (*)(CHIPApplicationLauncherClusterLauncherResponseCallback *)>
@@ -717,7 +717,7 @@ JNI_METHOD(void, ApplicationLauncherCluster, launchAppRequest)
     chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppRequest::Type request;
 
     request.data        = chip::JniUtfString(env, static_cast<jstring>(data)).charSpan();
-    request.application = chip::app::Clusters::ApplicationLauncher::Structs::Application::Type();
+    request.application = chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type();
 
     std::unique_ptr<CHIPApplicationLauncherClusterLauncherResponseCallback,
                     void (*)(CHIPApplicationLauncherClusterLauncherResponseCallback *)>
@@ -758,7 +758,7 @@ JNI_METHOD(void, ApplicationLauncherCluster, stopAppRequest)
 
     chip::app::Clusters::ApplicationLauncher::Commands::StopAppRequest::Type request;
 
-    request.application = chip::app::Clusters::ApplicationLauncher::Structs::Application::Type();
+    request.application = chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::Type();
 
     std::unique_ptr<CHIPApplicationLauncherClusterLauncherResponseCallback,
                     void (*)(CHIPApplicationLauncherClusterLauncherResponseCallback *)>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -29226,7 +29226,7 @@ class ApplicationLauncher(Cluster):
 
     class Structs:
         @dataclass
-        class Application(ClusterObject):
+        class ApplicationLauncherApplication(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
@@ -29244,11 +29244,11 @@ class ApplicationLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="application", Tag=1, Type=ApplicationLauncher.Structs.Application),
+                            ClusterObjectFieldDescriptor(Label="application", Tag=1, Type=ApplicationLauncher.Structs.ApplicationLauncherApplication),
                             ClusterObjectFieldDescriptor(Label="endpoint", Tag=2, Type=str),
                     ])
 
-            application: 'ApplicationLauncher.Structs.Application' = field(default_factory=lambda: ApplicationLauncher.Structs.Application())
+            application: 'ApplicationLauncher.Structs.ApplicationLauncherApplication' = field(default_factory=lambda: ApplicationLauncher.Structs.ApplicationLauncherApplication())
             endpoint: 'str' = ""
 
 
@@ -29265,11 +29265,11 @@ class ApplicationLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="data", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="application", Tag=1, Type=ApplicationLauncher.Structs.Application),
+                            ClusterObjectFieldDescriptor(Label="application", Tag=1, Type=ApplicationLauncher.Structs.ApplicationLauncherApplication),
                     ])
 
             data: 'str' = ""
-            application: 'ApplicationLauncher.Structs.Application' = field(default_factory=lambda: ApplicationLauncher.Structs.Application())
+            application: 'ApplicationLauncher.Structs.ApplicationLauncherApplication' = field(default_factory=lambda: ApplicationLauncher.Structs.ApplicationLauncherApplication())
 
         @dataclass
         class StopAppRequest(ClusterCommand):
@@ -29281,10 +29281,10 @@ class ApplicationLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.Application),
+                            ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.ApplicationLauncherApplication),
                     ])
 
-            application: 'ApplicationLauncher.Structs.Application' = field(default_factory=lambda: ApplicationLauncher.Structs.Application())
+            application: 'ApplicationLauncher.Structs.ApplicationLauncherApplication' = field(default_factory=lambda: ApplicationLauncher.Structs.ApplicationLauncherApplication())
 
         @dataclass
         class HideAppRequest(ClusterCommand):
@@ -29296,10 +29296,10 @@ class ApplicationLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.Application),
+                            ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.ApplicationLauncherApplication),
                     ])
 
-            application: 'ApplicationLauncher.Structs.Application' = field(default_factory=lambda: ApplicationLauncher.Structs.Application())
+            application: 'ApplicationLauncher.Structs.ApplicationLauncherApplication' = field(default_factory=lambda: ApplicationLauncher.Structs.ApplicationLauncherApplication())
 
         @dataclass
         class LauncherResponse(ClusterCommand):
@@ -29414,7 +29414,7 @@ class ApplicationBasic(Cluster):
                 ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000001, Type=uint),
                 ClusterObjectFieldDescriptor(Label="applicationName", Tag=0x00000002, Type=str),
                 ClusterObjectFieldDescriptor(Label="productId", Tag=0x00000003, Type=uint),
-                ClusterObjectFieldDescriptor(Label="applicationApp", Tag=0x00000004, Type=ApplicationBasic.Structs.Application),
+                ClusterObjectFieldDescriptor(Label="applicationApp", Tag=0x00000004, Type=ApplicationBasic.Structs.ApplicationBasicApplication),
                 ClusterObjectFieldDescriptor(Label="applicationStatus", Tag=0x00000005, Type=ApplicationBasic.Enums.ApplicationStatusEnum),
                 ClusterObjectFieldDescriptor(Label="applicationVersion", Tag=0x00000006, Type=str),
                 ClusterObjectFieldDescriptor(Label="allowedVendorList", Tag=0x00000007, Type=typing.List[uint]),
@@ -29427,7 +29427,7 @@ class ApplicationBasic(Cluster):
     vendorId: 'uint' = None
     applicationName: 'str' = None
     productId: 'uint' = None
-    applicationApp: 'ApplicationBasic.Structs.Application' = None
+    applicationApp: 'ApplicationBasic.Structs.ApplicationBasicApplication' = None
     applicationStatus: 'ApplicationBasic.Enums.ApplicationStatusEnum' = None
     applicationVersion: 'str' = None
     allowedVendorList: 'typing.List[uint]' = None
@@ -29445,7 +29445,7 @@ class ApplicationBasic(Cluster):
 
     class Structs:
         @dataclass
-        class Application(ClusterObject):
+        class ApplicationBasicApplication(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
@@ -29537,9 +29537,9 @@ class ApplicationBasic(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=ApplicationBasic.Structs.Application)
+                return ClusterObjectFieldDescriptor(Type=ApplicationBasic.Structs.ApplicationBasicApplication)
 
-            value: 'ApplicationBasic.Structs.Application' = field(default_factory=lambda: ApplicationBasic.Structs.Application())
+            value: 'ApplicationBasic.Structs.ApplicationBasicApplication' = field(default_factory=lambda: ApplicationBasic.Structs.ApplicationBasicApplication())
 
         @dataclass
         class ApplicationStatus(ClusterAttributeDescriptor):

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -371,13 +371,9 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            CHIPApplicationBasicClusterApplication * _Nonnull value;
-            value = [CHIPApplicationBasicClusterApplication new];
+            CHIPApplicationBasicClusterApplicationBasicApplication * _Nonnull value;
+            value = [CHIPApplicationBasicClusterApplicationBasicApplication new];
             value.catalogVendorId = [NSNumber numberWithUnsignedShort:cppValue.catalogVendorId];
-            value.catalogVendorId = [NSNumber numberWithUnsignedShort:cppValue.catalogVendorId];
-            value.applicationId = [[NSString alloc] initWithBytes:cppValue.applicationId.data()
-                                                           length:cppValue.applicationId.size()
-                                                         encoding:NSUTF8StringEncoding];
             value.applicationId = [[NSString alloc] initWithBytes:cppValue.applicationId.data()
                                                            length:cppValue.applicationId.size()
                                                          encoding:NSUTF8StringEncoding];

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -775,8 +775,6 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     ApplicationLauncher::Commands::HideAppRequest::Type request;
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
-    request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
-    request.application.applicationId = [self asCharSpan:params.application.applicationId];
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
 
     new CHIPApplicationLauncherClusterLauncherResponseCallbackBridge(
@@ -795,8 +793,6 @@ using namespace chip::app::Clusters;
     ApplicationLauncher::Commands::LaunchAppRequest::Type request;
     request.data = [self asCharSpan:params.data];
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
-    request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
-    request.application.applicationId = [self asCharSpan:params.application.applicationId];
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
 
     new CHIPApplicationLauncherClusterLauncherResponseCallbackBridge(
@@ -814,8 +810,6 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     ApplicationLauncher::Commands::StopAppRequest::Type request;
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
-    request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
-    request.application.applicationId = [self asCharSpan:params.application.applicationId];
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
 
     new CHIPApplicationLauncherClusterLauncherResponseCallbackBridge(

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -1642,17 +1642,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPApplicationLauncherClusterLaunchAppRequestParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
-@property (strong, nonatomic) CHIPApplicationLauncherClusterApplication * _Nonnull application;
+@property (strong, nonatomic) CHIPApplicationLauncherClusterApplicationLauncherApplication * _Nonnull application;
 - (instancetype)init;
 @end
 
 @interface CHIPApplicationLauncherClusterStopAppRequestParams : NSObject
-@property (strong, nonatomic) CHIPApplicationLauncherClusterApplication * _Nonnull application;
+@property (strong, nonatomic) CHIPApplicationLauncherClusterApplicationLauncherApplication * _Nonnull application;
 - (instancetype)init;
 @end
 
 @interface CHIPApplicationLauncherClusterHideAppRequestParams : NSObject
-@property (strong, nonatomic) CHIPApplicationLauncherClusterApplication * _Nonnull application;
+@property (strong, nonatomic) CHIPApplicationLauncherClusterApplicationLauncherApplication * _Nonnull application;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -3495,7 +3495,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _data = @"";
 
-        _application = [CHIPApplicationLauncherClusterApplication new];
+        _application = [CHIPApplicationLauncherClusterApplicationLauncherApplication new];
     }
     return self;
 }
@@ -3506,7 +3506,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _application = [CHIPApplicationLauncherClusterApplication new];
+        _application = [CHIPApplicationLauncherClusterApplicationLauncherApplication new];
     }
     return self;
 }
@@ -3517,7 +3517,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _application = [CHIPApplicationLauncherClusterApplication new];
+        _application = [CHIPApplicationLauncherClusterApplicationLauncherApplication new];
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -387,19 +387,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPApplicationLauncherClusterApplication : NSObject
+@interface CHIPApplicationLauncherClusterApplicationLauncherApplication : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
 @property (strong, nonatomic) NSString * _Nonnull applicationId;
 - (instancetype)init;
 @end
 
 @interface CHIPApplicationLauncherClusterApplicationEP : NSObject
-@property (strong, nonatomic) CHIPApplicationLauncherClusterApplication * _Nonnull application;
+@property (strong, nonatomic) CHIPApplicationLauncherClusterApplicationLauncherApplication * _Nonnull application;
 @property (strong, nonatomic) NSString * _Nonnull endpoint;
 - (instancetype)init;
 @end
 
-@interface CHIPApplicationBasicClusterApplication : NSObject
+@interface CHIPApplicationBasicClusterApplicationBasicApplication : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
 @property (strong, nonatomic) NSString * _Nonnull applicationId;
 - (instancetype)init;

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -792,7 +792,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplicationLauncherClusterApplication
+@implementation CHIPApplicationLauncherClusterApplicationLauncherApplication
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -810,7 +810,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _application = [CHIPApplicationLauncherClusterApplication new];
+        _application = [CHIPApplicationLauncherClusterApplicationLauncherApplication new];
 
         _endpoint = @"";
     }
@@ -818,7 +818,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplicationBasicClusterApplication
+@implementation CHIPApplicationBasicClusterApplicationBasicApplication
 - (instancetype)init
 {
     if (self = [super init]) {

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -132,17 +132,17 @@ typedef struct _BrandingInformation
     StyleInformation waterMark;
 } BrandingInformation;
 
-// Struct for Application
-typedef struct _Application
+// Struct for ApplicationLauncherApplication
+typedef struct _ApplicationLauncherApplication
 {
     uint16_t catalogVendorId;
     chip::CharSpan applicationId;
-} Application;
+} ApplicationLauncherApplication;
 
 // Struct for ApplicationEP
 typedef struct _ApplicationEP
 {
-    Application application;
+    ApplicationLauncherApplication application;
     chip::CharSpan endpoint;
 } ApplicationEP;
 
@@ -174,6 +174,13 @@ typedef struct _ActionStruct
     uint16_t SupportedCommands;
     uint8_t Status;
 } ActionStruct;
+
+// Struct for ApplicationBasicApplication
+typedef struct _ApplicationBasicApplication
+{
+    uint16_t catalogVendorId;
+    chip::CharSpan applicationId;
+} ApplicationBasicApplication;
 
 // Struct for BasicCommissioningInfoType
 typedef struct _BasicCommissioningInfoType

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -21053,7 +21053,7 @@ namespace Events {
 } // namespace AudioOutput
 namespace ApplicationLauncher {
 namespace Structs {
-namespace Application {
+namespace ApplicationLauncherApplication {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
@@ -21092,7 +21092,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Application
+} // namespace ApplicationLauncherApplication
 namespace ApplicationEP {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
@@ -21316,7 +21316,7 @@ namespace Events {
 } // namespace ApplicationLauncher
 namespace ApplicationBasic {
 namespace Structs {
-namespace Application {
+namespace ApplicationBasicApplication {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
@@ -21355,7 +21355,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Application
+} // namespace ApplicationBasicApplication
 } // namespace Structs
 
 namespace Commands {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -32718,7 +32718,7 @@ enum class ChannelFeature : uint32_t
 };
 
 namespace Structs {
-namespace Application {
+namespace ApplicationLauncherApplication {
 enum class Fields
 {
     kCatalogVendorId = 1,
@@ -32737,7 +32737,7 @@ public:
 
 using DecodableType = Type;
 
-} // namespace Application
+} // namespace ApplicationLauncherApplication
 namespace ApplicationEP {
 enum class Fields
 {
@@ -32748,7 +32748,7 @@ enum class Fields
 struct Type
 {
 public:
-    Structs::Application::Type application;
+    Structs::ApplicationLauncherApplication::Type application;
     chip::CharSpan endpoint;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -32801,7 +32801,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     chip::CharSpan data;
-    Structs::Application::Type application;
+    Structs::ApplicationLauncherApplication::Type application;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -32817,7 +32817,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     chip::CharSpan data;
-    Structs::Application::DecodableType application;
+    Structs::ApplicationLauncherApplication::DecodableType application;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchAppRequest
@@ -32834,7 +32834,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StopAppRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    Structs::Application::Type application;
+    Structs::ApplicationLauncherApplication::Type application;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -32849,7 +32849,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::StopAppRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    Structs::Application::DecodableType application;
+    Structs::ApplicationLauncherApplication::DecodableType application;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace StopAppRequest
@@ -32866,7 +32866,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::HideAppRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    Structs::Application::Type application;
+    Structs::ApplicationLauncherApplication::Type application;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -32881,7 +32881,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::HideAppRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    Structs::Application::DecodableType application;
+    Structs::ApplicationLauncherApplication::DecodableType application;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace HideAppRequest
@@ -33013,7 +33013,7 @@ enum class ApplicationStatusEnum : uint8_t
 };
 
 namespace Structs {
-namespace Application {
+namespace ApplicationBasicApplication {
 enum class Fields
 {
     kCatalogVendorId = 1,
@@ -33032,7 +33032,7 @@ public:
 
 using DecodableType = Type;
 
-} // namespace Application
+} // namespace ApplicationBasicApplication
 } // namespace Structs
 
 namespace Attributes {
@@ -33088,9 +33088,9 @@ struct TypeInfo
 namespace ApplicationApp {
 struct TypeInfo
 {
-    using Type             = chip::app::Clusters::ApplicationBasic::Structs::Application::Type;
-    using DecodableType    = chip::app::Clusters::ApplicationBasic::Structs::Application::DecodableType;
-    using DecodableArgType = const chip::app::Clusters::ApplicationBasic::Structs::Application::DecodableType &;
+    using Type             = chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type;
+    using DecodableType    = chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType;
+    using DecodableArgType = const chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationApp::Id; }

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -130,11 +130,11 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::AudioOutput::Structs::OutputInfo::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::ApplicationLauncher::Structs::Application::DecodableType & value);
+                    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::ApplicationBasic::Structs::Application::DecodableType & value);
+                    const chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType & value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
@@ -2069,7 +2069,7 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::ApplicationLauncher::Structs::Application::DecodableType & value)
+                    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApplication::DecodableType & value)
 {
     ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
     {
@@ -2116,7 +2116,7 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR LogValue(const char * label, size_t indent,
-                    const chip::app::Clusters::ApplicationBasic::Structs::Application::DecodableType & value)
+                    const chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType & value)
 {
     ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
     {

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -35808,8 +35808,6 @@ private:
         request.data = chip::Span<const char>("datagarbage: not in length on purpose", 4);
 
         request.application.catalogVendorId = 123U;
-        request.application.catalogVendorId = 123U;
-        request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
         request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -35843,8 +35841,6 @@ private:
         RequestType request;
 
         request.application.catalogVendorId = 123U;
-        request.application.catalogVendorId = 123U;
-        request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
         request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -35878,8 +35874,6 @@ private:
         RequestType request;
 
         request.application.catalogVendorId = 123U;
-        request.application.catalogVendorId = 123U;
-        request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
         request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {


### PR DESCRIPTION
#### Problem
* Both the ApplicationBasic and ApplicationLauncher clusters contain an `Application` struct. This causes our `zcl_struct_items_by_struct_name` helper to collect struct items from both `Application` structs, resulting in duplicate items.

#### Change overview
* Rename structs

#### Testing
* CI
