### PR TITLE
refresh subscription liveness after processing subscribe response

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -640,6 +640,8 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
 
     MoveToState(ClientState::SubscriptionActive);
 
+    RefreshLivenessCheckTimer();
+
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem
Subscription liveness timer does not run after subscription is established. Currently liveness timer is running after report is accepted during post-subscription.

#### Change overview
Call RefreshLivenessCheckTimer after we complete subscription response processing. 

#### Testing
Manually observe the liveness timer is running after subscription is established.

