### PR TITLE
Fix CASE session break for not fully implemented timers (FreeRTOS)

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1317,7 +1317,8 @@ CHIP_ERROR CASESession::SetEffectiveTime()
 {
     System::Clock::Milliseconds64 currentTimeMS;
     CHIP_ERROR err = System::SystemClock().GetClock_RealTimeMS(currentTimeMS);
-    if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+
+    if (err != CHIP_NO_ERROR)
     {
         ChipLogError(
             SecureChannel,
@@ -1325,7 +1326,6 @@ CHIP_ERROR CASESession::SetEffectiveTime()
         // TODO: Remove use of hardcoded time during CASE setup
         return GetHardcodedTime();
     }
-    ReturnErrorOnFailure(err);
 
     System::Clock::Seconds32 currentTime = std::chrono::duration_cast<System::Clock::Seconds32>(currentTimeMS);
     VerifyOrReturnError(UnixEpochToChipEpochTime(currentTime.count(), mValidContext.mEffectiveTime), CHIP_ERROR_INVALID_TIME);


### PR DESCRIPTION
Error catch on timer broadened to also allow NOT_SYNCED or other errors.

#### Problem
Establishing CASE sessions was made impossible for all FreeRTOS implementations.

#13517 added a fetch for time from GetClock_RealTimeMS() during the CASE flow
This returns NOT_SYNCED in the FreeRTOS case, which will cause an Error.
NOT_IMPLEMENTED was catched in the PR with a warning.

#### Change overview
Allowing all errors to use fallback mechanism.
This is a quick fix - further work is pending to solve this for these kind of platforms (see @pan-apple)

Note initialisation of the SystemTimer is also possible (but not done by any platforms).
It's however not decided what values should be used.

#### Testing
- sanity commissioning with QPG platform