### PR TITLE
[Mbed] Fix device commisioning - BLE adv and LWIP PKTINFO

### DIFF
--- a/docs/guides/mbedos_commissioning.md
+++ b/docs/guides/mbedos_commissioning.md
@@ -209,7 +209,7 @@ To build and install the Python Device Controller application check the guide
 In order to send commands to a device, it must be paired with the client and
 connected to the network.
 
-To run the commissioning process via BLE:
+To run the auto commissioning process via BLE:
 
 -   Run Device Controller:
 
@@ -219,27 +219,14 @@ To run the commissioning process via BLE:
 
         chip-device-ctrl > ble-scan
 
+-   Pass the Wi-Fi credentials to the device:
+
+        chip-device-ctrl > set-pairing-wifi-credential ssid credentials
+
 -   Connect the device via BLE (provide the accessory device discriminator,
     setup pin code and node ID):
 
         chip-device-ctrl > connect -ble 3840 20202021 1234
-
--   Pass the Wi-Fi credentials to the device:
-
-        chip-device-ctrl > zcl NetworkCommissioning AddOrUpdateWiFiNetwork 1234 0 0 ssid=str:TESTSSID credentials=str:P455W4RD breadcrumb=0 timeoutMs=1000
-
--   Enable the Wi-Fi interface:
-
-        chip-device-ctrl > zcl NetworkCommissioning ConnectNetwork 1234 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
-
--   Close BLE connection:
-
-        chip-device-ctrl > zcl NetworkCommissioning ConnectNetwork 1234 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
-
--   Discover IP address of the device (address is cached in the controller for
-    later usage). You should provide the fabric and node ID:
-
-        chip-device-ctrl > resolve 5544332211 1234
 
 ## Sending ZCL commands
 

--- a/examples/all-clusters-app/mbed/main/AppTask.cpp
+++ b/examples/all-clusters-app/mbed/main/AppTask.cpp
@@ -59,13 +59,6 @@ int AppTask::Init()
         },
         0);
 
