### PR TITLE
Add message receive and send tracing to chip-tool

### DIFF
--- a/examples/common/tracing/TraceHandlers.cpp
+++ b/examples/common/tracing/TraceHandlers.cpp
@@ -24,7 +24,11 @@
 #include "pw_trace/trace.h"
 #include "pw_trace_chip/trace_chip.h"
 #include "transport/TraceMessage.h"
+#include <lib/support/BytesToHex.h>
 #include <lib/support/logging/CHIPLogging.h>
+
+// For `s` std::string literal suffix
+using namespace std::string_literals;
 
 namespace chip {
 namespace trace {
@@ -50,21 +54,30 @@ public:
 
     void DeleteStream() { SetStream(nullptr); }
 
-    void Stream(const std::string & tag, const std::string & data)
+    void StartEvent(const std::string & label)
     {
         std::lock_guard<std::mutex> guard(mLock);
         if (mStream)
         {
-            mStream->Stream(tag, data);
+            mStream->StartEvent(label);
         }
     }
 
-    void Handler(const std::string & label)
+    void AddField(const std::string & tag, const std::string & data)
     {
         std::lock_guard<std::mutex> guard(mLock);
         if (mStream)
         {
-            mStream->Handler(label);
+            mStream->AddField(tag, data);
+        }
+    }
+
+    void FinishEvent()
+    {
+        std::lock_guard<std::mutex> guard(mLock);
+        if (mStream)
+        {
+            mStream->FinishEvent();
         }
     }
 
@@ -73,42 +86,215 @@ private:
     TraceStream * mStream = nullptr;
 };
 
-TraceOutput output;
-
-// TODO: Framework this into a registry of handlers for different message types.
-bool TraceDefaultHandler(const TraceEventFields & trace)
+struct TraceHandlerContext
 {
-    if (strcmp(trace.dataFormat, kTraceSecureMessageDataFormat) != 0 || trace.dataSize != sizeof(TraceSecureMessageData))
+    TraceOutput * sink;
+};
+
+TraceOutput gTraceOutput;
+TraceHandlerContext gTraceHandlerContext = { .sink = &gTraceOutput };
+
+std::string AsJsonKey(const std::string & key, const std::string & value, bool prepend_comma)
+{
+    return (prepend_comma ? ", "s : ""s) + "\""s + key + "\": " + value;
+}
+
+std::string AsFirstJsonKey(const std::string & key, const std::string & value)
+{
+    return AsJsonKey(key, value, /* prepend_comma = */false);
+}
+
+std::string AsNextJsonKey(const std::string & key, const std::string & value)
+{
+    return AsJsonKey(key, value, /* prepend_comma = */true);
+}
+
+std::string AsJsonString(const std::string & value)
+{
+    return "\""s + value + "\""s;
+}
+
+std::string AsJsonString(const Transport::PeerAddress * peerAddress)
+{
+    char convBuf[Transport::PeerAddress::kMaxToStringSize] = {0};
+
+    peerAddress->ToString(convBuf);
+    return convBuf;
+}
+
+std::string AsJsonBool(bool isTrue)
+{
+    return isTrue ? "true"s : "false"s;
+}
+
+std::string AsJsonHexString(const uint8_t * buf, size_t bufLen)
+{
+    // Fill a string long enough for the hex conversion, that will be overwritten
+    std::string hexBuf(2 * bufLen, '0');
+
+    Encoding::BytesToLowercaseHexBuffer(buf, bufLen, hexBuf.data(), hexBuf.size());
+
+    return AsJsonString(hexBuf);
+}
+
+std::string PacketHeaderToJson(const PacketHeader * packetHeader)
+{
+    std::string jsonBody;
+
+    uint32_t messageCounter = packetHeader->GetMessageCounter();
+    const Optional<NodeId> & sourceNodeId = packetHeader->GetSourceNodeId();
+    const Optional<NodeId> & destNodeId = packetHeader->GetDestinationNodeId();
+    const Optional<GroupId> & groupId = packetHeader->GetDestinationGroupId();
+    uint16_t sessionId = packetHeader->GetSessionId();
+    uint8_t messageFlags = packetHeader->GetMessageFlags();
+    uint8_t securityFlags = packetHeader->GetSecurityFlags();
+
+    jsonBody += AsFirstJsonKey("msg_counter", std::to_string(messageCounter));
+
+    if (sourceNodeId.HasValue())
+    {
+        jsonBody += AsNextJsonKey("source_node_id", std::to_string(sourceNodeId.Value()));
+    }
+
+    if (packetHeader->IsValidGroupMsg() && groupId.HasValue())
+    {
+        jsonBody += AsNextJsonKey("group_id", std::to_string(groupId.Value()));
+        jsonBody += AsNextJsonKey("group_key_hash", std::to_string(sessionId));
+    }
+    else if (destNodeId.HasValue())
+    {
+        jsonBody += AsNextJsonKey("dest_node_id", std::to_string(destNodeId.Value()));
+    }
+
+    jsonBody += AsNextJsonKey("session_id", std::to_string(sessionId));
+    jsonBody += AsNextJsonKey("msg_flags", std::to_string(messageFlags));
+    jsonBody += AsNextJsonKey("security_flags", std::to_string(securityFlags));
+
+    return jsonBody;
+}
+
+std::string PayloadHeaderToJson(const PayloadHeader * payloadHeader)
+{
+    uint16_t exchangeId = payloadHeader->GetExchangeID();
+    uint32_t protocolId = payloadHeader->GetProtocolID().ToFullyQualifiedSpecForm();
+    uint8_t protocolOpcode = payloadHeader->GetMessageType();
+    const Optional<uint32_t> & acknowledgedMessageCounter = payloadHeader->GetAckMessageCounter();
+    bool isInitiator = payloadHeader->IsInitiator();
+    bool needsAck = payloadHeader->NeedsAck();
+    uint8_t exchangeFlags = payloadHeader->GetExhangeFlags();
+
+    std::string jsonBody;
+
+    jsonBody += AsFirstJsonKey("exchange_flags", std::to_string(exchangeFlags));
+    jsonBody += AsNextJsonKey("exchange_id", std::to_string(exchangeId));
+    jsonBody += AsNextJsonKey("protocol_id", std::to_string(protocolId));
+    jsonBody += AsNextJsonKey("protocol_opcode", std::to_string(protocolOpcode));
+    jsonBody += AsNextJsonKey("is_initiator", AsJsonBool(isInitiator));
+    jsonBody += AsNextJsonKey("is_ack_requested", AsJsonBool(needsAck));
+
+    if (acknowledgedMessageCounter.HasValue())
+    {
+        jsonBody += AsNextJsonKey("acknowledged_msg_counter", std::to_string(acknowledgedMessageCounter.Value()));
+    }
+
+    return jsonBody;
+}
+
+bool SecureMessageSentHandler(const TraceEventFields & eventFields, TraceHandlerContext * context)
+{
+    if (eventFields.dataSize != sizeof(TraceSecureMessageSentData))
     {
         return false;
     }
 
-    const TraceSecureMessageData * msg = reinterpret_cast<const TraceSecureMessageData *>(trace.dataBuffer);
-    output.Handler("Default");
-    output.Stream("ExchangeId", std::to_string(msg->payloadHeader->GetExchangeID()));
-    output.Stream("MsgType", std::to_string(msg->payloadHeader->GetMessageType()));
-    output.Stream("MessageCounter", std::to_string(msg->packetHeader->GetMessageCounter()));
-    output.Stream("PacketSize", std::to_string(msg->packetSize));
+    const auto * eventData = reinterpret_cast<const TraceSecureMessageSentData *>(eventFields.dataBuffer);
+    std::string jsonBody = "{";
+    jsonBody += PacketHeaderToJson(eventData->packetHeader);
+    jsonBody += ", ";
+    jsonBody += PayloadHeaderToJson(eventData->payloadHeader);
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("payload_size", std::to_string(eventData->packetSize));
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("payload_hex", AsJsonHexString(eventData->packetPayload, eventData->packetSize));
+    jsonBody += "}";
+
+    TraceOutput * sink = context->sink;
+    sink->StartEvent(std::string{kTraceMessageEvent} + "." + kTraceMessageSentDataFormat);
+    sink->AddField("json", jsonBody);
+    sink->FinishEvent();
 
     return true;
+}
+
+bool SecureMessageReceivedHandler(const TraceEventFields & eventFields, TraceHandlerContext * context)
+{
+    if (eventFields.dataSize != sizeof(TraceSecureMessageReceivedData))
+    {
+        return false;
+    }
+
+    const auto * eventData = reinterpret_cast<const TraceSecureMessageReceivedData *>(eventFields.dataBuffer);
+
+    std::string jsonBody = "{";
+    jsonBody += AsFirstJsonKey("peer_address", AsJsonString(eventData->peerAddress));
+    jsonBody += ", ";
+    jsonBody += PacketHeaderToJson(eventData->packetHeader);
+    jsonBody += ", ";
+    jsonBody += PayloadHeaderToJson(eventData->payloadHeader);
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("payload_size", std::to_string(eventData->packetSize));
+    jsonBody += ", ";
+    jsonBody += AsFirstJsonKey("payload_hex", AsJsonHexString(eventData->packetPayload, eventData->packetSize));
+    jsonBody += "}";
+
+    TraceOutput * sink = context->sink;
+    sink->StartEvent(std::string{kTraceMessageEvent} + "." + kTraceMessageReceivedDataFormat);
+    sink->AddField("json", jsonBody);
+    sink->FinishEvent();
+
+    // Note that `eventData->session` is currently ignored.
+
+    return true;
+}
+
+// TODO: Framework this into a registry of handlers for different message types.
+bool TraceDefaultHandler(const TraceEventFields & eventFields, void * context)
+{
+    TraceHandlerContext * ourContext = reinterpret_cast<TraceHandlerContext *>(context);
+    if (ourContext == nullptr)
+    {
+        return false;
+    }
+
+    if (std::string{eventFields.dataFormat} == kTraceMessageSentDataFormat)
+    {
+        return SecureMessageSentHandler(eventFields, ourContext);
+    }
+    else if (std::string{eventFields.dataFormat} == kTraceMessageReceivedDataFormat)
+    {
+        return SecureMessageReceivedHandler(eventFields, ourContext);
+    }
+
+    return false;
 }
 
 } // namespace
 
 void SetTraceStream(TraceStream * stream)
 {
-    output.SetStream(stream);
+    gTraceOutput.SetStream(stream);
 }
 
 void InitTrace()
 {
-    RegisterTraceHandler(TraceDefaultHandler);
+    void * context = &gTraceHandlerContext;
+    RegisterTraceHandler(TraceDefaultHandler, context);
 }
 
 void DeInitTrace()
 {
     UnregisterAllTraceHandlers();
-    output.DeleteStream();
+    gTraceOutput.DeleteStream();
 }
 
 } // namespace trace

