### PR TITLE
Support persistent storage of WiFi Credentials for Infineon P6

### DIFF
--- a/examples/lighting-app/p6/src/AppTask.cpp
+++ b/examples/lighting-app/p6/src/AppTask.cpp
@@ -164,11 +164,10 @@ void AppTask::AppTaskMain(void * pvParameter)
 
     while (true)
     {
-        BaseType_t eventReceived = xQueueReceive(sAppEventQueue, &event, pdMS_TO_TICKS(10));
-        while (eventReceived == pdTRUE)
+        BaseType_t eventReceived = xQueueReceive(sAppEventQueue, &event, portMAX_DELAY);
+        if (eventReceived == pdTRUE)
         {
             sAppTask.DispatchEvent(&event);
-            eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
 
         // Collect connectivity and configuration state from the CHIP stack. Because
@@ -335,7 +334,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
     // FACTORY_RESET_TRIGGER_TIMEOUT to signal factory reset has been initiated.
     // To cancel factory reset: release the APP_FUNCTION_BUTTON once all LEDs
     // start blinking within the FACTORY_RESET_CANCEL_WINDOW_TIMEOUT
-    if (aEvent->ButtonEvent.Action == APP_BUTTON_PRESSED)
+    if (aEvent->ButtonEvent.Action == APP_BUTTON_RELEASED)
     {
         if (!sAppTask.mFunctionTimerActive && sAppTask.mFunction == Function::kNoneSelected)
         {

--- a/examples/lock-app/p6/src/AppTask.cpp
+++ b/examples/lock-app/p6/src/AppTask.cpp
@@ -161,11 +161,10 @@ void AppTask::AppTaskMain(void * pvParameter)
 
     while (true)
     {
-        BaseType_t eventReceived = xQueueReceive(sAppEventQueue, &event, pdMS_TO_TICKS(10));
-        while (eventReceived == pdTRUE)
+        BaseType_t eventReceived = xQueueReceive(sAppEventQueue, &event, portMAX_DELAY);
+        if (eventReceived == pdTRUE)
         {
             sAppTask.DispatchEvent(&event);
-            eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
         // Collect connectivity and configuration state from the CHIP stack. Because
         // the CHIP event loop is being run in a separate task, the stack must be
@@ -334,7 +333,7 @@ void AppTask::FunctionHandler(AppEvent * event)
     // FACTORY_RESET_TRIGGER_TIMEOUT to signal factory reset has been initiated.
     // To cancel factory reset: release the APP_FUNCTION_BUTTON once all LEDs
     // start blinking within the FACTORY_RESET_CANCEL_WINDOW_TIMEOUT
-    if (event->ButtonEvent.Action == APP_BUTTON_PRESSED)
+    if (event->ButtonEvent.Action == APP_BUTTON_RELEASED)
     {
         if (!sAppTask.mFunctionTimerActive && sAppTask.mFunction == Function::kNoneSelected)
         {

--- a/src/platform/P6/ConnectivityManagerImpl.cpp
+++ b/src/platform/P6/ConnectivityManagerImpl.cpp
@@ -55,6 +55,11 @@ ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
 ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode(void)
 {
+    uint32_t curWiFiMode;
+    mWiFiStationMode = (Internal::P6Utils::wifi_get_mode(curWiFiMode) == CHIP_NO_ERROR &&
+                        (curWiFiMode == WIFI_MODE_APSTA || curWiFiMode == WIFI_MODE_STA))
+        ? kWiFiStationMode_Enabled
+        : kWiFiStationMode_Disabled;
     return mWiFiStationMode;
 }
 
@@ -181,7 +186,6 @@ exit:
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
     CHIP_ERROR err                = CHIP_NO_ERROR;
-    cy_rslt_t result              = CY_RSLT_SUCCESS;
     mLastStationConnectFailTime   = System::Clock::kZero;
     mLastAPDemandTime             = System::Clock::kZero;
     mWiFiStationMode              = kWiFiStationMode_Disabled;
@@ -208,13 +212,8 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
         memcpy(wifiConfig.sta.password, CHIP_DEVICE_CONFIG_DEFAULT_STA_PASSWORD,
                min(strlen(CHIP_DEVICE_CONFIG_DEFAULT_STA_PASSWORD), sizeof(wifiConfig.sta.password)));
         wifiConfig.sta.security = CHIP_DEVICE_CONFIG_DEFAULT_STA_SECURITY;
-        result                  = Internal::P6Utils::p6_wifi_set_config(WIFI_IF_STA, &wifiConfig);
-        if (result != CY_RSLT_SUCCESS)
-        {
-            ChipLogError(DeviceLayer, "p6_wifi_set_config() failed: %d", (int) result);
-            SuccessOrExit(CHIP_ERROR_INTERNAL);
-        }
-        err = CHIP_NO_ERROR;
+        err                     = Internal::P6Utils::p6_wifi_set_config(WIFI_IF_STA, &wifiConfig);
+        SuccessOrExit(err);
     }
     // Force AP mode off for now.
     err = Internal::P6Utils::SetAPMode(false);
@@ -323,7 +322,6 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     wifi_config_t wifiConfig;
-    cy_rslt_t result = CY_RSLT_SUCCESS;
 
     memset(&wifiConfig.ap, 0, sizeof(wifi_config_ap_t));
     snprintf((char *) wifiConfig.ap.ssid, sizeof(wifiConfig.ap.ssid), "%s-%04X-%04X", CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX,
@@ -336,13 +334,8 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     wifiConfig.ap.ip_settings.gateway    = ap_mode_ip_settings.gateway;
 
     ChipLogProgress(DeviceLayer, "Configuring WiFi AP: SSID %s, channel %u", wifiConfig.ap.ssid, wifiConfig.ap.channel);
-    result = Internal::P6Utils::p6_wifi_set_config(WIFI_IF_AP, &wifiConfig);
-    if (result != CY_RSLT_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "p6_wifi_set_config(WIFI_IF_AP) failed: %d", (int) result);
-        err = CHIP_ERROR_INTERNAL;
-        SuccessOrExit(err);
-    }
+    err = Internal::P6Utils::p6_wifi_set_config(WIFI_IF_AP, &wifiConfig);
+    SuccessOrExit(err);
 
     err = Internal::P6Utils::p6_start_ap();
     if (err != CHIP_NO_ERROR)
@@ -478,6 +471,9 @@ void ConnectivityManagerImpl::DriveStationState()
     CHIP_ERROR err = CHIP_NO_ERROR;
     bool stationConnected;
 
+    // Refresh the current station mode by reading the configuration from storage.
+    GetWiFiStationMode();
+
     // If the station interface is NOT under application control...
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
@@ -609,6 +605,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                 event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
                 event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV4_Assigned;
                 PlatformMgr().PostEventOrDie(&event);
+                ChipLogProgress(DeviceLayer, "IPv4 Address Assigned : %s", ip4addr_ntoa(netif_ip4_addr(net_interface)));
             }
             // Search among the IPv6 addresses assigned to the interface for a Global Unicast
             // address (2000::/3) that is in the valid state.  If such an address is found...
@@ -622,6 +619,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                     event.Type                           = DeviceEventType::kInterfaceIpAddressChanged;
                     event.InterfaceIpAddressChanged.Type = InterfaceIpChangeType::kIpV6_Assigned;
                     PlatformMgr().PostEventOrDie(&event);
+                    ChipLogProgress(DeviceLayer, "IPv6 Address Assigned : %s", ip6addr_ntoa(netif_ip6_addr(net_interface, i)));
                 }
             }
         }

--- a/src/platform/P6/DeviceNetworkProvisioningDelegateImpl.cpp
+++ b/src/platform/P6/DeviceNetworkProvisioningDelegateImpl.cpp
@@ -27,7 +27,6 @@ namespace DeviceLayer {
 CHIP_ERROR DeviceNetworkProvisioningDelegateImpl::_ProvisionWiFiNetwork(const char * ssid, const char * passwd)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    cy_rslt_t rslt = CY_RSLT_SUCCESS;
 
     ChipLogProgress(NetworkProvisioning, "P6NetworkProvisioningDelegate: SSID: %s", ssid);
     err = ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled);
@@ -36,14 +35,10 @@ CHIP_ERROR DeviceNetworkProvisioningDelegateImpl::_ProvisionWiFiNetwork(const ch
     // Set the wifi configuration
     wifi_config_t wifi_config;
     Internal::P6Utils::populate_wifi_config_t(&wifi_config, WIFI_IF_STA, (const cy_wcm_ssid_t *) ssid,
-                                              (const cy_wcm_passphrase_t *) passwd, CHIP_DEVICE_CONFIG_DEFAULT_STA_SECURITY);
+                                              (const cy_wcm_passphrase_t *) passwd,
+                                              (strlen(passwd)) ? CHIP_DEVICE_CONFIG_DEFAULT_STA_SECURITY : CY_WCM_SECURITY_OPEN);
 
-    rslt = Internal::P6Utils::p6_wifi_set_config(WIFI_IF_STA, &wifi_config);
-    if (rslt != CY_RSLT_SUCCESS)
-    {
-        err = CHIP_ERROR_INTERNAL;
-        ChipLogError(DeviceLayer, "p6_wifi_set_config() failed");
-    }
+    err = Internal::P6Utils::p6_wifi_set_config(WIFI_IF_STA, &wifi_config);
     SuccessOrExit(err);
 
     err = ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled);

--- a/src/platform/P6/P6Config.cpp
+++ b/src/platform/P6/P6Config.cpp
@@ -73,6 +73,10 @@ const P6Config::Key P6Config::kConfigKey_ActiveLocale       = { kConfigNamespace
 const P6Config::Key P6Config::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 const P6Config::Key P6Config::kConfigKey_HourFormat         = { kConfigNamespace_ChipConfig, "hour-format" };
 const P6Config::Key P6Config::kConfigKey_CalendarType       = { kConfigNamespace_ChipConfig, "calendar-type" };
+const P6Config::Key P6Config::kConfigKey_WiFiSSID           = { kConfigNamespace_ChipConfig, "wifi-ssid" };
+const P6Config::Key P6Config::kConfigKey_WiFiPassword       = { kConfigNamespace_ChipConfig, "wifi-password" };
+const P6Config::Key P6Config::kConfigKey_WiFiSecurity       = { kConfigNamespace_ChipConfig, "wifi-security" };
+const P6Config::Key P6Config::kConfigKey_WiFiMode           = { kConfigNamespace_ChipConfig, "wifimode" };
 
 // Keys stored in the Chip-counters namespace
 const P6Config::Key P6Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };
@@ -212,9 +216,10 @@ bool P6Config::ConfigValueExists(Key key)
 // Clear out keys in config namespace
 CHIP_ERROR P6Config::FactoryResetConfig(void)
 {
-    const Key * config_keys[] = { &kConfigKey_FabricId,      &kConfigKey_ServiceConfig,     &kConfigKey_PairedAccountId,
-                                  &kConfigKey_ServiceId,     &kConfigKey_GroupKeyIndex,     &kConfigKey_LastUsedEpochKeyId,
-                                  &kConfigKey_FailSafeArmed, &kConfigKey_WiFiStationSecType };
+    const Key * config_keys[] = { &kConfigKey_FabricId,      &kConfigKey_ServiceConfig,      &kConfigKey_PairedAccountId,
+                                  &kConfigKey_ServiceId,     &kConfigKey_GroupKeyIndex,      &kConfigKey_LastUsedEpochKeyId,
+                                  &kConfigKey_FailSafeArmed, &kConfigKey_WiFiStationSecType, &kConfigKey_WiFiSSID,
+                                  &kConfigKey_WiFiPassword,  &kConfigKey_WiFiSecurity,       &kConfigKey_WiFiMode };
 
     for (uint32_t i = 0; i < (sizeof(config_keys) / sizeof(config_keys[0])); i++)
     {

--- a/src/platform/P6/P6Config.h
+++ b/src/platform/P6/P6Config.h
@@ -78,6 +78,10 @@ public:
     static const Key kConfigKey_Breadcrumb;
     static const Key kConfigKey_HourFormat;
     static const Key kConfigKey_CalendarType;
+    static const Key kConfigKey_WiFiSSID;
+    static const Key kConfigKey_WiFiPassword;
+    static const Key kConfigKey_WiFiSecurity;
+    static const Key kConfigKey_WiFiMode;
 
     // CHIP Counter keys
     static const Key kCounterKey_RebootCount;

--- a/src/platform/P6/P6Utils.h
+++ b/src/platform/P6/P6Utils.h
@@ -204,8 +204,8 @@ public:
     static CHIP_ERROR GetWiFiStationProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials);
     static CHIP_ERROR SetWiFiStationProvision(const Internal::DeviceNetworkInfo & netInfo);
     static CHIP_ERROR ClearWiFiStationProvision(void);
-    static cy_rslt_t p6_wifi_get_config(wifi_interface_t interface, wifi_config_t * conf);
-    static cy_rslt_t p6_wifi_set_config(wifi_interface_t interface, wifi_config_t * conf);
+    static CHIP_ERROR p6_wifi_get_config(wifi_interface_t interface, wifi_config_t * conf);
+    static CHIP_ERROR p6_wifi_set_config(wifi_interface_t interface, wifi_config_t * conf);
     static CHIP_ERROR p6_wifi_disconnect(void);
     static CHIP_ERROR p6_wifi_connect(void);
     static CHIP_ERROR p6_start_ap(void);
@@ -218,6 +218,14 @@ public:
     static CHIP_ERROR ping_init(void);
     static void unpack_xtlv_buf(const uint8_t * tlv_buf, uint16_t buflen, wl_cnt_ver_30_t * cnt, wl_cnt_ge40mcst_v1_t * cnt_ge40);
     static void heap_usage(heap_info_t * heap);
+    static CHIP_ERROR GetWiFiSSID(char * buf, size_t bufSize);
+    static CHIP_ERROR StoreWiFiSSID(char * buf);
+    static CHIP_ERROR GetWiFiPassword(char * buf, size_t bufSize);
+    static CHIP_ERROR StoreWiFiPassword(char * buf);
+    static CHIP_ERROR GetWiFiSecurityCode(uint32_t & security);
+    static CHIP_ERROR StoreWiFiSecurityCode(uint32_t security);
+    static CHIP_ERROR wifi_get_mode(uint32_t & security);
+    static CHIP_ERROR wifi_set_mode(uint32_t security);
 };
 
 } // namespace Internal


### PR DESCRIPTION
#### Problem
Wi-Fi Credentials are not saved in the persistent storage for Infineon P6 platform and device was not reconnected after reboot.
P6 Device is not going to deep sleep due to 10ms loop in Apptask 

#### Change overview
Saved WiFi Credentials in the storage for P6 and verified WiFi connect after reboot
Removed 10ms loop in the Apptask
Updated Button event type for Factory reset 

#### Testing
Verified Wi-Fi reconnect after reboot for P6 Platform
Verified Wi-Fi credentials save/restore working after reboot
