### PR TITLE
add CLI tab-to-autocomplete ability and implement for nrfconnect

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -61,7 +61,7 @@ static CHIP_ERROR SwitchCommandHandler(int argc, char ** argv)
 static void RegisterSwitchCommands()
 {
     static const shell_command_t sSwitchCommand = { SwitchCommandHandler, "switch", "Switch commands. Usage: switch [on|off]" };
-    Engine::Root().RegisterCommands(&sSwitchCommand, 1);
+    Engine::Root().RegisterCommands(&sSwitchCommand, 1, nullptr);
     return;
 }
 #endif // defined(ENABLE_CHIP_SHELL)

--- a/examples/all-clusters-app/esp32/main/OnOffCommands.cpp
+++ b/examples/all-clusters-app/esp32/main/OnOffCommands.cpp
@@ -90,12 +90,12 @@ void OnOffCommands::Register()
     static const shell_command_t subCommands[] = { { &OnLightHandler, "on", "Usage: OnOff on endpoint-id" },
                                                    { &OffLightHandler, "off", "Usage: OnOff off endpoint-id" },
                                                    { &ToggleLightHandler, "toggle", "Usage: OnOff toggle endpoint-id" } };
-    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands), "OnOff");
 
     // Register the root `OnOff` command in the top-level shell.
     static const shell_command_t onOffCommand = { &OnOffHandler, "OnOff", "OnOff commands" };
 
-    Engine::Root().RegisterCommands(&onOffCommand, 1);
+    Engine::Root().RegisterCommands(&onOffCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/examples/lighting-app/cyw30739/src/AppShellCommands.cpp
+++ b/examples/lighting-app/cyw30739/src/AppShellCommands.cpp
@@ -50,9 +50,9 @@ void RegisterAppShellCommands(void)
         .cmd_help = "App commands",
     };
 
-    sAppSubcommands.RegisterCommands(sAppSubCommands, ArraySize(sAppSubCommands));
+    sAppSubcommands.RegisterCommands(sAppSubCommands, ArraySize(sAppSubCommands), "app");
 
-    Engine::Root().RegisterCommands(&sAppCommand, 1);
+    Engine::Root().RegisterCommands(&sAppCommand, 1, nullptr);
 }
 
 CHIP_ERROR AppCommandHelpHandler(int argc, char * argv[])

--- a/examples/ota-provider-app/esp32/main/OTAProviderCommands.cpp
+++ b/examples/ota-provider-app/esp32/main/OTAProviderCommands.cpp
@@ -69,12 +69,12 @@ void OTAProviderCommands::Register()
           "Usage: OTAProvider delay <delay in seconds>" },
     };
 
-    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands), "OTAProvider");
 
     // Register the root `OTA Provider` command in the top-level shell.
     static const shell_command_t otaProviderCommand = { &OTAProviderHandler, "OTAProvider", "OTA Provider commands" };
 
-    Engine::Root().RegisterCommands(&otaProviderCommand, 1);
+    Engine::Root().RegisterCommands(&otaProviderCommand, 1, nullptr);
 }
 
 // Set Example OTA provider

--- a/examples/platform/esp32/shell_extension/heap_trace.cpp
+++ b/examples/platform/esp32/shell_extension/heap_trace.cpp
@@ -137,7 +137,7 @@ void RegisterHeapTraceCommands()
         { &HeapTraceTaskHandler, "task", "Dump heap usage of each task" },
 #endif // CONFIG_HEAP_TASK_TRACKING
     };
-    sShellHeapSubCommands.RegisterCommands(sHeapSubCommands, ArraySize(sHeapSubCommands));
+    sShellHeapSubCommands.RegisterCommands(sHeapSubCommands, ArraySize(sHeapSubCommands), "heap-trace");
 
 #if CONFIG_HEAP_TRACING_STANDALONE
     ESP_ERROR_CHECK(heap_trace_init_standalone(sTraceRecords, kNumHeapTraceRecords));
@@ -145,7 +145,7 @@ void RegisterHeapTraceCommands()
 #endif // CONFIG_HEAP_TRACING_STANDALONE
 
     static const shell_command_t sHeapCommand = { &HeapTraceDispatch, "heap-trace", "Heap debug tracing" };
-    Engine::Root().RegisterCommands(&sHeapCommand, 1);
+    Engine::Root().RegisterCommands(&sHeapCommand, 1, nullptr);
 }
 
 } // namespace chip

--- a/examples/platform/linux/CommissioneeShellCommands.cpp
+++ b/examples/platform/linux/CommissioneeShellCommands.cpp
@@ -148,7 +148,7 @@ void RegisterCommissioneeCommands()
                                                    "Commissionee commands. Usage: commissionee [command_name]" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -273,7 +273,7 @@ void RegisterControllerCommands()
                                                    "Controller commands. Usage: controller [command_name]" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/examples/shell/shell_common/cmd_misc.cpp
