### PR TITLE
[docker] Bump west version in nRF Connect Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /opt/NordicSemiconductor/nrfconnect
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
     cmake==3.21.2 \
-    west==0.11.1 \
+    west==0.12.0 \
     && west init -m https://github.com/nrfconnect/sdk-nrf \
     && git -C nrf fetch origin "$NCS_REVISION" \
     && git -C nrf checkout FETCH_HEAD \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.47 Version bump reason: [Ameba] Revise build script for otar
+0.5.48 Version bump reason: [nrf] Bump west version


### PR DESCRIPTION
#### Problem
nRF Docker doesn't build due to too old version of `west` tool.

#### Change overview
Bump west version.

#### Testing
Tested by Docker build workflow.
