### PR TITLE
[app] add reference counting for CASESessionManager

### DIFF
--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -74,17 +74,42 @@ public:
     virtual ~CASESessionManager() { mDNSResolver.Shutdown(); }
 
     /**
-     * Find an existing session for the given node ID, or trigger a new session request.
+     * Retain an existing session for the given node ID, or trigger a new session request.
      * The caller can optionally provide `onConnection` and `onFailure` callback objects. If provided,
      * these will be used to inform the caller about successful or failed connection establishment.
      * If the connection is already established, the `onConnection` callback will be immediately called.
+     *
+     * The reference count of the session will be incremented and shall be released by ReleaseSession when
+     * no longer used.
+     *
      */
-    CHIP_ERROR FindOrEstablishSession(PeerId peerId, Callback::Callback<OnDeviceConnected> * onConnection,
-                                      Callback::Callback<OnDeviceConnectionFailure> * onFailure);
+    CHIP_ERROR RetainSession(PeerId peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+                             Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
+    /**
+     * Finds an existing session for the given node ID.
+     * The reference count of the session won't be modified and the session can be closed by other clients
+     * if not retained explicitly.
+     *
+     */
     OperationalDeviceProxy * FindExistingSession(PeerId peerId);
 
+    /*
+     * Releases a session for the given node ID.
+     *
+     * Decrements the reference count of the session. The session will be closed when the referece count
+     * becomes zero.
+     *
+     */
     void ReleaseSession(PeerId peerId);
+
+    /*
+     * Shutdown the object.
+     *
+     * All the sessions will be closed regardless of their current reference count.
+     *
+     */
+    void Shutdown();
 
     /**
      * This API triggers the DNS-SD resolution for the given node ID. The node ID will be looked up

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -278,8 +278,8 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 
     ChipLogDetail(SoftwareUpdate, "Establishing session to provider node ID 0x" ChipLogFormatX64 " on fabric index %d",
                   ChipLogValueX64(mProviderNodeId), mProviderFabricIndex);
-    CHIP_ERROR err = mCASESessionManager->FindOrEstablishSession(fabricInfo->GetPeerIdForNode(mProviderNodeId),
-                                                                 &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    CHIP_ERROR err = mCASESessionManager->RetainSession(fabricInfo->GetPeerIdForNode(mProviderNodeId), &mOnConnectedCallback,
+                                                        &mOnConnectionFailureCallback);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    ChipLogError(SoftwareUpdate, "Cannot establish connection to provider: %" CHIP_ERROR_FORMAT, err.Format()));
 }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -257,6 +257,7 @@ void Server::Shutdown()
     mExchangeMgr.Shutdown();
     mSessions.Shutdown();
     mTransports.Close();
+    mCASESessionManager.Shutdown();
     mCommissioningWindowManager.Shutdown();
     chip::Platform::MemoryShutdown();
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -245,6 +245,7 @@ CHIP_ERROR DeviceController::Shutdown()
     mDeviceDiscoveryDelegate     = nullptr;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
+    mCASESessionManager->Shutdown();
     chip::Platform::Delete(mCASESessionManager);
     mCASESessionManager = nullptr;
 
@@ -1637,7 +1638,7 @@ void DeviceCommissioner::OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & 
 
     mDNSCache.Insert(nodeData);
 
-    mCASESessionManager->FindOrEstablishSession(nodeData.mPeerId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    mCASESessionManager->RetainSession(nodeData.mPeerId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
     DeviceController::OnNodeIdResolved(nodeData);
 }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -220,7 +220,7 @@ public:
                                           Callback::Callback<OnDeviceConnectionFailure> * onFailure)
     {
         VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
-        return mCASESessionManager->FindOrEstablishSession(mFabricInfo->GetPeerIdForNode(deviceId), onConnection, onFailure);
+        return mCASESessionManager->RetainSession(mFabricInfo->GetPeerIdForNode(deviceId), onConnection, onFailure);
     }
 
     /**


### PR DESCRIPTION

#### Problem

For sharing CASESession between multiple modules such as OTA requestor
and binding client, reference counting mechanism is required.

#### Change overview

* Add reference counting mechanism to `CASESessionManager`
* Add the missing shutdown process for `CASESessionManager`


#### Testing

Manuallly tested by chip-pairing. CI tests will also cover pairing and controlling.
