### PR TITLE
Disable android studio build

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -58,10 +58,10 @@ jobs:
               run: |
                 ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-{arm,arm64,x64,x86}-chip-*' build"
-            - name: Build Android Studio build (arm64 only)
-              run: |
-                ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-androidstudio-arm64-chip-tool' build"
+            # - name: Build Android Studio build (arm64 only)
+            #   run: |
+            #     ./scripts/run_in_build_env.sh \
+            #       "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-androidstudio-arm64-chip-tool' build"
             - name: Run Android build rule tests
               run: |
                 ./scripts/run_in_build_env.sh \


### PR DESCRIPTION
#### Problem
Android studio compilation seems to hang.

#### Change overview
Disable it. We still test general android compilation without studio.

We lose android studio configuration validation, however that does not seem as critical as training people to ignore android CI.

#### Testing
CI will test this for android being able to complete. Change is generally quite safe as it just disables a build step.
