### PR TITLE
Remove manufacturer code from attribute-storage APIs.

### DIFF
--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -594,29 +594,26 @@ static bool areZoneServerAttributesNonVolatile(EndpointId endpoint)
 {
     EmberAfAttributeMetadata * metadata;
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_IAS_CIE_ADDRESS_ATTRIBUTE_ID,
-                                              CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata =
+        emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_IAS_CIE_ADDRESS_ATTRIBUTE_ID, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_STATE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                              EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_STATE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_TYPE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                              EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_TYPE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_ID_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                              EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_IAS_ZONE_CLUSTER_ID, ZCL_ZONE_ID_ATTRIBUTE_ID, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1034,15 +1034,14 @@ static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoin
 {
     EmberAfAttributeMetadata * metadata;
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, LevelControl::Id, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                              EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, LevelControl::Id, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, LevelControl::Id, ZCL_START_UP_CURRENT_LEVEL_ATTRIBUTE_ID,
-                                              CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata =
+        emberAfLocateAttributeMetadata(endpoint, LevelControl::Id, ZCL_START_UP_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -486,15 +486,13 @@ bool OnOffServer::areStartUpOnOffServerAttributesNonVolatile(EndpointId endpoint
 {
     EmberAfAttributeMetadata * metadata;
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::OnOff::Id, CLUSTER_MASK_SERVER,
-                                              EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::OnOff::Id, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;
     }
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::StartUpOnOff::Id, CLUSTER_MASK_SERVER,
-                                              EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::StartUpOnOff::Id, CLUSTER_MASK_SERVER);
     if (!metadata->IsNonVolatile())
     {
         return false;

--- a/src/app/util/af-main-common.cpp
+++ b/src/app/util/af-main-common.cpp
@@ -576,14 +576,7 @@ void emAfMessageSentHandler(const MessageSendDestination & destination, EmberAps
 
     if (messageContents != NULL && messageContents[0] & ZCL_CLUSTER_SPECIFIC_COMMAND)
     {
-        emberAfClusterMessageSentWithMfgCodeCallback(
-            destination, apsFrame, messageLength, messageContents, status,
-            // If the manufacturer specific flag is set
-            // get read it as next part of message
-            // else use null code.
-            (((messageContents[0] & ZCL_MANUFACTURER_SPECIFIC_MASK) == ZCL_MANUFACTURER_SPECIFIC_MASK)
-                 ? emberAfGetInt16u(messageContents, 1, messageLength)
-                 : EMBER_AF_NULL_MANUFACTURER_CODE));
+        emberAfClusterMessageSentCallback(destination, apsFrame, messageLength, messageContents, status);
     }
 
     if (callback != NULL)

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -92,59 +92,29 @@
  * @return Returns pointer to the attribute metadata location.
  */
 EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                          chip::AttributeId attributeId, uint8_t mask, uint16_t manufacturerCode);
+                                                          chip::AttributeId attributeId, uint8_t mask);
 
 #ifdef DOXYGEN_SHOULD_SKIP_THIS
 /** @brief Returns true if the attribute exists. */
-bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t mask,
-                              uint16_t manufacturerCode);
+bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t mask);
 #else
-#define emberAfContainsAttribute(endpoint, clusterId, attributeId, mask, manufacturerCode)                                         \
-    (emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId, mask, manufacturerCode) != NULL)
+#define emberAfContainsAttribute(endpoint, clusterId, attributeId, mask)                                                           \
+    (emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId, mask) != NULL)
 #endif
-
-/**
- * @brief Returns true if endpoint contains a cluster, checking for mfg code.
- *
- * This function returns true regardless of whether
- * the endpoint contains server, client or both.
- * For standard libraries (when ClusterId < FC00),
- * the manufacturerCode is ignored.
- */
-bool emberAfContainsClusterWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode);
 
 /**
  * @brief Returns true if endpoint contains the ZCL cluster with specified id.
  *
  * This function returns true regardless of whether
  * the endpoint contains server, client or both in the Zigbee cluster Library.
- * This wraps emberAfContainsClusterWithMfgCode with
- * manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE
- * If this function is used with a manufacturer specific clusterId
- * then this will return the first cluster that it finds in the Cluster table.
- * and will not return any other clusters that share that id.
  */
 bool emberAfContainsCluster(chip::EndpointId endpoint, chip::ClusterId clusterId);