--- a/examples/common/tracing/TraceHandlers.cpp
+++ b/examples/common/tracing/TraceHandlers.cpp
@@ -101,12 +101,12 @@ std::string AsJsonKey(const std::string & key, const std::string & value, bool p
 
 std::string AsFirstJsonKey(const std::string & key, const std::string & value)
 {
-    return AsJsonKey(key, value, /* prepend_comma = */false);
+    return AsJsonKey(key, value, /* prepend_comma = */ false);
 }
 
 std::string AsNextJsonKey(const std::string & key, const std::string & value)
 {
-    return AsJsonKey(key, value, /* prepend_comma = */true);
+    return AsJsonKey(key, value, /* prepend_comma = */ true);
 }
 
 std::string AsJsonString(const std::string & value)
@@ -116,7 +116,7 @@ std::string AsJsonString(const std::string & value)
 
 std::string AsJsonString(const Transport::PeerAddress * peerAddress)
 {
-    char convBuf[Transport::PeerAddress::kMaxToStringSize] = {0};
+    char convBuf[Transport::PeerAddress::kMaxToStringSize] = { 0 };
 
     peerAddress->ToString(convBuf);
     return convBuf;
@@ -141,13 +141,13 @@ std::string PacketHeaderToJson(const PacketHeader * packetHeader)
 {
     std::string jsonBody;
 
-    uint32_t messageCounter = packetHeader->GetMessageCounter();
+    uint32_t messageCounter               = packetHeader->GetMessageCounter();
     const Optional<NodeId> & sourceNodeId = packetHeader->GetSourceNodeId();
-    const Optional<NodeId> & destNodeId = packetHeader->GetDestinationNodeId();
-    const Optional<GroupId> & groupId = packetHeader->GetDestinationGroupId();
-    uint16_t sessionId = packetHeader->GetSessionId();
-    uint8_t messageFlags = packetHeader->GetMessageFlags();
-    uint8_t securityFlags = packetHeader->GetSecurityFlags();
+    const Optional<NodeId> & destNodeId   = packetHeader->GetDestinationNodeId();
+    const Optional<GroupId> & groupId     = packetHeader->GetDestinationGroupId();
+    uint16_t sessionId                    = packetHeader->GetSessionId();
+    uint8_t messageFlags                  = packetHeader->GetMessageFlags();
+    uint8_t securityFlags                 = packetHeader->GetSecurityFlags();
 
     jsonBody += AsFirstJsonKey("msg_counter", std::to_string(messageCounter));
 
@@ -175,13 +175,13 @@ std::string PacketHeaderToJson(const PacketHeader * packetHeader)
 
 std::string PayloadHeaderToJson(const PayloadHeader * payloadHeader)
 {
-    uint16_t exchangeId = payloadHeader->GetExchangeID();
-    uint32_t protocolId = payloadHeader->GetProtocolID().ToFullyQualifiedSpecForm();
-    uint8_t protocolOpcode = payloadHeader->GetMessageType();
+    uint16_t exchangeId                                   = payloadHeader->GetExchangeID();
+    uint32_t protocolId                                   = payloadHeader->GetProtocolID().ToFullyQualifiedSpecForm();
+    uint8_t protocolOpcode                                = payloadHeader->GetMessageType();
     const Optional<uint32_t> & acknowledgedMessageCounter = payloadHeader->GetAckMessageCounter();
-    bool isInitiator = payloadHeader->IsInitiator();
-    bool needsAck = payloadHeader->NeedsAck();
-    uint8_t exchangeFlags = payloadHeader->GetExhangeFlags();
+    bool isInitiator                                      = payloadHeader->IsInitiator();
+    bool needsAck                                         = payloadHeader->NeedsAck();
+    uint8_t exchangeFlags                                 = payloadHeader->GetExhangeFlags();
 
     std::string jsonBody;
 
@@ -208,7 +208,7 @@ bool SecureMessageSentHandler(const TraceEventFields & eventFields, TraceHandler
     }
 
     const auto * eventData = reinterpret_cast<const TraceSecureMessageSentData *>(eventFields.dataBuffer);
-    std::string jsonBody = "{";
+    std::string jsonBody   = "{";
     jsonBody += PacketHeaderToJson(eventData->packetHeader);
     jsonBody += ", ";
     jsonBody += PayloadHeaderToJson(eventData->payloadHeader);
@@ -219,7 +219,7 @@ bool SecureMessageSentHandler(const TraceEventFields & eventFields, TraceHandler
     jsonBody += "}";
 
     TraceOutput * sink = context->sink;
-    sink->StartEvent(std::string{kTraceMessageEvent} + "." + kTraceMessageSentDataFormat);
+    sink->StartEvent(std::string{ kTraceMessageEvent } + "." + kTraceMessageSentDataFormat);
     sink->AddField("json", jsonBody);
     sink->FinishEvent();
 
@@ -248,7 +248,7 @@ bool SecureMessageReceivedHandler(const TraceEventFields & eventFields, TraceHan
     jsonBody += "}";
 
     TraceOutput * sink = context->sink;
-    sink->StartEvent(std::string{kTraceMessageEvent} + "." + kTraceMessageReceivedDataFormat);
+    sink->StartEvent(std::string{ kTraceMessageEvent } + "." + kTraceMessageReceivedDataFormat);
     sink->AddField("json", jsonBody);
     sink->FinishEvent();
 
@@ -266,11 +266,11 @@ bool TraceDefaultHandler(const TraceEventFields & eventFields, void * context)
         return false;
     }
 
-    if (std::string{eventFields.dataFormat} == kTraceMessageSentDataFormat)
+    if (std::string{ eventFields.dataFormat } == kTraceMessageSentDataFormat)
     {
         return SecureMessageSentHandler(eventFields, ourContext);
     }
-    else if (std::string{eventFields.dataFormat} == kTraceMessageReceivedDataFormat)
+    else if (std::string{ eventFields.dataFormat } == kTraceMessageReceivedDataFormat)
     {
         return SecureMessageReceivedHandler(eventFields, ourContext);
     }

--- a/examples/common/tracing/TraceHandlers.h
+++ b/examples/common/tracing/TraceHandlers.h
@@ -39,7 +39,7 @@ class TraceStreamLog : public TraceStream
 public:
     void StartEvent(const std::string & label) override
     {
-        mStreamLine = ">>>" + label + "<<<\t";
+        mStreamLine   = ">>>" + label + "<<<\t";
         mIsFirstField = true;
     }
 
@@ -49,10 +49,8 @@ public:
         mIsFirstField = false;
     }
 
-    void FinishEvent() override
-    {
-        ChipLogAutomation("TraceStream:%s", mStreamLine.c_str());
-    }
+    void FinishEvent() override { ChipLogAutomation("TraceStream:%s", mStreamLine.c_str()); }
+
 protected:
     std::string mStreamLine;
     bool mIsFirstField = true;
@@ -84,10 +82,7 @@ public:
         }
     }
 
-    void FinishEvent() override
-    {
-
-    }
+    void FinishEvent() override {}
 
 private:
     std::ofstream mFile;

--- a/examples/platform/linux/pw_trace_chip/public/pw_trace_chip/trace_chip.h
+++ b/examples/platform/linux/pw_trace_chip/public/pw_trace_chip/trace_chip.h
@@ -69,10 +69,10 @@ struct TraceEventFields
     size_t dataSize;
 };
 
-typedef bool (*TraceHandlerCallback)(const TraceEventFields & trace);
+typedef bool (*TraceHandlerCallback)(const TraceEventFields & eventFields, void * context);
 
-// Register a trace handler which gets called for all data trace events.
-void RegisterTraceHandler(TraceHandlerCallback callback);
+// Register an additional trace handler which gets called for all data trace events with the given context
+void RegisterTraceHandler(TraceHandlerCallback callback, void * context);
 void UnregisterAllTraceHandlers();
 
 // These are what the facade actually calls.

--- a/examples/platform/linux/pw_trace_chip/trace.cc
+++ b/examples/platform/linux/pw_trace_chip/trace.cc
@@ -58,7 +58,7 @@ void TraceEvent(const char * module, const char * label, TraceEventType eventTyp
 void RegisterTraceHandler(TraceHandlerCallback callback, void * context)
 {
     std::lock_guard<std::mutex> guard(handlerLock);
-    traceHandlers.push_back(TraceHandlerEntry{callback, context});
+    traceHandlers.push_back(TraceHandlerEntry{ callback, context });
 }
 
 void UnregisterAllTraceHandlers()

--- a/examples/platform/linux/pw_trace_chip/trace.cc
+++ b/examples/platform/linux/pw_trace_chip/trace.cc
@@ -25,31 +25,40 @@
 
 namespace chip {
 namespace trace {
+
 namespace {
 
+struct TraceHandlerEntry
+{
+    // Handler callback that will receive the event
+    TraceHandlerCallback callback;
+    // Registration-time context provided for the given handler
+    void * context;
+};
+
 std::mutex handlerLock;
-std::vector<TraceHandlerCallback> traceHandlers;
+std::vector<TraceHandlerEntry> traceHandlers;
 
 } // namespace
 
 void TraceEvent(const char * module, const char * label, TraceEventType eventType, const char * group, uint32_t traceId,
                 uint8_t flags, const char * dataFormat, const void * dataBuffer, size_t dataSize)
 {
-    TraceEventFields fields = { module, label, eventType, group, traceId, flags, dataFormat, dataBuffer, dataSize };
+    TraceEventFields eventFields = { module, label, eventType, group, traceId, flags, dataFormat, dataBuffer, dataSize };
     std::lock_guard<std::mutex> guard(handlerLock);
     for (const auto & handler : traceHandlers)
     {
-        if (handler(fields))
+        if (handler.callback(eventFields, handler.context))
         {
             return;
         }
     }
 }
 
-void RegisterTraceHandler(TraceHandlerCallback callback)
+void RegisterTraceHandler(TraceHandlerCallback callback, void * context)
 {
     std::lock_guard<std::mutex> guard(handlerLock);
-    traceHandlers.push_back(callback);
+    traceHandlers.push_back(TraceHandlerEntry{callback, context});
 }
 
 void UnregisterAllTraceHandlers()

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -29,8 +29,6 @@
 #include <lib/support/SafeInt.h>
 #include <transport/SecureMessageCodec.h>
 
-#include "transport/TraceMessage.h"
-
 namespace chip {
 
 using System::PacketBuffer;
@@ -53,7 +51,6 @@ CHIP_ERROR Encrypt(Transport::SecureSession * session, PayloadHeader & payloadHe
     uint8_t * data    = msgBuf->Start();
     uint16_t totalLen = msgBuf->TotalLength();
 
-    CHIP_TRACE_MESSAGE(payloadHeader, packetHeader, data, totalLen);
     MessageAuthenticationCode mac;
     ReturnErrorOnFailure(session->EncryptBeforeSend(data, totalLen, data, packetHeader, mac));
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -29,6 +29,7 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include "transport/TraceMessage.h"
 #include <app/util/basic-types.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPKeyIds.h>
@@ -40,7 +41,6 @@
 #include <transport/GroupSession.h>
 #include <transport/PairingSession.h>
 #include <transport/SecureMessageCodec.h>
-#include "transport/TraceMessage.h"
 #include <transport/TransportMgr.h>
 
 #include <inttypes.h>

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -19,20 +19,37 @@
 #pragma once
 
 #include <core/CHIPBuildConfig.h>
+#include <transport/Session.h>
 #include <transport/raw/MessageHeader.h>
+#include <transport/raw/PeerAddress.h>
 
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 #include "pw_trace/trace.h"
 
-#define CHIP_TRACE_MESSAGE(payloadHeader, packetHeader, data, dataLen)                                                             \
+#define CHIP_TRACE_MESSAGE_SENT(payloadHeader, packetHeader, data, dataLen)                                                        \
     do                                                                                                                             \
     {                                                                                                                              \
-        ::chip::trace::TraceSecureMessageData _trace_data{ &payloadHeader, &packetHeader, data, dataLen };                         \
-        PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceSecureMessageDataFormat,                                           \
-                              reinterpret_cast<const char *>(&_trace_data), sizeof(_trace_data));                                  \
+        const ::chip::trace::TraceSecureMessageSentData _trace_data{ &payloadHeader, &packetHeader, data, dataLen };               \
+        PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceMessageSentDataFormat,                                             \
+                              reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
     } while (0)
+
+#define CHIP_TRACE_MESSAGE_RECEIVED(payloadHeader, packetHeader, session, peerAddress, data, dataLen)                              \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        const ::chip::trace::TraceSecureMessageReceivedData _trace_data {                                                          \
+            &payloadHeader, &packetHeader, session, &peerAddress, data, dataLen };                                                  \
+        PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceMessageReceivedDataFormat,                                         \
+                              reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
+    } while (0)
+
 #else
-#define CHIP_TRACE_MESSAGE(payloadHeader, packetHeader, data, dataLen)                                                             \
+#define CHIP_TRACE_MESSAGE_SENT(payloadHeader, packetHeader, data, dataLen)                                                        \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
+
+#define CHIP_TRACE_MESSAGE_RECEIVED(payloadHeader, packetHeader, session, peerAddress, data, dataLen)                              \
     do                                                                                                                             \
     {                                                                                                                              \
     } while (0)
@@ -42,13 +59,25 @@
 namespace chip {
 namespace trace {
 
-constexpr const char * kTraceSecureMessageDataFormat = "SecMsg";
+constexpr const char * kTraceMessageEvent = "SecureMsg";
+constexpr const char * kTraceMessageSentDataFormat = "SecMsgSent";
+constexpr const char * kTraceMessageReceivedDataFormat = "SecMsgReceived";
 
-struct TraceSecureMessageData
+struct TraceSecureMessageSentData
 {
-    PayloadHeader * payloadHeader;
-    PacketHeader * packetHeader;
-    uint8_t * packetPayload;
+    const PayloadHeader * payloadHeader;
+    const PacketHeader * packetHeader;
+    const uint8_t * packetPayload;
+    size_t packetSize;
+};
+
+struct TraceSecureMessageReceivedData
+{
+    const PayloadHeader * payloadHeader;
+    const PacketHeader * packetHeader;
+    const Transport::Session * session;
+    const Transport::PeerAddress * peerAddress;
+    const uint8_t * packetPayload;
     size_t packetSize;
 };
 

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -37,8 +37,8 @@
 #define CHIP_TRACE_MESSAGE_RECEIVED(payloadHeader, packetHeader, session, peerAddress, data, dataLen)                              \
     do                                                                                                                             \
     {                                                                                                                              \
-        const ::chip::trace::TraceSecureMessageReceivedData _trace_data {                                                          \
-            &payloadHeader, &packetHeader, session, &peerAddress, data, dataLen };                                                  \
+        const ::chip::trace::TraceSecureMessageReceivedData _trace_data{ &payloadHeader, &packetHeader, session,                   \
+                                                                         &peerAddress,   data,          dataLen };                 \
         PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceMessageReceivedDataFormat,                                         \
                               reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
     } while (0)
@@ -59,8 +59,8 @@
 namespace chip {
 namespace trace {
 
-constexpr const char * kTraceMessageEvent = "SecureMsg";
-constexpr const char * kTraceMessageSentDataFormat = "SecMsgSent";
+constexpr const char * kTraceMessageEvent              = "SecureMsg";
+constexpr const char * kTraceMessageSentDataFormat     = "SecMsgSent";
 constexpr const char * kTraceMessageReceivedDataFormat = "SecMsgReceived";
 
 struct TraceSecureMessageSentData

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -439,6 +439,9 @@ public:
     /** Get the secure msg type from this header. */
     uint8_t GetMessageType() const { return mMessageType; }
 
+    /** Get the raw exchange flags from this header. */
+    uint8_t GetExhangeFlags() const { return mExchangeFlags.Raw(); }
+
     /** Check whether the header has a given secure message type */
     bool HasMessageType(uint8_t type) const { return mMessageType == type; }
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>


### PR DESCRIPTION
#### Problem

- There doesn't exist a clean way to see all message-layer messages going in/out of chip-tool to assist the following use-cases:
  - Making test verification steps that don't rely on stable logs in-band of the business logic (e.g. BDX testing)
  - Testing MRP
  - Automatic the expectation/parsing of IM messages from test harness
 
Also, there didn't exist a way to see all traffic without encryption hacks for a given node, to assist in debugging.

#### Change overview

- Move existing send tracing from `SecureMessageCodec` to `SessionManager` to allow covering both received and sent messages
- Add received message tracing
- Update trace handling to be flexible to receiving a context pointer.
- Refactor trace handling logic in common/tracing to be more flexible to future needs
- Add bookend `FinishEvent` to the `TraceStream` interface to assist in event flushing.

What it looks like in the logs with `--trace_log 1` in chip-tool (and tracing enabled, which it isn't by default in the build yet):

Two messages, one outgoing, one incoming:

> [1642198394.740868][1851914:1851919] CHIP:ATM: TraceStream:>>>SecureMsg.SecMsgSent<<<	json|{"msg_counter": 1218820235, "session_id": 0, "msg_flags": 0, "security_flags": 0, "exchange_flags": 5, "exchange_id": 24662, "protocol_id": 0, "protocol_opcode": 32, "is_initiator": true, "is_ack_requested": true, "payload_size": 56, "payload_hex": "1530012069dcc043eed5febc214476b96f3b7dd7d29ca665cf20aece524835cb3c9375e1240201240300280435052501881325022c011818"}
>

> [1642198394.742024][1851914:1851919] CHIP:ATM: TraceStream:>>>SecureMsg.SecMsgReceived<<<	json|{"peer_address": "UDP:[fdda:ebcf:9d95:0:a238:3d3c:5a29:1f3d%eno1]:5540", "msg_counter": 2683499691, "session_id": 0, "msg_flags": 0, "security_flags": 0, "exchange_flags": 6, "exchange_id": 24662, "protocol_id": 0, "protocol_opcode": 33, "is_initiator": false, "is_ack_requested": true, "acknowledged_msg_counter": 1218820235, "payload_size": 111, "payload_hex": "1530012069dcc043eed5febc214476b96f3b7dd7d29ca665cf20aece524835cb3c9375e1300220543ba1aa453e12eaa538cedcd674adb6d88f037088fb48e57884972601009c2d24030135042401643002105350414b453250204b65792053616c741835052501881325022c011818"}
> 


After basic parsing to recover JSON:
```json
[
  {
    "timestamp": 1642198394.740868,
    "pid": 1851914,
    "tid": 1851919,
    "type": "SecureMsg.SecMsgSent",
    "data": {
      "msg_counter": 1218820235,
      "session_id": 0,
      "msg_flags": 0,
      "security_flags": 0,
      "exchange_flags": 5,
      "exchange_id": 24662,
      "protocol_id": 0,
      "protocol_opcode": 32,
      "is_initiator": true,
      "is_ack_requested": true,
      "payload_size": 56,
      "payload_hex": "1530012069dcc043eed5febc214476b96f3b7dd7d29ca665cf20aece524835cb3c9375e1240201240300280435052501881325022c011818"
    }
  },
  {
    "timestamp": 1642198394.742024,
    "pid": 1851914,
    "tid": 1851919,
    "type": "SecureMsg.SecMsgReceived",
    "data": {
      "peer_address": "UDP:[fdda:ebcf:9d95:0:a238:3d3c:5a29:1f3d%eno1]:5540",
      "msg_counter": 2683499691,
      "session_id": 0,
      "msg_flags": 0,
      "security_flags": 0,
      "exchange_flags": 6,
      "exchange_id": 24662,
      "protocol_id": 0,
      "protocol_opcode": 33,
      "is_initiator": false,
      "is_ack_requested": true,
      "acknowledged_msg_counter": 1218820235,
      "payload_size": 111,
      "payload_hex": "1530012069dcc043eed5febc214476b96f3b7dd7d29ca665cf20aece524835cb3c9375e1300220543ba1aa453e12eaa538cedcd674adb6d88f037088fb48e57884972601009c2d24030135042401643002105350414b453250204b65792053616c741835052501881325022c011818"
    }
  }
]
```

#### Testing
- Integration tests pass, unit tests all pass
- Validated manually through several runs that with chip-tool (using `--trace_log 1`) that dumped received/sent message traces  match the outer higher-level (but less detailed) logs around them
