### PR TITLE
ESP32: Add cli option for OnOff in all-clusters-app

### DIFF
--- a/examples/all-clusters-app/esp32/main/OnOffCommands.cpp
+++ b/examples/all-clusters-app/esp32/main/OnOffCommands.cpp
@@ -1,0 +1,102 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <OnOffCommands.h>
+#include <lib/shell/Commands.h>
+#include <lib/shell/Engine.h>
+#include <lib/shell/commands/Help.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <lib/core/CHIPCore.h>
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
+#include <lib/shell/Engine.h>
+#include <lib/shell/commands/Help.h>
+#include <lib/support/CHIPArgParser.hpp>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace Shell {
+namespace {
+
+Shell::Engine sSubShell;
+
+CHIP_ERROR OnOffHandler(int argc, char ** argv)
+{
+    if (argc == 0)
+    {
+        sSubShell.ForEachCommand(PrintCommandHelp, nullptr);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR error = sSubShell.ExecCommand(argc, argv);
+
+    if (error != CHIP_NO_ERROR)
+    {
+        streamer_printf(streamer_get(), "Error: %" CHIP_ERROR_FORMAT "\r\n", error.Format());
+    }
+
+    return error;
+}
+
+static CHIP_ERROR OnLightHandler(int argc, char ** argv)
+{
+    if (argc != 1)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    chip::app::Clusters::OnOff::Attributes::OnOff::Set(atoi(argv[0]), 1);
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR OffLightHandler(int argc, char ** argv)
+{
+    if (argc != 1)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    chip::app::Clusters::OnOff::Attributes::OnOff::Set(atoi(argv[0]), 0);
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR ToggleLightHandler(int argc, char ** argv)
+{
+    if (argc != 1)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    bool value;
+    chip::app::Clusters::OnOff::Attributes::OnOff::Get(atoi(argv[0]), &value);
+    chip::app::Clusters::OnOff::Attributes::OnOff::Set(atoi(argv[0]), !value);
+    return CHIP_NO_ERROR;
+}
+
+} // namespace
+
+void OnOffCommands::Register()
+{
+    static const shell_command_t subCommands[] = { { &OnLightHandler, "on", "Usage: OnOff on endpoint-id" },
+                                                   { &OffLightHandler, "off", "Usage: OnOff off endpoint-id" },
+                                                   { &ToggleLightHandler, "toggle", "Usage: OnOff toggle endpoint-id" } };
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+
+    // Register the root `OnOff` command in the top-level shell.
+    static const shell_command_t onOffCommand = { &OnOffHandler, "OnOff", "OnOff commands" };
+
+    Engine::Root().RegisterCommands(&onOffCommand, 1);
+}
+
+} // namespace Shell
+} // namespace chip

--- a/examples/all-clusters-app/esp32/main/include/OnOffCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/OnOffCommands.h
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace Shell {
+
+class OnOffCommands
+{
+public:
+    // delete the copy constructor
+    OnOffCommands(const OnOffCommands &) = delete;
+    // delete the move constructor
+    OnOffCommands(OnOffCommands &&) = delete;
+    // delete the assignment operator
+    OnOffCommands & operator=(const OnOffCommands &) = delete;
+
+    static OnOffCommands & GetInstance()
+    {
+        static OnOffCommands instance;
+        return instance;
+    }
+
+    // Register the OTA provider commands
+    void Register();
+
+private:
+    OnOffCommands() {}
+};
+
+} // namespace Shell
+} // namespace chip

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -82,7 +82,10 @@
 #include <platform/ThreadStackManager.h>
 #endif
 
+#include <OnOffCommands.h>
+
 using namespace ::chip;
+using namespace ::chip::Shell;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
@@ -587,6 +590,8 @@ extern "C" void app_main()
 
 #if CONFIG_ENABLE_CHIP_SHELL
     chip::LaunchShell();
+    OnOffCommands & onOffCommands = OnOffCommands::GetInstance();
+    onOffCommands.Register();
 #endif // CONFIG_ENABLE_CHIP_SHELL
 
 #if CONFIG_OPENTHREAD_ENABLED


### PR DESCRIPTION
#### Change overview
This PR adds CLI commands to handle on/off commands of OnOff cluster

#### Testing
* Tested using chip-tool
* Usage :
         i.matter OnOff on <endpoint_id>
         ii. matter OnOff off <endpoint_id>