### PR TITLE
Fix Local Session ID allocation to be global

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -619,6 +619,15 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
 
     params.systemState->SessionMgr()->RegisterRecoveryDelegate(*this);
 
+#if 0 // TODO: SessionID persistence results in bugs when instantiating multiple DeviceCommissioners
+      // on multiple fabrics due to not doing persistence completely, i.e not persisting the session ID
+      // upon completion of CASE. This results in the 2nd-to-N commissioners upon initialization picking
+      // up a stale value for the next available session ID and colliding with a previously picked local session ID
+      // from another commissioner instance.
+      //
+      // For now, just disable all persistence.
+      //
+
     uint16_t nextKeyID = 0;
     uint16_t size      = sizeof(nextKeyID);
     CHIP_ERROR error   = mStorageDelegate->SyncGetKeyValue(kNextAvailableKeyID, &nextKeyID, size);
@@ -627,6 +636,8 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
         nextKeyID = 0;
     }
     ReturnErrorOnFailure(mIDAllocator.ReserveUpTo(nextKeyID));
+#endif
+
     mPairingDelegate = params.pairingDelegate;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
@@ -840,7 +851,10 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 
     // Immediately persist the updated mNextKeyID value
     // TODO maybe remove FreeRendezvousSession() since mNextKeyID is always persisted immediately
-    PersistNextKeyId();
+    //
+    // Disabling session ID persistence (see previous comment in Init() about persisting key ids)
+    //
+    // PersistNextKeyId();
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -619,13 +619,10 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
 
     params.systemState->SessionMgr()->RegisterRecoveryDelegate(*this);
 
-#if 0 // TODO: SessionID persistence results in bugs when instantiating multiple DeviceCommissioners
-      // on multiple fabrics due to not doing persistence completely, i.e not persisting the session ID
-      // upon completion of CASE. This results in the 2nd-to-N commissioners upon initialization picking
-      // up a stale value for the next available session ID and colliding with a previously picked local session ID
-      // from another commissioner instance.
-      //
-      // For now, just disable all persistence.
+#if 0 //
+      // We cannot reinstantiate session ID allocator state from each fabric-scoped commissioner
+      // individually because the session ID allocator space is and must be shared for all users
+      // of the Session Manager. Disable persistence for now. #12821 tracks a proper fix this issue.
       //
 
     uint16_t nextKeyID = 0;

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -21,14 +21,16 @@
 
 namespace chip {
 
+uint16_t SessionIDAllocator::sNextAvailable = 1;
+
 CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 {
-    VerifyOrReturnError(mNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
-    VerifyOrReturnError(mNextAvailable > kUnsecuredSessionId, CHIP_ERROR_INTERNAL);
-    id = mNextAvailable;
+    VerifyOrReturnError(sNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(sNextAvailable > kUnsecuredSessionId, CHIP_ERROR_INTERNAL);
+    id = sNextAvailable;
 
     // TODO - Update SessionID allocator to use freed session IDs
-    mNextAvailable++;
+    sNextAvailable++;
 
     return CHIP_NO_ERROR;
 }
@@ -36,19 +38,19 @@ CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 void SessionIDAllocator::Free(uint16_t id)
 {
     // As per spec 4.4.1.3 Session ID of 0 is reserved for Unsecure communication
-    if (mNextAvailable > (kUnsecuredSessionId + 1) && (mNextAvailable - 1) == id)
+    if (sNextAvailable > (kUnsecuredSessionId + 1) && (sNextAvailable - 1) == id)
     {
-        mNextAvailable--;
+        sNextAvailable--;
     }
 }
 
 CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
 {
     VerifyOrReturnError(id < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
-    if (id >= mNextAvailable)
+    if (id >= sNextAvailable)
     {
-        mNextAvailable = id;
-        mNextAvailable++;
+        sNextAvailable = id;
+        sNextAvailable++;
     }
 
     // TODO - Check if ID is already allocated in SessionIDAllocator::Reserve()
@@ -59,23 +61,23 @@ CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
 CHIP_ERROR SessionIDAllocator::ReserveUpTo(uint16_t id)
 {
     VerifyOrReturnError(id < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
-    if (id >= mNextAvailable)
+    if (id >= sNextAvailable)
     {
-        mNextAvailable = id;
-        mNextAvailable++;
+        sNextAvailable = id;
+        sNextAvailable++;
     }
 
     // TODO - Update ReserveUpTo to mark all IDs in use
     // Current SessionIDAllocator only tracks the smallest unused session ID.
     // If/when we change it to track all in use IDs, we should also update ReserveUpTo
-    // to reserve all individual session IDs, instead of just setting the mNextAvailable.
+    // to reserve all individual session IDs, instead of just setting the sNextAvailable.
 
     return CHIP_NO_ERROR;
 }
 
 uint16_t SessionIDAllocator::Peek()
 {
-    return mNextAvailable;
+    return sNextAvailable;
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -27,6 +27,9 @@
 // available keys (either session or group), and the particular encryption/message
 // integrity algorithm to use for the message.The Session ID field is always present.
 // A Session ID of 0 SHALL indicate an unsecured session with no encryption or message integrity checking.
+//
+// The Session ID is allocated from a global numerical space shared across all fabrics and nodes on the resident process instance.
+//
 
 namespace chip {
 
@@ -46,7 +49,7 @@ private:
     static constexpr uint16_t kMaxSessionID       = UINT16_MAX;
     static constexpr uint16_t kUnsecuredSessionId = 0;
 
-    uint16_t mNextAvailable = 1;
+    static uint16_t sNextAvailable;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -44,56 +44,58 @@ void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
 void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
-
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 1);
+    uint16_t i = allocator.Peek();
 
     uint16_t id;
 
-    for (uint16_t i = 1; i < 17; i++)
+    for (uint16_t j = 0; j < 17; j++)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+        NL_TEST_ASSERT(inSuite, id == (i + j));
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + j + 1));
     }
 
     // Free an intermediate ID
     allocator.Free(10);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 17);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 17));
 
     // Free the last allocated ID
-    allocator.Free(16);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 16);
+    allocator.Free(i + 16);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 16));
 
     // Free some random unallocated ID
     allocator.Free(100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 16);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 16));
 }
 
 void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
