### PR TITLE
Add occupancy sensor to the all-clusters-app

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -507,6 +507,12 @@ void SetupPretendDevices()
     AddEndpoint("Door 2");
     AddCluster("Door");
     AddAttribute("State", "Closed");
+
+    AddDevice("Occupancy Sensor");
+    AddEndpoint("External");
+    AddCluster("Occupancy Sensor");
+    AddAttribute("Occupancy", "1");
+    app::Clusters::OccupancySensing::Attributes::Occupancy::Set(1, 1);
 }
 
 WiFiWidget pairingWindowLED;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Adds occupancy sensor default value

#### Change overview
Add support for occupancy sensor

#### Testing
How was this tested? (at least one bullet point required)
* Tested using m5stack