-
-/**
- * @brief Returns true if endpoint has cluster server, checking for mfg code.
- *
- * This function returns true if
- * the endpoint contains server of a given cluster.
- * For standard librarys (when ClusterId < FC00), the manufacturerCode is ignored.
- */
-bool emberAfContainsServerWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode);
 
 /**
  * @brief Returns true if endpoint contains the ZCL server with specified id.
  *
  * This function returns true if
  * the endpoint contains server of a given cluster.
- * This wraps emberAfContainsServer with
- * manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE
- * If this function is used with a manufacturer specific clusterId
- * then this will return the first cluster that it finds in the Cluster table.
- * and will not return any other clusters that share that id.
  */
 bool emberAfContainsServer(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
@@ -160,25 +130,10 @@ bool emberAfContainsServer(chip::EndpointId endpoint, chip::ClusterId clusterId)
 bool emberAfContainsServerFromIndex(uint16_t index, chip::ClusterId clusterId);
 
 /**
- * @brief Returns true if endpoint contains cluster client.
- *
- * This function returns true if
- * the endpoint contains client of a given cluster.
- * For standard library clusters (when ClusterId < FC00),
- * the manufacturerCode is ignored.
- */
-bool emberAfContainsClientWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode);
-
-/**
  * @brief Returns true if endpoint contains the ZCL client with specified id.
  *
  * This function returns true if
  * the endpoint contains client of a given cluster.
- * This wraps emberAfContainsClient with
- * manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE
- * If this function is used with a manufacturer specific clusterId
- * then this will return the first cluster that it finds in the Cluster table.
- * and will not return any other clusters that share that id.
  */
 bool emberAfContainsClient(chip::EndpointId endpoint, chip::ClusterId clusterId);
 

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -114,7 +114,7 @@ app::AttributeAccessInterface * gAttributeAccessOverrides = nullptr;
 // Forward declarations
 
 // Returns endpoint index within a given cluster
-static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask, uint16_t manufacturerCode);
+static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask);
 
 //------------------------------------------------------------------------------
 
@@ -266,10 +266,10 @@ bool emberAfIsThisDataTypeAListType(EmberAfAttributeType dataType)
 }
 
 // This function is used to call the per-cluster default response callback
