### PR TITLE
Replace cluster_attributes with server_cluster_attributes

### DIFF
--- a/src/app/zap-templates/templates/app/MatterIDL.zapt
+++ b/src/app/zap-templates/templates/app/MatterIDL.zapt
@@ -30,7 +30,7 @@
   }
 
   {{/zcl_events}}
-  {{#chip_cluster_attributes}}
+  {{#chip_server_cluster_attributes}}
   attribute(
     {{~#if isWritableAttribute~}}
       writable
@@ -44,7 +44,7 @@
     {{~#if isList~}}
       []
     {{~/if}} = {{code}};
-  {{/chip_cluster_attributes}}
+  {{/chip_server_cluster_attributes}}
   {{#chip_cluster_commands}}
   {{#if arguments}}
 

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -222,20 +222,6 @@ function chip_cluster_commands(options)
 }
 
 /**
- * Creates block iterator over the cluster attributes for a given cluster/side.
- *
- * This function is meant to be used inside a {{#chip_*_clusters}}
- * block. It will throw otherwise.
- *
- * @param {*} options
- */
-function chip_cluster_attributes(options)
-{
-  const attributes = getAttributes.call(this, 'chip_cluster_attributes');
-
-  return asBlocks.call(this, attributes, options);
-}
-/**
  * Creates block iterator over the cluster responses for a given cluster/side.
  *
  * This function is meant to be used inside a {{#chip_*_clusters}}
@@ -467,7 +453,6 @@ exports.chip_has_server_clusters                             = chip_has_server_c
 exports.chip_cluster_commands                                = chip_cluster_commands;
 exports.chip_cluster_command_arguments                       = chip_cluster_command_arguments;
 exports.chip_cluster_command_arguments_with_structs_expanded = chip_cluster_command_arguments_with_structs_expanded;
-exports.chip_cluster_attributes                              = chip_cluster_attributes;
 exports.chip_server_global_responses                         = chip_server_global_responses;
 exports.chip_cluster_responses                               = chip_cluster_responses;
 exports.chip_cluster_response_arguments                      = chip_cluster_response_arguments


### PR DESCRIPTION
#### Problem
I was told during IDL code review that matter only has `server` cluster attributes. Having a separate call used for "all attributes" is not useful  and makes the code harder to maintain.

#### Change overview
Delete useless method, replace with the one used everywhere else

#### Testing
ZAP idl generation confirms that no IDL changes after the update.