### PR TITLE
Have commissioner call cleanup on error.

### DIFF
--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -35,7 +35,7 @@ public:
     void CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report) override;
 
 private:
-    CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage);
+    CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR lastErr);
     DeviceCommissioner * mCommissioner;
     CommissioneeDeviceProxy * mCommissioneeDeviceProxy = nullptr;
     OperationalDeviceProxy * mOperationalDeviceProxy   = nullptr;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1875,7 +1875,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         ChipLogProgress(Controller, "Rendezvous cleanup");
         if (mPairingDelegate != nullptr)
         {
-            mPairingDelegate->OnCommissioningComplete(proxy->GetDeviceId(), CHIP_NO_ERROR);
+            mPairingDelegate->OnCommissioningComplete(proxy->GetDeviceId(), params.GetCompletionStatus());
         }
         mCommissioningStage = CommissioningStage::kSecurePairing;
         break;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -91,12 +91,15 @@ public:
         mThreadOperationalDataset.SetValue(threadOperationalDataset);
         return *this;
     }
+    void SetCompletionStatus(CHIP_ERROR err) { completionStatus = err; }
+    CHIP_ERROR GetCompletionStatus() { return completionStatus; }
 
 private:
     Optional<ByteSpan> mCSRNonce;         ///< CSR Nonce passed by the commissioner
     Optional<ByteSpan> mAttestationNonce; ///< Attestation Nonce passed by the commissioner
     Optional<WiFiCredentials> mWiFiCreds;
     Optional<ByteSpan> mThreadOperationalDataset;
+    CHIP_ERROR completionStatus = CHIP_NO_ERROR;
 };
 
 class CommissioningDelegate


### PR DESCRIPTION
#### Problem
Commissioning doesn't auto-reset itself on error

#### Change overview
Calls commissioning cleanup on error

#### Testing
Forced an error in commissioning (added code to cause one of the steps to error on the first attempt). Tested in chip-device-ctrl by establishing a pase connection, then calling commission (failure), then commission again (success).