-void emberAfClusterDefaultResponseWithMfgCodeCallback(EndpointId endpoint, ClusterId clusterId, CommandId commandId,
-                                                      EmberAfStatus status, uint8_t clientServerMask, uint16_t manufacturerCode)
+void emberAfClusterDefaultResponseCallback(EndpointId endpoint, ClusterId clusterId, CommandId commandId, EmberAfStatus status,
+                                           uint8_t clientServerMask)
 {
-    EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(endpoint, clusterId, clientServerMask, manufacturerCode);
+    EmberAfCluster * cluster = emberAfFindCluster(endpoint, clusterId, clientServerMask);
     if (cluster != NULL)
     {
         EmberAfGenericClusterFunction f = emberAfFindClusterFunction(cluster, CLUSTER_MASK_DEFAULT_RESPONSE_FUNCTION);
@@ -282,27 +282,16 @@ void emberAfClusterDefaultResponseWithMfgCodeCallback(EndpointId endpoint, Clust
     }
 }
 
-// This function is used to call the per-cluster default response callback, and
-// wraps the emberAfClusterDefaultResponseWithMfgCodeCallback with a
-// EMBER_AF_NULL_MANUFACTURER_CODE.
-void emberAfClusterDefaultResponseCallback(EndpointId endpoint, ClusterId clusterId, CommandId commandId, EmberAfStatus status,
-                                           uint8_t clientServerMask)
-{
-    emberAfClusterDefaultResponseWithMfgCodeCallback(endpoint, clusterId, commandId, status, clientServerMask,
-                                                     EMBER_AF_NULL_MANUFACTURER_CODE);
-}
-
 // This function is used to call the per-cluster message sent callback
-void emberAfClusterMessageSentWithMfgCodeCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
-                                                  uint16_t msgLen, uint8_t * message, EmberStatus status, uint16_t mfgCode)
+void emberAfClusterMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame, uint16_t msgLen,
+                                       uint8_t * message, EmberStatus status)
 {
     if (apsFrame != NULL && message != NULL && msgLen != 0)
     {
-        EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(
+        EmberAfCluster * cluster = emberAfFindCluster(
             apsFrame->sourceEndpoint, apsFrame->clusterId,
             (((message[0] & ZCL_FRAME_CONTROL_DIRECTION_MASK) == ZCL_FRAME_CONTROL_SERVER_TO_CLIENT) ? CLUSTER_MASK_SERVER
-                                                                                                     : CLUSTER_MASK_CLIENT),
-            mfgCode);
+                                                                                                     : CLUSTER_MASK_CLIENT));
         if (cluster != NULL)
         {
             EmberAfGenericClusterFunction f = emberAfFindClusterFunction(cluster, CLUSTER_MASK_MESSAGE_SENT_FUNCTION);
@@ -316,20 +305,10 @@ void emberAfClusterMessageSentWithMfgCodeCallback(const MessageSendDestination &
     }
 }
 
-// This function is used to call the per-cluster message sent callback, and
-// wraps the emberAfClusterMessageSentWithMfgCodeCallback with a
-// EMBER_AF_NULL_MANUFACTURER_CODE.
-void emberAfClusterMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame, uint16_t msgLen,
-                                       uint8_t * message, EmberStatus status)
-{
-    emberAfClusterMessageSentWithMfgCodeCallback(destination, apsFrame, msgLen, message, status, EMBER_AF_NULL_MANUFACTURER_CODE);
-}
-
 // This function is used to call the per-cluster attribute changed callback
 void emAfClusterAttributeChangedCallback(const app::ConcreteAttributePath & attributePath, uint8_t clientServerMask)
 {
-    EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(attributePath.mEndpointId, attributePath.mClusterId, clientServerMask,
-                                                             EMBER_AF_NULL_MANUFACTURER_CODE);
+    EmberAfCluster * cluster = emberAfFindCluster(attributePath.mEndpointId, attributePath.mClusterId, clientServerMask);
     if (cluster != NULL)
     {
         EmberAfGenericClusterFunction f = emberAfFindClusterFunction(cluster, CLUSTER_MASK_ATTRIBUTE_CHANGED_FUNCTION);
@@ -344,8 +323,7 @@ void emAfClusterAttributeChangedCallback(const app::ConcreteAttributePath & attr
 EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttributePath & attributePath, uint8_t clientServerMask,
                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value)
 {
-    EmberAfCluster * cluster = emberAfFindClusterWithMfgCode(attributePath.mEndpointId, attributePath.mClusterId, clientServerMask,
-                                                             EMBER_AF_NULL_MANUFACTURER_CODE);
+    EmberAfCluster * cluster = emberAfFindCluster(attributePath.mEndpointId, attributePath.mClusterId, clientServerMask);
     if (cluster == NULL)
     {
         return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
@@ -396,7 +374,7 @@ void emAfCallInits(void)
 
 // Returns the pointer to metadata, or null if it is not found
 EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
-                                                          uint8_t mask, uint16_t manufacturerCode)
+                                                          uint8_t mask)
 {
     EmberAfAttributeMetadata * metadata = NULL;
     EmberAfAttributeSearchRecord record;
@@ -643,8 +621,8 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
     return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE; // Sorry, attribute was not found.
 }
 
-EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpointType, ClusterId clusterId,
-                                                     EmberAfClusterMask mask, uint16_t manufacturerCode, uint8_t * index)
+EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, ClusterId clusterId, EmberAfClusterMask mask,
+                                          uint8_t * index)
 {
     uint8_t i;
     uint8_t scopedIndex = 0;
@@ -673,15 +651,6 @@ EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpo
     return NULL;
 }
 
