### PR TITLE
Handle write on identifyTime attribute on esp32 side

### DIFF
--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -45,6 +45,7 @@ private:
 #if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
     void OnColorControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 #endif
-    void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
+    void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint16_t size,
+                                               uint8_t * value);
     bool mEndpointOnOffState[2];
 };

--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -45,5 +45,6 @@ private:
 #if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
     void OnColorControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 #endif
+    void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     bool mEndpointOnOffState[2];
 };


### PR DESCRIPTION
#### What is being fixed?  
Handled attribute write command for identifyTime attribute on esp32 side in all-clusters-app 

#### Change overview
Added OnIdentifyAttributeChangeCallback in DeviceCallbacks.cpp

#### Testing
* Tested commissioning and cluster control using chip-tool