### PR TITLE
Ensure pointers in AndroidDeviceControllerWrapper are init to nullptr

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -120,12 +120,12 @@ private:
     bool mNodeIdRequested             = false;
 
     // These fields allow us to release the string/byte array memory later.
-    jstring ssidStr;
-    jstring passwordStr;
-    const char * ssid;
-    const char * password;
-    jbyteArray operationalDatasetBytes;
-    jbyte * operationalDataset;
+    jstring ssidStr                    = nullptr;
+    jstring passwordStr                = nullptr;
+    const char * ssid                  = nullptr;
+    const char * password              = nullptr;
+    jbyteArray operationalDatasetBytes = nullptr;
+    jbyte * operationalDataset         = nullptr;
 
     AndroidDeviceControllerWrapper(ChipDeviceControllerPtr controller) : mController(std::move(controller))
     {


### PR DESCRIPTION
* Fixes a crash attempting to release an uninitialized pointer
* Fixes #13556

#### Testing
Tested locally on an Android device on the reported code path without a crash.