### PR TITLE
Fixed up Session ID logging

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -472,7 +472,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 
     if (!session.HasValue())
     {
-        ChipLogError(Inet, "Data received on an unknown session (LS:%d). Dropping it!", packetHeader.GetSessionId());
+        ChipLogError(Inet, "Data received on an unknown session (LSID=%d). Dropping it!", packetHeader.GetSessionId());
         return;
     }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -309,7 +309,7 @@ CHIP_ERROR SessionManager::NewPairing(SessionHolder & sessionHolder, const Optio
         mSecureSessions.ReleaseSession(session.Value()->AsSecureSession());
     }
 
-    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", LS:%d PS:%d!",
+    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", LSID:%d PSID:%d!",
                   ChipLogValueX64(peerNodeId), localSessionId, peerSessionId);
     session = mSecureSessions.CreateNewSecureSession(pairing->GetSecureSessionType(), localSessionId, peerNodeId,
                                                      pairing->GetPeerCATs(), peerSessionId, fabric, pairing->GetMRPConfig());

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -309,8 +309,8 @@ CHIP_ERROR SessionManager::NewPairing(SessionHolder & sessionHolder, const Optio
         mSecureSessions.ReleaseSession(session.Value()->AsSecureSession());
     }
 
-    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
-                  peerSessionId);
+    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", session LS%d:PS%d!!",
+                  ChipLogValueX64(peerNodeId), localSessionId, peerSessionId);
     session = mSecureSessions.CreateNewSecureSession(pairing->GetSecureSessionType(), localSessionId, peerNodeId,
                                                      pairing->GetPeerCATs(), peerSessionId, fabric, pairing->GetMRPConfig());
     ReturnErrorCodeIf(!session.HasValue(), CHIP_ERROR_NO_MEMORY);
@@ -472,7 +472,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 
     if (!session.HasValue())
     {
-        ChipLogError(Inet, "Data received on an unknown connection (%d). Dropping it!!", packetHeader.GetSessionId());
+        ChipLogError(Inet, "Data received on an unknown session (LS%d). Dropping it!!", packetHeader.GetSessionId());
         return;
     }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -309,7 +309,7 @@ CHIP_ERROR SessionManager::NewPairing(SessionHolder & sessionHolder, const Optio
         mSecureSessions.ReleaseSession(session.Value()->AsSecureSession());
     }
 
-    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", session LS%d:PS%d!!",
+    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", LS:%d PS:%d!",
                   ChipLogValueX64(peerNodeId), localSessionId, peerSessionId);
     session = mSecureSessions.CreateNewSecureSession(pairing->GetSecureSessionType(), localSessionId, peerNodeId,
                                                      pairing->GetPeerCATs(), peerSessionId, fabric, pairing->GetMRPConfig());

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -472,7 +472,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 
     if (!session.HasValue())
     {
-        ChipLogError(Inet, "Data received on an unknown session (LS%d). Dropping it!!", packetHeader.GetSessionId());
+        ChipLogError(Inet, "Data received on an unknown session (LS:%d). Dropping it!", packetHeader.GetSessionId());
         return;
     }
 


### PR DESCRIPTION
This fixes the session ID logging in SessionManager to be more aligned
with spec terminology as well as logging both local and peer session IDs
to make debugging a lot easier.