-// This functions wraps emberAfFindClusterInTypeWithMfgCode with
-// a manufacturerCode of EMBER_AF_NULL_MANUFACTURER_CODE.
-EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, ClusterId clusterId, EmberAfClusterMask mask)
-{
-    return emberAfFindClusterInTypeWithMfgCode(endpointType, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE);
-}
-
-// This code is used during unit tests for clusters that do not involve manufacturer code.
-// Should this code be used in other locations, manufacturerCode should be added.
 uint8_t emberAfClusterIndexInMatchingEndpoints(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
 {
     uint8_t ep;
@@ -689,7 +658,7 @@ uint8_t emberAfClusterIndexInMatchingEndpoints(EndpointId endpoint, ClusterId cl
     for (ep = 0; ep < emberAfEndpointCount(); ep++)
     {
         EmberAfEndpointType * endpointType = emAfEndpoints[ep].endpointType;
-        if (emberAfFindClusterInTypeWithMfgCode(endpointType, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL)
+        if (emberAfFindClusterInType(endpointType, clusterId, mask) != NULL)
         {
             index++;
             if (emAfEndpoints[ep].endpoint == endpoint)
@@ -708,7 +677,7 @@ uint8_t emberAfClusterIndex(EndpointId endpoint, ClusterId clusterId, EmberAfClu
     for (ep = 0; ep < emberAfEndpointCount(); ep++)
     {
         EmberAfEndpointType * endpointType = emAfEndpoints[ep].endpointType;
-        if (emberAfFindClusterInTypeWithMfgCode(endpointType, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE, &index) != NULL)
+        if (emberAfFindClusterInType(endpointType, clusterId, mask, &index) != NULL)
         {
             if (emAfEndpoints[ep].endpoint == endpoint)
             {
@@ -719,46 +688,26 @@ uint8_t emberAfClusterIndex(EndpointId endpoint, ClusterId clusterId, EmberAfClu
     return 0xFF;
 }
 
-// Returns true uf endpoint contains passed cluster
-bool emberAfContainsClusterWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
-{
-    return (emberAfFindClusterWithMfgCode(endpoint, clusterId, 0, manufacturerCode) != NULL);
-}
-
-// Returns true if endpoint contains passed cluster as a server
-bool emberAfContainsServerWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
-{
-    return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_SERVER, manufacturerCode) != NULL);
-}
-
-// Returns true if endpoint contains passed cluster as a client
-bool emberAfContainsClientWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
-{
-    return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_CLIENT, manufacturerCode) != NULL);
-}
-
-// Wraps emberAfContainsClusterWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
-// This will find the first cluster that has the clusterId given, regardless of mfgCode.
+// Returns whether the given endpoint has the client or server of the given
+// cluster on it.
 bool emberAfContainsCluster(EndpointId endpoint, ClusterId clusterId)
 {
-    return (emberAfFindClusterWithMfgCode(endpoint, clusterId, 0, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
+    return (emberAfFindCluster(endpoint, clusterId, 0) != NULL);
 }
 
-// Wraps emberAfContainsServerWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
-// This will find the first server that has the clusterId given, regardless of mfgCode.
+// Returns whether the given endpoint has the server of the given cluster on it.
 bool emberAfContainsServer(EndpointId endpoint, ClusterId clusterId)
 {
-    return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
+    return (emberAfFindCluster(endpoint, clusterId, CLUSTER_MASK_SERVER) != NULL);
 }
 
-// Wraps emberAfContainsClientWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
-// This will find the first client that has the clusterId given, regardless of mfgCode.
+// Returns whether the given endpoint has the client of the given cluster on it.
 bool emberAfContainsClient(EndpointId endpoint, ClusterId clusterId)
 {
-    return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_CLIENT, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
+    return (emberAfFindCluster(endpoint, clusterId, CLUSTER_MASK_CLIENT) != NULL);
 }
 
-// This will find the first server that has the clusterId given from the index of endpoint, regardless of mfgCode.
+// This will find the first server that has the clusterId given from the index of endpoint.
 bool emberAfContainsServerFromIndex(uint16_t index, ClusterId clusterId)
 {
     if (index == 0xFFFF)
@@ -767,8 +716,7 @@ bool emberAfContainsServerFromIndex(uint16_t index, ClusterId clusterId)
     }
     else
     {
-        return emberAfFindClusterInTypeWithMfgCode(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER,
-                                                   EMBER_AF_NULL_MANUFACTURER_CODE);
+        return emberAfFindClusterInType(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER);
     }
 }
 
@@ -805,9 +753,8 @@ void EnabledEndpointsWithServerCluster::EnsureMatchingEndpoint()
 } // namespace app
 } // namespace chip
 
-// Finds the cluster that matches endpoint, clusterId, direction, and manufacturerCode.
-EmberAfCluster * emberAfFindClusterWithMfgCode(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask,
-                                               uint16_t manufacturerCode)
+// Finds the cluster that matches endpoint, clusterId, direction.
+EmberAfCluster * emberAfFindCluster(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
 {
     uint16_t ep = emberAfIndexFromEndpoint(endpoint);
     if (ep == 0xFFFF)
@@ -816,70 +763,39 @@ EmberAfCluster * emberAfFindClusterWithMfgCode(EndpointId endpoint, ClusterId cl
     }
     else
     {
-        return emberAfFindClusterInTypeWithMfgCode(emAfEndpoints[ep].endpointType, clusterId, mask, manufacturerCode);
+        return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
     }
 }
 
-// This function wraps emberAfFindClusterWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
-// and will ignore the manufacturerCode when trying to find clusters.
-// This will return the first cluster in the cluster table that matches the parameters given.
-EmberAfCluster * emberAfFindCluster(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
-{
-    return emberAfFindClusterWithMfgCode(endpoint, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE);
-}
-
 // Returns cluster within the endpoint; Does not ignore disabled endpoints
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(EndpointId endpoint, ClusterId clusterId,
-                                                                         EmberAfClusterMask mask, uint16_t manufacturerCode)
+EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
 {
     uint16_t ep = emberAfIndexFromEndpointIncludingDisabledEndpoints(endpoint);
     if (ep < MAX_ENDPOINT_COUNT)
     {
-        return emberAfFindClusterInTypeWithMfgCode(emAfEndpoints[ep].endpointType, clusterId, mask, manufacturerCode);
+        return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
     }
     return NULL;
 }
 
-// Returns cluster within the endpoint; Does not ignore disabled endpoints
-// This will ignore manufacturerCode.
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
-{
-    return emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(endpoint, clusterId, mask, EMBER_AF_NULL_MANUFACTURER_CODE);
-}
-
-// Server wrapper for findClusterEndpointIndex.
-static uint16_t emberAfFindClusterServerEndpointIndexWithMfgCode(EndpointId endpoint, ClusterId clusterId,
-                                                                 uint16_t manufacturerCode)
-{
-    return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_SERVER, manufacturerCode);
-}
-
-// Client wrapper for findClusterEndpointIndex.
-uint16_t emberAfFindClusterClientEndpointIndexWithMfgCode(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode)
-{
-    return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_CLIENT, manufacturerCode);
-}
-
 // Server wrapper for findClusterEndpointIndex
-// This will ignore manufacturerCode, and return the index for the first server that matches on clusterId
 uint16_t emberAfFindClusterServerEndpointIndex(EndpointId endpoint, ClusterId clusterId)
 {
-    return emberAfFindClusterServerEndpointIndexWithMfgCode(endpoint, clusterId, EMBER_AF_NULL_MANUFACTURER_CODE);
+    return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_SERVER);
 }
 
 // Client wrapper for findClusterEndpointIndex
-// This will ignore manufacturerCode, and return the index for the first client that matches on clusterId
 uint16_t emberAfFindClusterClientEndpointIndex(EndpointId endpoint, ClusterId clusterId)
 {
-    return emberAfFindClusterClientEndpointIndexWithMfgCode(endpoint, clusterId, EMBER_AF_NULL_MANUFACTURER_CODE);
+    return findClusterEndpointIndex(endpoint, clusterId, CLUSTER_MASK_CLIENT);
 }
 
 // Returns the endpoint index within a given cluster
-static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask, uint16_t manufacturerCode)
+static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterId, uint8_t mask)
 {
     uint16_t i, epi = 0;
 
-    if (emberAfFindClusterWithMfgCode(endpoint, clusterId, mask, manufacturerCode) == NULL)
+    if (emberAfFindCluster(endpoint, clusterId, mask) == NULL)
     {
         return 0xFFFF;
     }
@@ -890,11 +806,8 @@ static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterI
         {
             break;
         }
-        epi = static_cast<uint16_t>(epi +
-                                    ((emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(emAfEndpoints[i].endpoint, clusterId,
-                                                                                              mask, manufacturerCode) != NULL)
-                                         ? 1
-                                         : 0));
+        epi = static_cast<uint16_t>(
+            epi + ((emberAfFindClusterIncludingDisabledEndpoints(emAfEndpoints[i].endpoint, clusterId, mask) != NULL) ? 1 : 0));
     }
 
     return epi;

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -128,8 +128,6 @@ bool emAfMatchCluster(EmberAfCluster * cluster, EmberAfAttributeSearchRecord * a
 bool emAfMatchAttribute(EmberAfCluster * cluster, EmberAfAttributeMetadata * am, EmberAfAttributeSearchRecord * attRecord);
 
 // Check if a cluster is implemented or not. If yes, the cluster is returned.
-// If the cluster is not manufacturerSpecific [ClusterId < FC00] then
-// manufacturerCode argument is ignored otherwise checked.
 //
 // mask = 0 -> find either client or server
 // mask = CLUSTER_MASK_CLIENT -> find client
@@ -138,10 +136,8 @@ bool emAfMatchAttribute(EmberAfCluster * cluster, EmberAfAttributeMetadata * am,
 // If a pointer to an index is provided, it will be updated to point to the relative index of the cluster
 // within the set of clusters that match the mask criteria.
 //
-EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpointType, chip::ClusterId clusterId,
-                                                     EmberAfClusterMask mask, uint16_t manufacturerCode, uint8_t * index = nullptr);
-
-EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, chip::ClusterId clusterId, EmberAfClusterMask mask);
+EmberAfCluster * emberAfFindClusterInType(EmberAfEndpointType * endpointType, chip::ClusterId clusterId, EmberAfClusterMask mask,
+                                          uint8_t * index = nullptr);
 
 // For a given cluster and mask, retrieves the list of endpoints sorted by endpoint that contain the matching cluster and returns
 // the index within that list that matches the given endpoint.
@@ -182,19 +178,9 @@ chip::Optional<chip::ClusterId> emberAfGetNthClusterId(chip::EndpointId endpoint
 uint8_t emberAfGetClustersFromEndpoint(chip::EndpointId endpoint, chip::ClusterId * clusterList, uint8_t listLen, bool server);
 
 // Returns cluster within the endpoint, or NULL if it isn't there
-EmberAfCluster * emberAfFindClusterWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId, EmberAfClusterMask mask,
-                                               uint16_t manufacturerCode);
-
-// Returns cluster within the endpoint, or NULL if it isn't there
-// This wraps emberAfFindClusterWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
 EmberAfCluster * emberAfFindCluster(chip::EndpointId endpoint, chip::ClusterId clusterId, EmberAfClusterMask mask);
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints
-EmberAfCluster * emberAfFindClusterIncludingDisabledEndpointsWithMfgCode(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                                         EmberAfClusterMask mask, uint16_t manufacturerCode);
-
-// Returns cluster within the endpoint; Does not ignore disabled endpoints
-// This wraps emberAfFindClusterIncludingDisabledEndpointsWithMfgCode with EMBER_AF_NULL_MANUFACTURER_CODE
 EmberAfCluster * emberAfFindClusterIncludingDisabledEndpoints(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                               EmberAfClusterMask mask);
 
@@ -226,24 +212,14 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const chip::app::ConcreteAt
                                                      uint8_t clientServerMask, EmberAfAttributeType attributeType, uint16_t size,
                                                      uint8_t * value);
 
-// Calls the default response callback for a specific cluster, and wraps emberAfClusterDefaultResponseWithMfgCodeCallback
+// Calls the default response callback for a specific cluster.
 // with the EMBER_NULL_MANUFACTURER_CODE
 void emberAfClusterDefaultResponseCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::CommandId commandId,
                                            EmberAfStatus status, uint8_t clientServerMask);
 
