### PR TITLE
[ci] Add git package to Doxygen image

### DIFF
--- a/integrations/docker/images/chip-build-doxygen/Dockerfile
+++ b/integrations/docker/images/chip-build-doxygen/Dockerfile
@@ -3,4 +3,5 @@ FROM alpine:3.15
 RUN apk --no-cache add \
   doxygen=1.9.2-r1 \
   graphviz=2.49.3-r0 \
-  bash=5.1.8-r0
+  bash=5.1.8-r0 \
+  git=2.34.1-r0

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.45 Version bump reason: [Ameba] Support NetworkCommissioning
+0.5.46 Version bump reason: [Doxygen] Adding git missing package


### PR DESCRIPTION
#### Problem
The `scripts/helpers/doxygen.sh` script uses git command line during its execution.

```
[Doxygen/Build Doxygen]   🐳  docker exec cmd=[sh -e -c /opt/connectedhomeip/workflow/2] user= workdir=
[Doxygen/Build Doxygen]   | scripts/helpers/doxygen.sh: line 21: git: command not found
[Doxygen/Build Doxygen]   | warning: Tag 'OUTPUT_TEXT_DIRECTION' at line 102 of file 'docs/Doxyfile' has become obsolete.
...
```

#### Change overview
This change includes that package into its `Dockerfile`

#### Testing
Using the `act` tool the error disappears
 