-    // Start BLE advertising if needed
-    if (!CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART)
-    {
-        ChipLogProgress(NotSpecified, "Enabling BLE advertising.");
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
-
     chip::DeviceLayer::ConnectivityMgrImpl().StartWiFiManagement();
 
     // Init ZCL Data Model and start server

--- a/examples/all-clusters-app/mbed/mbed_app.json
+++ b/examples/all-clusters-app/mbed/mbed_app.json
@@ -5,6 +5,7 @@
             "platform.stdio-baud-rate": 115200,
             "lwip.ipv6-enabled": true,
             "lwip.raw-socket-enabled": true,
+            "lwip.netbuf-recvinfo-enabled": true,
             "nsapi.default-wifi-security": "WPA_WPA2",
             "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
             "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",

--- a/examples/lighting-app/mbed/CMakeLists.txt
+++ b/examples/lighting-app/mbed/CMakeLists.txt
@@ -4,9 +4,10 @@
 cmake_minimum_required(VERSION 3.19.0)
 
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
-get_filename_component(APP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
 get_filename_component(MBED_COMMON ${CHIP_ROOT}/examples/platform/mbed REALPATH)
+get_filename_component(LIGHTING_COMMON ${CHIP_ROOT}/examples/lighting-app/lighting-common REALPATH)
 get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
+get_filename_component(NLIO_ROOT ${CHIP_ROOT}/third_party/nlio/repo/include REALPATH)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/config.in
@@ -19,6 +20,7 @@ set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET chip-mbed-lighting-app-example)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
+include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
 
 project(${APP_TARGET})
 
@@ -32,77 +34,30 @@ add_subdirectory(${CHIP_ROOT}/config/mbed ./chip_build)
 mbed_configure_app_target(${APP_TARGET})
 
 target_include_directories(${APP_TARGET} PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR}
-                           ${CMAKE_CURRENT_SOURCE_DIR}/main/include/
-                           ${APP_ROOT}/lighting-common
+                           main/include/
+                           ${LIGHTING_COMMON}
                            ${MBED_COMMON}/util/include
                            ${GEN_DIR}/app-common
                            ${GEN_DIR}/lighting-app
-                           ${CHIP_ROOT}/src/app
-                           ${CHIP_ROOT}/third_party/nlio/repo/include
+                           ${NLIO_ROOT}
 )
 
 # TODO - re-use chip_data_model.cmake to add cluster implementations.
 target_sources(${APP_TARGET} PRIVATE
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/AppTask.cpp
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/LightingManager.cpp
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/main.cpp
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/ZclCallbacks.cpp
+               main/AppTask.cpp
+               main/LightingManager.cpp
+               main/main.cpp
+               main/ZclCallbacks.cpp
                ${GEN_DIR}/lighting-app/zap-generated/callback-stub.cpp
                ${GEN_DIR}/lighting-app/zap-generated/IMClusterCommandHandler.cpp
                ${MBED_COMMON}/util/LEDWidget.cpp
-               ${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
-               ${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-               ${CHIP_ROOT}/src/app/util/DataModelHandler.cpp
-               ${CHIP_ROOT}/src/app/util/af-event.cpp
-               ${CHIP_ROOT}/src/app/util/af-main-common.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-size-util.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-storage.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-table.cpp
-               ${CHIP_ROOT}/src/app/util/binding-table.cpp
-               ${CHIP_ROOT}/src/app/util/chip-message-send.cpp
-               ${CHIP_ROOT}/src/app/util/client-api.cpp
-               ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
-               ${CHIP_ROOT}/src/app/util/ember-print.cpp
-               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
-               ${CHIP_ROOT}/src/app/util/message.cpp
-               ${CHIP_ROOT}/src/app/util/util.cpp
-               ${CHIP_ROOT}/src/app/server/EchoHandler.cpp
-               ${CHIP_ROOT}/src/app/server/Dnssd.cpp
-               ${CHIP_ROOT}/src/app/server/OnboardingCodesUtil.cpp
-               ${CHIP_ROOT}/src/app/server/Server.cpp
-               ${CHIP_ROOT}/src/app/server/CommissioningWindowManager.cpp
-               ${CHIP_ROOT}/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/basic/basic.cpp
-               ${CHIP_ROOT}/src/app/clusters/bindings/BindingManager.cpp
-               ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
-               ${CHIP_ROOT}/src/app/clusters/descriptor/descriptor.cpp
-               ${CHIP_ROOT}/src/app/clusters/identify-server/identify-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/unit-localization-server/unit-localization-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/fixed-label-server/fixed-label-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/user-label-server/user-label-server.cpp               
-               ${CHIP_ROOT}/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/switch-server/switch-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp               	                                    
-               ${CHIP_ROOT}/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/level-control/level-control.cpp
-               ${CHIP_ROOT}/src/app/clusters/color-control-server/color-control-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/network-commissioning-old/network-commissioning-ember.cpp
-               ${CHIP_ROOT}/src/app/clusters/network-commissioning-old/network-commissioning-old.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/OTARequestor.cpp
-               ${CHIP_ROOT}/src/app/clusters/groups-server/groups-server.cpp
+)
+
+chip_configure_data_model(${APP_TARGET}
+    INCLUDE_CLIENT_CALLBACKS
+    INCLUDE_SERVER
+    ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lighting-common/lighting-app.zap
+    GEN_DIR ${GEN_DIR}/lighting-app/zap-generated
 )
 
 target_link_libraries(${APP_TARGET} mbed-os-posix-socket mbed-os mbed-ble mbed-events mbed-netsocket mbed-storage mbed-storage-kv-global-api mbed-mbedtls mbed-emac chip)

--- a/examples/lighting-app/mbed/README.md
+++ b/examples/lighting-app/mbed/README.md
@@ -334,8 +334,8 @@ The following states are possible:
     procedure. **LEDs 1-4** blink in unison when the factory reset procedure is
     initiated.
 
--   _Pressed for less than 3 s_ &mdash; Initiates the OTA software update
-    process. This feature is not currently supported.
+-   _Pressed for less than 3 s_ &mdash; Delete all fabric IDs and start BLE
+    advertising.
 
 **Button 1** &mdash; Pressing the button once changes the lighting state to the
 opposite one.

--- a/examples/lighting-app/mbed/main/include/AppTask.h
+++ b/examples/lighting-app/mbed/main/include/AppTask.h
@@ -61,6 +61,7 @@ private:
     {
         kFunction_NoneSelected   = 0,
         kFunction_SoftwareUpdate = 0,
+        kFunction_StartBleAdv    = 1,
         kFunction_FactoryReset,
 
         kFunction_Invalid

--- a/examples/lighting-app/mbed/mbed_app.json
+++ b/examples/lighting-app/mbed/mbed_app.json
@@ -5,6 +5,7 @@
             "platform.stdio-baud-rate": 115200,
             "lwip.ipv6-enabled": true,
             "lwip.raw-socket-enabled": true,
+            "lwip.netbuf-recvinfo-enabled": true,
             "nsapi.default-wifi-security": "WPA_WPA2",
             "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
             "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",

--- a/examples/lock-app/mbed/CMakeLists.txt
+++ b/examples/lock-app/mbed/CMakeLists.txt
@@ -4,9 +4,9 @@
 cmake_minimum_required(VERSION 3.19.0)
 
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
-get_filename_component(APP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
 get_filename_component(MBED_COMMON ${CHIP_ROOT}/examples/platform/mbed REALPATH)
 get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
+get_filename_component(NLIO_ROOT ${CHIP_ROOT}/third_party/nlio/repo/include REALPATH)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/config.in
@@ -19,6 +19,7 @@ set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET chip-mbed-lock-app-example)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
+include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
 
 project(${APP_TARGET})
 
@@ -32,69 +33,26 @@ add_subdirectory(${CHIP_ROOT}/config/mbed ./chip_build)
 mbed_configure_app_target(${APP_TARGET})
 
 target_include_directories(${APP_TARGET} PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR}
-                           ${CMAKE_CURRENT_SOURCE_DIR}/main/include/
-                           ${MBED_COMMON}/util/include
-                           ${CHIP_ROOT}/src/app
-                           ${CHIP_ROOT}/third_party/nlio/repo/include
+                           main/include/
                            ${GEN_DIR}/app-common
                            ${GEN_DIR}/lock-app
+                           ${NLIO_ROOT}
+                           ${MBED_COMMON}/util/include                       
 )
 
 target_sources(${APP_TARGET} PRIVATE
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/AppTask.cpp
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/BoltLockManager.cpp
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/main.cpp
-               ${CMAKE_CURRENT_SOURCE_DIR}/main/ZclCallbacks.cpp
+               main/AppTask.cpp
+               main/BoltLockManager.cpp
+               main/main.cpp
+               main/ZclCallbacks.cpp
                ${GEN_DIR}/lock-app/zap-generated/callback-stub.cpp
                ${GEN_DIR}/lock-app/zap-generated/IMClusterCommandHandler.cpp
                ${MBED_COMMON}/util/LEDWidget.cpp
-               ${CHIP_ROOT}/src/app/util/DataModelHandler.cpp
-               ${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
-               ${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-               ${CHIP_ROOT}/src/app/util/af-event.cpp
-               ${CHIP_ROOT}/src/app/util/af-main-common.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-size-util.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-storage.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-table.cpp
-               ${CHIP_ROOT}/src/app/util/binding-table.cpp
-               ${CHIP_ROOT}/src/app/util/chip-message-send.cpp
-               ${CHIP_ROOT}/src/app/util/client-api.cpp
-               ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
-               ${CHIP_ROOT}/src/app/util/ember-print.cpp
-               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
-               ${CHIP_ROOT}/src/app/util/message.cpp
-               ${CHIP_ROOT}/src/app/util/util.cpp
-               ${CHIP_ROOT}/src/app/server/EchoHandler.cpp
-               ${CHIP_ROOT}/src/app/server/Dnssd.cpp
-               ${CHIP_ROOT}/src/app/server/OnboardingCodesUtil.cpp
-               ${CHIP_ROOT}/src/app/server/Server.cpp
-               ${CHIP_ROOT}/src/app/server/CommissioningWindowManager.cpp
-               ${CHIP_ROOT}/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/basic/basic.cpp
-               ${CHIP_ROOT}/src/app/clusters/bindings/BindingManager.cpp
-               ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
-               ${CHIP_ROOT}/src/app/clusters/descriptor/descriptor.cpp
-               ${CHIP_ROOT}/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/unit-localization-server/unit-localization-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/fixed-label-server/fixed-label-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/switch-server/switch-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/network-commissioning-old/network-commissioning-ember.cpp
-               ${CHIP_ROOT}/src/app/clusters/network-commissioning-old/network-commissioning-old.cpp
-               ${CHIP_ROOT}/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/power-source-server/power-source-server.cpp
-               ${CHIP_ROOT}/src/app/clusters/user-label-server/user-label-server.cpp
+)
+
+chip_configure_data_model(${APP_TARGET}
+    INCLUDE_SERVER
+    ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 
 target_link_libraries(${APP_TARGET} mbed-os-posix-socket mbed-os mbed-ble mbed-events mbed-netsocket mbed-storage mbed-storage-kv-global-api mbed-mbedtls mbed-emac chip)

--- a/examples/lock-app/mbed/README.md
+++ b/examples/lock-app/mbed/README.md
@@ -322,8 +322,8 @@ possible:
     procedure. **LEDs 1-4** blink in unison when the factory reset procedure is
     initiated.
 
--   _Pressed for less than 3 s_ &mdash; Initiates the OTA software update
-    process. This feature is not currently supported.
+-   _Pressed for less than 3 s_ &mdash; Delete all fabric IDs and start BLE
+    advertising
 
 **Button 1** &mdash; Pressing the button once changes the lock state to the
 opposite one.

--- a/examples/lock-app/mbed/main/AppTask.cpp
+++ b/examples/lock-app/mbed/main/AppTask.cpp
@@ -120,13 +120,6 @@ int AppTask::Init()
     BoltLockMgr().Init();
     BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 
-    // Start BLE advertising if needed
-    if (!CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART)
-    {
-        ChipLogProgress(NotSpecified, "Enabling BLE advertising.");
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
-
     chip::DeviceLayer::ConnectivityMgrImpl().StartWiFiManagement();
 
     // Init ZCL Data Model and start server
@@ -370,7 +363,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
         return;
 
     // If we reached here, the button was held past FACTORY_RESET_TRIGGER_TIMEOUT, initiate factory reset
-    if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
+    if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_StartBleAdv)
     {
         ChipLogProgress(NotSpecified, "Factory Reset Triggered. Release button within %ums to cancel.",
                         FACTORY_RESET_CANCEL_WINDOW_TIMEOUT);
@@ -415,17 +408,29 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
         {
             sAppTask.StartTimer(FACTORY_RESET_TRIGGER_TIMEOUT);
 
-            sAppTask.mFunction = kFunction_SoftwareUpdate;
+            sAppTask.mFunction = kFunction_StartBleAdv;
         }
     }
     else
     {
         // If the button was released before factory reset got initiated, trigger a software update.
-        if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
+        if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_StartBleAdv)
         {
             sAppTask.CancelTimer();
             sAppTask.mFunction = kFunction_NoneSelected;
-            ChipLogError(NotSpecified, "Software Update not supported.");
+
+            chip::Server::GetInstance().GetFabricTable().DeleteAllFabrics();
+
+            if (ConnectivityMgr().IsBLEAdvertisingEnabled())
+            {
+                ChipLogProgress(NotSpecified, "BLE advertising is already enabled");
+                return;
+            }
+
+            if (chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow() != CHIP_NO_ERROR)
+            {
+                ChipLogProgress(NotSpecified, "OpenBasicCommissioningWindow() failed");
+            }
         }
         else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_FactoryReset)
         {

--- a/examples/lock-app/mbed/main/include/AppTask.h
+++ b/examples/lock-app/mbed/main/include/AppTask.h
@@ -59,6 +59,7 @@ private:
     {
         kFunction_NoneSelected   = 0,
         kFunction_SoftwareUpdate = 0,
+        kFunction_StartBleAdv    = 1,
         kFunction_FactoryReset,
 
         kFunction_Invalid

--- a/examples/lock-app/mbed/mbed_app.json
+++ b/examples/lock-app/mbed/mbed_app.json
@@ -5,6 +5,7 @@
             "platform.stdio-baud-rate": 115200,
             "lwip.ipv6-enabled": true,
             "lwip.raw-socket-enabled": true,
+            "lwip.netbuf-recvinfo-enabled": true,
             "nsapi.default-wifi-security": "WPA_WPA2",
             "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
             "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",

--- a/examples/pigweed-app/mbed/mbed_app.json
+++ b/examples/pigweed-app/mbed/mbed_app.json
@@ -5,6 +5,7 @@
             "platform.stdio-baud-rate": 115200,
             "lwip.ipv6-enabled": true,
             "lwip.raw-socket-enabled": true,
+            "lwip.netbuf-recvinfo-enabled": true,
             "nsapi.default-wifi-security": "WPA_WPA2",
             "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
             "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",

--- a/examples/shell/mbed/mbed_app.json
+++ b/examples/shell/mbed/mbed_app.json
@@ -5,6 +5,7 @@
             "platform.stdio-baud-rate": 115200,
             "lwip.ipv6-enabled": true,
             "lwip.raw-socket-enabled": true,
+            "lwip.netbuf-recvinfo-enabled": true,
             "nsapi.default-wifi-security": "WPA_WPA2",
             "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
             "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",

--- a/src/test_driver/mbed/unit_tests/mbed_app.json
+++ b/src/test_driver/mbed/unit_tests/mbed_app.json
@@ -9,6 +9,7 @@
             "lwip.ipv6-enabled": true,
             "lwip.raw-socket-enabled": true,
             "lwip.pbuf-pool-size": 16,
+            "lwip.netbuf-recvinfo-enabled": true,
             "nsapi.default-wifi-security": "WPA_WPA2",
             "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
             "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",


### PR DESCRIPTION
#### Problem
We need to fix some issues to improve the device commissioning process according to a new specification.

1. Enable LWIP recvinfo feature - is necessary after Mbed-os update #13416 
2. Add start BLE advertising after push button
3. Apps Cmake files refactor - use chip_configure_data_model to include generated files

#### Change overview
Add LWIP recvinfo flag to mbed application
Add chip_configure_data_model to lock-app and lighting-app cmake
Add start BLE advertising after push button
Update mbed documentation

#### Testing
Build and run Mbed examples, commissioning device with chip-device-controller
