### PR TITLE
Remove unused manufacturerCode field of EmberAfAttributeSearchRecord.

### DIFF
--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -132,10 +132,7 @@ typedef struct
     chip::EndpointId endpoint;
 
     /**
-     * Cluster that the attribute is located on. If the cluster
-     * id is inside the manufacturer specific range, 0xfc00 - 0xffff,
-     * The manufacturer code should also be set to the code associated
-     * with the manufacturer specific cluster.
+     * Cluster that the attribute is located on.
      */
     chip::ClusterId clusterId;
 
@@ -147,33 +144,10 @@ typedef struct
     EmberAfClusterMask clusterMask;
 
     /**
-     * The two byte identifier for the attribute. If the cluster id is
-     * inside the manufacturer specific range 0xfc00 - 0xffff, or the manufacturer
-     * code is NOT 0, the attribute is assumed to be manufacturer specific.
+     * The identifier for the attribute.
      */
     chip::AttributeId attributeId;
-
-    /**
-     * Manufacturer Code associated with the cluster and or attribute.
-     * If the cluster id is inside the manufacturer specific
-     * range, this value should indicate the manufacturer code for the
-     * manufacturer specific cluster. Otherwise if this value is non zero,
-     * and the cluster id is a standard ZCL cluster,
-     * it is assumed that the attribute being sought is a manufacturer specific
-     * extension to the standard ZCL cluster indicated by the cluster id.
-     */
-    uint16_t manufacturerCode;
 } EmberAfAttributeSearchRecord;
