### PR TITLE
Move IDL copy logic into generate.py so we can individually update files

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -92,12 +92,32 @@ def runArgumentsParser():
 
     return (zap_file, zcl_file, templates_file, output_dir)
 
+def extractGeneratedIdl(output_dir, zap_config_path):
+    """Find a file Clusters.matter in the output directory and
+       place it along with the input zap file.
+
+       Intent is to make the "zap content" more humanly understandable.
+    """
+    idl_path = os.path.join(output_dir, "Clusters.matter")
+    if not os.path.exists(idl_path):
+        return
+
+    target_path = zap_config_path.replace(".zap", ".matter")
+    if not target_path.endswith(".matter"):
+        # We expect "something.zap" and don't handle corner cases of
+        # multiple extensions. This is to work with existing codebase only
+        raise Error("Unexpected input zap file  %s" % self.zap_config)
+
+    os.rename(idl_path, target_path)
+
 
 def runGeneration(zap_file, zcl_file, templates_file, output_dir):
     generator_dir = getDirPath('third_party/zap/repo')
     os.chdir(generator_dir)
     subprocess.check_call(['node', './src-script/zap-generate.js', '-z',
                           zcl_file, '-g', templates_file, '-i', zap_file, '-o', output_dir])
+
+    extractGeneratedIdl(output_dir, zap_file)
 
 
 def runClangPrettifier(templates_file, output_dir):

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -92,6 +92,7 @@ def runArgumentsParser():
 
     return (zap_file, zcl_file, templates_file, output_dir)
 
+
 def extractGeneratedIdl(output_dir, zap_config_path):
     """Find a file Clusters.matter in the output directory and
        place it along with the input zap file.

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -53,27 +53,6 @@ class ZAPGenerateTarget:
         logging.info("Generating target: %s" % " ".join(cmd))
         subprocess.check_call(cmd)
 
-    def extractAnyGeneratedIDL(self):
-        """Searches for Clusters.matter in the output directory and if found,
-        will move it to stay along with the zap file config
-        """
-        if not self.output_dir:
-            # TODO: where do things get generated if no output dir?
-            # Assume here that IDL is not generated in such cases
-            return
-
-        idl_path = os.path.join(self.output_dir, "Clusters.matter")
-        if not os.path.exists(idl_path):
-            return
-
-        target_path = self.zap_config.replace(".zap", ".matter")
-        if not target_path.endswith(".matter"):
-            # We expect "something.zap" and don't handle corner cases of
-            # multiple extensions. This is to work with existing codebase only
-            raise Error("Unexpected input zap file  %s" % self.zap_config)
-
-        os.rename(idl_path, target_path)
-
 
 def checkPythonVersion():
     if sys.version_info[0] < 3:
@@ -174,7 +153,6 @@ def main():
     targets = getTargets()
     for target in targets:
         target.generate()
-        target.extractAnyGeneratedIDL()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Problem
IDL files for matter are only copied/moved when regenerate-all is run, which is slow.

#### Change overview
Move the logic into generate.py

#### Testing
Manually ran the generate (with changed zapt) and observed differences.
CI will validate that this is a "no changes" operation.