-// Calls the default response callback for a specific cluster.
-void emberAfClusterDefaultResponseWithMfgCodeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                      chip::CommandId commandId, EmberAfStatus status, uint8_t clientServerMask,
-                                                      uint16_t manufacturerCode);
-
-// Calls the message sent callback for a specific cluster, and wraps emberAfClusterMessageSentWithMfgCodeCallback
+// Calls the message sent callback for a specific cluster.
 void emberAfClusterMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame, uint16_t msgLen,
                                        uint8_t * message, EmberStatus status);
-
-// Calls the message sent callback for a specific cluster.
-void emberAfClusterMessageSentWithMfgCodeCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame,
-                                                  uint16_t msgLen, uint8_t * message, EmberStatus status,
-                                                  uint16_t manufacturerCode);
 
 // Checks a cluster mask byte against ticks passed bitmask
 // returns true if the mask matches a passed interval

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -382,7 +382,7 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, c
     else
     {
         attributeMetadata =
-            emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId, CLUSTER_MASK_SERVER, 0);
+            emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId, CLUSTER_MASK_SERVER);
     }
 
     if (attributeCluster == nullptr && attributeMetadata == nullptr)
@@ -835,7 +835,7 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
     // happen when the above TODO is resolved.
     ConcreteDataAttributePath aPath(aClusterInfo.mEndpointId, aClusterInfo.mClusterId, aClusterInfo.mAttributeId);
     const EmberAfAttributeMetadata * attributeMetadata =
-        emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId, CLUSTER_MASK_SERVER, 0);
+        emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId, CLUSTER_MASK_SERVER);
 
     AttributePathParams attributePathParams(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
 


### PR DESCRIPTION
Matter does not use a separate manufacturer code.

#### Problem
Useless argument in function signatures.

#### Change overview
Remove the argument.

#### Testing
Code compiles, no behavior changes.