### PR TITLE
[OTA] Add NotifyUpdateApplied API to OTA Requestor

### DIFF
--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -121,7 +121,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     OTAProviderDelegate * delegate = GetDelegate(endpoint);
 
-    ChipLogDetail(Zcl, "OTA Provider received NotifyUpdateUpplied");
+    ChipLogDetail(Zcl, "OTA Provider received NotifyUpdateApplied");
 
     if (SendStatusIfDelegateNull(endpoint))
     {

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -43,6 +43,7 @@ public:
         kQueryImage = 0,
         kStartBDX,
         kApplyUpdate,
+        kNotifyUpdateApplied,
     };
 
     OTARequestor() : mOnConnectedCallback(OnConnected, this), mOnConnectionFailureCallback(OnConnectionFailure, this) {}
@@ -61,6 +62,9 @@ public:
 
     // Send ApplyImage
     void ApplyUpdate() override;
+
+    // Send NotifyUpdateApplied
+    void NotifyUpdateApplied() override;
 
     //////////// BDXDownloader::StateDelegate Implementation ///////////////
     void OnDownloadStateChanged(OTADownloader::State state) override;
@@ -189,6 +193,11 @@ private:
     };
 
     /**
+     * Generate an update token using the operational node ID in case of token lost, received in QueryImageResponse
+     */
+    CHIP_ERROR GenerateUpdateToken();
+
+    /**
      * Send QueryImage request using values matching Basic cluster
      */
     CHIP_ERROR SendQueryImageRequest(OperationalDeviceProxy & deviceProxy);
@@ -209,6 +218,11 @@ private:
     CHIP_ERROR SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy);
 
     /**
+     * Send NotifyUpdateApplied request
+     */
+    CHIP_ERROR SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy);
+
+    /**
      * Session connection callbacks
      */
     static void OnConnected(void * context, OperationalDeviceProxy * deviceProxy);
@@ -227,6 +241,12 @@ private:
      */
     static void OnApplyUpdateResponse(void * context, const ApplyUpdateResponseDecodableType & response);
     static void OnApplyUpdateFailure(void * context, EmberAfStatus);
+
+    /**
+     * NotifyUpdateApplied callbacks
+     */
+    static void OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response);
+    static void OnNotifyUpdateAppliedFailure(void * context, EmberAfStatus);
 
     OTARequestorDriver * mOtaRequestorDriver  = nullptr;
     NodeId mProviderNodeId                    = kUndefinedNodeId;

--- a/src/include/platform/OTARequestorDriver.h
+++ b/src/include/platform/OTARequestorDriver.h
@@ -40,6 +40,15 @@ struct UpdateDescription
     ByteSpan metadataForRequestor;
 };
 
+enum class UpdateFailureState
+{
+    kQuerying,
+    kDownloading,
+    kApplying,
+    kNotifying,
+    kAwaitingNextAction,
+};
+
 enum class UpdateNotFoundReason
 {
     Busy,
@@ -61,7 +70,7 @@ public:
     virtual uint16_t GetMaxDownloadBlockSize() { return 1024; }
 
     /// Called when an error occurs at any OTA requestor operation
-    virtual void HandleError(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum state, CHIP_ERROR error) = 0;
+    virtual void HandleError(UpdateFailureState state, CHIP_ERROR error) = 0;
 
     /// Called when the latest query found a software update
     virtual void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) = 0;

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -64,6 +64,9 @@ public:
     // Send ApplyImage command
     virtual void ApplyUpdate() = 0;
 
+    // Send NotifyUpdateApplied command
+    virtual void NotifyUpdateApplied() = 0;
+
     // Manually set OTA Provider parameters
     virtual void TestModeSetProviderParameters(NodeId nodeId, FabricIndex fabIndex, EndpointId endpointId) = 0;
 };

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -59,6 +59,20 @@ CHIP_ERROR ApplyImageHandler(int argc, char ** argv)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR NotifyImageHandler(int argc, char ** argv)
+{
+    VerifyOrReturnError(GetRequestorInstance() != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const FabricIndex fabricIndex       = static_cast<FabricIndex>(strtoul(argv[0], nullptr, 10));
+    const NodeId providerNodeId         = static_cast<NodeId>(strtoull(argv[1], nullptr, 10));
+    const EndpointId providerEndpointId = static_cast<EndpointId>(strtoul(argv[2], nullptr, 10));
+
+    GetRequestorInstance()->TestModeSetProviderParameters(providerNodeId, fabricIndex, providerEndpointId);
+    PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->NotifyUpdateApplied(); });
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR OtaHandler(int argc, char ** argv)
 {
     if (argc == 0)
@@ -85,6 +99,8 @@ void RegisterOtaCommands()
         { &QueryImageHandler, "query", "Query for a new image. Usage: ota query <fabric-index> <provider-node-id> <endpoint-id>" },
         { &ApplyImageHandler, "apply",
           "Apply the current update. Usage ota apply <fabric-index> <provider-node-id> <endpoint-id>" },
+        { &NotifyImageHandler, "notify",
+          "Notify the new image has been applied. Usage: ota notify <fabric-index> <provider-node-id> <endpoint-id>" },
     };
 
     sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));

--- a/src/platform/GenericOTARequestorDriver.cpp
+++ b/src/platform/GenericOTARequestorDriver.cpp
@@ -44,7 +44,7 @@ uint16_t GenericOTARequestorDriver::GetMaxDownloadBlockSize()
     return 1024;
 }
 
-void GenericOTARequestorDriver::HandleError(OTAUpdateStateEnum state, CHIP_ERROR error)
+void GenericOTARequestorDriver::HandleError(UpdateFailureState state, CHIP_ERROR error)
 {
     // TODO: Schedule the next QueryImage
 }