-
+    uint16_t i = allocator.Peek();
     uint16_t id;
 
-    for (uint16_t i = 1; i < 16; i++)
+    for (uint16_t j = 0; j < 17; j++)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+        NL_TEST_ASSERT(inSuite, id == (i + j));
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + j + 1));
     }
 
-    allocator.Reserve(100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 101);
+    i = allocator.Peek();
+    allocator.Reserve(i + 100);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 101));
 }
 
 void TestSessionIDAllocator_ReserveUpTo(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
+    uint16_t i = allocator.Peek();
 
-    allocator.ReserveUpTo(100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 101);
+    i = allocator.Peek();
+    allocator.Reserve(i + 100);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 101));
 }
 
 // Test Suite

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -24,23 +24,6 @@
 
 using namespace chip;
 
-void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
-{
-    SessionIDAllocator allocator;
-
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 1);
-
-    uint16_t id;
-
-    for (uint16_t i = 1; i < 16; i++)
-    {
-        CHIP_ERROR err = allocator.Allocate(id);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 1));
-    }
-}
-
 void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
@@ -106,7 +89,6 @@ void TestSessionIDAllocator_ReserveUpTo(nlTestSuite * inSuite, void * inContext)
 // clang-format off
 static const nlTest sTests[] =
 {
-    NL_TEST_DEF("SessionIDAllocator_Allocate", TestSessionIDAllocator_Allocate),
     NL_TEST_DEF("SessionIDAllocator_Free", TestSessionIDAllocator_Free),
     NL_TEST_DEF("SessionIDAllocator_Reserve", TestSessionIDAllocator_Reserve),
     NL_TEST_DEF("SessionIDAllocator_ReserveUpTo", TestSessionIDAllocator_ReserveUpTo),

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -37,7 +37,7 @@ void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 1));
     }
 }
 
