### PR TITLE
[Simulated Device] Print the list of available test commands if the command is unknown

### DIFF
--- a/examples/placeholder/linux/include/MatterCallbacks.h
+++ b/examples/placeholder/linux/include/MatterCallbacks.h
@@ -39,6 +39,7 @@ TestCommand * GetTargetTest()
     if (test.get() == nullptr)
     {
         ChipLogError(chipTool, "Specified test command does not exist: %s", command);
+        PrintTestCommands();
         return nullptr;
     }
 

--- a/examples/placeholder/templates/tests-commands.zapt
+++ b/examples/placeholder/templates/tests-commands.zapt
@@ -21,3 +21,17 @@ std::unique_ptr<TestCommand>GetTestCommand(std::string testName)
 
   return nullptr;
 }
+
+void PrintTestCommands()
+{
+  {{#if (getTests)}}
+  {{#chip_tests (getTests)}}
+  {{#first}}
+  ChipLogError(chipTool, "Supported commands:");
+  {{/first}}
+  ChipLogError(chipTool, "\t* {{filename}}");
+  {{else}}
+  ChipLogError("\t No available commands.");
+  {{/chip_tests}}
+  {{/if}}
+}

--- a/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
@@ -395,3 +395,9 @@ std::unique_ptr<TestCommand> GetTestCommand(std::string testName)
 
     return nullptr;
 }
+
+void PrintTestCommands()
+{
+    ChipLogError(chipTool, "Supported commands:");
+    ChipLogError(chipTool, "\t* Test_TC_DM_1_3_Simulated");
+}

--- a/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
@@ -395,3 +395,9 @@ std::unique_ptr<TestCommand> GetTestCommand(std::string testName)
 
     return nullptr;
 }
+
+void PrintTestCommands()
+{
+    ChipLogError(chipTool, "Supported commands:");
+    ChipLogError(chipTool, "\t* Test_TC_DM_1_3_Simulated");
+}


### PR DESCRIPTION
#### Problem

When using the `--command` of the simulated device (`./out/app1/chip-app1 --command foo`) it only prints that the `command` does not exists, but it does not print a list of commands.
One needs to manually inspect the generated tests code to see the available names...

#### Change overview
 * Print the list of available tests

#### Testing
 I have checked that it works by running `./out/app1/chip-app1 --command foo`