### PR TITLE
ESP32: Wi-Fi - Use the default STA configuration

### DIFF
--- a/src/platform/ESP32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningWiFiDriver.cpp
@@ -132,8 +132,6 @@ CHIP_ERROR ESPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
     memset(&wifiConfig, 0, sizeof(wifiConfig));
     memcpy(wifiConfig.sta.ssid, ssid, std::min(ssidLen, static_cast<uint8_t>(sizeof(wifiConfig.sta.ssid))));
     memcpy(wifiConfig.sta.password, key, std::min(keyLen, static_cast<uint8_t>(sizeof(wifiConfig.sta.password))));
-    wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
-    wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 
     // Configure the ESP WiFi interface.
     esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);


### PR DESCRIPTION
#### Problem
ESP32 Wi-Fi STA configuration uses all channel scan instead of the default fast scan.
Fast scan should be used as it quits after finding first AP with the matching requirements rather than still continuing to browse all channels

#### Change overview
* Removed setting all channel scan (so that the default fast scan will be used)
* Removed setting the sort method as well. The same is the default value, but it is okay if the users don't know/set it explicitly.

#### Testing
* Successful commissioning and cluster control using chip-tool