+++ b/examples/shell/shell_common/cmd_misc.cpp
@@ -68,5 +68,5 @@ static shell_command_t cmds_misc[] = {
 
 void cmd_misc_init()
 {
-    Engine::Root().RegisterCommands(cmds_misc, ArraySize(cmds_misc));
+    Engine::Root().RegisterCommands(cmds_misc, ArraySize(cmds_misc), nullptr);
 }

--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -193,6 +193,6 @@ void cmd_otcli_init()
 #endif
 
     // Register the root otcli command with the top-level shell.
-    Engine::Root().RegisterCommands(&cmds_otcli_root, 1);
+    Engine::Root().RegisterCommands(&cmds_otcli_root, 1, nullptr);
 #endif // CHIP_ENABLE_OPENTHREAD
 }

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -483,5 +483,5 @@ static shell_command_t cmds_ping[] = {
 
 void cmd_ping_init()
 {
-    Engine::Root().RegisterCommands(cmds_ping, ArraySize(cmds_ping));
+    Engine::Root().RegisterCommands(cmds_ping, ArraySize(cmds_ping), nullptr);
 }

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -406,5 +406,5 @@ static shell_command_t cmds_send[] = {
 
 void cmd_send_init()
 {
-    Engine::Root().RegisterCommands(cmds_send, ArraySize(cmds_send));
+    Engine::Root().RegisterCommands(cmds_send, ArraySize(cmds_send), nullptr);
 }

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -228,8 +228,8 @@ void cmd_app_server_init()
     std::atexit(CmdAppServerAtExit);
 
     // Register `server` subcommands with the local shell dispatcher.
-    sShellServerSubcommands.RegisterCommands(sServerSubCommands, ArraySize(sServerSubCommands));
+    sShellServerSubcommands.RegisterCommands(sServerSubCommands, ArraySize(sServerSubCommands), "server");
 
     // Register the root `server` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sServerComand, 1);
+    Engine::Root().RegisterCommands(&sServerComand, 1, nullptr);
 }

--- a/examples/tv-app/linux/AppPlatformShellCommands.cpp
+++ b/examples/tv-app/linux/AppPlatformShellCommands.cpp
@@ -192,7 +192,7 @@ void RegisterAppPlatformCommands()
     static const shell_command_t sDeviceComand = { &AppPlatformHandler, "app", "App commands. Usage: app [command_name]" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -55,9 +55,9 @@ int Engine::Init()
 
 void Engine::ForEachCommand(shell_command_iterator_t * on_command, void * arg)
 {
-    for (unsigned i = 0; i < this->_commandCount; i++)
+    for (unsigned i = 0; i < _commandCount; i++)
     {
-        if (on_command(this->_commands[i], arg) != CHIP_NO_ERROR)
+        if (on_command(_commands[i], arg) != CHIP_NO_ERROR)
         {
             return;
         }

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -119,21 +119,6 @@ void Engine::InsertShellMap(char const * prefix, Engine * shell)
     Engine::theShellMapListHead = new_map;
 }
 
-// CHIP_ERROR process_completion(shell_command_t * cmd, void * arg)
-// {
-//     cmd_completion_context * ctx = (cmd_completion_context *) ((void **) arg)[0];
-//     char * _incomplete_cmd       = (char *) ((void **) arg)[1];
-//     // For end nodes like "ble adv", need to avoid duplicate returns.
-//     // Return for prefix="ble adv" cmd=""; reject for prefix="ble" cmd="adv"
-//     if ((strcmp(cmd->cmd_name, _incomplete_cmd) != 0 && strncmp(cmd->cmd_name, _incomplete_cmd, strlen(_incomplete_cmd)) == 0) ||
-//         strcmp(_incomplete_cmd, "") == 0)
-//     {
-//         ctx->cmdc++;
-//         ctx->cmdv[ctx->cmdc - 1] = cmd;
-//     }
-//     return CHIP_NO_ERROR;
-// };
-
 CHIP_ERROR Engine::GetCommandCompletions(cmd_completion_context * context)
 {
 

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -171,8 +171,8 @@ CHIP_ERROR Engine::GetCommandCompletions(cmd_completion_context * context)
         // - there is no "incomplete command" so set it to empty
         prefix         = new char[buf_len + 1];
         incomplete_cmd = new char[1];
-        strlcpy(prefix, buf, buf_len + 1);
-        strlcpy(incomplete_cmd, "", 1);
+        strncpy(prefix, buf, buf_len + 1);
+        strncpy(incomplete_cmd, "", 1);
     }
     else
     {
@@ -182,8 +182,8 @@ CHIP_ERROR Engine::GetCommandCompletions(cmd_completion_context * context)
         bool no_space  = (last_space_idx == -1) ? true : false;
         prefix         = new char[last_space_idx + 1 + no_space];
         incomplete_cmd = new char[buf_len - last_space_idx];
-        strlcpy(prefix, buf, last_space_idx + 1 + no_space);
-        strlcpy(incomplete_cmd, &buf[last_space_idx + 1], buf_len - last_space_idx);
+        strncpy(prefix, buf, last_space_idx + 1 + no_space);
+        strncpy(incomplete_cmd, &buf[last_space_idx + 1], buf_len - last_space_idx);
     }
 
     // Array to pass arguments into the ForEachCommand call

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -21,23 +21,19 @@
  *      Source implementation for a generic shell API for CHIP examples.
  */
 
-#include <lib/shell/Engine.h>
-
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Commands.h>
+#include <lib/shell/Engine.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#include <algorithm>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
-#include <map>
 #include <stdbool.h>
 #include <stdint.h>
-#include <vector>
 
 using namespace chip::Logging;
 
@@ -45,7 +41,7 @@ namespace chip {
 namespace Shell {
 
 Engine Engine::theEngineRoot;
-shell_map_t Engine::theShellMap;
+shell_map * Engine::theShellMapListHead = NULL;
 
 int Engine::Init()
 {
@@ -59,9 +55,9 @@ int Engine::Init()
 
 void Engine::ForEachCommand(shell_command_iterator_t * on_command, void * arg)
 {
-    for (auto * _command : _commandSet)
+    for (unsigned i = 0; i < this->_commandCount; i++)
     {
-        if (on_command(_command, arg) != CHIP_NO_ERROR)
+        if (on_command(this->_commands[i], arg) != CHIP_NO_ERROR)
         {
             return;
         }
@@ -75,60 +71,174 @@ void Engine::RegisterCommands(shell_command_t * command_set, unsigned count, con
         prefix = "";
     }
 
-    if (_commandSet.size() + count > CHIP_SHELL_MAX_MODULES)
+    if (_commandCount + count > CHIP_SHELL_MAX_MODULES)
     {
-        ChipLogError(Shell, "Max number of commands reached\n");
+        ChipLogError(Shell, "Max number of commands registered to this shell");
         assert(0);
     }
 
     for (unsigned i = 0; i < count; i++)
     {
-        _commandSet.push_back(command_set + i);
+        _commands[_commandCount + i] = &command_set[i];
     }
+    _commandCount += count;
 
-    Engine::AddToShellMap(prefix, this);
+    Engine::InsertShellMap(prefix, this);
 }
 
-void Engine::AddToShellMap(char const * prefix, Engine * shell)
+void Engine::InsertShellMap(char const * prefix, Engine * shell)
 {
-    shell_map_t::iterator it = Engine::ShellMap().find(prefix);
-    if (it == Engine::ShellMap().end())
+    shell_map_t * map = Engine::theShellMapListHead;
+    while (map != NULL)
     {
-        Engine::ShellMap().insert(shell_map_t::value_type(prefix, { shell }));
-    }
-    else if (std::find(it->second.begin(), it->second.end(), shell) == it->second.end())
-    {
-        it->second.push_back(shell);
-    }
-}
-
-std::vector<shell_command_t *> Engine::GetCommandSuggestions(const char * prefix)
-{
-    if (prefix == nullptr)
-    {
-        prefix = "";
-    }
-
-    shell_map_t::iterator engine_map = Engine::ShellMap().find(prefix);
-    std::vector<shell_command_t *> next_commands;
-
-    if (engine_map == Engine::ShellMap().end())
-    {
-        return next_commands;
-    }
-
-    std::vector<Engine *> engines = engine_map->second;
-
-    for (auto engine : engines)
-    {
-        std::vector<shell_command_t *> engine_commands = engine->GetCommandSet();
-
-        for (auto engine_command : engine_commands)
+        if (strcmp(prefix, map->prefix) == 0)
         {
-            next_commands.push_back(engine_command);
+            for (size_t i = 0; i < map->enginec; i++)
+            {
+                if (map->enginev[i] == shell)
+                {
+                    return;
+                }
+            }
+            if (map->enginec == sizeof(map->enginev))
+            {
+                ChipLogError(Shell, "Max number of shells registered under this prefix");
+                assert(0);
+            }
+            map->enginev[map->enginec] = shell;
+            map->enginec++;
+            return;
+        }
+        map = map->next;
+    }
+    shell_map_t * new_map       = new shell_map_t;
+    new_map->prefix             = prefix;
+    new_map->enginev[0]         = shell;
+    new_map->enginec            = 1;
+    new_map->next               = Engine::theShellMapListHead;
+    Engine::theShellMapListHead = new_map;
+}
+
+// CHIP_ERROR process_completion(shell_command_t * cmd, void * arg)
+// {
+//     cmd_completion_context * ctx = (cmd_completion_context *) ((void **) arg)[0];
+//     char * _incomplete_cmd       = (char *) ((void **) arg)[1];
+//     // For end nodes like "ble adv", need to avoid duplicate returns.
+//     // Return for prefix="ble adv" cmd=""; reject for prefix="ble" cmd="adv"
+//     if ((strcmp(cmd->cmd_name, _incomplete_cmd) != 0 && strncmp(cmd->cmd_name, _incomplete_cmd, strlen(_incomplete_cmd)) == 0) ||
+//         strcmp(_incomplete_cmd, "") == 0)
+//     {
+//         ctx->cmdc++;
+//         ctx->cmdv[ctx->cmdc - 1] = cmd;
+//     }
+//     return CHIP_NO_ERROR;
+// };
+
+CHIP_ERROR Engine::GetCommandCompletions(cmd_completion_context * context)
+{
+
+    if (Engine::theShellMapListHead == NULL)
+    {
+        ChipLogDetail(Shell, "There isn't any command registered yet.");
+        return CHIP_NO_ERROR;
+    }
+    const char * buf = context->line_buf;
+    if (buf == nullptr)
+    {
+        buf = "";
+    }
+
+    int last_space_idx = -1;
+    int buf_len        = strlen(buf);
+
+    // find space in buf
+    for (int i = buf_len - 1; i > -1; i--)
+    {
+        if (buf[i] == ' ')
+        {
+            last_space_idx = i;
+            break;
         }
     }
-    return next_commands;
+
+    // check whether the buf perfectly matches a prefix
+    bool perfect_match = false;
+    shell_map_t * map  = Engine::theShellMapListHead;
+
+    while (map != NULL)
+    {
+
+        if (strcmp(buf, map->prefix) == 0)
+        {
+            perfect_match = true;
+            break;
+        }
+        map = map->next;
+    }
+
+    char * prefix;
+    char * incomplete_cmd;
+
+    if (perfect_match)
+    {
+        // If it's a perfect match
+        // - use the whole buf as the prefix
+        // - there is no "incomplete command" so set it to empty
+        prefix         = new char[buf_len + 1];
+        incomplete_cmd = new char[1];
+        strlcpy(prefix, buf, buf_len + 1);
+        strlcpy(incomplete_cmd, "", 1);
+    }
+    else
+    {
+        // If it's not a perfect match:
+        // - prefix is up to the last space
+        // - incomplete_cmd is what's after the last space
+        bool no_space  = (last_space_idx == -1) ? true : false;
+        prefix         = new char[last_space_idx + 1 + no_space];
+        incomplete_cmd = new char[buf_len - last_space_idx];
+        strlcpy(prefix, buf, last_space_idx + 1 + no_space);
+        strlcpy(incomplete_cmd, &buf[last_space_idx + 1], buf_len - last_space_idx);
+    }
+
+    // Array to pass arguments into the ForEachCommand call
+    void * lambda_args[] = { context, incomplete_cmd };
+    map                  = Engine::theShellMapListHead;
+
+    while (map != NULL && context->cmdc < CHIP_SHELL_MAX_CMD_COMPLETIONS)
+    {
+        if (strcmp(prefix, map->prefix) == 0)
+        {
+            context->ret_prefix = map->prefix;
+            for (unsigned i = 0; i < map->enginec; i++)
+            {
+                map->enginev[i]->ForEachCommand(
+                    [](shell_command_t * cmd, void * arg) -> CHIP_ERROR {
+                        cmd_completion_context * ctx = (cmd_completion_context *) ((void **) arg)[0];
+                        char * _incomplete_cmd       = (char *) ((void **) arg)[1];
+                        // For end nodes like "ble adv", need to avoid duplicate returns.
+                        // Return for prefix="ble adv" cmd=""; reject for prefix="ble" cmd="adv"
+                        if ((strcmp(cmd->cmd_name, _incomplete_cmd) != 0 &&
+                             strncmp(cmd->cmd_name, _incomplete_cmd, strlen(_incomplete_cmd)) == 0) ||
+                            strcmp(_incomplete_cmd, "") == 0)
+                        {
+                            ctx->cmdc++;
+                            ctx->cmdv[ctx->cmdc - 1] = cmd;
+                        }
+                        return CHIP_NO_ERROR;
+                    },
+                    lambda_args);
+            }
+            break;
+        }
+
+        map = map->next;
+    }
+
+    delete[] prefix;
+    delete[] incomplete_cmd;
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Engine::ExecCommand(int argc, char * argv[])
@@ -136,12 +246,12 @@ CHIP_ERROR Engine::ExecCommand(int argc, char * argv[])
     CHIP_ERROR retval = CHIP_ERROR_INVALID_ARGUMENT;
     VerifyOrReturnError(argc > 0, retval);
     // Find the command
-    for (unsigned i = 0; i < _commandSet.size(); i++)
+    for (unsigned i = 0; i < _commandCount; i++)
     {
-        if (strcmp(argv[0], _commandSet[i]->cmd_name) == 0)
+        if (strcmp(argv[0], _commands[i]->cmd_name) == 0)
         {
             // Execute the command!
-            retval = _commandSet[i]->cmd_func(argc - 1, argv + 1);
+            retval = _commands[i]->cmd_func(argc - 1, argv + 1);
             break;
         }
     }

--- a/src/lib/shell/MainLoopZephyr.cpp
+++ b/src/lib/shell/MainLoopZephyr.cpp
@@ -16,17 +16,15 @@
  */
 #include <cstring>
 #include <init.h>
-#include <map>
 #include <shell/shell.h>
 #include <stdio.h>
-#include <string>
-#include <vector>
 
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Engine.h>
 #include <lib/shell/streamer_zephyr.h>
 #include <lib/support/CodeUtils.h>
 
+using chip::Shell::cmd_completion_context;
 using chip::Shell::Engine;
 using chip::Shell::shell_command_t;
 using chip::Shell::shell_map_t;
@@ -54,36 +52,42 @@ static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
 const struct shell_static_entry * build_command_tree(const char * prefix, const char * syntax, const char * help)
 {
 
-    std::string sub_prefix_str = prefix;
-
-    // concatenate prefix and syntax to construct the prefix string for command suggestion.
-
+    char * sub_prefix = new char[strlen(prefix) + strlen(syntax) + 2];
+    size_t pos        = 0;
     if (strcmp(prefix, "") != 0)
     {
-        sub_prefix_str += " ";
+        strncpy(&sub_prefix[pos], prefix, strlen(prefix));
+        pos += strlen(prefix);
+        strncpy(&sub_prefix[pos], " ", 1);
+        pos += 1;
     }
+    strncpy(&sub_prefix[pos], syntax, strlen(syntax) + 1);
 
-    sub_prefix_str += syntax;
+    cmd_completion_context context = cmd_completion_context(sub_prefix);
+    CHIP_ERROR ret                 = Engine::GetCommandCompletions(&context);
 
-    const char * sub_prefix = sub_prefix_str.c_str();
-
-    std::vector<shell_command_t *> subcmds = Engine::GetCommandSuggestions(sub_prefix);
-
-    const shell_static_entry * static_entry;
-
-    if (subcmds.size() > 0)
+    const struct shell_static_entry * static_entry;
+    if (ret == CHIP_NO_ERROR && context.cmdc != 0)
     {
-        // Non-leaf node, recursively build tree for each child node
-        const struct shell_static_entry * sub_static_entry = new shell_static_entry[subcmds.size() + 1];
-        for (size_t i = 0; i < subcmds.size(); i++)
+        const struct shell_static_entry * sub_static_entry = new shell_static_entry[context.cmdc + 1];
+        for (size_t i = 0; i < context.cmdc; i++)
         {
-            const struct shell_static_entry * sub_entry =
-                build_command_tree(sub_prefix, subcmds[i]->cmd_name, subcmds[i]->cmd_help);
+            shell_command_t * subcmd                    = context.cmdv[i];
+            const struct shell_static_entry * sub_entry = build_command_tree(sub_prefix, subcmd->cmd_name, subcmd->cmd_help);
+            if (sub_entry == nullptr)
+            {
+                // leaf node, the command should require no argument but can accept optional arguments
+                const struct shell_static_entry leaf_entry = {
+                    .syntax = subcmd->cmd_name, .help = subcmd->cmd_help, .subcmd = NULL, .handler = NULL, .args = { 0, 10 }
+                };
+                memcpy((shell_static_entry *) &sub_static_entry[i], &leaf_entry, sizeof(struct shell_static_entry));
+                continue;
+            }
             memcpy((shell_static_entry *) &sub_static_entry[i], sub_entry, sizeof(struct shell_static_entry));
         }
 
         // Zephyr's shell_cmd_entry.u.entry needs an additional NULL element to terminate the array.
-        memset((shell_static_entry *) &sub_static_entry[subcmds.size()], 0, sizeof(struct shell_static_entry));
+        memset((shell_static_entry *) &sub_static_entry[context.cmdc], 0, sizeof(struct shell_static_entry));
 
         const struct shell_cmd_entry * sub_cmd_entry =
             new const shell_cmd_entry{ .is_dynamic = false,
@@ -101,11 +105,9 @@ const struct shell_static_entry * build_command_tree(const char * prefix, const 
     }
     else
     {
-        // the leaf nodes should have 0 required arguments but accepts a few (set 10 here) optional arguments.
-        static_entry =
-            new const shell_static_entry{ .syntax = syntax, .help = help, .subcmd = NULL, .handler = NULL, .args = { 0, 10 } };
+        static_entry = nullptr;
     }
-
+    delete[] sub_prefix;
     return static_entry;
 }
 
@@ -122,7 +124,6 @@ static int RegisterCommands(const struct device * dev)
     register_matter_command_to_zephyr();
     return 0;
 }
-
 SYS_INIT(RegisterCommands, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 namespace chip {

--- a/src/lib/shell/MainLoopZephyr.cpp
+++ b/src/lib/shell/MainLoopZephyr.cpp
@@ -14,14 +14,22 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <cstring>
 #include <init.h>
+#include <map>
 #include <shell/shell.h>
+#include <stdio.h>
+#include <string>
+#include <vector>
 
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Engine.h>
 #include <lib/shell/streamer_zephyr.h>
+#include <lib/support/CodeUtils.h>
 
 using chip::Shell::Engine;
+using chip::Shell::shell_command_t;
+using chip::Shell::shell_map_t;
 
 static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
 {
@@ -29,15 +37,93 @@ static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
     return (Engine::Root().ExecCommand(argc - 1, argv + 1) == CHIP_NO_ERROR) ? 0 : -ENOEXEC;
 }
 
+/**
+ * This recursive function obtains all sub-commands (possbile completions) for a command node
+ * and build it into a tree of Zephyr's shell_static_entry structure.
+ *
+ * @param prefix                  The path/prefix until the root command node of the tree, without tailing space.
+ *                                e.g. "dns browse". Set to emptry string "" if building tree for a root-level command.
+ * @param syntax                  The single-word command name/syntax for the root node of the tree. e.g. "resolve".
+ *                                Set to emptry string "" if calling to build from the root (to include all commands).
+ * @param help                    The help text for the command at roote node of the tree. Set to NULL if none.
+ *
+ * @return                        The shell_static_entry structure tree that chains all the sub-commands from the
+ *                                requested command node.
+ *
+ */
+const struct shell_static_entry * build_command_tree(const char * prefix, const char * syntax, const char * help)
+{
+
+    std::string sub_prefix_str = prefix;
+
+    // concatenate prefix and syntax to construct the prefix string for command suggestion.
+
+    if (strcmp(prefix, "") != 0)
+    {
+        sub_prefix_str += " ";
+    }
+
+    sub_prefix_str += syntax;
+
+    const char * sub_prefix = sub_prefix_str.c_str();
+
+    std::vector<shell_command_t *> subcmds = Engine::GetCommandSuggestions(sub_prefix);
+
+    const shell_static_entry * static_entry;
+
+    if (subcmds.size() > 0)
+    {
+        // Non-leaf node, recursively build tree for each child node
+        const struct shell_static_entry * sub_static_entry = new shell_static_entry[subcmds.size() + 1];
+        for (size_t i = 0; i < subcmds.size(); i++)
+        {
+            const struct shell_static_entry * sub_entry =
+                build_command_tree(sub_prefix, subcmds[i]->cmd_name, subcmds[i]->cmd_help);
+            memcpy((shell_static_entry *) &sub_static_entry[i], sub_entry, sizeof(struct shell_static_entry));
+        }
+
+        // Zephyr's shell_cmd_entry.u.entry needs an additional NULL element to terminate the array.
+        memset((shell_static_entry *) &sub_static_entry[subcmds.size()], 0, sizeof(struct shell_static_entry));
+
+        const struct shell_cmd_entry * sub_cmd_entry =
+            new const shell_cmd_entry{ .is_dynamic = false,
+                                       .u          = { .entry = (const struct shell_static_entry *) sub_static_entry } };
+
+        // The non-leaf nodes should require at least 1 required argument (for its child)
+        // Set the root command to use syntax "matter"
+        // Only the root "matter" node should have a handler function in Zephry-shell, so that all commands are sent
+        // to be dispatched by their registered Engine instances.
+        static_entry = new const shell_static_entry{ .syntax  = (strcmp(syntax, "") == 0) ? "matter" : syntax,
+                                                     .help    = help,
+                                                     .subcmd  = (const struct shell_cmd_entry *) sub_cmd_entry,
+                                                     .handler = (strcmp(syntax, "") == 0) ? cmd_matter : NULL,
+                                                     .args    = { 1, 10 } };
+    }
+    else
+    {
+        // the leaf nodes should have 0 required arguments but accepts a few (set 10 here) optional arguments.
+        static_entry =
+            new const shell_static_entry{ .syntax = syntax, .help = help, .subcmd = NULL, .handler = NULL, .args = { 0, 10 } };
+    }
+
+    return static_entry;
+}
+
+static void register_matter_command_to_zephyr()
+{
+    static const struct shell_static_entry _shell_matter = *build_command_tree("", "", "Matter commands");
+    static const struct shell_cmd_entry shell_cmd_matter __attribute__((section("." STRINGIFY(shell_root_cmd_matter))))
+    __attribute__((used)) = { .is_dynamic = false, .u = { .entry = &_shell_matter } };
+}
+
 static int RegisterCommands(const struct device * dev)
 {
     Engine::Root().RegisterDefaultCommands();
+    register_matter_command_to_zephyr();
     return 0;
 }
 
-SYS_INIT(RegisterCommands, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-
-SHELL_CMD_ARG_REGISTER(matter, NULL, "Matter commands", cmd_matter, 1, 10);
+SYS_INIT(RegisterCommands, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 namespace chip {
 namespace Shell {

--- a/src/lib/shell/commands/BLE.cpp
+++ b/src/lib/shell/commands/BLE.cpp
@@ -111,10 +111,10 @@ void RegisterBLECommands()
     static const shell_command_t sBLECommand = { &BLEDispatch, "ble", "BLE transport commands" };
 
     // Register `device` subcommands with the local shell dispatcher.
-    sShellDeviceSubcommands.RegisterCommands(sBLESubCommands, ArraySize(sBLESubCommands));
+    sShellDeviceSubcommands.RegisterCommands(sBLESubCommands, ArraySize(sBLESubCommands), "ble");
 
     // Register the root `btp` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sBLECommand, 1);
+    Engine::Root().RegisterCommands(&sBLECommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Base64.cpp
+++ b/src/lib/shell/commands/Base64.cpp
@@ -88,10 +88,10 @@ void RegisterBase64Commands()
     static const shell_command_t sBase64Command = { &Base64Dispatch, "base64", "Base64 encode / decode utilities" };
 
     // Register `base64` subcommands with the local shell dispatcher.
-    sShellBase64Commands.RegisterCommands(sBase64SubCommands, ArraySize(sBase64SubCommands));
+    sShellBase64Commands.RegisterCommands(sBase64SubCommands, ArraySize(sBase64SubCommands), "base64");
 
     // Register the root `base64` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sBase64Command, 1);
+    Engine::Root().RegisterCommands(&sBase64Command, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Config.cpp
+++ b/src/lib/shell/commands/Config.cpp
@@ -191,7 +191,6 @@ static CHIP_ERROR ConfigHandler(int argc, char ** argv)
 
 void RegisterConfigCommands()
 {
-
     static const shell_command_t sConfigComand = { &ConfigHandler, "config",
                                                    "Manage device configuration. Usage to dump value: config [param_name] and "
                                                    "to set some values (discriminator): config [param_name] [param_value]." };
@@ -206,10 +205,9 @@ void RegisterConfigCommands()
     };
 
     // Register `config` subcommands with the local shell dispatcher.
-    sShellConfigSubcommands.RegisterCommands(sConfigSubCommands, ArraySize(sConfigSubCommands));
-
+    sShellConfigSubcommands.RegisterCommands(sConfigSubCommands, ArraySize(sConfigSubCommands), "config");
     // Register the root `config` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sConfigComand, 1);
+    Engine::Root().RegisterCommands(&sConfigComand, 1, nullptr);
     return;
 }
 

--- a/src/lib/shell/commands/Device.cpp
+++ b/src/lib/shell/commands/Device.cpp
@@ -65,10 +65,10 @@ void RegisterDeviceCommands()
     static const shell_command_t sDeviceComand = { &DeviceHandler, "device", "Device management commands" };
 
     // Register `device` subcommands with the local shell dispatcher.
-    sShellDeviceSubcommands.RegisterCommands(sDeviceSubCommands, ArraySize(sDeviceSubCommands));
+    sShellDeviceSubcommands.RegisterCommands(sDeviceSubCommands, ArraySize(sDeviceSubCommands), "device");
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -250,13 +250,13 @@ void RegisterDnsCommands()
     static const shell_command_t sDnsCommand = { &DnsHandler, "dns", "Dns client commands" };
 
     // Register `dns browse` subcommands
-    sShellDnsBrowseSubcommands.RegisterCommands(sDnsBrowseSubCommands, ArraySize(sDnsBrowseSubCommands));
+    sShellDnsBrowseSubcommands.RegisterCommands(sDnsBrowseSubCommands, ArraySize(sDnsBrowseSubCommands), "dns browse");
 
     // Register `dns` subcommands with the local shell dispatcher.
-    sShellDnsSubcommands.RegisterCommands(sDnsSubCommands, ArraySize(sDnsSubCommands));
+    sShellDnsSubcommands.RegisterCommands(sDnsSubCommands, ArraySize(sDnsSubCommands), "dns");
 
     // Register the root `dns` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDnsCommand, 1);
+    Engine::Root().RegisterCommands(&sDnsCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Meta.cpp
+++ b/src/lib/shell/commands/Meta.cpp
@@ -71,7 +71,7 @@ void RegisterMetaCommands()
 
     std::atexit(AtExitShell);
 
-    Engine::Root().RegisterCommands(sCmds, ArraySize(sCmds), "");
+    Engine::Root().RegisterCommands(sCmds, ArraySize(sCmds), nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Meta.cpp
+++ b/src/lib/shell/commands/Meta.cpp
@@ -71,7 +71,7 @@ void RegisterMetaCommands()
 
     std::atexit(AtExitShell);
 
-    Engine::Root().RegisterCommands(sCmds, ArraySize(sCmds));
+    Engine::Root().RegisterCommands(sCmds, ArraySize(sCmds), "");
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/NFC.cpp
+++ b/src/lib/shell/commands/NFC.cpp
@@ -90,7 +90,7 @@ void RegisterNFCCommands()
                                                    "Start, stop or get nfc emulation state. Usage: nfc <start|stop|state>" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/OnboardingCodes.cpp
+++ b/src/lib/shell/commands/OnboardingCodes.cpp
@@ -169,7 +169,7 @@ void RegisterOnboardingCodesCommands()
     };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -203,7 +203,7 @@ void RegisterOtaCommands()
     // Register the root `ota` command in the top-level shell.
     static const shell_command_t otaCommand = { &OtaHandler, "ota", "OTA commands" };
 
-    Engine::Root().RegisterCommands(&otaCommand, 1);
+    Engine::Root().RegisterCommands(&otaCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -198,7 +198,7 @@ void RegisterOtaCommands()
         { &ProgressHandler, "progress", "Gets progress of a current image update process. Usage: ota progress" }
     };
 
-    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands), "ota");
 
     // Register the root `ota` command in the top-level shell.
     static const shell_command_t otaCommand = { &OtaHandler, "ota", "OTA commands" };

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -138,8 +138,8 @@ void RegisterWiFiCommands()
     };
     static const shell_command_t sWiFiCommand = { &WiFiDispatch, "wifi", "Usage: wifi <subcommand>" };
 
-    sShellWiFiSubCommands.RegisterCommands(sWiFiSubCommands, ArraySize(sWiFiSubCommands));
-    Engine::Root().RegisterCommands(&sWiFiCommand, 1);
+    sShellWiFiSubCommands.RegisterCommands(sWiFiSubCommands, ArraySize(sWiFiSubCommands), "wifi");
+    Engine::Root().RegisterCommands(&sWiFiCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -20,6 +20,7 @@
 
 #include "driver/uart.h"
 #include "esp_console.h"
+#include "esp_log.h"
 #include "esp_vfs_dev.h"
 #include "linenoise/linenoise.h"
 #include <fcntl.h>
@@ -42,6 +43,82 @@ static int chip_command_handler(int argc, char ** argv)
         err = CHIP_ERROR_INVALID_ARGUMENT;
     }
     return static_cast<int>(err.AsInteger());
+}
+
+void get_command_completion(const char * buf, linenoiseCompletions * lc)
+{
+    size_t len                 = strlen(buf);
+    const char * matter_prefix = "matter ";
+
+    if (len > 6 && strncmp(buf, matter_prefix, 6) == 0)
+    {
+        // remove "matter " prefix for suggestion lookup
+        buf = &buf[7];
+        len = len - 7;
+
+        int last_space_idx = -1;
+
+        for (int i = len - 1; i > -1; i--)
+        {
+            if (buf[i] == ' ')
+            {
+                last_space_idx = i;
+                break;
+            }
+        }
+
+        // Get the last token of user input which may be an incomplete command name
+        // for comparing with completion candidates
+        char * incomplete_cmd = new char[len - last_space_idx];
+
+        // In case of cursor at the last space, there is no incomplete command to match,
+        // len = 0, last_space_idx = -1 and strylcpy here will copy only 1 char from the
+        // cursor position, that is the null terminator.
+        strlcpy(incomplete_cmd, &buf[last_space_idx + 1], len - last_space_idx);
+
+        char * prefix = new char[last_space_idx + 2];
+
+        if (last_space_idx == -1)
+        {
+            // For root commands (when there is no space after the "matter " prefix
+            // e.g. "matter config", "matter device"), look up with empty string ""
+            strlcpy(prefix, "", 1);
+        }
+        else
+        {
+            // Get the user input until (not included) the last space in buf,
+            // this will be use to look up completion candidates
+            strlcpy(prefix, buf, last_space_idx + 1);
+        }
+
+        std::vector<shell_command_t *> cmdSuggestions = Engine::GetCommandSuggestions(prefix);
+
+        for (auto suggestion : cmdSuggestions)
+        {
+            // When there is an incomplete command to match, find the matched candidates and add them;
+            // When there isn't an incomplete command to match, compare size is zero so strncmp
+            // returns 0 for all candidates, thus add all candidates.
+            if (strncmp(incomplete_cmd, suggestion->cmd_name, strlen(incomplete_cmd)) == 0)
+            {
+                std::string cmd_completion = matter_prefix;
+                if (strcmp(prefix, "") != 0)
+                {
+                    cmd_completion += prefix;
+                    cmd_completion += " ";
+                }
+                cmd_completion += suggestion->cmd_name;
+                linenoiseAddCompletion(lc, cmd_completion.c_str());
+            }
+        }
+        delete incomplete_cmd;
+        delete prefix;
+    }
+    else
+    {
+        // When the command isn't prefixed with "matter ", call the default esp
+        // get completion function to get the non-matter registered commands
+        return esp_console_get_completion(buf, lc);
+    }
 }
 
 int streamer_esp32_init(streamer_t * streamer)
@@ -80,8 +157,9 @@ int streamer_esp32_init(streamer_t * streamer)
         linenoiseSetDumbMode(1);
     }
 
-    esp_console_cmd_t command = { .command = "matter", .help = "Matter utilities", .func = chip_command_handler };
-    ESP_ERROR_CHECK(esp_console_cmd_register(&command));
+    esp_console_cmd_t matter_command = { .command = "matter", .help = "Matter utilities", .func = chip_command_handler };
+    ESP_ERROR_CHECK(esp_console_cmd_register(&matter_command));
+    linenoiseSetCompletionCallback(&get_command_completion);
     return 0;
 }
 


### PR DESCRIPTION
#### Problem
* Fixes #13269 
* There is currently no method to provide autocompletion for CLI, fix that.

#### Change overview

- Require command prefix/path as argument at time of command registration (e.g. "dns" is prefix for "dns resolve" and "dns browse")
- Add `Engine::GetCmdCompletion` to provide command completion based on command prefixes
- Implement the tab autocompletion for nRF Connect platform

#### Testing
Build and tested manually with 

nRF52840dk and nRF52840dongle with lighting-app example
![cli-tab](https://user-images.githubusercontent.com/1249037/149801535-858bcf0d-c54d-49db-941e-6201ef0800e3.gif)

updated Jan 26: I couldn't get the esp32 implementation to work properly after addressing review comments, so removing  the esp32 implementation from this PR and will do another PR later once fixed.