### PR TITLE
[OTA] QueryImageResponse status reflects command line input

### DIFF
--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -54,7 +54,7 @@ constexpr uint16_t kOptionQueryImageBehavior   = 'q';
 constexpr uint16_t kOptionDelayedActionTimeSec = 'd';
 
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
-OTAProviderExample::queryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
+OTAProviderExample::QueryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
 uint32_t gDelayedActionTimeSec                                 = 0;
 const char * gOtaFilepath                                      = nullptr;
 
@@ -91,7 +91,7 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
         }
         else if (strcmp(aValue, "UpdateNotAvailable") == 0)
         {
-            gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
+            gQueryImageBehavior = OTAProviderExample::kRespondWithNotAvailable;
         }
         else
         {

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -44,19 +44,19 @@ public:
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::DecodableType & commandData) override;
 
-    enum queryImageBehaviorType
+    enum QueryImageBehaviorType
     {
         kRespondWithUpdateAvailable,
         kRespondWithBusy,
         kRespondWithNotAvailable
     };
-    void SetQueryImageBehavior(queryImageBehaviorType behavior) { mQueryImageBehavior = behavior; }
+    void SetQueryImageBehavior(QueryImageBehaviorType behavior) { mQueryImageBehavior = behavior; }
     void SetDelayedActionTimeSec(uint32_t time) { mDelayedActionTimeSec = time; }
 
 private:
     BdxOtaSender mBdxOtaSender;
     static constexpr size_t kFilepathBufLen = 256;
     char mOTAFilePath[kFilepathBufLen]; // null-terminated
-    queryImageBehaviorType mQueryImageBehavior;
+    QueryImageBehaviorType mQueryImageBehavior;
     uint32_t mDelayedActionTimeSec;
 };


### PR DESCRIPTION
#### Problem
Currently, when `UpdateNotAvailable` is specified as the command line input to ota-provider-app, the status for `UpdateAvailable` is still sent as part of QueryImageResponse
Fixes: https://github.com/project-chip/connectedhomeip/issues/13387

#### Change overview
Send `NotAvailable` status as part of QueryImageResponse when the command line specifies `UpdateNotAvailable`

#### Testing
```
chip-ota-provider-app -f test.bin -q UpdateNotAvailable
chip-tool pairing onnetwork 0xBEEFFEEB 20202021
chip-ota-requestor-app -d 30 -u 5550
chip-tool pairing onnetwork-long 0x1234567890 20202021 30
chip-tool otasoftwareupdaterequestor announce-ota-provider 0x00000000BEEFFEEB 0 0 0 0x0000001234567890 0
```
Verified that the QueryImageResponse on the Requestor side received the correct status of 2 for `NotAvailable`:
```
[1642134593781] [30502:3780102] CHIP: [SWU] QueryImageResponse:
[1642134593781] [30502:3780102] CHIP: [SWU]   status: 2
[1642134593781] [30502:3780102] CHIP: [SWU]   delayedActionTime: 0 seconds
[1642134593781] [30502:3780102] CHIP: [SWU]   imageURI: bdx://00000000BEEFFEEB/test.bin
[1642134593781] [30502:3780102] CHIP: [SWU]   softwareVersion: 1
[1642134593781] [30502:3780102] CHIP: [SWU]   softwareVersionString: Example-Image-V0.1
[1642134593781] [30502:3780102] CHIP: [SWU]   updateToken: 32
[1642134593781] [30502:3780102] CHIP: [SWU]   userConsentNeeded: 0
[1642134593781] [30502:3780102] CHIP: [SWU]   metadataForRequestor: 0
```