### PR TITLE
ESP:Remove ApplyUpdateRequest console command from ESP ota-requestor-app

### DIFF
--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -40,18 +40,13 @@ After commissioning is successful, announce OTA provider's presence using
 chip-tool. On receiving this command OTA requestor will query for OTA image.
 
 ```
-./out/debug/chip-tool otasoftwareupdaterequestor announce-ota-provider 12345 0 0 12346 0
+./out/debug/chip-tool otasoftwareupdaterequestor announce-ota-provider 12345 0 0 0 12346 0
 ```
 
 ## Apply update request
 
-Once transfer is complete OTA Requestor should take permission from the OTA
-Provider for applying the OTA image. Use the following command from OTA
-requestor prompt
-
-```
-esp32> ApplyUpdateRequest
-```
+Once transfer is complete OTA Requestor will take permission from the OTA
+Provider for applying the OTA image automatically.
 
 Then reboot the device manually to boot from upgraded OTA image.
 

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -32,11 +32,6 @@
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Server.h>
 
-#include <cmath>
-#include <cstdio>
-#include <string>
-#include <vector>
-
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
@@ -45,8 +40,6 @@
 #include "OTAImageProcessorImpl.h"
 #include "platform/GenericOTARequestorDriver.h"
 #include "platform/OTARequestorInterface.h"
-#include <argtable3/argtable3.h>
-#include <esp_console.h>
 
 using namespace ::chip;
 using namespace ::chip::System;
@@ -54,54 +47,15 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-struct CmdArgs
-{
-    struct arg_end * end;
-};
-
 namespace {
 const char * TAG = "ota-requester-app";
 static DeviceCallbacks EchoCallbacks;
-CmdArgs applyUpdateCmdArgs;
 
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 } // namespace
-
-int ESPApplyUpdateCmdHandler(int argc, char ** argv)
-{
-    gRequestorCore.ApplyUpdate();
-    ESP_LOGI(TAG, "Apply the Update");
-    return 0;
-}
-
-void ESPInitConsole(void)
-{
-    esp_console_repl_t * repl                = NULL;
-    esp_console_repl_config_t replConfig     = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
-    esp_console_dev_uart_config_t uartConfig = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
-    /* Prompt to be printed before each line.
-     * This can be customized, made dynamic, etc.
-     */
-    replConfig.prompt = "esp32 >";
-
-    esp_console_register_help_command();
-
-    esp_console_cmd_t applyUpdateCommand;
-    memset(&applyUpdateCommand, 0, sizeof(applyUpdateCommand));
-
-    applyUpdateCmdArgs.end = arg_end(1);
-
-    applyUpdateCommand.command = "ApplyUpdateRequest", applyUpdateCommand.help = "Request to OTA update image",
-    applyUpdateCommand.func = &ESPApplyUpdateCmdHandler, applyUpdateCommand.argtable = &applyUpdateCmdArgs;
-
-    esp_console_cmd_register(&applyUpdateCommand);
-
-    esp_console_new_repl_uart(&uartConfig, &replConfig, &repl);
-    esp_console_start_repl(repl);
-}
 
 extern "C" void app_main()
 {
@@ -140,7 +94,6 @@ extern "C" void app_main()
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
-    ESPInitConsole();
     SetRequestorInstance(&gRequestorCore);
     gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);


### PR DESCRIPTION
#### Problem
Now the OTARequestor can send the ApplyImage command to the OTAProvider and apply the image downloaded, so we don't need the ApplyUpdateRequest console command now.

#### Change overview
Remove ESPConsole in ota-requestor-app of ESP platform.

#### Testing
Test with ESP32C3 manually.