### PR TITLE
Fix glob for NRF building (name "nrf52840" was changed to "nrf52840dk")

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -35,7 +35,7 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*-nrf52840-{lock,light}*' build --create-archives
+              --target-glob '*-nrf52840*{lock,light}*' build --create-archives
               /workspace/artifacts/
       waitFor:
           - Bootstrap


### PR DESCRIPTION
#### Problem
After nrf dongle build fix in  #13285, glob was too strict, failing to build after "dk" and "dongle" suffixes were created

#### Change overview

Replace the glob slightly

#### Testing
N/A - this is a cloudbuild update.