-
-/**
- * A struct used to construct a table of manufacturer codes for
- * manufacturer specific attributes and clusters.
- */
-typedef struct
-{
-    uint16_t index;
-    uint16_t manufacturerCode;
-} EmberAfManufacturerCodeEntry;
 
 /**
  * This type is used to compare two ZCL attribute values. The size of this data

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -400,11 +400,10 @@ EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, C
 {
     EmberAfAttributeMetadata * metadata = NULL;
     EmberAfAttributeSearchRecord record;
-    record.endpoint         = endpoint;
-    record.clusterId        = clusterId;
-    record.clusterMask      = mask;
-    record.attributeId      = attributeId;
-    record.manufacturerCode = manufacturerCode;
+    record.endpoint    = endpoint;
+    record.clusterId   = clusterId;
+    record.clusterMask = mask;
+    record.attributeId = attributeId;
     emAfReadOrWriteAttribute(&record, &metadata,
                              NULL,   // buffer
                              0,      // buffer size
@@ -1270,11 +1269,10 @@ void emAfLoadAttributeDefaults(EndpointId endpoint, bool ignoreStorage)
                 if (!am->IsExternal())
                 {
                     EmberAfAttributeSearchRecord record;
-                    record.endpoint         = de->endpoint;
-                    record.clusterId        = cluster->clusterId;
-                    record.clusterMask      = (emberAfAttributeIsClient(am) ? CLUSTER_MASK_CLIENT : CLUSTER_MASK_SERVER);
-                    record.attributeId      = am->attributeId;
-                    record.manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE;
+                    record.endpoint    = de->endpoint;
+                    record.clusterId   = cluster->clusterId;
+                    record.clusterMask = (emberAfAttributeIsClient(am) ? CLUSTER_MASK_CLIENT : CLUSTER_MASK_SERVER);
+                    record.attributeId = am->attributeId;
 
                     if (ptr == nullptr)
                     {

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -171,80 +171,6 @@ EmberAfStatus emberAfReadManufacturerSpecificClientAttribute(EndpointId endpoint
     return emAfReadAttribute(endpoint, cluster, attributeID, CLUSTER_MASK_CLIENT, manufacturerCode, dataPtr, readLength, NULL);
 }
 
-bool emberAfReadSequentialAttributesAddToResponse(EndpointId endpoint, ClusterId clusterId, AttributeId startAttributeId,
-                                                  uint8_t mask, uint16_t manufacturerCode, uint8_t maxAttributeIds,
-                                                  bool includeAccessControl)
-{
-    uint16_t i;
-    uint16_t discovered = 0;
-    uint16_t skipped    = 0;
-    uint16_t total      = 0;
-
-    EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(endpoint, clusterId, mask, manufacturerCode);
-
-    EmberAfAttributeSearchRecord record;
-    record.endpoint         = endpoint;
-    record.clusterId        = clusterId;
-    record.clusterMask      = mask;
-    record.attributeId      = startAttributeId;
-    record.manufacturerCode = manufacturerCode;
-
-    // If we don't have the cluster or it doesn't match the search, we're done.
-    if (cluster == NULL || !emAfMatchCluster(cluster, &record))
-    {
-        return true;
-    }
-
-    for (i = 0; i < cluster->attributeCount; i++)
-    {
-        EmberAfAttributeMetadata * metadata = &cluster->attributes[i];
-
-        // If the cluster is not manufacturer-specific, an attribute is considered
-        // only if its manufacturer code matches that of the command (which may be
-        // unset).
-        if (!emberAfClusterIsManufacturerSpecific(cluster))
-        {
-            record.attributeId = metadata->attributeId;
-            if (!emAfMatchAttribute(cluster, metadata, &record))
-            {
-                continue;
-            }
-        }
-
-        if (metadata->attributeId < startAttributeId)
-        {
-            skipped++;
-        }
-        else if (discovered < maxAttributeIds)
-        {
-            emberAfPutInt32uInResp(metadata->attributeId);
-            emberAfPutInt8uInResp(metadata->attributeType);
-            if (includeAccessControl)
-            {
-                // bit 0 : Readable <-- All our attributes are readable
-                // bit 1 : Writable <-- The only thing we track in the attribute metadata mask
-                // bit 2 : Reportable <-- All our attributes are reportable
-                emberAfPutInt8uInResp((metadata->mask & ATTRIBUTE_MASK_WRITABLE) ? 0x07 : 0x05);
-            }
-            discovered++;
-        }
-        else
-        {
-            // MISRA requires ..else if.. to have terminating else.
-        }
-        total++;
-    }
-
-    // We are finished if there are no more attributes to find, which means the
-    // number of attributes discovered plus the number skipped equals the total
-    // attributes in the cluster.  For manufacturer-specific clusters, the total
-    // includes all attributes in the cluster.  For standard ZCL clusters, if the
-    // the manufacturer code is set, the total is the number of attributes that
-    // match the manufacturer code.  Otherwise, the total is the number of
-    // standard ZCL attributes in the cluster.
-    return (discovered + skipped == total);
-}
-
 static void emberAfAttributeDecodeAndPrintCluster(ClusterId cluster, uint16_t mfgCode)
 {
 #if defined(EMBER_AF_PRINT_ENABLE) && defined(EMBER_AF_PRINT_ATTRIBUTES)
@@ -542,11 +468,10 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
 {
     EmberAfAttributeMetadata * metadata = NULL;
     EmberAfAttributeSearchRecord record;
-    record.endpoint         = endpoint;
-    record.clusterId        = cluster;
-    record.clusterMask      = mask;
-    record.attributeId      = attributeID;
-    record.manufacturerCode = manufacturerCode;
+    record.endpoint    = endpoint;
+    record.clusterId   = cluster;
+    record.clusterMask = mask;
+    record.attributeId = attributeID;
     emAfReadOrWriteAttribute(&record, &metadata,
                              NULL,   // buffer
                              0,      // buffer size
@@ -689,12 +614,11 @@ EmberAfStatus emAfReadAttribute(EndpointId endpoint, ClusterId cluster, Attribut
     EmberAfAttributeMetadata * metadata = NULL;
     EmberAfAttributeSearchRecord record;
     EmberAfStatus status;
-    record.endpoint         = endpoint;
-    record.clusterId        = cluster;
-    record.clusterMask      = mask;
-    record.attributeId      = attributeID;
-    record.manufacturerCode = manufacturerCode;
-    status                  = emAfReadOrWriteAttribute(&record, &metadata, dataPtr, readLength,
+    record.endpoint    = endpoint;
+    record.clusterId   = cluster;
+    record.clusterMask = mask;
+    record.attributeId = attributeID;
+    status             = emAfReadOrWriteAttribute(&record, &metadata, dataPtr, readLength,
                                       false); // write?
 
     if (status == EMBER_ZCL_STATUS_SUCCESS)

--- a/src/app/util/attribute-table.h
+++ b/src/app/util/attribute-table.h
@@ -57,10 +57,6 @@ EmberAfStatus emberAfAppendAttributeReportFields(chip::EndpointId endpoint, chip
                                                  uint8_t * bufIndex);
 void emberAfPrintAttributeTable(void);
 
-bool emberAfReadSequentialAttributesAddToResponse(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                  chip::AttributeId startAttributeId, uint8_t mask, uint16_t manufacturerCode,
-                                                  uint8_t maxAttributeIds, bool includeAccessControl);
-
 EmberAfStatus emAfWriteAttribute(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID, uint8_t mask,
                                  uint16_t manufacturerCode, uint8_t * data, EmberAfAttributeType dataType,
                                  bool overrideReadOnlyAndDataType, bool justTest);

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -462,7 +462,6 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, c
     record.clusterId          = aPath.mClusterId;
     record.clusterMask        = CLUSTER_MASK_SERVER;
     record.attributeId        = aPath.mAttributeId;
-    record.manufacturerCode   = EMBER_AF_NULL_MANUFACTURER_CODE;
     EmberAfStatus emberStatus = emAfReadOrWriteAttribute(&record, &attributeMetadata, attributeData, sizeof(attributeData),
                                                          /* write = */ false);
 


### PR DESCRIPTION
It's only written, never read.

The emberAfReadSequentialAttributesAddToResponse function that was one
of the writers is unused, so removing that too.

#### Problem
Dead code.

#### Change overview
Remove dead code.

#### Testing
No behavior changes.