### PR TITLE
Use last known good time to validate certs in CASE handshake

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -965,5 +965,19 @@ CHIP_ERROR ExtractSKIDFromChipCert(const ByteSpan & chipCert, CertificateKeyId &
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ExtractNotValidBeforeFromChipCert(const ByteSpan & chipCert, uint32_t & notValidBefore)
+{
+    ChipCertificateSet certSet;
+    ChipCertificateData certData;
+
+    ReturnErrorOnFailure(certSet.Init(&certData, 1));
+
+    ReturnErrorOnFailure(certSet.LoadCert(chipCert, BitFlags<CertDecodeFlags>()));
+
+    notValidBefore = certData.mNotBeforeTime;
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace Credentials
 } // namespace chip

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -847,5 +847,14 @@ CHIP_ERROR ExtractPublicKeyFromChipCert(const ByteSpan & chipCert, P256PublicKey
  */
 CHIP_ERROR ExtractSKIDFromChipCert(const ByteSpan & chipCert, CertificateKeyId & skid);
 
+/**
+ * Extract validity start timestamp from a chip certificate.
+ * This does not perform any sort of validation on the certificate structure
+ * structure than parsing it.
+ *
+ * Can return any error that can be returned from parsing the cert.
+ */
+CHIP_ERROR ExtractNotValidBeforeFromChipCert(const ByteSpan & chipCert, uint32_t & notValidBefore);
+
 } // namespace Credentials
 } // namespace chip

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -832,7 +832,7 @@ CHIP_ERROR ExtractNodeIdFabricIdFromOpCert(const ByteSpan & opcert, NodeId * nod
 /**
  * Extract Public Key from a chip certificate in ByteSpan TLV-encoded form.
  * This does not perform any sort of validation on the certificate structure
- * structure than parsing it.
+ * other than parsing it.
  *
  * Can return any error that can be returned from parsing the cert.
  */
@@ -841,7 +841,7 @@ CHIP_ERROR ExtractPublicKeyFromChipCert(const ByteSpan & chipCert, P256PublicKey
 /**
  * Extract Subject Key Identifier from a chip certificate in ByteSpan TLV-encoded form.
  * This does not perform any sort of validation on the certificate structure
- * structure than parsing it.
+ * other than parsing it.
  *
  * Can return any error that can be returned from parsing the cert.
  */
@@ -850,7 +850,7 @@ CHIP_ERROR ExtractSKIDFromChipCert(const ByteSpan & chipCert, CertificateKeyId &
 /**
  * Extract validity start timestamp from a chip certificate.
  * This does not perform any sort of validation on the certificate structure
- * structure than parsing it.
+ * other than parsing it.
  *
  * Can return any error that can be returned from parsing the cert.
  */

--- a/src/lib/support/TimeUtils.h
+++ b/src/lib/support/TimeUtils.h
@@ -176,6 +176,17 @@ extern void ChipEpochToCalendarTime(uint32_t chipEpochTime, uint16_t & year, uin
  */
 extern bool UnixEpochToChipEpochTime(uint32_t unixEpochTime, uint32_t & chipEpochTime);
 
+inline bool ChipEpochToUnixEpochTime(uint32_t chipEpochTime, uint32_t & unixEpochTime)
+{
+    if (kChipEpochSecondsSinceUnixEpoch <= UINT32_MAX - chipEpochTime)
+    {
+        unixEpochTime = chipEpochTime + kChipEpochSecondsSinceUnixEpoch;
+        return true;
+    }
+
+    return false;
+}
+
 /**
  *  @def secondsToMilliseconds
  *

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -279,6 +279,66 @@ public:
      *                                      current time.
      */
     virtual CHIP_ERROR SetClock_RealTime(Microseconds64 aNewCurTime) = 0;
+
+    /**
+     * This function returns the last known good time (set via the call to SetClock_LastKnownGoodTime()) API.
+     *
+     * @param[out] aTime                 The last known good time, expressed as Unix time scaled to microseconds.
+     *
+     * @retval #CHIP_NO_ERROR            If the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_TIME  If the "last known good time" was not set.
+     */
+    virtual CHIP_ERROR GetClock_LastKnownGoodTime(Microseconds64 & aTime)
+    {
+        if (mLastKnownGoodTime == Microseconds64(0))
+        {
+            return CHIP_ERROR_INVALID_TIME;
+        }
+        aTime = mLastKnownGoodTime;
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * This function returns the last known good time (set via the call to SetClock_LastKnownGoodTime()) API.
+     *
+     * @note
+     *   This function is reserved for internal use by the System Clock.  Users of the System
+     *   Clock should call System::Clock::GetClock_RealTimeMS().
+     *
+     * @param[out] aTime                 The last known good time, expressed as Unix time scaled to milliseconds.
+     *
+     * @retval #CHIP_NO_ERROR            If the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_TIME  If the "last known good time" was not set.
+     */
+    virtual CHIP_ERROR GetClock_LastKnownGoodTimeMS(Milliseconds64 & aTime)
+    {
+        if (mLastKnownGoodTime == Microseconds64(0))
+        {
+            return CHIP_ERROR_INVALID_TIME;
+        }
+        aTime = std::chrono::duration_cast<System::Clock::Milliseconds64>(mLastKnownGoodTime);
+        ;
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * This function updates the value of last known good time.
+     *
+     * @param[in] aNewTime                The new time, expressed as Unix time scaled to microseconds.
+     * @param[in] aForceUpdaate           If true, update the time even if the new time is older than current time.
+     *                                    (by default, aForceUpdate is false)
+     *
+     */
+    virtual void SetClock_LastKnownGoodTime(Microseconds64 aNewTime, bool aForceUpdate = false)
+    {
+        if (aForceUpdate || aNewTime > mLastKnownGoodTime)
+        {
+            mLastKnownGoodTime = aNewTime;
+        }
+    }
+
+private:
+    Microseconds64 mLastKnownGoodTime = Microseconds64(0);
 };
 
 // Currently we have a single implementation class, ClockImpl, whose members are implemented in build-specific files.

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -288,7 +288,7 @@ public:
      * @retval #CHIP_NO_ERROR            If the method succeeded.
      * @retval #CHIP_ERROR_INVALID_TIME  If the "last known good time" was not set.
      */
-    virtual CHIP_ERROR GetClock_LastKnownGoodTime(Microseconds64 & aTime)
+    CHIP_ERROR GetClock_LastKnownGoodTime(Microseconds64 & aTime)
     {
         if (mLastKnownGoodTime == Microseconds64(0))
         {
@@ -310,14 +310,13 @@ public:
      * @retval #CHIP_NO_ERROR            If the method succeeded.
      * @retval #CHIP_ERROR_INVALID_TIME  If the "last known good time" was not set.
      */
-    virtual CHIP_ERROR GetClock_LastKnownGoodTimeMS(Milliseconds64 & aTime)
+    CHIP_ERROR GetClock_LastKnownGoodTimeMS(Milliseconds64 & aTime)
     {
         if (mLastKnownGoodTime == Microseconds64(0))
         {
             return CHIP_ERROR_INVALID_TIME;
         }
         aTime = std::chrono::duration_cast<System::Clock::Milliseconds64>(mLastKnownGoodTime);
-        ;
         return CHIP_NO_ERROR;
     }
 
@@ -329,7 +328,7 @@ public:
      *                                    (by default, aForceUpdate is false)
      *
      */
-    virtual void SetClock_LastKnownGoodTime(Microseconds64 aNewTime, bool aForceUpdate = false)
+    void SetClock_LastKnownGoodTime(Microseconds64 aNewTime, bool aForceUpdate = false)
     {
         if (aForceUpdate || aNewTime > mLastKnownGoodTime)
         {


### PR DESCRIPTION
#### Problem
`RealTime` is not implemented on all platforms, as TimeSync is not a mandatory feature for V1.0. The CASESession setup is trying to use `RealTime` to validate operational certificate validity. The devices that do not implement `RealTime` may not return the expected error code. This is causing CASE session setup failures.


#### Change overview
This PR adds support for `Last Known Good Time` feature. Currently, the LKGT will be updated to the latest time in the `notValidBefore` field of the NOCs received during commissioning process. The API can be used to update the LKGT based on other triggers in future.

The CASESession state machine will use LKGT if the `RealTime` is not available for a platform to validate the operational certificates.

#### Testing
Tested using `TestCASESession` for Darwin platform. This platform does not currently support `RealTime`. It was relying on the hardcoded time. With this change, the test is using the LKGT instead of the hardcoded time.