@@ -52,21 +52,21 @@ void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == (i + j));
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + j + 1));
+        NL_TEST_ASSERT(inSuite, id == static_cast<uint16_t>(i + j));
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + j + 1));
     }
 
     // Free an intermediate ID
     allocator.Free(10);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 17));
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 17));
 
     // Free the last allocated ID
-    allocator.Free(i + 16);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 16));
+    allocator.Free(static_cast<uint16_t>(i + 16));
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 16));
 
     // Free some random unallocated ID
     allocator.Free(100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 16));
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 16));
 }
 
 void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
@@ -79,13 +79,13 @@ void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == (i + j));
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + j + 1));
+        NL_TEST_ASSERT(inSuite, id == static_cast<uint16_t>(i + j));
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + j + 1));
     }
 
     i = allocator.Peek();
-    allocator.Reserve(i + 100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 101));
+    allocator.Reserve(static_cast<uint16_t>(i + 100));
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 101));
 }
 
 void TestSessionIDAllocator_ReserveUpTo(nlTestSuite * inSuite, void * inContext)
@@ -94,8 +94,8 @@ void TestSessionIDAllocator_ReserveUpTo(nlTestSuite * inSuite, void * inContext)
     uint16_t i = allocator.Peek();
 
     i = allocator.Peek();
-    allocator.Reserve(i + 100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == (i + 101));
+    allocator.Reserve(static_cast<uint16_t>(i + 100));
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == static_cast<uint16_t>(i + 101));
 }
 
 // Test Suite


### PR DESCRIPTION
#### Problem

The `SessionIDAllocator` is instantiated uniquely within each controller instance. This usually results in collisions. To prevent those, persistent storage was used to effectively synchronize these and store/retrieve a single shared value across all controller instances. The 'next session ID' key was updated anytime PASE session was established, but not for CASE.

This meant that upon construction of each unique controller instance, it would incorrectly load a stale value for the next session ID from storage and consequently, pick the same session ID that a previous controller selected. This caused all kinds of havoc when establishing CASE with two controller instances to a given server.

A proper fix will take time (tracked in #12821). This fix removes persistence for now (since I believe no one is actively relying on it) and makes the SessionIDAllocator global.

### Sequence of events show-casing failure:

F1:Ctrlr1 is created. Commission a target.

* PASE is initiated. Load LSID from disk (0). LSID1 is used. LSID2 is persisted to storage.
* CASE is initiated. LSID2 is used (LSID not persisted)

F2:Ctrl1 is created. Commission target.

* PASE is initiated. Load LSID from disk (2). LSID3 is used. LSID4 is persisted to storage.
* CASE is initiated. LSID4 is used (LSID not persisted)

So far, so good. We have two functional case sessions.

---- Restart controller side SDK instance ----- 

F1:Ctrl1 connects over CASE to target.

* Load LSID from disk (4). LSID5 is used to connect over CASE to the target.

F2:Ctrl1 connects over CASE to target.

* Load LSID from disk (4). LSID5 is used to connect over CASE to the target <--- collision.

Now, this by itself hasn't caused visible problems yet. However, what's happening is that F1C1 is actually referencing the same session within the sessions tracked by `SessionManager` as that being used by F2C1, which means it's actually using F2C1's CASE session to send its traffic!

F3:Ctrl1 is created. Commission target.

* PASE is initiated. Load LSID from disk (4). LSID5 is used. LSID6 is persisted to storage.
* CASE is initiated. LSID6 is used.

At this point, both F1C1 and F2C2's session handles are actually pointing the F3C1's PASE session. However, that PASE session is no longer valid on the target, so if you try to communicate through F1C2 or F2C2, you get "unknown session" error on the target.

#### Testing

This logic was tested in the Python REPL with multi-fabric commissioning.