### PR TITLE
Cluster id should always be 4 bytes long

### DIFF
--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -331,7 +331,7 @@ public:
     }
 
 protected:
-    ClusterBase(uint16_t cluster) : mClusterId(cluster) {}
+    ClusterBase(uint32_t cluster) : mClusterId(cluster) {}
 
     const ClusterId mClusterId;
     DeviceProxy * mDevice;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -331,7 +331,7 @@ public:
     }
 
 protected:
-    ClusterBase(uint32_t cluster) : mClusterId(cluster) {}
+    ClusterBase(ClusterId cluster) : mClusterId(cluster) {}
 
     const ClusterId mClusterId;
     DeviceProxy * mDevice;


### PR DESCRIPTION
#### Problem
Having uint16 for `ClusterBase` leads to compile failure when manufacturer id is not 0 (Matter default case).

#### Change overview
Changed `ClusterBase` to `ClusterId`.

#### Testing
Tested by compiling chip-tool with a custom cluster that has manufacturer id which is not 0. 