### PR TITLE
Remove some spam when activating with zsh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -99,6 +99,4 @@ unset _PW_BANNER_FUNC
 unset _PW_TEXT
 unset PW_DOCTOR_SKIP_CIPD_CHECKS
 
-unset -f pw_cleanup
-unset -f _pw_hello
 unset -f _chip_bootstrap_banner


### PR DESCRIPTION

#### Problem

scripts/activate.sh:unset:102: no such hash table element: pw_cleanup
scripts/activate.sh:unset:103: no such hash table element: _pw_hello

#### Change overview

Remove unneeded environment cleanup.

#### Testing

zsh -c 'source scripts/activate.sh'