### PR TITLE
Remove expectedValueHasProp now that we have a generic hasProperty helper

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -23,7 +23,7 @@
         type/optionality/nullability information for them for our recursive
         call. }}
     {{#zcl_struct_items_by_struct_name type}}
-      {{#if (expectedValueHasProp ../expected label)}}
+      {{#if (hasProperty ../expected label)}}
         {{>valueEquals label=(concat ../label "." (asLowerCamelCase label)) actual=(concat ../actual "." (asLowerCamelCase label)) expected=(lookup ../expected label) depth=(incrementDepth depth)}}
       {{/if}}
     {{/zcl_struct_items_by_struct_name}}

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -645,11 +645,6 @@ function isLiteralNull(value, options)
   return (value === null) || (value instanceof NullObject);
 }
 
-function expectedValueHasProp(value, name)
-{
-  return name in value;
-}
-
 function octetStringEscapedForCLiteral(value)
 {
   // Escape control characters, things outside the ASCII range, and single
@@ -693,6 +688,5 @@ exports.chip_tests_config_get_default_value = chip_tests_config_get_default_valu
 exports.chip_tests_config_get_type          = chip_tests_config_get_type;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
 exports.isLiteralNull                       = isLiteralNull;
-exports.expectedValueHasProp                = expectedValueHasProp;
 exports.octetStringEscapedForCLiteral       = octetStringEscapedForCLiteral;
 exports.if_include_struct_item_value        = if_include_struct_item_value;

--- a/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
@@ -20,7 +20,7 @@
         type/optionality/nullability information for them for our recursive
         call. }}
     {{#zcl_struct_items_by_struct_name type}}
-      {{#if (expectedValueHasProp ../expected label)}}
+      {{#if (hasProperty ../expected label)}}
         {{>check_test_value actual=(concat "((CHIP" (asUpperCamelCase ../cluster) "Cluster" (asUpperCamelCase ../type) " *)" ../actual ")." (asStructPropertyName label)) expected=(lookup ../expected label) cluster=../cluster}}
       {{/if}}
     {{/zcl_struct_items_by_struct_name}}


### PR DESCRIPTION
#### Problem
Multiple helpers that do the same thing.

#### Change overview
Remove one of them.

#### Testing
No changes to generated code or behavior.