@@ -52,7 +52,7 @@ void GenericOTARequestorDriver::HandleError(OTAUpdateStateEnum state, CHIP_ERROR
 void GenericOTARequestorDriver::UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay)
 {
     VerifyOrDie(mRequestor != nullptr);
-    ScheduleDelayedAction(OTAUpdateStateEnum::kDelayedOnQuery, delay,
+    ScheduleDelayedAction(UpdateFailureState::kDownloading, delay,
                           [](System::Layer *, void * context) { ToDriver(context)->mRequestor->DownloadUpdate(); });
 }
 
@@ -70,14 +70,14 @@ void GenericOTARequestorDriver::UpdateDownloaded()
 void GenericOTARequestorDriver::UpdateConfirmed(System::Clock::Seconds32 delay)
 {
     VerifyOrDie(mImageProcessor != nullptr);
-    ScheduleDelayedAction(OTAUpdateStateEnum::kDelayedOnApply, delay,
+    ScheduleDelayedAction(UpdateFailureState::kApplying, delay,
                           [](System::Layer *, void * context) { ToDriver(context)->mImageProcessor->Apply(); });
 }
 
 void GenericOTARequestorDriver::UpdateSuspended(System::Clock::Seconds32 delay)
 {
     VerifyOrDie(mRequestor != nullptr);
-    ScheduleDelayedAction(OTAUpdateStateEnum::kDelayedOnApply, delay,
+    ScheduleDelayedAction(UpdateFailureState::kAwaitingNextAction, delay,
                           [](System::Layer *, void * context) { ToDriver(context)->mRequestor->ApplyUpdate(); });
 }
 
@@ -87,7 +87,7 @@ void GenericOTARequestorDriver::UpdateDiscontinued()
     mImageProcessor->Abort();
 }
 
-void GenericOTARequestorDriver::ScheduleDelayedAction(OTAUpdateStateEnum state, System::Clock::Seconds32 delay,
+void GenericOTARequestorDriver::ScheduleDelayedAction(UpdateFailureState state, System::Clock::Seconds32 delay,
                                                       System::TimerCompleteCallback action)
 {
     CHIP_ERROR error = SystemLayer().StartTimer(std::chrono::duration_cast<System::Clock::Timeout>(delay), action, this);

--- a/src/platform/GenericOTARequestorDriver.h
+++ b/src/platform/GenericOTARequestorDriver.h
@@ -45,7 +45,7 @@ public:
     bool CanConsent() override;
     uint16_t GetMaxDownloadBlockSize() override;
 
-    void HandleError(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum state, CHIP_ERROR error) override;
+    void HandleError(UpdateFailureState state, CHIP_ERROR error) override;
     void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) override;
     void UpdateNotFound(UpdateNotFoundReason reason, System::Clock::Seconds32 delay) override;
     void UpdateDownloaded() override;
@@ -54,8 +54,7 @@ public:
     void UpdateDiscontinued() override;
 
 private:
-    void ScheduleDelayedAction(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum state, System::Clock::Seconds32 delay,
-                               System::TimerCompleteCallback action);
+    void ScheduleDelayedAction(UpdateFailureState state, System::Clock::Seconds32 delay, System::TimerCompleteCallback action);
 
     OTARequestorInterface * mRequestor           = nullptr;
     OTAImageProcessorInterface * mImageProcessor = nullptr;

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/clusters/ota-requestor/OTADownloader.h>
+#include <platform/OTARequestorInterface.h>
 
 #include "OTAImageProcessorImpl.h"
 
@@ -42,6 +43,7 @@ CHIP_ERROR OTAImageProcessorImpl::Finalize()
 
 CHIP_ERROR OTAImageProcessorImpl::Apply()
 {
+    DeviceLayer::PlatformMgr().ScheduleWork(HandleApply, reinterpret_cast<intptr_t>(this));
     return CHIP_NO_ERROR;
 }
 
@@ -119,6 +121,15 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     imageProcessor->ReleaseBlock();
 
     ChipLogProgress(SoftwareUpdate, "OTA image downloaded to %s", imageProcessor->mParams.imageFile.data());
+}
+
+void OTAImageProcessorImpl::HandleApply(intptr_t context)
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor != nullptr)
+    {
+        requestor->NotifyUpdateApplied();
+    }
 }
 
 void OTAImageProcessorImpl::HandleAbort(intptr_t context)

--- a/src/platform/Linux/OTAImageProcessorImpl.h
+++ b/src/platform/Linux/OTAImageProcessorImpl.h
@@ -42,6 +42,7 @@ private:
     //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
     static void HandlePrepareDownload(intptr_t context);
     static void HandleFinalize(intptr_t context);
+    static void HandleApply(intptr_t context);
     static void HandleAbort(intptr_t context);
     static void HandleProcessBlock(intptr_t context);
 


### PR DESCRIPTION
#### Problem
Currently, after an OTA image has been applied, there is no way to notify the provider of this
Fixes: https://github.com/project-chip/connectedhomeip/issues/9527

#### Change overview
- Add a new `NotifyUpdateApplied` API to be called whenever provider should be notified that an image has been successfully applied
- Decouple the usage of `OTAUpdateStateEnum` from `HandleError` as more specific state for notifying is needed
- Call `NotifyUpdateApplied` from the Linux implementation of Apply to update states and notify appropriately

#### Testing
Manual testing of Linux provider/requestor transfer
- Verified that after a transfer is completed, the provider receives the NotifyUpdateApplied request