### PR TITLE
[IDL] remove reportable

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -40,13 +40,13 @@ server cluster AccessControl = 31 {
     OCTET_STRING data = 1;
   }
 
-  attribute(writable, reportable) AccessControlEntry acl[] = 0;
-  attribute(writable, reportable) ExtensionEntry extension[] = 1;
+  attribute(writable) AccessControlEntry acl[] = 0;
+  attribute(writable) ExtensionEntry extension[] = 1;
   attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster AccountLogin = 1294 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -65,7 +65,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -93,14 +93,14 @@ server cluster ApplicationBasic = 1293 {
     kActiveVisibleNotFocus = 3;
   }
 
-  attribute(readonly, reportable) char_string vendorName = 0;
-  attribute(readonly, reportable) int16u vendorId = 1;
-  attribute(readonly, reportable) char_string applicationName = 2;
-  attribute(readonly, reportable) int16u productId = 3;
-  attribute(readonly, reportable) ApplicationStatusEnum applicationStatus = 5;
-  attribute(readonly, reportable) char_string applicationVersion = 6;
+  attribute(readonly) char_string vendorName = 0;
+  attribute(readonly) int16u vendorId = 1;
+  attribute(readonly) char_string applicationName = 2;
+  attribute(readonly) int16u productId = 3;
+  attribute(readonly) ApplicationStatusEnum applicationStatus = 5;
+  attribute(readonly) char_string applicationVersion = 6;
   attribute(readonly) vendor_id allowedVendorList[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ApplicationLauncher = 1292 {
@@ -115,8 +115,8 @@ server cluster ApplicationLauncher = 1292 {
     CHAR_STRING applicationId = 2;
   }
 
-  attribute(readonly, reportable) INT16U applicationLauncherList[] = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) INT16U applicationLauncherList[] = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster AudioOutput = 1291 {
@@ -135,17 +135,17 @@ server cluster AudioOutput = 1291 {
     CHAR_STRING name = 3;
   }
 
-  attribute(readonly, reportable) OutputInfo audioOutputList[] = 0;
-  attribute(readonly, reportable) int8u currentAudioOutput = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) OutputInfo audioOutputList[] = 0;
+  attribute(readonly) int8u currentAudioOutput = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster BarrierControl = 259 {
-  attribute(readonly, reportable) enum8 barrierMovingState = 1;
-  attribute(readonly, reportable) bitmap16 barrierSafetyStatus = 2;
-  attribute(readonly, reportable) bitmap8 barrierCapabilities = 3;
-  attribute(readonly, reportable) int8u barrierPosition = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 barrierMovingState = 1;
+  attribute(readonly) bitmap16 barrierSafetyStatus = 2;
+  attribute(readonly) bitmap8 barrierCapabilities = 3;
+  attribute(readonly) int8u barrierPosition = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BarrierControlGoToPercentRequest {
     INT8U percentOpen = 0;
@@ -170,39 +170,39 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
 
 server cluster BinaryInputBasic = 15 {
-  attribute(writable, reportable) boolean outOfService = 81;
-  attribute(writable, reportable) boolean presentValue = 85;
-  attribute(readonly, reportable) bitmap8 statusFlags = 111;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) boolean outOfService = 81;
+  attribute(writable) boolean presentValue = 85;
+  attribute(readonly) bitmap8 statusFlags = 111;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Binding = 30 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BindRequest {
     NODE_ID nodeId = 0;
@@ -227,8 +227,8 @@ server cluster BooleanState = 69 {
     boolean stateValue = 0;
   }
 
-  attribute(readonly, reportable) boolean stateValue = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean stateValue = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster BridgedActions = 37 {
@@ -289,14 +289,14 @@ server cluster BridgedActions = 37 {
     ActionErrorEnum error = 3;
   }
 
-  attribute(readonly, reportable) ActionStruct actionList[] = 0;
-  attribute(readonly, reportable) EndpointListStruct endpointList[] = 1;
-  attribute(readonly, reportable) long_char_string setupUrl = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) ActionStruct actionList[] = 0;
+  attribute(readonly) EndpointListStruct endpointList[] = 1;
+  attribute(readonly) long_char_string setupUrl = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster BridgedDeviceBasic = 57 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Channel = 1284 {
@@ -317,8 +317,8 @@ server cluster Channel = 1284 {
     CHAR_STRING affiliateCallSign = 5;
   }
 
-  attribute(readonly, reportable) ChannelInfo channelList[] = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) ChannelInfo channelList[] = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ColorControl = 768 {
@@ -368,59 +368,59 @@ server cluster ColorControl = 768 {
     kDown = 3;
   }
 
-  attribute(readonly, reportable) int8u currentHue = 0;
-  attribute(readonly, reportable) int8u currentSaturation = 1;
-  attribute(readonly, reportable) int16u remainingTime = 2;
-  attribute(readonly, reportable) int16u currentX = 3;
-  attribute(readonly, reportable) int16u currentY = 4;
-  attribute(readonly, reportable) enum8 driftCompensation = 5;
-  attribute(readonly, reportable) char_string compensationText = 6;
-  attribute(readonly, reportable) int16u colorTemperature = 7;
-  attribute(readonly, reportable) enum8 colorMode = 8;
-  attribute(writable, reportable) bitmap8 colorControlOptions = 15;
-  attribute(readonly, reportable) int8u numberOfPrimaries = 16;
-  attribute(readonly, reportable) int16u primary1X = 17;
-  attribute(readonly, reportable) int16u primary1Y = 18;
-  attribute(readonly, reportable) int8u primary1Intensity = 19;
-  attribute(readonly, reportable) int16u primary2X = 21;
-  attribute(readonly, reportable) int16u primary2Y = 22;
-  attribute(readonly, reportable) int8u primary2Intensity = 23;
-  attribute(readonly, reportable) int16u primary3X = 25;
-  attribute(readonly, reportable) int16u primary3Y = 26;
-  attribute(readonly, reportable) int8u primary3Intensity = 27;
-  attribute(readonly, reportable) int16u primary4X = 32;
-  attribute(readonly, reportable) int16u primary4Y = 33;
-  attribute(readonly, reportable) int8u primary4Intensity = 34;
-  attribute(readonly, reportable) int16u primary5X = 36;
-  attribute(readonly, reportable) int16u primary5Y = 37;
-  attribute(readonly, reportable) int8u primary5Intensity = 38;
-  attribute(readonly, reportable) int16u primary6X = 40;
-  attribute(readonly, reportable) int16u primary6Y = 41;
-  attribute(readonly, reportable) int8u primary6Intensity = 42;
-  attribute(writable, reportable) int16u whitePointX = 48;
-  attribute(writable, reportable) int16u whitePointY = 49;
-  attribute(writable, reportable) int16u colorPointRX = 50;
-  attribute(writable, reportable) int16u colorPointRY = 51;
-  attribute(writable, reportable) int8u colorPointRIntensity = 52;
-  attribute(writable, reportable) int16u colorPointGX = 54;
-  attribute(writable, reportable) int16u colorPointGY = 55;
-  attribute(writable, reportable) int8u colorPointGIntensity = 56;
-  attribute(writable, reportable) int16u colorPointBX = 58;
-  attribute(writable, reportable) int16u colorPointBY = 59;
-  attribute(writable, reportable) int8u colorPointBIntensity = 60;
-  attribute(readonly, reportable) int16u enhancedCurrentHue = 16384;
-  attribute(readonly, reportable) enum8 enhancedColorMode = 16385;
-  attribute(readonly, reportable) int8u colorLoopActive = 16386;
-  attribute(readonly, reportable) int8u colorLoopDirection = 16387;
-  attribute(readonly, reportable) int16u colorLoopTime = 16388;
-  attribute(readonly, reportable) int16u colorLoopStartEnhancedHue = 16389;
-  attribute(readonly, reportable) int16u colorLoopStoredEnhancedHue = 16390;
-  attribute(readonly, reportable) bitmap16 colorCapabilities = 16394;
-  attribute(readonly, reportable) int16u colorTempPhysicalMin = 16395;
-  attribute(readonly, reportable) int16u colorTempPhysicalMax = 16396;
-  attribute(readonly, reportable) int16u coupleColorTempToLevelMinMireds = 16397;
-  attribute(writable, reportable) int16u startUpColorTemperatureMireds = 16400;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentHue = 0;
+  attribute(readonly) int8u currentSaturation = 1;
+  attribute(readonly) int16u remainingTime = 2;
+  attribute(readonly) int16u currentX = 3;
+  attribute(readonly) int16u currentY = 4;
+  attribute(readonly) enum8 driftCompensation = 5;
+  attribute(readonly) char_string compensationText = 6;
+  attribute(readonly) int16u colorTemperature = 7;
+  attribute(readonly) enum8 colorMode = 8;
+  attribute(writable) bitmap8 colorControlOptions = 15;
+  attribute(readonly) int8u numberOfPrimaries = 16;
+  attribute(readonly) int16u primary1X = 17;
+  attribute(readonly) int16u primary1Y = 18;
+  attribute(readonly) int8u primary1Intensity = 19;
+  attribute(readonly) int16u primary2X = 21;
+  attribute(readonly) int16u primary2Y = 22;
+  attribute(readonly) int8u primary2Intensity = 23;
+  attribute(readonly) int16u primary3X = 25;
+  attribute(readonly) int16u primary3Y = 26;
+  attribute(readonly) int8u primary3Intensity = 27;
+  attribute(readonly) int16u primary4X = 32;
+  attribute(readonly) int16u primary4Y = 33;
+  attribute(readonly) int8u primary4Intensity = 34;
+  attribute(readonly) int16u primary5X = 36;
+  attribute(readonly) int16u primary5Y = 37;
+  attribute(readonly) int8u primary5Intensity = 38;
+  attribute(readonly) int16u primary6X = 40;
+  attribute(readonly) int16u primary6Y = 41;
+  attribute(readonly) int8u primary6Intensity = 42;
+  attribute(writable) int16u whitePointX = 48;
+  attribute(writable) int16u whitePointY = 49;
+  attribute(writable) int16u colorPointRX = 50;
+  attribute(writable) int16u colorPointRY = 51;
+  attribute(writable) int8u colorPointRIntensity = 52;
+  attribute(writable) int16u colorPointGX = 54;
+  attribute(writable) int16u colorPointGY = 55;
+  attribute(writable) int8u colorPointGIntensity = 56;
+  attribute(writable) int16u colorPointBX = 58;
+  attribute(writable) int16u colorPointBY = 59;
+  attribute(writable) int8u colorPointBIntensity = 60;
+  attribute(readonly) int16u enhancedCurrentHue = 16384;
+  attribute(readonly) enum8 enhancedColorMode = 16385;
+  attribute(readonly) int8u colorLoopActive = 16386;
+  attribute(readonly) int8u colorLoopDirection = 16387;
+  attribute(readonly) int16u colorLoopTime = 16388;
+  attribute(readonly) int16u colorLoopStartEnhancedHue = 16389;
+  attribute(readonly) int16u colorLoopStoredEnhancedHue = 16390;
+  attribute(readonly) bitmap16 colorCapabilities = 16394;
+  attribute(readonly) int16u colorTempPhysicalMin = 16395;
+  attribute(readonly) int16u colorTempPhysicalMax = 16396;
+  attribute(readonly) int16u coupleColorTempToLevelMinMireds = 16397;
+  attribute(writable) int16u startUpColorTemperatureMireds = 16400;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ColorLoopSetRequest {
     ColorLoopUpdateFlags updateFlags = 0;
@@ -655,9 +655,9 @@ server cluster ContentLauncher = 1290 {
     MetricTypeEnum metric = 3;
   }
 
-  attribute(readonly, reportable) CHAR_STRING acceptHeaderList[] = 0;
-  attribute(writable, reportable) bitmap32 supportedStreamingProtocols = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
+  attribute(writable) bitmap32 supportedStreamingProtocols = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Descriptor = 29 {
@@ -666,11 +666,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -939,10 +939,10 @@ server cluster DoorLock = 257 {
     nullable INT16U dataIndex = 6;
   }
 
-  attribute(readonly, reportable) DlLockState lockState = 0;
-  attribute(readonly, reportable) DlLockType lockType = 1;
-  attribute(readonly, reportable) boolean actuatorEnabled = 2;
-  attribute(readonly, reportable) DlDoorState doorState = 3;
+  attribute(readonly) DlLockState lockState = 0;
+  attribute(readonly) DlLockType lockType = 1;
+  attribute(readonly) boolean actuatorEnabled = 2;
+  attribute(readonly) DlDoorState doorState = 3;
   attribute(writable) int32u doorOpenEvents = 4;
   attribute(writable) int32u doorClosedEvents = 5;
   attribute(writable) int16u openPeriod = 6;
@@ -954,19 +954,19 @@ server cluster DoorLock = 257 {
   attribute(readonly) int8u maxPINCodeLength = 23;
   attribute(readonly) int8u minPINCodeLength = 24;
   attribute(readonly) bitmap8 credentialRulesSupport = 27;
-  attribute(writable, reportable) char_string language = 33;
-  attribute(writable, reportable) int32u autoRelockTime = 35;
-  attribute(writable, reportable) int8u soundVolume = 36;
-  attribute(writable, reportable) DlOperatingMode operatingMode = 37;
+  attribute(writable) char_string language = 33;
+  attribute(writable) int32u autoRelockTime = 35;
+  attribute(writable) int8u soundVolume = 36;
+  attribute(writable) DlOperatingMode operatingMode = 37;
   attribute(readonly) bitmap16 supportedOperatingModes = 38;
   attribute(readonly) bitmap16 defaultConfigurationRegister = 39;
-  attribute(writable, reportable) boolean enableOneTouchLocking = 41;
+  attribute(writable) boolean enableOneTouchLocking = 41;
   attribute(writable) boolean enableInsideStatusLED = 42;
-  attribute(writable, reportable) boolean enablePrivacyModeButton = 43;
-  attribute(writable, reportable) int8u wrongCodeEntryLimit = 48;
-  attribute(writable, reportable) int8u userCodeTemporaryDisableTime = 49;
+  attribute(writable) boolean enablePrivacyModeButton = 43;
+  attribute(writable) int8u wrongCodeEntryLimit = 48;
+  attribute(writable) int8u userCodeTemporaryDisableTime = 49;
   attribute(writable) boolean requirePINforRemoteOperation = 51;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ClearCredentialRequest {
     DlCredential credential = 0;
@@ -1046,18 +1046,18 @@ server cluster DoorLock = 257 {
 }
 
 server cluster ElectricalMeasurement = 2820 {
-  attribute(readonly, reportable) bitmap32 measurementType = 0;
-  attribute(readonly, reportable) int32s totalActivePower = 772;
-  attribute(readonly, reportable) int16u rmsVoltage = 1285;
-  attribute(readonly, reportable) int16u rmsVoltageMin = 1286;
-  attribute(readonly, reportable) int16u rmsVoltageMax = 1287;
-  attribute(readonly, reportable) int16u rmsCurrent = 1288;
-  attribute(readonly, reportable) int16u rmsCurrentMin = 1289;
-  attribute(readonly, reportable) int16u rmsCurrentMax = 1290;
-  attribute(readonly, reportable) int16s activePower = 1291;
-  attribute(readonly, reportable) int16s activePowerMin = 1292;
-  attribute(readonly, reportable) int16s activePowerMax = 1293;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 measurementType = 0;
+  attribute(readonly) int32s totalActivePower = 772;
+  attribute(readonly) int16u rmsVoltage = 1285;
+  attribute(readonly) int16u rmsVoltageMin = 1286;
+  attribute(readonly) int16u rmsVoltageMax = 1287;
+  attribute(readonly) int16u rmsCurrent = 1288;
+  attribute(readonly) int16u rmsCurrentMin = 1289;
+  attribute(readonly) int16u rmsCurrentMax = 1290;
+  attribute(readonly) int16s activePower = 1291;
+  attribute(readonly) int16s activePowerMin = 1292;
+  attribute(readonly) int16s activePowerMax = 1293;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster EthernetNetworkDiagnostics = 55 {
@@ -1074,17 +1074,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
@@ -1095,11 +1095,11 @@ server cluster FixedLabel = 64 {
 }
 
 server cluster FlowMeasurement = 1028 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GeneralCommissioning = 48 {
@@ -1120,12 +1120,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -1238,15 +1238,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GroupKeyManagement = 63 {
@@ -1279,11 +1279,11 @@ server cluster GroupKeyManagement = 63 {
     INT64U epochStartTime2 = 7;
   }
 
-  attribute(readonly, reportable) GroupKey groupKeyMap[] = 0;
-  attribute(readonly, reportable) GroupInfo groupTable[] = 1;
+  attribute(readonly) GroupKey groupKeyMap[] = 0;
+  attribute(readonly) GroupInfo groupTable[] = 1;
   attribute(readonly) int16u maxGroupsPerFabric = 2;
   attribute(readonly) int16u maxGroupKeysPerFabric = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct KeySetReadRequest {
     INT16U groupKeySetID = 0;
@@ -1316,8 +1316,8 @@ server cluster GroupKeyManagement = 63 {
 }
 
 server cluster Groups = 4 {
-  attribute(readonly, reportable) bitmap8 nameSupport = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 nameSupport = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
     INT16U groupId = 0;
@@ -1397,12 +1397,12 @@ server cluster IasZone = 1280 {
     kInvalidZoneType = 65535;
   }
 
-  attribute(readonly, reportable) enum8 zoneState = 0;
-  attribute(readonly, reportable) enum16 zoneType = 1;
-  attribute(readonly, reportable) bitmap16 zoneStatus = 2;
-  attribute(writable, reportable) node_id iasCieAddress = 16;
-  attribute(readonly, reportable) int8u zoneId = 17;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 zoneState = 0;
+  attribute(readonly) enum16 zoneType = 1;
+  attribute(readonly) bitmap16 zoneStatus = 2;
+  attribute(writable) node_id iasCieAddress = 16;
+  attribute(readonly) int8u zoneId = 17;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ZoneEnrollRequestRequest {
     IasZoneType zoneType = 0;
@@ -1448,9 +1448,9 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -1476,12 +1476,12 @@ server cluster IlluminanceMeasurement = 1024 {
     kCmos = 1;
   }
 
-  attribute(readonly, reportable) int16u measuredValue = 0;
-  attribute(readonly, reportable) int16u minMeasuredValue = 1;
-  attribute(readonly, reportable) int16u maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
-  attribute(readonly, reportable) enum8 lightSensorType = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u measuredValue = 0;
+  attribute(readonly) int16u minMeasuredValue = 1;
+  attribute(readonly) int16u maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
+  attribute(readonly) enum8 lightSensorType = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster KeypadInput = 1289 {
@@ -1580,7 +1580,7 @@ server cluster KeypadInput = 1289 {
     kInvalidKeyInCurrentState = 2;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster LevelControl = 8 {
@@ -1594,22 +1594,22 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u remainingTime = 1;
-  attribute(readonly, reportable) int8u minLevel = 2;
-  attribute(readonly, reportable) int8u maxLevel = 3;
-  attribute(readonly, reportable) int16u currentFrequency = 4;
-  attribute(readonly, reportable) int16u minFrequency = 5;
-  attribute(readonly, reportable) int16u maxFrequency = 6;
-  attribute(writable, reportable) bitmap8 options = 15;
-  attribute(writable, reportable) int16u onOffTransitionTime = 16;
-  attribute(writable, reportable) int8u onLevel = 17;
-  attribute(writable, reportable) int16u onTransitionTime = 18;
-  attribute(writable, reportable) int16u offTransitionTime = 19;
-  attribute(writable, reportable) int8u defaultMoveRate = 20;
-  attribute(writable, reportable) int8u startUpCurrentLevel = 16384;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u remainingTime = 1;
+  attribute(readonly) int8u minLevel = 2;
+  attribute(readonly) int8u maxLevel = 3;
+  attribute(readonly) int16u currentFrequency = 4;
+  attribute(readonly) int16u minFrequency = 5;
+  attribute(readonly) int16u maxFrequency = 6;
+  attribute(writable) bitmap8 options = 15;
+  attribute(writable) int16u onOffTransitionTime = 16;
+  attribute(writable) int8u onLevel = 17;
+  attribute(writable) int16u onTransitionTime = 18;
+  attribute(writable) int16u offTransitionTime = 19;
+  attribute(writable) int8u defaultMoveRate = 20;
+  attribute(writable) int8u startUpCurrentLevel = 16384;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -1670,7 +1670,7 @@ server cluster LocalizationConfiguration = 43 {
 }
 
 server cluster LowPower = 1288 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Sleep(): DefaultSuccess = 0;
 }
@@ -1698,9 +1698,9 @@ server cluster MediaInput = 1287 {
     CHAR_STRING description = 4;
   }
 
-  attribute(readonly, reportable) InputInfo mediaInputList[] = 0;
-  attribute(readonly, reportable) int8u currentMediaInput = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) InputInfo mediaInputList[] = 0;
+  attribute(readonly) int8u currentMediaInput = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster MediaPlayback = 1286 {
@@ -1720,13 +1720,13 @@ server cluster MediaPlayback = 1286 {
     kSeekOutOfRange = 5;
   }
 
-  attribute(readonly, reportable) PlaybackStateEnum playbackState = 0;
-  attribute(readonly, reportable) epoch_us startTime = 1;
-  attribute(readonly, reportable) int64u duration = 2;
-  attribute(readonly, reportable) single playbackSpeed = 4;
-  attribute(readonly, reportable) int64u seekRangeEnd = 5;
-  attribute(readonly, reportable) int64u seekRangeStart = 6;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) PlaybackStateEnum playbackState = 0;
+  attribute(readonly) epoch_us startTime = 1;
+  attribute(readonly) int64u duration = 2;
+  attribute(readonly) single playbackSpeed = 4;
+  attribute(readonly) int64u seekRangeEnd = 5;
+  attribute(readonly) int64u seekRangeStart = 6;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ModeSelect = 80 {
@@ -1736,12 +1736,12 @@ server cluster ModeSelect = 80 {
     INT32U semanticTag = 3;
   }
 
-  attribute(readonly, reportable) int8u currentMode = 0;
-  attribute(readonly, reportable) ModeOptionStruct supportedModes[] = 1;
-  attribute(writable, reportable) int8u onMode = 2;
-  attribute(readonly, reportable) int8u startUpMode = 3;
-  attribute(readonly, reportable) char_string description = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentMode = 0;
+  attribute(readonly) ModeOptionStruct supportedModes[] = 1;
+  attribute(writable) int8u onMode = 2;
+  attribute(readonly) int8u startUpMode = 3;
+  attribute(readonly) char_string description = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ChangeToModeRequest {
     INT8U newMode = 0;
@@ -1809,7 +1809,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -1890,7 +1890,7 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -1975,11 +1975,11 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     nullable INT64S platformCode = 3;
   }
 
-  attribute(writable, reportable) ProviderLocation defaultOtaProviders[] = 0;
-  attribute(readonly, reportable) boolean updatePossible = 1;
-  attribute(readonly, reportable) OTAUpdateStateEnum updateState = 2;
-  attribute(readonly, reportable) int8u updateStateProgress = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) ProviderLocation defaultOtaProviders[] = 0;
+  attribute(readonly) boolean updatePossible = 1;
+  attribute(readonly) OTAUpdateStateEnum updateState = 2;
+  attribute(readonly) int8u updateStateProgress = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AnnounceOtaProviderRequest {
     node_id providerNodeId = 0;
@@ -1993,10 +1993,10 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
 }
 
 server cluster OccupancySensing = 1030 {
-  attribute(readonly, reportable) bitmap8 occupancy = 0;
-  attribute(readonly, reportable) enum8 occupancySensorType = 1;
-  attribute(readonly, reportable) bitmap8 occupancySensorTypeBitmap = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 occupancy = 0;
+  attribute(readonly) enum8 occupancySensorType = 1;
+  attribute(readonly) bitmap8 occupancySensorTypeBitmap = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster OnOff = 6 {
@@ -2015,13 +2015,13 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) boolean globalSceneControl = 16384;
-  attribute(writable, reportable) int16u onTime = 16385;
-  attribute(writable, reportable) int16u offWaitTime = 16386;
-  attribute(writable, reportable) enum8 startUpOnOff = 16387;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) boolean globalSceneControl = 16384;
+  attribute(writable) int16u onTime = 16385;
+  attribute(writable) int16u offWaitTime = 16386;
+  attribute(writable) enum8 startUpOnOff = 16387;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OffWithEffectRequest {
     OnOffEffectIdentifier effectId = 0;
@@ -2043,9 +2043,9 @@ server cluster OnOff = 6 {
 }
 
 server cluster OnOffSwitchConfiguration = 7 {
-  attribute(readonly, reportable) enum8 switchType = 0;
-  attribute(writable, reportable) enum8 switchActions = 16;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 switchType = 0;
+  attribute(writable) enum8 switchActions = 16;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster OperationalCredentials = 62 {
@@ -2071,12 +2071,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -2151,17 +2151,17 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster PowerSource = 47 {
-  attribute(readonly, reportable) enum8 status = 0;
-  attribute(readonly, reportable) int8u order = 1;
-  attribute(readonly, reportable) char_string description = 2;
-  attribute(readonly, reportable) int32u batteryVoltage = 11;
-  attribute(readonly, reportable) int8u batteryPercentRemaining = 12;
-  attribute(readonly, reportable) int32u batteryTimeRemaining = 13;
-  attribute(readonly, reportable) enum8 batteryChargeLevel = 14;
-  attribute(readonly, reportable) ENUM8 activeBatteryFaults[] = 18;
-  attribute(readonly, reportable) enum8 batteryChargeState = 26;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 status = 0;
+  attribute(readonly) int8u order = 1;
+  attribute(readonly) char_string description = 2;
+  attribute(readonly) int32u batteryVoltage = 11;
+  attribute(readonly) int8u batteryPercentRemaining = 12;
+  attribute(readonly) int32u batteryTimeRemaining = 13;
+  attribute(readonly) enum8 batteryChargeLevel = 14;
+  attribute(readonly) ENUM8 activeBatteryFaults[] = 18;
+  attribute(readonly) enum8 batteryChargeState = 26;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster PowerSourceConfiguration = 46 {
@@ -2170,10 +2170,10 @@ server cluster PowerSourceConfiguration = 46 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster PumpConfigurationAndControl = 512 {
@@ -2244,40 +2244,40 @@ server cluster PumpConfigurationAndControl = 512 {
   info event TurbineOperation = 16 {
   }
 
-  attribute(readonly, reportable) int16s maxPressure = 0;
-  attribute(readonly, reportable) int16u maxSpeed = 1;
-  attribute(readonly, reportable) int16u maxFlow = 2;
-  attribute(readonly, reportable) int16s minConstPressure = 3;
-  attribute(readonly, reportable) int16s maxConstPressure = 4;
-  attribute(readonly, reportable) int16s minCompPressure = 5;
-  attribute(readonly, reportable) int16s maxCompPressure = 6;
-  attribute(readonly, reportable) int16u minConstSpeed = 7;
-  attribute(readonly, reportable) int16u maxConstSpeed = 8;
-  attribute(readonly, reportable) int16u minConstFlow = 9;
-  attribute(readonly, reportable) int16u maxConstFlow = 10;
-  attribute(readonly, reportable) int16s minConstTemp = 11;
-  attribute(readonly, reportable) int16s maxConstTemp = 12;
-  attribute(readonly, reportable) bitmap16 pumpStatus = 16;
-  attribute(readonly, reportable) enum8 effectiveOperationMode = 17;
-  attribute(readonly, reportable) enum8 effectiveControlMode = 18;
-  attribute(readonly, reportable) int16s capacity = 19;
-  attribute(readonly, reportable) int16u speed = 20;
-  attribute(writable, reportable) int24u lifetimeRunningHours = 21;
-  attribute(readonly, reportable) int24u power = 22;
-  attribute(writable, reportable) int32u lifetimeEnergyConsumed = 23;
-  attribute(writable, reportable) enum8 operationMode = 32;
-  attribute(writable, reportable) enum8 controlMode = 33;
-  attribute(readonly, reportable) bitmap16 alarmMask = 34;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s maxPressure = 0;
+  attribute(readonly) int16u maxSpeed = 1;
+  attribute(readonly) int16u maxFlow = 2;
+  attribute(readonly) int16s minConstPressure = 3;
+  attribute(readonly) int16s maxConstPressure = 4;
+  attribute(readonly) int16s minCompPressure = 5;
+  attribute(readonly) int16s maxCompPressure = 6;
+  attribute(readonly) int16u minConstSpeed = 7;
+  attribute(readonly) int16u maxConstSpeed = 8;
+  attribute(readonly) int16u minConstFlow = 9;
+  attribute(readonly) int16u maxConstFlow = 10;
+  attribute(readonly) int16s minConstTemp = 11;
+  attribute(readonly) int16s maxConstTemp = 12;
+  attribute(readonly) bitmap16 pumpStatus = 16;
+  attribute(readonly) enum8 effectiveOperationMode = 17;
+  attribute(readonly) enum8 effectiveControlMode = 18;
+  attribute(readonly) int16s capacity = 19;
+  attribute(readonly) int16u speed = 20;
+  attribute(writable) int24u lifetimeRunningHours = 21;
+  attribute(readonly) int24u power = 22;
+  attribute(writable) int32u lifetimeEnergyConsumed = 23;
+  attribute(writable) enum8 operationMode = 32;
+  attribute(writable) enum8 controlMode = 33;
+  attribute(readonly) bitmap16 alarmMask = 34;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster RelativeHumidityMeasurement = 1029 {
-  attribute(readonly, reportable) int16u measuredValue = 0;
-  attribute(readonly, reportable) int16u minMeasuredValue = 1;
-  attribute(readonly, reportable) int16u maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u measuredValue = 0;
+  attribute(readonly) int16u minMeasuredValue = 1;
+  attribute(readonly) int16u maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Scenes = 5 {
@@ -2287,12 +2287,12 @@ server cluster Scenes = 5 {
     INT8U value = 3;
   }
 
-  attribute(readonly, reportable) int8u sceneCount = 0;
-  attribute(readonly, reportable) int8u currentScene = 1;
-  attribute(readonly, reportable) int16u currentGroup = 2;
-  attribute(readonly, reportable) boolean sceneValid = 3;
-  attribute(readonly, reportable) bitmap8 nameSupport = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u sceneCount = 0;
+  attribute(readonly) int8u currentScene = 1;
+  attribute(readonly) int16u currentGroup = 2;
+  attribute(readonly) boolean sceneValid = 3;
+  attribute(readonly) bitmap8 nameSupport = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddSceneRequest {
     INT16U groupId = 0;
@@ -2393,12 +2393,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetWatermarks(): DefaultSuccess = 0;
 }
@@ -2434,11 +2434,11 @@ server cluster Switch = 59 {
     INT8U totalNumberOfPressesCounted = 1;
   }
 
-  attribute(readonly, reportable) int8u numberOfPositions = 0;
-  attribute(readonly, reportable) int8u currentPosition = 1;
-  attribute(readonly, reportable) int8u multiPressMax = 2;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u numberOfPositions = 0;
+  attribute(readonly) int8u currentPosition = 1;
+  attribute(readonly) int8u multiPressMax = 2;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TargetNavigator = 1285 {
@@ -2453,17 +2453,17 @@ server cluster TargetNavigator = 1285 {
     CHAR_STRING name = 2;
   }
 
-  attribute(readonly, reportable) TargetInfo targetNavigatorList[] = 0;
+  attribute(readonly) TargetInfo targetNavigatorList[] = 0;
   attribute(readonly) int8u currentNavigatorTarget = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TestCluster = 1295 {
@@ -2530,84 +2530,84 @@ server cluster TestCluster = 1295 {
     SimpleEnum arg6[] = 6;
   }
 
-  attribute(writable, reportable) boolean boolean = 0;
-  attribute(writable, reportable) bitmap8 bitmap8 = 1;
-  attribute(writable, reportable) bitmap16 bitmap16 = 2;
-  attribute(writable, reportable) bitmap32 bitmap32 = 3;
-  attribute(writable, reportable) bitmap64 bitmap64 = 4;
-  attribute(writable, reportable) int8u int8u = 5;
-  attribute(writable, reportable) int16u int16u = 6;
-  attribute(writable, reportable) int24u int24u = 7;
-  attribute(writable, reportable) int32u int32u = 8;
-  attribute(writable, reportable) int40u int40u = 9;
-  attribute(writable, reportable) int48u int48u = 10;
-  attribute(writable, reportable) int56u int56u = 11;
-  attribute(writable, reportable) int64u int64u = 12;
-  attribute(writable, reportable) int8s int8s = 13;
-  attribute(writable, reportable) int16s int16s = 14;
-  attribute(writable, reportable) int24s int24s = 15;
-  attribute(writable, reportable) int32s int32s = 16;
-  attribute(writable, reportable) int40s int40s = 17;
-  attribute(writable, reportable) int48s int48s = 18;
-  attribute(writable, reportable) int56s int56s = 19;
-  attribute(writable, reportable) int64s int64s = 20;
-  attribute(writable, reportable) enum8 enum8 = 21;
-  attribute(writable, reportable) enum16 enum16 = 22;
-  attribute(writable, reportable) single floatSingle = 23;
-  attribute(writable, reportable) double floatDouble = 24;
-  attribute(writable, reportable) octet_string octetString = 25;
-  attribute(writable, reportable) INT8U listInt8u[] = 26;
-  attribute(writable, reportable) OCTET_STRING listOctetString[] = 27;
-  attribute(writable, reportable) TestListStructOctet listStructOctetString[] = 28;
-  attribute(writable, reportable) long_octet_string longOctetString = 29;
-  attribute(writable, reportable) char_string charString = 30;
-  attribute(writable, reportable) long_char_string longCharString = 31;
-  attribute(writable, reportable) epoch_us epochUs = 32;
-  attribute(writable, reportable) epoch_s epochS = 33;
-  attribute(writable, reportable) vendor_id vendorId = 34;
-  attribute(writable, reportable) NullablesAndOptionalsStruct listNullablesAndOptionalsStruct[] = 35;
-  attribute(writable, reportable) SimpleEnum enumAttr = 36;
-  attribute(writable, reportable) SimpleStruct structAttr = 37;
-  attribute(writable, reportable) int8u rangeRestrictedInt8u = 38;
-  attribute(writable, reportable) int8s rangeRestrictedInt8s = 39;
-  attribute(writable, reportable) int16u rangeRestrictedInt16u = 40;
-  attribute(writable, reportable) int16s rangeRestrictedInt16s = 41;
+  attribute(writable) boolean boolean = 0;
+  attribute(writable) bitmap8 bitmap8 = 1;
+  attribute(writable) bitmap16 bitmap16 = 2;
+  attribute(writable) bitmap32 bitmap32 = 3;
+  attribute(writable) bitmap64 bitmap64 = 4;
+  attribute(writable) int8u int8u = 5;
+  attribute(writable) int16u int16u = 6;
+  attribute(writable) int24u int24u = 7;
+  attribute(writable) int32u int32u = 8;
+  attribute(writable) int40u int40u = 9;
+  attribute(writable) int48u int48u = 10;
+  attribute(writable) int56u int56u = 11;
+  attribute(writable) int64u int64u = 12;
+  attribute(writable) int8s int8s = 13;
+  attribute(writable) int16s int16s = 14;
+  attribute(writable) int24s int24s = 15;
+  attribute(writable) int32s int32s = 16;
+  attribute(writable) int40s int40s = 17;
+  attribute(writable) int48s int48s = 18;
+  attribute(writable) int56s int56s = 19;
+  attribute(writable) int64s int64s = 20;
+  attribute(writable) enum8 enum8 = 21;
+  attribute(writable) enum16 enum16 = 22;
+  attribute(writable) single floatSingle = 23;
+  attribute(writable) double floatDouble = 24;
+  attribute(writable) octet_string octetString = 25;
+  attribute(writable) INT8U listInt8u[] = 26;
+  attribute(writable) OCTET_STRING listOctetString[] = 27;
+  attribute(writable) TestListStructOctet listStructOctetString[] = 28;
+  attribute(writable) long_octet_string longOctetString = 29;
+  attribute(writable) char_string charString = 30;
+  attribute(writable) long_char_string longCharString = 31;
+  attribute(writable) epoch_us epochUs = 32;
+  attribute(writable) epoch_s epochS = 33;
+  attribute(writable) vendor_id vendorId = 34;
+  attribute(writable) NullablesAndOptionalsStruct listNullablesAndOptionalsStruct[] = 35;
+  attribute(writable) SimpleEnum enumAttr = 36;
+  attribute(writable) SimpleStruct structAttr = 37;
+  attribute(writable) int8u rangeRestrictedInt8u = 38;
+  attribute(writable) int8s rangeRestrictedInt8s = 39;
+  attribute(writable) int16u rangeRestrictedInt16u = 40;
+  attribute(writable) int16s rangeRestrictedInt16s = 41;
   attribute(readonly) LONG_OCTET_STRING listLongOctetString[] = 42;
-  attribute(writable, reportable) boolean timedWriteBoolean = 48;
-  attribute(writable, reportable) boolean nullableBoolean = 32768;
-  attribute(writable, reportable) bitmap8 nullableBitmap8 = 32769;
-  attribute(writable, reportable) bitmap16 nullableBitmap16 = 32770;
-  attribute(writable, reportable) bitmap32 nullableBitmap32 = 32771;
-  attribute(writable, reportable) bitmap64 nullableBitmap64 = 32772;
-  attribute(writable, reportable) int8u nullableInt8u = 32773;
-  attribute(writable, reportable) int16u nullableInt16u = 32774;
-  attribute(writable, reportable) int24u nullableInt24u = 32775;
-  attribute(writable, reportable) int32u nullableInt32u = 32776;
-  attribute(writable, reportable) int40u nullableInt40u = 32777;
-  attribute(writable, reportable) int48u nullableInt48u = 32778;
-  attribute(writable, reportable) int56u nullableInt56u = 32779;
-  attribute(writable, reportable) int64u nullableInt64u = 32780;
-  attribute(writable, reportable) int8s nullableInt8s = 32781;
-  attribute(writable, reportable) int16s nullableInt16s = 32782;
-  attribute(writable, reportable) int24s nullableInt24s = 32783;
-  attribute(writable, reportable) int32s nullableInt32s = 32784;
-  attribute(writable, reportable) int40s nullableInt40s = 32785;
-  attribute(writable, reportable) int48s nullableInt48s = 32786;
-  attribute(writable, reportable) int56s nullableInt56s = 32787;
-  attribute(writable, reportable) int64s nullableInt64s = 32788;
-  attribute(writable, reportable) enum8 nullableEnum8 = 32789;
-  attribute(writable, reportable) enum16 nullableEnum16 = 32790;
-  attribute(writable, reportable) single nullableFloatSingle = 32791;
-  attribute(writable, reportable) double nullableFloatDouble = 32792;
-  attribute(writable, reportable) octet_string nullableOctetString = 32793;
-  attribute(writable, reportable) char_string nullableCharString = 32798;
-  attribute(writable, reportable) SimpleEnum nullableEnumAttr = 32804;
-  attribute(writable, reportable) SimpleStruct nullableStruct = 32805;
-  attribute(writable, reportable) int8u nullableRangeRestrictedInt8u = 32806;
-  attribute(writable, reportable) int8s nullableRangeRestrictedInt8s = 32807;
-  attribute(writable, reportable) int16u nullableRangeRestrictedInt16u = 32808;
-  attribute(writable, reportable) int16s nullableRangeRestrictedInt16s = 32809;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) boolean timedWriteBoolean = 48;
+  attribute(writable) boolean nullableBoolean = 32768;
+  attribute(writable) bitmap8 nullableBitmap8 = 32769;
+  attribute(writable) bitmap16 nullableBitmap16 = 32770;
+  attribute(writable) bitmap32 nullableBitmap32 = 32771;
+  attribute(writable) bitmap64 nullableBitmap64 = 32772;
+  attribute(writable) int8u nullableInt8u = 32773;
+  attribute(writable) int16u nullableInt16u = 32774;
+  attribute(writable) int24u nullableInt24u = 32775;
+  attribute(writable) int32u nullableInt32u = 32776;
+  attribute(writable) int40u nullableInt40u = 32777;
+  attribute(writable) int48u nullableInt48u = 32778;
+  attribute(writable) int56u nullableInt56u = 32779;
+  attribute(writable) int64u nullableInt64u = 32780;
+  attribute(writable) int8s nullableInt8s = 32781;
+  attribute(writable) int16s nullableInt16s = 32782;
+  attribute(writable) int24s nullableInt24s = 32783;
+  attribute(writable) int32s nullableInt32s = 32784;
+  attribute(writable) int40s nullableInt40s = 32785;
+  attribute(writable) int48s nullableInt48s = 32786;
+  attribute(writable) int56s nullableInt56s = 32787;
+  attribute(writable) int64s nullableInt64s = 32788;
+  attribute(writable) enum8 nullableEnum8 = 32789;
+  attribute(writable) enum16 nullableEnum16 = 32790;
+  attribute(writable) single nullableFloatSingle = 32791;
+  attribute(writable) double nullableFloatDouble = 32792;
+  attribute(writable) octet_string nullableOctetString = 32793;
+  attribute(writable) char_string nullableCharString = 32798;
+  attribute(writable) SimpleEnum nullableEnumAttr = 32804;
+  attribute(writable) SimpleStruct nullableStruct = 32805;
+  attribute(writable) int8u nullableRangeRestrictedInt8u = 32806;
+  attribute(writable) int8s nullableRangeRestrictedInt8s = 32807;
+  attribute(writable) int16u nullableRangeRestrictedInt16u = 32808;
+  attribute(writable) int16s nullableRangeRestrictedInt16s = 32809;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SimpleStructEchoRequestRequest {
     SimpleStruct arg1 = 0;
@@ -2723,32 +2723,32 @@ server cluster Thermostat = 513 {
     kHeatAndCoolSetpoints = 2;
   }
 
-  attribute(readonly, reportable) int16s localTemperature = 0;
-  attribute(readonly, reportable) int16s absMinHeatSetpointLimit = 3;
-  attribute(readonly, reportable) int16s absMaxHeatSetpointLimit = 4;
-  attribute(readonly, reportable) int16s absMinCoolSetpointLimit = 5;
-  attribute(readonly, reportable) int16s absMaxCoolSetpointLimit = 6;
-  attribute(writable, reportable) int16s occupiedCoolingSetpoint = 17;
-  attribute(writable, reportable) int16s occupiedHeatingSetpoint = 18;
-  attribute(writable, reportable) int16s minHeatSetpointLimit = 21;
-  attribute(writable, reportable) int16s maxHeatSetpointLimit = 22;
-  attribute(writable, reportable) int16s minCoolSetpointLimit = 23;
-  attribute(writable, reportable) int16s maxCoolSetpointLimit = 24;
-  attribute(writable, reportable) int8s minSetpointDeadBand = 25;
-  attribute(writable, reportable) enum8 controlSequenceOfOperation = 27;
-  attribute(writable, reportable) enum8 systemMode = 28;
-  attribute(readonly, reportable) enum8 startOfWeek = 32;
-  attribute(readonly, reportable) int8u numberOfWeeklyTransitions = 33;
-  attribute(readonly, reportable) int8u numberOfDailyTransitions = 34;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s localTemperature = 0;
+  attribute(readonly) int16s absMinHeatSetpointLimit = 3;
+  attribute(readonly) int16s absMaxHeatSetpointLimit = 4;
+  attribute(readonly) int16s absMinCoolSetpointLimit = 5;
+  attribute(readonly) int16s absMaxCoolSetpointLimit = 6;
+  attribute(writable) int16s occupiedCoolingSetpoint = 17;
+  attribute(writable) int16s occupiedHeatingSetpoint = 18;
+  attribute(writable) int16s minHeatSetpointLimit = 21;
+  attribute(writable) int16s maxHeatSetpointLimit = 22;
+  attribute(writable) int16s minCoolSetpointLimit = 23;
+  attribute(writable) int16s maxCoolSetpointLimit = 24;
+  attribute(writable) int8s minSetpointDeadBand = 25;
+  attribute(writable) enum8 controlSequenceOfOperation = 27;
+  attribute(writable) enum8 systemMode = 28;
+  attribute(readonly) enum8 startOfWeek = 32;
+  attribute(readonly) int8u numberOfWeeklyTransitions = 33;
+  attribute(readonly) int8u numberOfDailyTransitions = 34;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThermostatUserInterfaceConfiguration = 516 {
-  attribute(writable, reportable) enum8 temperatureDisplayMode = 0;
-  attribute(writable, reportable) enum8 keypadLockout = 1;
-  attribute(writable, reportable) enum8 scheduleProgrammingVisibility = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) enum8 temperatureDisplayMode = 0;
+  attribute(writable) enum8 keypadLockout = 1;
+  attribute(writable) enum8 scheduleProgrammingVisibility = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -2828,71 +2828,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
@@ -2903,8 +2903,8 @@ server cluster UserLabel = 65 {
 }
 
 server cluster WakeOnLan = 1283 {
-  attribute(readonly, reportable) char_string wakeOnLanMacAddress = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) char_string wakeOnLanMacAddress = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster WiFiNetworkDiagnostics = 54 {
@@ -2951,46 +2951,46 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
 
 server cluster WindowCovering = 258 {
-  attribute(readonly, reportable) enum8 type = 0;
-  attribute(readonly, reportable) int16u currentPositionLift = 3;
-  attribute(readonly, reportable) int16u currentPositionTilt = 4;
-  attribute(readonly, reportable) bitmap8 configStatus = 7;
-  attribute(readonly, reportable) Percent currentPositionLiftPercentage = 8;
-  attribute(readonly, reportable) Percent currentPositionTiltPercentage = 9;
-  attribute(readonly, reportable) bitmap8 operationalStatus = 10;
-  attribute(readonly, reportable) Percent100ths targetPositionLiftPercent100ths = 11;
-  attribute(readonly, reportable) Percent100ths targetPositionTiltPercent100ths = 12;
-  attribute(readonly, reportable) enum8 endProductType = 13;
-  attribute(readonly, reportable) Percent100ths currentPositionLiftPercent100ths = 14;
-  attribute(readonly, reportable) Percent100ths currentPositionTiltPercent100ths = 15;
-  attribute(readonly, reportable) int16u installedOpenLimitLift = 16;
-  attribute(readonly, reportable) int16u installedClosedLimitLift = 17;
-  attribute(readonly, reportable) int16u installedOpenLimitTilt = 18;
-  attribute(readonly, reportable) int16u installedClosedLimitTilt = 19;
-  attribute(writable, reportable) bitmap8 mode = 23;
-  attribute(readonly, reportable) bitmap16 safetyStatus = 26;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 type = 0;
+  attribute(readonly) int16u currentPositionLift = 3;
+  attribute(readonly) int16u currentPositionTilt = 4;
+  attribute(readonly) bitmap8 configStatus = 7;
+  attribute(readonly) Percent currentPositionLiftPercentage = 8;
+  attribute(readonly) Percent currentPositionTiltPercentage = 9;
+  attribute(readonly) bitmap8 operationalStatus = 10;
+  attribute(readonly) Percent100ths targetPositionLiftPercent100ths = 11;
+  attribute(readonly) Percent100ths targetPositionTiltPercent100ths = 12;
+  attribute(readonly) enum8 endProductType = 13;
+  attribute(readonly) Percent100ths currentPositionLiftPercent100ths = 14;
+  attribute(readonly) Percent100ths currentPositionTiltPercent100ths = 15;
+  attribute(readonly) int16u installedOpenLimitLift = 16;
+  attribute(readonly) int16u installedClosedLimitLift = 17;
+  attribute(readonly) int16u installedOpenLimitTilt = 18;
+  attribute(readonly) int16u installedClosedLimitTilt = 19;
+  attribute(writable) bitmap8 mode = 23;
+  attribute(readonly) bitmap16 safetyStatus = 26;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command DownOrClose(): DefaultSuccess = 1;
   command StopMotion(): DefaultSuccess = 2;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,18 +57,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Descriptor = 29 {
@@ -77,11 +77,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -128,17 +128,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -164,12 +164,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -282,15 +282,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster LevelControl = 8 {
@@ -304,22 +304,22 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u remainingTime = 1;
-  attribute(readonly, reportable) int8u minLevel = 2;
-  attribute(readonly, reportable) int8u maxLevel = 3;
-  attribute(readonly, reportable) int16u currentFrequency = 4;
-  attribute(readonly, reportable) int16u minFrequency = 5;
-  attribute(readonly, reportable) int16u maxFrequency = 6;
-  attribute(writable, reportable) bitmap8 options = 15;
-  attribute(writable, reportable) int16u onOffTransitionTime = 16;
-  attribute(writable, reportable) int8u onLevel = 17;
-  attribute(writable, reportable) int16u onTransitionTime = 18;
-  attribute(writable, reportable) int16u offTransitionTime = 19;
-  attribute(writable, reportable) int8u defaultMoveRate = 20;
-  attribute(writable, reportable) int8u startUpCurrentLevel = 16384;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u remainingTime = 1;
+  attribute(readonly) int8u minLevel = 2;
+  attribute(readonly) int8u maxLevel = 3;
+  attribute(readonly) int16u currentFrequency = 4;
+  attribute(readonly) int16u minFrequency = 5;
+  attribute(readonly) int16u maxFrequency = 6;
+  attribute(writable) bitmap8 options = 15;
+  attribute(writable) int16u onOffTransitionTime = 16;
+  attribute(writable) int8u onLevel = 17;
+  attribute(writable) int16u onTransitionTime = 18;
+  attribute(writable) int16u offTransitionTime = 19;
+  attribute(writable) int8u defaultMoveRate = 20;
+  attribute(writable) int8u startUpCurrentLevel = 16384;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -438,7 +438,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -514,8 +514,8 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -545,12 +545,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -637,12 +637,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Switch = 59 {
@@ -676,11 +676,11 @@ server cluster Switch = 59 {
     INT8U totalNumberOfPressesCounted = 1;
   }
 
-  attribute(readonly, reportable) int8u numberOfPositions = 0;
-  attribute(readonly, reportable) int8u currentPosition = 1;
-  attribute(readonly, reportable) int8u multiPressMax = 2;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u numberOfPositions = 0;
+  attribute(readonly) int8u currentPosition = 1;
+  attribute(readonly) int8u multiPressMax = 2;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -760,71 +760,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -876,21 +876,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/door-lock-app/door-lock-common/door-lock-app.matter
+++ b/examples/door-lock-app/door-lock-common/door-lock-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,18 +57,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Descriptor = 29 {
@@ -77,11 +77,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -350,25 +350,25 @@ server cluster DoorLock = 257 {
     nullable INT16U dataIndex = 6;
   }
 
-  attribute(readonly, reportable) DlLockState lockState = 0;
-  attribute(readonly, reportable) DlLockType lockType = 1;
-  attribute(readonly, reportable) boolean actuatorEnabled = 2;
-  attribute(readonly, reportable) DlDoorState doorState = 3;
+  attribute(readonly) DlLockState lockState = 0;
+  attribute(readonly) DlLockType lockType = 1;
+  attribute(readonly) boolean actuatorEnabled = 2;
+  attribute(readonly) DlDoorState doorState = 3;
   attribute(readonly) int16u numberOfTotalUsersSupported = 17;
   attribute(readonly) int16u numberOfPINUsersSupported = 18;
   attribute(readonly) int8u maxPINCodeLength = 23;
   attribute(readonly) int8u minPINCodeLength = 24;
   attribute(readonly) bitmap8 credentialRulesSupport = 27;
-  attribute(writable, reportable) char_string language = 33;
-  attribute(writable, reportable) int32u autoRelockTime = 35;
-  attribute(writable, reportable) int8u soundVolume = 36;
-  attribute(writable, reportable) DlOperatingMode operatingMode = 37;
+  attribute(writable) char_string language = 33;
+  attribute(writable) int32u autoRelockTime = 35;
+  attribute(writable) int8u soundVolume = 36;
+  attribute(writable) DlOperatingMode operatingMode = 37;
   attribute(readonly) bitmap16 supportedOperatingModes = 38;
-  attribute(writable, reportable) boolean enableOneTouchLocking = 41;
-  attribute(writable, reportable) boolean enablePrivacyModeButton = 43;
-  attribute(writable, reportable) int8u wrongCodeEntryLimit = 48;
-  attribute(writable, reportable) int8u userCodeTemporaryDisableTime = 49;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) boolean enableOneTouchLocking = 41;
+  attribute(writable) boolean enablePrivacyModeButton = 43;
+  attribute(writable) int8u wrongCodeEntryLimit = 48;
+  attribute(writable) int8u userCodeTemporaryDisableTime = 49;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ClearCredentialRequest {
     DlCredential credential = 0;
@@ -461,17 +461,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -497,12 +497,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -615,15 +615,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster LocalizationConfiguration = 43 {
@@ -690,7 +690,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -773,12 +773,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -883,12 +883,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -968,71 +968,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -1084,21 +1084,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,26 +57,26 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ColorControl = 768 {
@@ -126,28 +126,28 @@ server cluster ColorControl = 768 {
     kDown = 3;
   }
 
-  attribute(readonly, reportable) int8u currentHue = 0;
-  attribute(readonly, reportable) int8u currentSaturation = 1;
-  attribute(readonly, reportable) int16u remainingTime = 2;
-  attribute(readonly, reportable) int16u currentX = 3;
-  attribute(readonly, reportable) int16u currentY = 4;
-  attribute(readonly, reportable) int16u colorTemperature = 7;
-  attribute(readonly, reportable) enum8 colorMode = 8;
-  attribute(writable, reportable) bitmap8 colorControlOptions = 15;
-  attribute(readonly, reportable) int8u numberOfPrimaries = 16;
-  attribute(readonly, reportable) int16u enhancedCurrentHue = 16384;
-  attribute(readonly, reportable) enum8 enhancedColorMode = 16385;
-  attribute(readonly, reportable) int8u colorLoopActive = 16386;
-  attribute(readonly, reportable) int8u colorLoopDirection = 16387;
-  attribute(readonly, reportable) int16u colorLoopTime = 16388;
-  attribute(readonly, reportable) int16u colorLoopStartEnhancedHue = 16389;
-  attribute(readonly, reportable) int16u colorLoopStoredEnhancedHue = 16390;
-  attribute(readonly, reportable) bitmap16 colorCapabilities = 16394;
-  attribute(readonly, reportable) int16u colorTempPhysicalMin = 16395;
-  attribute(readonly, reportable) int16u colorTempPhysicalMax = 16396;
-  attribute(readonly, reportable) int16u coupleColorTempToLevelMinMireds = 16397;
-  attribute(writable, reportable) int16u startUpColorTemperatureMireds = 16400;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentHue = 0;
+  attribute(readonly) int8u currentSaturation = 1;
+  attribute(readonly) int16u remainingTime = 2;
+  attribute(readonly) int16u currentX = 3;
+  attribute(readonly) int16u currentY = 4;
+  attribute(readonly) int16u colorTemperature = 7;
+  attribute(readonly) enum8 colorMode = 8;
+  attribute(writable) bitmap8 colorControlOptions = 15;
+  attribute(readonly) int8u numberOfPrimaries = 16;
+  attribute(readonly) int16u enhancedCurrentHue = 16384;
+  attribute(readonly) enum8 enhancedColorMode = 16385;
+  attribute(readonly) int8u colorLoopActive = 16386;
+  attribute(readonly) int8u colorLoopDirection = 16387;
+  attribute(readonly) int16u colorLoopTime = 16388;
+  attribute(readonly) int16u colorLoopStartEnhancedHue = 16389;
+  attribute(readonly) int16u colorLoopStoredEnhancedHue = 16390;
+  attribute(readonly) bitmap16 colorCapabilities = 16394;
+  attribute(readonly) int16u colorTempPhysicalMin = 16395;
+  attribute(readonly) int16u colorTempPhysicalMax = 16396;
+  attribute(readonly) int16u coupleColorTempToLevelMinMireds = 16397;
+  attribute(writable) int16u startUpColorTemperatureMireds = 16400;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ColorLoopSetRequest {
     ColorLoopUpdateFlags updateFlags = 0;
@@ -324,11 +324,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -375,17 +375,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
@@ -413,12 +413,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -531,15 +531,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Identify = 3 {
@@ -565,9 +565,9 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -598,22 +598,22 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u remainingTime = 1;
-  attribute(readonly, reportable) int8u minLevel = 2;
-  attribute(readonly, reportable) int8u maxLevel = 3;
-  attribute(readonly, reportable) int16u currentFrequency = 4;
-  attribute(readonly, reportable) int16u minFrequency = 5;
-  attribute(readonly, reportable) int16u maxFrequency = 6;
-  attribute(writable, reportable) bitmap8 options = 15;
-  attribute(writable, reportable) int16u onOffTransitionTime = 16;
-  attribute(writable, reportable) int8u onLevel = 17;
-  attribute(writable, reportable) int16u onTransitionTime = 18;
-  attribute(writable, reportable) int16u offTransitionTime = 19;
-  attribute(writable, reportable) int8u defaultMoveRate = 20;
-  attribute(writable, reportable) int8u startUpCurrentLevel = 16384;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u remainingTime = 1;
+  attribute(readonly) int8u minLevel = 2;
+  attribute(readonly) int8u maxLevel = 3;
+  attribute(readonly) int16u currentFrequency = 4;
+  attribute(readonly) int16u minFrequency = 5;
+  attribute(readonly) int16u maxFrequency = 6;
+  attribute(writable) bitmap8 options = 15;
+  attribute(writable) int16u onOffTransitionTime = 16;
+  attribute(writable) int8u onLevel = 17;
+  attribute(writable) int16u onTransitionTime = 18;
+  attribute(writable) int16u offTransitionTime = 19;
+  attribute(writable) int8u defaultMoveRate = 20;
+  attribute(writable) int8u startUpCurrentLevel = 16384;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -732,7 +732,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -813,7 +813,7 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -909,11 +909,11 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     nullable INT64S platformCode = 3;
   }
 
-  attribute(writable, reportable) ProviderLocation defaultOtaProviders[] = 0;
-  attribute(readonly, reportable) boolean updatePossible = 1;
-  attribute(readonly, reportable) OTAUpdateStateEnum updateState = 2;
-  attribute(readonly, reportable) int8u updateStateProgress = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) ProviderLocation defaultOtaProviders[] = 0;
+  attribute(readonly) boolean updatePossible = 1;
+  attribute(readonly) OTAUpdateStateEnum updateState = 2;
+  attribute(readonly) int8u updateStateProgress = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AnnounceOtaProviderRequest {
     node_id providerNodeId = 0;
@@ -927,10 +927,10 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
 }
 
 server cluster OccupancySensing = 1030 {
-  attribute(readonly, reportable) bitmap8 occupancy = 0;
-  attribute(readonly, reportable) enum8 occupancySensorType = 1;
-  attribute(readonly, reportable) bitmap8 occupancySensorTypeBitmap = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 occupancy = 0;
+  attribute(readonly) enum8 occupancySensorType = 1;
+  attribute(readonly) bitmap8 occupancySensorTypeBitmap = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster OnOff = 6 {
@@ -949,13 +949,13 @@ client cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) boolean globalSceneControl = 16384;
-  attribute(writable, reportable) int16u onTime = 16385;
-  attribute(writable, reportable) int16u offWaitTime = 16386;
-  attribute(writable, reportable) enum8 startUpOnOff = 16387;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) boolean globalSceneControl = 16384;
+  attribute(writable) int16u onTime = 16385;
+  attribute(writable) int16u offWaitTime = 16386;
+  attribute(writable) enum8 startUpOnOff = 16387;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster OnOff = 6 {
@@ -974,13 +974,13 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) boolean globalSceneControl = 16384;
-  attribute(writable, reportable) int16u onTime = 16385;
-  attribute(writable, reportable) int16u offWaitTime = 16386;
-  attribute(writable, reportable) enum8 startUpOnOff = 16387;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) boolean globalSceneControl = 16384;
+  attribute(writable) int16u onTime = 16385;
+  attribute(writable) int16u offWaitTime = 16386;
+  attribute(writable) enum8 startUpOnOff = 16387;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OffWithEffectRequest {
     OnOffEffectIdentifier effectId = 0;
@@ -1002,9 +1002,9 @@ server cluster OnOff = 6 {
 }
 
 server cluster OnOffSwitchConfiguration = 7 {
-  attribute(readonly, reportable) enum8 switchType = 0;
-  attribute(writable, reportable) enum8 switchActions = 16;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 switchType = 0;
+  attribute(writable) enum8 switchActions = 16;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster OperationalCredentials = 62 {
@@ -1030,12 +1030,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -1122,12 +1122,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetWatermarks(): DefaultSuccess = 0;
 }
@@ -1242,71 +1242,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
@@ -1360,21 +1360,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,18 +57,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Descriptor = 29 {
@@ -77,11 +77,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -128,17 +128,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -164,12 +164,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -282,15 +282,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster LocalizationConfiguration = 43 {
@@ -357,7 +357,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -433,13 +433,13 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) boolean globalSceneControl = 16384;
-  attribute(writable, reportable) int16u onTime = 16385;
-  attribute(writable, reportable) int16u offWaitTime = 16386;
-  attribute(writable, reportable) enum8 startUpOnOff = 16387;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) boolean globalSceneControl = 16384;
+  attribute(writable) int16u onTime = 16385;
+  attribute(writable) int16u offWaitTime = 16386;
+  attribute(writable) enum8 startUpOnOff = 16387;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -469,12 +469,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -579,12 +579,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -664,71 +664,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -780,21 +780,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -29,12 +29,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -133,7 +133,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -214,7 +214,7 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -281,12 +281,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -21,18 +21,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
@@ -60,12 +60,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -164,7 +164,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -245,7 +245,7 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -341,11 +341,11 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     nullable INT64S platformCode = 3;
   }
 
-  attribute(writable, reportable) ProviderLocation defaultOtaProviders[] = 0;
-  attribute(readonly, reportable) boolean updatePossible = 1;
-  attribute(readonly, reportable) OTAUpdateStateEnum updateState = 2;
-  attribute(readonly, reportable) int8u updateStateProgress = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) ProviderLocation defaultOtaProviders[] = 0;
+  attribute(readonly) boolean updatePossible = 1;
+  attribute(readonly) OTAUpdateStateEnum updateState = 2;
+  attribute(readonly) int8u updateStateProgress = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AnnounceOtaProviderRequest {
     node_id providerNodeId = 0;
@@ -381,12 +381,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -16,26 +16,26 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ColorControl = 768 {
@@ -85,12 +85,12 @@ server cluster ColorControl = 768 {
     kDown = 3;
   }
 
-  attribute(readonly, reportable) int16u currentX = 3;
-  attribute(readonly, reportable) int16u currentY = 4;
-  attribute(writable, reportable) bitmap8 colorControlOptions = 15;
-  attribute(readonly, reportable) int16u coupleColorTempToLevelMinMireds = 16397;
-  attribute(writable, reportable) int16u startUpColorTemperatureMireds = 16400;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u currentX = 3;
+  attribute(readonly) int16u currentY = 4;
+  attribute(writable) bitmap8 colorControlOptions = 15;
+  attribute(readonly) int16u coupleColorTempToLevelMinMireds = 16397;
+  attribute(writable) int16u startUpColorTemperatureMireds = 16400;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveColorRequest {
     INT16S rateX = 0;
@@ -126,11 +126,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GeneralCommissioning = 48 {
@@ -151,9 +151,9 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -189,8 +189,8 @@ server cluster GeneralCommissioning = 48 {
 }
 
 server cluster Groups = 4 {
-  attribute(readonly, reportable) bitmap8 nameSupport = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 nameSupport = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
     INT16U groupId = 0;
@@ -266,9 +266,9 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -293,8 +293,8 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -407,8 +407,8 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) NetworkCommissioningStatus lastNetworkingStatus = 5;
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -484,8 +484,8 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -515,12 +515,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -601,12 +601,12 @@ server cluster Scenes = 5 {
     INT8U value = 3;
   }
 
-  attribute(readonly, reportable) int8u sceneCount = 0;
-  attribute(readonly, reportable) int8u currentScene = 1;
-  attribute(readonly, reportable) int16u currentGroup = 2;
-  attribute(readonly, reportable) boolean sceneValid = 3;
-  attribute(readonly, reportable) bitmap8 nameSupport = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u sceneCount = 0;
+  attribute(readonly) int8u currentScene = 1;
+  attribute(readonly) int16u currentGroup = 2;
+  attribute(readonly) boolean sceneValid = 3;
+  attribute(readonly) bitmap8 nameSupport = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddSceneRequest {
     INT16U groupId = 0;
@@ -695,17 +695,17 @@ server cluster Scenes = 5 {
 }
 
 client cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -16,26 +16,26 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ColorControl = 768 {
@@ -85,12 +85,12 @@ server cluster ColorControl = 768 {
     kDown = 3;
   }
 
-  attribute(readonly, reportable) int16u currentX = 3;
-  attribute(readonly, reportable) int16u currentY = 4;
-  attribute(writable, reportable) bitmap8 colorControlOptions = 15;
-  attribute(readonly, reportable) int16u coupleColorTempToLevelMinMireds = 16397;
-  attribute(writable, reportable) int16u startUpColorTemperatureMireds = 16400;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u currentX = 3;
+  attribute(readonly) int16u currentY = 4;
+  attribute(writable) bitmap8 colorControlOptions = 15;
+  attribute(readonly) int16u coupleColorTempToLevelMinMireds = 16397;
+  attribute(writable) int16u startUpColorTemperatureMireds = 16400;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveColorRequest {
     INT16S rateX = 0;
@@ -126,11 +126,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GeneralCommissioning = 48 {
@@ -151,9 +151,9 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -189,8 +189,8 @@ server cluster GeneralCommissioning = 48 {
 }
 
 server cluster Groups = 4 {
-  attribute(readonly, reportable) bitmap8 nameSupport = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 nameSupport = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
     INT16U groupId = 0;
@@ -266,9 +266,9 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -293,8 +293,8 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -407,8 +407,8 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) NetworkCommissioningStatus lastNetworkingStatus = 5;
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -484,8 +484,8 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -515,12 +515,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -601,12 +601,12 @@ server cluster Scenes = 5 {
     INT8U value = 3;
   }
 
-  attribute(readonly, reportable) int8u sceneCount = 0;
-  attribute(readonly, reportable) int8u currentScene = 1;
-  attribute(readonly, reportable) int16u currentGroup = 2;
-  attribute(readonly, reportable) boolean sceneValid = 3;
-  attribute(readonly, reportable) bitmap8 nameSupport = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u sceneCount = 0;
+  attribute(readonly) int8u currentScene = 1;
+  attribute(readonly) int16u currentGroup = 2;
+  attribute(readonly) boolean sceneValid = 3;
+  attribute(readonly) bitmap8 nameSupport = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddSceneRequest {
     INT16U groupId = 0;
@@ -695,17 +695,17 @@ server cluster Scenes = 5 {
 }
 
 client cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,18 +57,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
@@ -79,11 +79,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -122,17 +122,17 @@ server cluster FixedLabel = 64 {
 }
 
 client cluster FlowMeasurement = 1028 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FlowMeasurement = 1028 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GeneralCommissioning = 48 {
@@ -153,12 +153,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -271,15 +271,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster LevelControl = 8 {
@@ -293,8 +293,8 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -413,7 +413,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -489,8 +489,8 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -520,12 +520,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -600,17 +600,17 @@ server cluster OperationalCredentials = 62 {
 }
 
 client cluster PressureMeasurement = 1027 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster PressureMeasurement = 1027 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster PumpConfigurationAndControl = 512 {
@@ -681,32 +681,32 @@ server cluster PumpConfigurationAndControl = 512 {
   info event TurbineOperation = 16 {
   }
 
-  attribute(readonly, reportable) int16s maxPressure = 0;
-  attribute(readonly, reportable) int16u maxSpeed = 1;
-  attribute(readonly, reportable) int16u maxFlow = 2;
-  attribute(readonly, reportable) int16s minConstPressure = 3;
-  attribute(readonly, reportable) int16s maxConstPressure = 4;
-  attribute(readonly, reportable) int16s minCompPressure = 5;
-  attribute(readonly, reportable) int16s maxCompPressure = 6;
-  attribute(readonly, reportable) int16u minConstSpeed = 7;
-  attribute(readonly, reportable) int16u maxConstSpeed = 8;
-  attribute(readonly, reportable) int16u minConstFlow = 9;
-  attribute(readonly, reportable) int16u maxConstFlow = 10;
-  attribute(readonly, reportable) int16s minConstTemp = 11;
-  attribute(readonly, reportable) int16s maxConstTemp = 12;
-  attribute(readonly, reportable) bitmap16 pumpStatus = 16;
-  attribute(readonly, reportable) enum8 effectiveOperationMode = 17;
-  attribute(readonly, reportable) enum8 effectiveControlMode = 18;
-  attribute(readonly, reportable) int16s capacity = 19;
-  attribute(readonly, reportable) int16u speed = 20;
-  attribute(writable, reportable) int24u lifetimeRunningHours = 21;
-  attribute(readonly, reportable) int24u power = 22;
-  attribute(writable, reportable) int32u lifetimeEnergyConsumed = 23;
-  attribute(writable, reportable) enum8 operationMode = 32;
-  attribute(writable, reportable) enum8 controlMode = 33;
-  attribute(readonly, reportable) bitmap16 alarmMask = 34;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s maxPressure = 0;
+  attribute(readonly) int16u maxSpeed = 1;
+  attribute(readonly) int16u maxFlow = 2;
+  attribute(readonly) int16s minConstPressure = 3;
+  attribute(readonly) int16s maxConstPressure = 4;
+  attribute(readonly) int16s minCompPressure = 5;
+  attribute(readonly) int16s maxCompPressure = 6;
+  attribute(readonly) int16u minConstSpeed = 7;
+  attribute(readonly) int16u maxConstSpeed = 8;
+  attribute(readonly) int16u minConstFlow = 9;
+  attribute(readonly) int16u maxConstFlow = 10;
+  attribute(readonly) int16s minConstTemp = 11;
+  attribute(readonly) int16s maxConstTemp = 12;
+  attribute(readonly) bitmap16 pumpStatus = 16;
+  attribute(readonly) enum8 effectiveOperationMode = 17;
+  attribute(readonly) enum8 effectiveControlMode = 18;
+  attribute(readonly) int16s capacity = 19;
+  attribute(readonly) int16u speed = 20;
+  attribute(writable) int24u lifetimeRunningHours = 21;
+  attribute(readonly) int24u power = 22;
+  attribute(writable) int32u lifetimeEnergyConsumed = 23;
+  attribute(writable) enum8 operationMode = 32;
+  attribute(writable) enum8 controlMode = 33;
+  attribute(readonly) bitmap16 alarmMask = 34;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster SoftwareDiagnostics = 52 {
@@ -722,26 +722,26 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -821,71 +821,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,18 +57,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
@@ -79,11 +79,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -130,17 +130,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -149,10 +149,10 @@ server cluster FixedLabel = 64 {
 }
 
 client cluster FlowMeasurement = 1028 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GeneralCommissioning = 48 {
@@ -173,12 +173,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -291,15 +291,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster LevelControl = 8 {
@@ -313,8 +313,8 @@ client cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -433,7 +433,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -509,8 +509,8 @@ client cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -540,12 +540,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -620,10 +620,10 @@ server cluster OperationalCredentials = 62 {
 }
 
 client cluster PressureMeasurement = 1027 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster PumpConfigurationAndControl = 512 {
@@ -694,14 +694,14 @@ client cluster PumpConfigurationAndControl = 512 {
   info event TurbineOperation = 16 {
   }
 
-  attribute(readonly, reportable) int16s maxPressure = 0;
-  attribute(readonly, reportable) int16u maxSpeed = 1;
-  attribute(readonly, reportable) int16u maxFlow = 2;
-  attribute(readonly, reportable) enum8 effectiveOperationMode = 17;
-  attribute(readonly, reportable) enum8 effectiveControlMode = 18;
-  attribute(readonly, reportable) int16s capacity = 19;
-  attribute(writable, reportable) enum8 operationMode = 32;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s maxPressure = 0;
+  attribute(readonly) int16u maxSpeed = 1;
+  attribute(readonly) int16u maxFlow = 2;
+  attribute(readonly) enum8 effectiveOperationMode = 17;
+  attribute(readonly) enum8 effectiveControlMode = 18;
+  attribute(readonly) int16s capacity = 19;
+  attribute(writable) enum8 operationMode = 32;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster SoftwareDiagnostics = 52 {
@@ -717,19 +717,19 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -809,71 +809,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -925,21 +925,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,18 +57,18 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Descriptor = 29 {
@@ -77,11 +77,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -128,17 +128,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -164,12 +164,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -282,15 +282,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster LocalizationConfiguration = 43 {
@@ -357,7 +357,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
@@ -434,12 +434,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -518,16 +518,16 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -579,21 +579,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,32 +57,32 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
 
 server cluster Binding = 30 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BindRequest {
     NODE_ID nodeId = 0;
@@ -108,11 +108,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -159,17 +159,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -195,12 +195,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -313,15 +313,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GroupKeyManagement = 63 {
@@ -343,14 +343,14 @@ server cluster GroupKeyManagement = 63 {
     CHAR_STRING groupName = 3;
   }
 
-  attribute(readonly, reportable) GroupKey groupKeyMap[] = 0;
-  attribute(readonly, reportable) GroupInfo groupTable[] = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) GroupKey groupKeyMap[] = 0;
+  attribute(readonly) GroupInfo groupTable[] = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Groups = 4 {
-  attribute(readonly, reportable) bitmap8 nameSupport = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 nameSupport = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
     INT16U groupId = 0;
@@ -426,9 +426,9 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -465,9 +465,9 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -545,7 +545,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -626,7 +626,7 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -693,12 +693,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -779,12 +779,12 @@ server cluster Scenes = 5 {
     INT8U value = 3;
   }
 
-  attribute(readonly, reportable) int8u sceneCount = 0;
-  attribute(readonly, reportable) int8u currentScene = 1;
-  attribute(readonly, reportable) int16u currentGroup = 2;
-  attribute(readonly, reportable) boolean sceneValid = 3;
-  attribute(readonly, reportable) bitmap8 nameSupport = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u sceneCount = 0;
+  attribute(readonly) int8u currentScene = 1;
+  attribute(readonly) int16u currentGroup = 2;
+  attribute(readonly) boolean sceneValid = 3;
+  attribute(readonly) bitmap8 nameSupport = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddSceneRequest {
     INT16U groupId = 0;
@@ -885,12 +885,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Thermostat = 513 {
@@ -900,25 +900,25 @@ server cluster Thermostat = 513 {
     kHeatAndCoolSetpoints = 2;
   }
 
-  attribute(readonly, reportable) int16s localTemperature = 0;
-  attribute(readonly, reportable) int16s absMinHeatSetpointLimit = 3;
-  attribute(readonly, reportable) int16s absMaxHeatSetpointLimit = 4;
-  attribute(readonly, reportable) int16s absMinCoolSetpointLimit = 5;
-  attribute(readonly, reportable) int16s absMaxCoolSetpointLimit = 6;
-  attribute(writable, reportable) int16s occupiedCoolingSetpoint = 17;
-  attribute(writable, reportable) int16s occupiedHeatingSetpoint = 18;
-  attribute(writable, reportable) int16s minHeatSetpointLimit = 21;
-  attribute(writable, reportable) int16s maxHeatSetpointLimit = 22;
-  attribute(writable, reportable) int16s minCoolSetpointLimit = 23;
-  attribute(writable, reportable) int16s maxCoolSetpointLimit = 24;
-  attribute(writable, reportable) int8s minSetpointDeadBand = 25;
-  attribute(writable, reportable) enum8 controlSequenceOfOperation = 27;
-  attribute(writable, reportable) enum8 systemMode = 28;
-  attribute(readonly, reportable) enum8 startOfWeek = 32;
-  attribute(readonly, reportable) int8u numberOfWeeklyTransitions = 33;
-  attribute(readonly, reportable) int8u numberOfDailyTransitions = 34;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s localTemperature = 0;
+  attribute(readonly) int16s absMinHeatSetpointLimit = 3;
+  attribute(readonly) int16s absMaxHeatSetpointLimit = 4;
+  attribute(readonly) int16s absMinCoolSetpointLimit = 5;
+  attribute(readonly) int16s absMaxCoolSetpointLimit = 6;
+  attribute(writable) int16s occupiedCoolingSetpoint = 17;
+  attribute(writable) int16s occupiedHeatingSetpoint = 18;
+  attribute(writable) int16s minHeatSetpointLimit = 21;
+  attribute(writable) int16s maxHeatSetpointLimit = 22;
+  attribute(writable) int16s minCoolSetpointLimit = 23;
+  attribute(writable) int16s maxCoolSetpointLimit = 24;
+  attribute(writable) int8s minSetpointDeadBand = 25;
+  attribute(writable) enum8 controlSequenceOfOperation = 27;
+  attribute(writable) enum8 systemMode = 28;
+  attribute(readonly) enum8 startOfWeek = 32;
+  attribute(readonly) int8u numberOfWeeklyTransitions = 33;
+  attribute(readonly) int8u numberOfDailyTransitions = 34;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GetWeeklyScheduleRequest {
     DayOfWeek daysToReturn = 0;
@@ -1037,71 +1037,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -1153,21 +1153,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -7,7 +7,7 @@ struct LabelStruct {
 }
 
 server cluster AccountLogin = 1294 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequestRequest {
     CHAR_STRING tempAccountIdentifier = 0;
@@ -43,7 +43,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -76,15 +76,15 @@ server cluster ApplicationBasic = 1293 {
     CHAR_STRING applicationId = 2;
   }
 
-  attribute(readonly, reportable) char_string vendorName = 0;
-  attribute(readonly, reportable) int16u vendorId = 1;
-  attribute(readonly, reportable) char_string applicationName = 2;
-  attribute(readonly, reportable) int16u productId = 3;
+  attribute(readonly) char_string vendorName = 0;
+  attribute(readonly) int16u vendorId = 1;
+  attribute(readonly) char_string applicationName = 2;
+  attribute(readonly) int16u productId = 3;
   attribute(writable) ApplicationBasicApplication applicationApp = 4;
-  attribute(readonly, reportable) ApplicationStatusEnum applicationStatus = 5;
-  attribute(readonly, reportable) char_string applicationVersion = 6;
+  attribute(readonly) ApplicationStatusEnum applicationStatus = 5;
+  attribute(readonly) char_string applicationVersion = 6;
   attribute(readonly) vendor_id allowedVendorList[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ApplicationLauncher = 1292 {
@@ -104,9 +104,9 @@ server cluster ApplicationLauncher = 1292 {
     CHAR_STRING applicationId = 2;
   }
 
-  attribute(readonly, reportable) INT16U applicationLauncherList[] = 0;
-  attribute(writable, reportable) ApplicationEP applicationLauncherApp = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) INT16U applicationLauncherList[] = 0;
+  attribute(writable) ApplicationEP applicationLauncherApp = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct HideAppRequestRequest {
     ApplicationLauncherApplication application = 0;
@@ -147,9 +147,9 @@ server cluster AudioOutput = 1291 {
     CHAR_STRING name = 3;
   }
 
-  attribute(readonly, reportable) OutputInfo audioOutputList[] = 0;
-  attribute(readonly, reportable) int8u currentAudioOutput = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) OutputInfo audioOutputList[] = 0;
+  attribute(readonly) int8u currentAudioOutput = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct RenameOutputRequestRequest {
     INT8U index = 0;
@@ -179,31 +179,31 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
 
 client cluster Binding = 30 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BindRequest {
     NODE_ID nodeId = 0;
@@ -224,7 +224,7 @@ client cluster Binding = 30 {
 }
 
 server cluster Binding = 30 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BindRequest {
     NODE_ID nodeId = 0;
@@ -269,10 +269,10 @@ server cluster Channel = 1284 {
     LineupInfoTypeEnum lineupInfoType = 4;
   }
 
-  attribute(readonly, reportable) ChannelInfo channelList[] = 0;
-  attribute(writable, reportable) LineupInfo channelLineup = 1;
-  attribute(writable, reportable) ChannelInfo currentChannel = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) ChannelInfo channelList[] = 0;
+  attribute(writable) LineupInfo channelLineup = 1;
+  attribute(writable) ChannelInfo currentChannel = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ChangeChannelByNumberRequestRequest {
     INT16U majorNumber = 0;
@@ -361,9 +361,9 @@ server cluster ContentLauncher = 1290 {
     MetricTypeEnum metric = 3;
   }
 
-  attribute(readonly, reportable) CHAR_STRING acceptHeaderList[] = 0;
-  attribute(writable, reportable) bitmap32 supportedStreamingProtocols = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
+  attribute(writable) bitmap32 supportedStreamingProtocols = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct LaunchContentRequestRequest {
     BOOLEAN autoPlay = 0;
@@ -392,11 +392,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -443,17 +443,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -479,12 +479,12 @@ client cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -537,12 +537,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -655,15 +655,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GroupKeyManagement = 63 {
@@ -685,9 +685,9 @@ server cluster GroupKeyManagement = 63 {
     CHAR_STRING groupName = 3;
   }
 
-  attribute(readonly, reportable) GroupKey groupKeyMap[] = 0;
-  attribute(readonly, reportable) GroupInfo groupTable[] = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) GroupKey groupKeyMap[] = 0;
+  attribute(readonly) GroupInfo groupTable[] = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster KeypadInput = 1289 {
@@ -786,7 +786,7 @@ server cluster KeypadInput = 1289 {
     kInvalidKeyInCurrentState = 2;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SendKeyRequestRequest {
     CecKeyCode keyCode = 0;
@@ -806,22 +806,22 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u remainingTime = 1;
-  attribute(readonly, reportable) int8u minLevel = 2;
-  attribute(readonly, reportable) int8u maxLevel = 3;
-  attribute(readonly, reportable) int16u currentFrequency = 4;
-  attribute(readonly, reportable) int16u minFrequency = 5;
-  attribute(readonly, reportable) int16u maxFrequency = 6;
-  attribute(writable, reportable) bitmap8 options = 15;
-  attribute(writable, reportable) int16u onOffTransitionTime = 16;
-  attribute(writable, reportable) int8u onLevel = 17;
-  attribute(writable, reportable) int16u onTransitionTime = 18;
-  attribute(writable, reportable) int16u offTransitionTime = 19;
-  attribute(writable, reportable) int8u defaultMoveRate = 20;
-  attribute(writable, reportable) int8u startUpCurrentLevel = 16384;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u remainingTime = 1;
+  attribute(readonly) int8u minLevel = 2;
+  attribute(readonly) int8u maxLevel = 3;
+  attribute(readonly) int16u currentFrequency = 4;
+  attribute(readonly) int16u minFrequency = 5;
+  attribute(readonly) int16u maxFrequency = 6;
+  attribute(writable) bitmap8 options = 15;
+  attribute(writable) int16u onOffTransitionTime = 16;
+  attribute(writable) int8u onLevel = 17;
+  attribute(writable) int16u onTransitionTime = 18;
+  attribute(writable) int16u offTransitionTime = 19;
+  attribute(writable) int8u defaultMoveRate = 20;
+  attribute(writable) int8u startUpCurrentLevel = 16384;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -882,7 +882,7 @@ server cluster LocalizationConfiguration = 43 {
 }
 
 server cluster LowPower = 1288 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Sleep(): DefaultSuccess = 0;
 }
@@ -910,9 +910,9 @@ server cluster MediaInput = 1287 {
     CHAR_STRING description = 4;
   }
 
-  attribute(readonly, reportable) InputInfo mediaInputList[] = 0;
-  attribute(readonly, reportable) int8u currentMediaInput = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) InputInfo mediaInputList[] = 0;
+  attribute(readonly) int8u currentMediaInput = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct RenameInputRequestRequest {
     INT8U index = 0;
@@ -951,14 +951,14 @@ server cluster MediaPlayback = 1286 {
     INT64U position = 2;
   }
 
-  attribute(readonly, reportable) PlaybackStateEnum playbackState = 0;
-  attribute(readonly, reportable) epoch_us startTime = 1;
-  attribute(readonly, reportable) int64u duration = 2;
-  attribute(writable, reportable) PlaybackPosition position = 3;
-  attribute(readonly, reportable) single playbackSpeed = 4;
-  attribute(readonly, reportable) int64u seekRangeEnd = 5;
-  attribute(readonly, reportable) int64u seekRangeStart = 6;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) PlaybackStateEnum playbackState = 0;
+  attribute(readonly) epoch_us startTime = 1;
+  attribute(readonly) int64u duration = 2;
+  attribute(writable) PlaybackPosition position = 3;
+  attribute(readonly) single playbackSpeed = 4;
+  attribute(readonly) int64u seekRangeEnd = 5;
+  attribute(readonly) int64u seekRangeStart = 6;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SeekRequestRequest {
     INT64U position = 0;
@@ -1048,7 +1048,7 @@ client cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -1167,7 +1167,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -1248,7 +1248,7 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -1308,8 +1308,8 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -1339,12 +1339,12 @@ client cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -1430,12 +1430,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -1510,10 +1510,10 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster RelativeHumidityMeasurement = 1029 {
-  attribute(readonly, reportable) int16u measuredValue = 0;
-  attribute(readonly, reportable) int16u minMeasuredValue = 1;
-  attribute(readonly, reportable) int16u maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u measuredValue = 0;
+  attribute(readonly) int16u minMeasuredValue = 1;
+  attribute(readonly) int16u maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster SoftwareDiagnostics = 52 {
@@ -1529,12 +1529,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TargetNavigator = 1285 {
@@ -1549,9 +1549,9 @@ server cluster TargetNavigator = 1285 {
     CHAR_STRING name = 2;
   }
 
-  attribute(readonly, reportable) TargetInfo targetNavigatorList[] = 0;
+  attribute(readonly) TargetInfo targetNavigatorList[] = 0;
   attribute(readonly) int8u currentNavigatorTarget = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct NavigateTargetRequestRequest {
     INT8U target = 0;
@@ -1643,71 +1643,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -1716,8 +1716,8 @@ server cluster UserLabel = 65 {
 }
 
 server cluster WakeOnLan = 1283 {
-  attribute(readonly, reportable) char_string wakeOnLanMacAddress = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) char_string wakeOnLanMacAddress = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster WiFiNetworkDiagnostics = 54 {
@@ -1764,21 +1764,21 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -7,7 +7,7 @@ struct LabelStruct {
 }
 
 client cluster AccountLogin = 1294 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequestRequest {
     CHAR_STRING tempAccountIdentifier = 0;
@@ -39,7 +39,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -67,13 +67,13 @@ client cluster ApplicationBasic = 1293 {
     kActiveVisibleNotFocus = 3;
   }
 
-  attribute(readonly, reportable) char_string vendorName = 0;
-  attribute(readonly, reportable) int16u vendorId = 1;
-  attribute(readonly, reportable) char_string applicationName = 2;
-  attribute(readonly, reportable) int16u productId = 3;
-  attribute(readonly, reportable) ApplicationStatusEnum applicationStatus = 5;
-  attribute(readonly, reportable) char_string applicationVersion = 6;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) char_string vendorName = 0;
+  attribute(readonly) int16u vendorId = 1;
+  attribute(readonly) char_string applicationName = 2;
+  attribute(readonly) int16u productId = 3;
+  attribute(readonly) ApplicationStatusEnum applicationStatus = 5;
+  attribute(readonly) char_string applicationVersion = 6;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster ApplicationLauncher = 1292 {
@@ -88,8 +88,8 @@ client cluster ApplicationLauncher = 1292 {
     CHAR_STRING applicationId = 2;
   }
 
-  attribute(readonly, reportable) INT16U applicationLauncherList[] = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) INT16U applicationLauncherList[] = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct HideAppRequestRequest {
     ApplicationLauncherApplication application = 0;
@@ -125,8 +125,8 @@ client cluster AudioOutput = 1291 {
     CHAR_STRING name = 3;
   }
 
-  attribute(readonly, reportable) OutputInfo audioOutputList[] = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) OutputInfo audioOutputList[] = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct RenameOutputRequestRequest {
     INT8U index = 0;
@@ -142,11 +142,11 @@ client cluster AudioOutput = 1291 {
 }
 
 server cluster BarrierControl = 259 {
-  attribute(readonly, reportable) enum8 barrierMovingState = 1;
-  attribute(readonly, reportable) bitmap16 barrierSafetyStatus = 2;
-  attribute(readonly, reportable) bitmap8 barrierCapabilities = 3;
-  attribute(readonly, reportable) int8u barrierPosition = 10;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 barrierMovingState = 1;
+  attribute(readonly) bitmap16 barrierSafetyStatus = 2;
+  attribute(readonly) bitmap8 barrierCapabilities = 3;
+  attribute(readonly) int8u barrierPosition = 10;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BarrierControlGoToPercentRequest {
     INT8U percentOpen = 0;
@@ -171,39 +171,39 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
 
 server cluster BinaryInputBasic = 15 {
-  attribute(writable, reportable) boolean outOfService = 81;
-  attribute(writable, reportable) boolean presentValue = 85;
-  attribute(readonly, reportable) bitmap8 statusFlags = 111;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) boolean outOfService = 81;
+  attribute(writable) boolean presentValue = 85;
+  attribute(readonly) bitmap8 statusFlags = 111;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Binding = 30 {
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BindRequest {
     NODE_ID nodeId = 0;
@@ -224,21 +224,21 @@ server cluster Binding = 30 {
 }
 
 server cluster BridgedDeviceBasic = 57 {
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) int16u vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(readonly, reportable) boolean reachable = 17;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) int16u vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(readonly) boolean reachable = 17;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Leave(): DefaultSuccess = 2;
   command ReachableChanged(): DefaultSuccess = 3;
@@ -271,10 +271,10 @@ client cluster Channel = 1284 {
     LineupInfoTypeEnum lineupInfoType = 4;
   }
 
-  attribute(readonly, reportable) ChannelInfo channelList[] = 0;
-  attribute(writable, reportable) LineupInfo channelLineup = 1;
-  attribute(writable, reportable) ChannelInfo currentChannel = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) ChannelInfo channelList[] = 0;
+  attribute(writable) LineupInfo channelLineup = 1;
+  attribute(writable) ChannelInfo currentChannel = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ChangeChannelByNumberRequestRequest {
     INT16U majorNumber = 0;
@@ -341,57 +341,57 @@ server cluster ColorControl = 768 {
     kDown = 3;
   }
 
-  attribute(readonly, reportable) int8u currentHue = 0;
-  attribute(readonly, reportable) int8u currentSaturation = 1;
-  attribute(readonly, reportable) int16u remainingTime = 2;
-  attribute(readonly, reportable) int16u currentX = 3;
-  attribute(readonly, reportable) int16u currentY = 4;
-  attribute(readonly, reportable) enum8 driftCompensation = 5;
-  attribute(readonly, reportable) char_string compensationText = 6;
-  attribute(readonly, reportable) int16u colorTemperature = 7;
-  attribute(readonly, reportable) enum8 colorMode = 8;
-  attribute(writable, reportable) bitmap8 colorControlOptions = 15;
-  attribute(readonly, reportable) int8u numberOfPrimaries = 16;
-  attribute(readonly, reportable) int16u primary1X = 17;
-  attribute(readonly, reportable) int16u primary1Y = 18;
-  attribute(readonly, reportable) int8u primary1Intensity = 19;
-  attribute(readonly, reportable) int16u primary2X = 21;
-  attribute(readonly, reportable) int16u primary2Y = 22;
-  attribute(readonly, reportable) int8u primary2Intensity = 23;
-  attribute(readonly, reportable) int16u primary3X = 25;
-  attribute(readonly, reportable) int16u primary3Y = 26;
-  attribute(readonly, reportable) int8u primary3Intensity = 27;
-  attribute(readonly, reportable) int16u primary4X = 32;
-  attribute(readonly, reportable) int16u primary4Y = 33;
-  attribute(readonly, reportable) int8u primary4Intensity = 34;
-  attribute(readonly, reportable) int16u primary5X = 36;
-  attribute(readonly, reportable) int16u primary5Y = 37;
-  attribute(readonly, reportable) int8u primary5Intensity = 38;
-  attribute(readonly, reportable) int16u primary6X = 40;
-  attribute(readonly, reportable) int16u primary6Y = 41;
-  attribute(readonly, reportable) int8u primary6Intensity = 42;
-  attribute(writable, reportable) int16u whitePointX = 48;
-  attribute(writable, reportable) int16u whitePointY = 49;
-  attribute(writable, reportable) int16u colorPointRX = 50;
-  attribute(writable, reportable) int16u colorPointRY = 51;
-  attribute(writable, reportable) int8u colorPointRIntensity = 52;
-  attribute(writable, reportable) int16u colorPointGX = 54;
-  attribute(writable, reportable) int16u colorPointGY = 55;
-  attribute(writable, reportable) int8u colorPointGIntensity = 56;
-  attribute(writable, reportable) int16u colorPointBX = 58;
-  attribute(writable, reportable) int16u colorPointBY = 59;
-  attribute(writable, reportable) int8u colorPointBIntensity = 60;
-  attribute(readonly, reportable) int16u enhancedCurrentHue = 16384;
-  attribute(readonly, reportable) enum8 enhancedColorMode = 16385;
-  attribute(readonly, reportable) int8u colorLoopActive = 16386;
-  attribute(readonly, reportable) int8u colorLoopDirection = 16387;
-  attribute(readonly, reportable) int16u colorLoopTime = 16388;
-  attribute(readonly, reportable) bitmap16 colorCapabilities = 16394;
-  attribute(readonly, reportable) int16u colorTempPhysicalMin = 16395;
-  attribute(readonly, reportable) int16u colorTempPhysicalMax = 16396;
-  attribute(readonly, reportable) int16u coupleColorTempToLevelMinMireds = 16397;
-  attribute(writable, reportable) int16u startUpColorTemperatureMireds = 16400;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentHue = 0;
+  attribute(readonly) int8u currentSaturation = 1;
+  attribute(readonly) int16u remainingTime = 2;
+  attribute(readonly) int16u currentX = 3;
+  attribute(readonly) int16u currentY = 4;
+  attribute(readonly) enum8 driftCompensation = 5;
+  attribute(readonly) char_string compensationText = 6;
+  attribute(readonly) int16u colorTemperature = 7;
+  attribute(readonly) enum8 colorMode = 8;
+  attribute(writable) bitmap8 colorControlOptions = 15;
+  attribute(readonly) int8u numberOfPrimaries = 16;
+  attribute(readonly) int16u primary1X = 17;
+  attribute(readonly) int16u primary1Y = 18;
+  attribute(readonly) int8u primary1Intensity = 19;
+  attribute(readonly) int16u primary2X = 21;
+  attribute(readonly) int16u primary2Y = 22;
+  attribute(readonly) int8u primary2Intensity = 23;
+  attribute(readonly) int16u primary3X = 25;
+  attribute(readonly) int16u primary3Y = 26;
+  attribute(readonly) int8u primary3Intensity = 27;
+  attribute(readonly) int16u primary4X = 32;
+  attribute(readonly) int16u primary4Y = 33;
+  attribute(readonly) int8u primary4Intensity = 34;
+  attribute(readonly) int16u primary5X = 36;
+  attribute(readonly) int16u primary5Y = 37;
+  attribute(readonly) int8u primary5Intensity = 38;
+  attribute(readonly) int16u primary6X = 40;
+  attribute(readonly) int16u primary6Y = 41;
+  attribute(readonly) int8u primary6Intensity = 42;
+  attribute(writable) int16u whitePointX = 48;
+  attribute(writable) int16u whitePointY = 49;
+  attribute(writable) int16u colorPointRX = 50;
+  attribute(writable) int16u colorPointRY = 51;
+  attribute(writable) int8u colorPointRIntensity = 52;
+  attribute(writable) int16u colorPointGX = 54;
+  attribute(writable) int16u colorPointGY = 55;
+  attribute(writable) int8u colorPointGIntensity = 56;
+  attribute(writable) int16u colorPointBX = 58;
+  attribute(writable) int16u colorPointBY = 59;
+  attribute(writable) int8u colorPointBIntensity = 60;
+  attribute(readonly) int16u enhancedCurrentHue = 16384;
+  attribute(readonly) enum8 enhancedColorMode = 16385;
+  attribute(readonly) int8u colorLoopActive = 16386;
+  attribute(readonly) int8u colorLoopDirection = 16387;
+  attribute(readonly) int16u colorLoopTime = 16388;
+  attribute(readonly) bitmap16 colorCapabilities = 16394;
+  attribute(readonly) int16u colorTempPhysicalMin = 16395;
+  attribute(readonly) int16u colorTempPhysicalMax = 16396;
+  attribute(readonly) int16u coupleColorTempToLevelMinMireds = 16397;
+  attribute(writable) int16u startUpColorTemperatureMireds = 16400;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveColorRequest {
     INT16S rateX = 0;
@@ -580,9 +580,9 @@ client cluster ContentLauncher = 1290 {
     MetricTypeEnum metric = 3;
   }
 
-  attribute(readonly, reportable) CHAR_STRING acceptHeaderList[] = 0;
-  attribute(writable, reportable) bitmap32 supportedStreamingProtocols = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
+  attribute(writable) bitmap32 supportedStreamingProtocols = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct LaunchContentRequestRequest {
     BOOLEAN autoPlay = 0;
@@ -606,11 +606,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster DiagnosticLogs = 50 {
@@ -879,10 +879,10 @@ server cluster DoorLock = 257 {
     nullable INT16U dataIndex = 6;
   }
 
-  attribute(readonly, reportable) DlLockState lockState = 0;
-  attribute(readonly, reportable) DlLockType lockType = 1;
-  attribute(readonly, reportable) boolean actuatorEnabled = 2;
-  attribute(readonly, reportable) DlDoorState doorState = 3;
+  attribute(readonly) DlLockState lockState = 0;
+  attribute(readonly) DlLockType lockType = 1;
+  attribute(readonly) boolean actuatorEnabled = 2;
+  attribute(readonly) DlDoorState doorState = 3;
   attribute(writable) int32u doorOpenEvents = 4;
   attribute(writable) int32u doorClosedEvents = 5;
   attribute(writable) int16u openPeriod = 6;
@@ -894,19 +894,19 @@ server cluster DoorLock = 257 {
   attribute(readonly) int8u maxPINCodeLength = 23;
   attribute(readonly) int8u minPINCodeLength = 24;
   attribute(readonly) bitmap8 credentialRulesSupport = 27;
-  attribute(writable, reportable) char_string language = 33;
-  attribute(writable, reportable) int32u autoRelockTime = 35;
-  attribute(writable, reportable) int8u soundVolume = 36;
-  attribute(writable, reportable) DlOperatingMode operatingMode = 37;
+  attribute(writable) char_string language = 33;
+  attribute(writable) int32u autoRelockTime = 35;
+  attribute(writable) int8u soundVolume = 36;
+  attribute(writable) DlOperatingMode operatingMode = 37;
   attribute(readonly) bitmap16 supportedOperatingModes = 38;
   attribute(readonly) bitmap16 defaultConfigurationRegister = 39;
-  attribute(writable, reportable) boolean enableOneTouchLocking = 41;
+  attribute(writable) boolean enableOneTouchLocking = 41;
   attribute(writable) boolean enableInsideStatusLED = 42;
-  attribute(writable, reportable) boolean enablePrivacyModeButton = 43;
-  attribute(writable, reportable) int8u wrongCodeEntryLimit = 48;
-  attribute(writable, reportable) int8u userCodeTemporaryDisableTime = 49;
+  attribute(writable) boolean enablePrivacyModeButton = 43;
+  attribute(writable) int8u wrongCodeEntryLimit = 48;
+  attribute(writable) int8u userCodeTemporaryDisableTime = 49;
   attribute(writable) boolean requirePINforRemoteOperation = 51;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ClearCredentialRequest {
     DlCredential credential = 0;
@@ -999,17 +999,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -1018,10 +1018,10 @@ server cluster FixedLabel = 64 {
 }
 
 server cluster FlowMeasurement = 1028 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GeneralCommissioning = 48 {
@@ -1042,12 +1042,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -1160,15 +1160,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster GroupKeyManagement = 63 {
@@ -1190,14 +1190,14 @@ server cluster GroupKeyManagement = 63 {
     CHAR_STRING groupName = 3;
   }
 
-  attribute(readonly, reportable) GroupKey groupKeyMap[] = 0;
-  attribute(readonly, reportable) GroupInfo groupTable[] = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) GroupKey groupKeyMap[] = 0;
+  attribute(readonly) GroupInfo groupTable[] = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Groups = 4 {
-  attribute(readonly, reportable) bitmap8 nameSupport = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 nameSupport = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
     INT16U groupId = 0;
@@ -1277,12 +1277,12 @@ server cluster IasZone = 1280 {
     kInvalidZoneType = 65535;
   }
 
-  attribute(readonly, reportable) enum8 zoneState = 0;
-  attribute(readonly, reportable) enum16 zoneType = 1;
-  attribute(readonly, reportable) bitmap16 zoneStatus = 2;
-  attribute(writable, reportable) node_id iasCieAddress = 16;
-  attribute(readonly, reportable) int8u zoneId = 17;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 zoneState = 0;
+  attribute(readonly) enum16 zoneType = 1;
+  attribute(readonly) bitmap16 zoneStatus = 2;
+  attribute(writable) node_id iasCieAddress = 16;
+  attribute(readonly) int8u zoneId = 17;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ZoneEnrollRequestRequest {
     IasZoneType zoneType = 0;
@@ -1328,8 +1328,8 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -1439,7 +1439,7 @@ client cluster KeypadInput = 1289 {
     kInvalidKeyInCurrentState = 2;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SendKeyRequestRequest {
     CecKeyCode keyCode = 0;
@@ -1459,21 +1459,21 @@ server cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u remainingTime = 1;
-  attribute(readonly, reportable) int8u minLevel = 2;
-  attribute(readonly, reportable) int8u maxLevel = 3;
-  attribute(readonly, reportable) int16u currentFrequency = 4;
-  attribute(readonly, reportable) int16u minFrequency = 5;
-  attribute(readonly, reportable) int16u maxFrequency = 6;
-  attribute(writable, reportable) bitmap8 options = 15;
-  attribute(writable, reportable) int16u onOffTransitionTime = 16;
-  attribute(writable, reportable) int8u onLevel = 17;
-  attribute(writable, reportable) int16u onTransitionTime = 18;
-  attribute(writable, reportable) int16u offTransitionTime = 19;
-  attribute(writable, reportable) int8u defaultMoveRate = 20;
-  attribute(writable, reportable) int8u startUpCurrentLevel = 16384;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u remainingTime = 1;
+  attribute(readonly) int8u minLevel = 2;
+  attribute(readonly) int8u maxLevel = 3;
+  attribute(readonly) int16u currentFrequency = 4;
+  attribute(readonly) int16u minFrequency = 5;
+  attribute(readonly) int16u maxFrequency = 6;
+  attribute(writable) bitmap8 options = 15;
+  attribute(writable) int16u onOffTransitionTime = 16;
+  attribute(writable) int8u onLevel = 17;
+  attribute(writable) int16u onTransitionTime = 18;
+  attribute(writable) int16u offTransitionTime = 19;
+  attribute(writable) int8u defaultMoveRate = 20;
+  attribute(writable) int8u startUpCurrentLevel = 16384;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -1556,8 +1556,8 @@ client cluster MediaInput = 1287 {
     CHAR_STRING description = 4;
   }
 
-  attribute(readonly, reportable) InputInfo mediaInputList[] = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) InputInfo mediaInputList[] = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct RenameInputRequestRequest {
     INT8U index = 0;
@@ -1591,7 +1591,7 @@ client cluster MediaPlayback = 1286 {
     kSeekOutOfRange = 5;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SeekRequestRequest {
     INT64U position = 0;
@@ -1677,7 +1677,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -1758,7 +1758,7 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     kDownloadProtocolNotSupported = 3;
   }
 
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -1803,10 +1803,10 @@ server cluster OtaSoftwareUpdateProvider = 41 {
 }
 
 server cluster OccupancySensing = 1030 {
-  attribute(readonly, reportable) bitmap8 occupancy = 0;
-  attribute(readonly, reportable) enum8 occupancySensorType = 1;
-  attribute(readonly, reportable) bitmap8 occupancySensorTypeBitmap = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap8 occupancy = 0;
+  attribute(readonly) enum8 occupancySensorType = 1;
+  attribute(readonly) bitmap8 occupancySensorTypeBitmap = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster OnOff = 6 {
@@ -1825,13 +1825,13 @@ server cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) boolean globalSceneControl = 16384;
-  attribute(writable, reportable) int16u onTime = 16385;
-  attribute(writable, reportable) int16u offWaitTime = 16386;
-  attribute(writable, reportable) enum8 startUpOnOff = 16387;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) boolean globalSceneControl = 16384;
+  attribute(writable) int16u onTime = 16385;
+  attribute(writable) int16u offWaitTime = 16386;
+  attribute(writable) enum8 startUpOnOff = 16387;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Off(): DefaultSuccess = 0;
   command On(): DefaultSuccess = 1;
@@ -1861,12 +1861,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -1941,17 +1941,17 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster PressureMeasurement = 1027 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster RelativeHumidityMeasurement = 1029 {
-  attribute(readonly, reportable) int16u measuredValue = 0;
-  attribute(readonly, reportable) int16u minMeasuredValue = 1;
-  attribute(readonly, reportable) int16u maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u measuredValue = 0;
+  attribute(readonly) int16u minMeasuredValue = 1;
+  attribute(readonly) int16u maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Scenes = 5 {
@@ -1961,12 +1961,12 @@ server cluster Scenes = 5 {
     INT8U value = 3;
   }
 
-  attribute(readonly, reportable) int8u sceneCount = 0;
-  attribute(readonly, reportable) int8u currentScene = 1;
-  attribute(readonly, reportable) int16u currentGroup = 2;
-  attribute(readonly, reportable) boolean sceneValid = 3;
-  attribute(readonly, reportable) bitmap8 nameSupport = 4;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u sceneCount = 0;
+  attribute(readonly) int8u currentScene = 1;
+  attribute(readonly) int16u currentGroup = 2;
+  attribute(readonly) boolean sceneValid = 3;
+  attribute(readonly) bitmap8 nameSupport = 4;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddSceneRequest {
     INT16U groupId = 0;
@@ -2067,12 +2067,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Switch = 59 {
@@ -2106,9 +2106,9 @@ server cluster Switch = 59 {
     INT8U totalNumberOfPressesCounted = 1;
   }
 
-  attribute(readonly, reportable) int8u numberOfPositions = 0;
-  attribute(readonly, reportable) int8u currentPosition = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int8u numberOfPositions = 0;
+  attribute(readonly) int8u currentPosition = 1;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster TargetNavigator = 1285 {
@@ -2123,8 +2123,8 @@ client cluster TargetNavigator = 1285 {
     CHAR_STRING name = 2;
   }
 
-  attribute(readonly, reportable) TargetInfo targetNavigatorList[] = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) TargetInfo targetNavigatorList[] = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct NavigateTargetRequestRequest {
     INT8U target = 0;
@@ -2135,10 +2135,10 @@ client cluster TargetNavigator = 1285 {
 }
 
 server cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster TestCluster = 1295 {
@@ -2163,27 +2163,27 @@ server cluster TestCluster = 1295 {
     SimpleEnum arg6[] = 6;
   }
 
-  attribute(writable, reportable) boolean boolean = 0;
-  attribute(writable, reportable) bitmap8 bitmap8 = 1;
-  attribute(writable, reportable) bitmap16 bitmap16 = 2;
-  attribute(writable, reportable) bitmap32 bitmap32 = 3;
-  attribute(writable, reportable) bitmap64 bitmap64 = 4;
-  attribute(writable, reportable) int8u int8u = 5;
-  attribute(writable, reportable) int16u int16u = 6;
-  attribute(writable, reportable) int32u int32u = 8;
-  attribute(writable, reportable) int64u int64u = 12;
-  attribute(writable, reportable) int8s int8s = 13;
-  attribute(writable, reportable) int16s int16s = 14;
-  attribute(writable, reportable) int32s int32s = 16;
-  attribute(writable, reportable) int64s int64s = 20;
-  attribute(writable, reportable) enum8 enum8 = 21;
-  attribute(writable, reportable) enum16 enum16 = 22;
-  attribute(writable, reportable) octet_string octetString = 25;
-  attribute(writable, reportable) INT8U listInt8u[] = 26;
-  attribute(writable, reportable) OCTET_STRING listOctetString[] = 27;
-  attribute(writable, reportable) TestListStructOctet listStructOctetString[] = 28;
-  attribute(writable, reportable) long_octet_string longOctetString = 29;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(writable) boolean boolean = 0;
+  attribute(writable) bitmap8 bitmap8 = 1;
+  attribute(writable) bitmap16 bitmap16 = 2;
+  attribute(writable) bitmap32 bitmap32 = 3;
+  attribute(writable) bitmap64 bitmap64 = 4;
+  attribute(writable) int8u int8u = 5;
+  attribute(writable) int16u int16u = 6;
+  attribute(writable) int32u int32u = 8;
+  attribute(writable) int64u int64u = 12;
+  attribute(writable) int8s int8s = 13;
+  attribute(writable) int16s int16s = 14;
+  attribute(writable) int32s int32s = 16;
+  attribute(writable) int64s int64s = 20;
+  attribute(writable) enum8 enum8 = 21;
+  attribute(writable) enum16 enum16 = 22;
+  attribute(writable) octet_string octetString = 25;
+  attribute(writable) INT8U listInt8u[] = 26;
+  attribute(writable) OCTET_STRING listOctetString[] = 27;
+  attribute(writable) TestListStructOctet listStructOctetString[] = 28;
+  attribute(writable) long_octet_string longOctetString = 29;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   response struct TestSpecificResponse {
     INT8U returnValue = 0;
@@ -2201,16 +2201,16 @@ server cluster Thermostat = 513 {
     kHeatAndCoolSetpoints = 2;
   }
 
-  attribute(readonly, reportable) int16s localTemperature = 0;
-  attribute(writable, reportable) int16s occupiedCoolingSetpoint = 17;
-  attribute(writable, reportable) int16s occupiedHeatingSetpoint = 18;
-  attribute(writable, reportable) enum8 controlSequenceOfOperation = 27;
-  attribute(writable, reportable) enum8 systemMode = 28;
-  attribute(readonly, reportable) enum8 startOfWeek = 32;
-  attribute(readonly, reportable) int8u numberOfWeeklyTransitions = 33;
-  attribute(readonly, reportable) int8u numberOfDailyTransitions = 34;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16s localTemperature = 0;
+  attribute(writable) int16s occupiedCoolingSetpoint = 17;
+  attribute(writable) int16s occupiedHeatingSetpoint = 18;
+  attribute(writable) enum8 controlSequenceOfOperation = 27;
+  attribute(writable) enum8 systemMode = 28;
+  attribute(readonly) enum8 startOfWeek = 32;
+  attribute(readonly) int8u numberOfWeeklyTransitions = 33;
+  attribute(readonly) int8u numberOfDailyTransitions = 34;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   response struct GetWeeklyScheduleResponse {
     ENUM8 numberOfTransitionsForSequence = 0;
@@ -2297,71 +2297,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -2370,8 +2370,8 @@ server cluster UserLabel = 65 {
 }
 
 server cluster WakeOnLan = 1283 {
-  attribute(readonly, reportable) char_string wakeOnLanMacAddress = 0;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) char_string wakeOnLanMacAddress = 0;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster WiFiNetworkDiagnostics = 54 {
@@ -2418,43 +2418,43 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster WindowCovering = 258 {
-  attribute(readonly, reportable) enum8 type = 0;
-  attribute(readonly, reportable) int16u currentPositionLift = 3;
-  attribute(readonly, reportable) int16u currentPositionTilt = 4;
-  attribute(readonly, reportable) bitmap8 configStatus = 7;
-  attribute(readonly, reportable) Percent currentPositionLiftPercentage = 8;
-  attribute(readonly, reportable) Percent currentPositionTiltPercentage = 9;
-  attribute(readonly, reportable) bitmap8 operationalStatus = 10;
-  attribute(readonly, reportable) Percent100ths targetPositionLiftPercent100ths = 11;
-  attribute(readonly, reportable) Percent100ths targetPositionTiltPercent100ths = 12;
-  attribute(readonly, reportable) enum8 endProductType = 13;
-  attribute(readonly, reportable) Percent100ths currentPositionLiftPercent100ths = 14;
-  attribute(readonly, reportable) Percent100ths currentPositionTiltPercent100ths = 15;
-  attribute(readonly, reportable) int16u installedOpenLimitLift = 16;
-  attribute(readonly, reportable) int16u installedClosedLimitLift = 17;
-  attribute(readonly, reportable) int16u installedOpenLimitTilt = 18;
-  attribute(readonly, reportable) int16u installedClosedLimitTilt = 19;
-  attribute(writable, reportable) bitmap8 mode = 23;
-  attribute(readonly, reportable) bitmap16 safetyStatus = 26;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 type = 0;
+  attribute(readonly) int16u currentPositionLift = 3;
+  attribute(readonly) int16u currentPositionTilt = 4;
+  attribute(readonly) bitmap8 configStatus = 7;
+  attribute(readonly) Percent currentPositionLiftPercentage = 8;
+  attribute(readonly) Percent currentPositionTiltPercentage = 9;
+  attribute(readonly) bitmap8 operationalStatus = 10;
+  attribute(readonly) Percent100ths targetPositionLiftPercent100ths = 11;
+  attribute(readonly) Percent100ths targetPositionTiltPercent100ths = 12;
+  attribute(readonly) enum8 endProductType = 13;
+  attribute(readonly) Percent100ths currentPositionLiftPercent100ths = 14;
+  attribute(readonly) Percent100ths currentPositionTiltPercent100ths = 15;
+  attribute(readonly) int16u installedOpenLimitLift = 16;
+  attribute(readonly) int16u installedClosedLimitLift = 17;
+  attribute(readonly) int16u installedOpenLimitTilt = 18;
+  attribute(readonly) int16u installedClosedLimitTilt = 19;
+  attribute(writable) bitmap8 mode = 23;
+  attribute(readonly) bitmap16 safetyStatus = 26;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -22,7 +22,7 @@ server cluster AdministratorCommissioning = 60 {
   attribute(readonly) int8u windowStatus = 0;
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -57,24 +57,24 @@ server cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) int16u clusterRevision = 65533;
 }
 
@@ -84,11 +84,11 @@ server cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster EthernetNetworkDiagnostics = 55 {
@@ -105,17 +105,17 @@ server cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster FixedLabel = 64 {
@@ -141,12 +141,12 @@ server cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -259,15 +259,15 @@ server cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster Identify = 3 {
@@ -293,9 +293,9 @@ server cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
+  attribute(writable) int16u identifyTime = 0;
   attribute(readonly) enum8 identifyType = 1;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -379,7 +379,7 @@ server cluster NetworkCommissioning = 49 {
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -462,12 +462,12 @@ server cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -542,17 +542,17 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster PowerSource = 47 {
-  attribute(readonly, reportable) enum8 status = 0;
-  attribute(readonly, reportable) int8u order = 1;
-  attribute(readonly, reportable) char_string description = 2;
-  attribute(readonly, reportable) int32u batteryVoltage = 11;
-  attribute(readonly, reportable) int8u batteryPercentRemaining = 12;
-  attribute(readonly, reportable) int32u batteryTimeRemaining = 13;
-  attribute(readonly, reportable) enum8 batteryChargeLevel = 14;
-  attribute(readonly, reportable) ENUM8 activeBatteryFaults[] = 18;
-  attribute(readonly, reportable) enum8 batteryChargeState = 26;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 status = 0;
+  attribute(readonly) int8u order = 1;
+  attribute(readonly) char_string description = 2;
+  attribute(readonly) int32u batteryVoltage = 11;
+  attribute(readonly) int8u batteryPercentRemaining = 12;
+  attribute(readonly) int32u batteryTimeRemaining = 13;
+  attribute(readonly) enum8 batteryChargeLevel = 14;
+  attribute(readonly) ENUM8 activeBatteryFaults[] = 18;
+  attribute(readonly) enum8 batteryChargeState = 26;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster SoftwareDiagnostics = 52 {
@@ -568,12 +568,12 @@ server cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {
@@ -653,71 +653,71 @@ server cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster UserLabel = 65 {
@@ -769,44 +769,44 @@ server cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 server cluster WindowCovering = 258 {
-  attribute(readonly, reportable) enum8 type = 0;
-  attribute(readonly, reportable) int16u currentPositionLift = 3;
-  attribute(readonly, reportable) int16u currentPositionTilt = 4;
-  attribute(readonly, reportable) bitmap8 configStatus = 7;
-  attribute(readonly, reportable) Percent currentPositionLiftPercentage = 8;
-  attribute(readonly, reportable) Percent currentPositionTiltPercentage = 9;
-  attribute(readonly, reportable) bitmap8 operationalStatus = 10;
-  attribute(readonly, reportable) Percent100ths targetPositionLiftPercent100ths = 11;
-  attribute(readonly, reportable) Percent100ths targetPositionTiltPercent100ths = 12;
-  attribute(readonly, reportable) enum8 endProductType = 13;
-  attribute(readonly, reportable) Percent100ths currentPositionLiftPercent100ths = 14;
-  attribute(readonly, reportable) Percent100ths currentPositionTiltPercent100ths = 15;
-  attribute(readonly, reportable) int16u installedOpenLimitLift = 16;
-  attribute(readonly, reportable) int16u installedClosedLimitLift = 17;
-  attribute(readonly, reportable) int16u installedOpenLimitTilt = 18;
-  attribute(readonly, reportable) int16u installedClosedLimitTilt = 19;
-  attribute(writable, reportable) bitmap8 mode = 23;
-  attribute(readonly, reportable) bitmap16 safetyStatus = 26;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) enum8 type = 0;
+  attribute(readonly) int16u currentPositionLift = 3;
+  attribute(readonly) int16u currentPositionTilt = 4;
+  attribute(readonly) bitmap8 configStatus = 7;
+  attribute(readonly) Percent currentPositionLiftPercentage = 8;
+  attribute(readonly) Percent currentPositionTiltPercentage = 9;
+  attribute(readonly) bitmap8 operationalStatus = 10;
+  attribute(readonly) Percent100ths targetPositionLiftPercent100ths = 11;
+  attribute(readonly) Percent100ths targetPositionTiltPercent100ths = 12;
+  attribute(readonly) enum8 endProductType = 13;
+  attribute(readonly) Percent100ths currentPositionLiftPercent100ths = 14;
+  attribute(readonly) Percent100ths currentPositionTiltPercent100ths = 15;
+  attribute(readonly) int16u installedOpenLimitLift = 16;
+  attribute(readonly) int16u installedClosedLimitLift = 17;
+  attribute(readonly) int16u installedOpenLimitTilt = 18;
+  attribute(readonly) int16u installedClosedLimitTilt = 19;
+  attribute(writable) bitmap8 mode = 23;
+  attribute(readonly) bitmap16 safetyStatus = 26;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GoToLiftPercentageRequest {
     Percent liftPercentageValue = 0;

--- a/src/app/zap-templates/templates/app/MatterIDL.zapt
+++ b/src/app/zap-templates/templates/app/MatterIDL.zapt
@@ -37,9 +37,6 @@
     {{~else~}}
       readonly
     {{~/if~}}
-    {{~#if isReportableAttribute~}}
-      , reportable
-    {{~/if~}}
     ) {{type}} {{asLowerCamelCase name~}}
     {{~#if isList~}}
       []

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -40,15 +40,15 @@ client cluster AccessControl = 31 {
     OCTET_STRING data = 1;
   }
 
-  attribute(writable, reportable) AccessControlEntry acl[] = 0;
-  attribute(writable, reportable) ExtensionEntry extension[] = 1;
+  attribute(writable) AccessControlEntry acl[] = 0;
+  attribute(writable) ExtensionEntry extension[] = 1;
   attribute(readonly) attrib_id attributeList[] = 65531;
   attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster AccountLogin = 1294 {
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequestRequest {
     CHAR_STRING tempAccountIdentifier = 0;
@@ -85,7 +85,7 @@ client cluster AdministratorCommissioning = 60 {
   attribute(readonly) fabric_idx adminFabricIndex = 1;
   attribute(readonly) int16u adminVendorId = 2;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OpenBasicCommissioningWindowRequest {
     INT16U commissioningTimeout = 0;
@@ -118,16 +118,16 @@ client cluster ApplicationBasic = 1293 {
     CHAR_STRING applicationId = 2;
   }
 
-  attribute(readonly, reportable) char_string vendorName = 0;
-  attribute(readonly, reportable) int16u vendorId = 1;
-  attribute(readonly, reportable) char_string applicationName = 2;
-  attribute(readonly, reportable) int16u productId = 3;
+  attribute(readonly) char_string vendorName = 0;
+  attribute(readonly) int16u vendorId = 1;
+  attribute(readonly) char_string applicationName = 2;
+  attribute(readonly) int16u productId = 3;
   attribute(writable) ApplicationBasicApplication applicationApp = 4;
-  attribute(readonly, reportable) ApplicationStatusEnum applicationStatus = 5;
-  attribute(readonly, reportable) char_string applicationVersion = 6;
+  attribute(readonly) ApplicationStatusEnum applicationStatus = 5;
+  attribute(readonly) char_string applicationVersion = 6;
   attribute(readonly) vendor_id allowedVendorList[] = 7;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster ApplicationLauncher = 1292 {
@@ -142,9 +142,9 @@ client cluster ApplicationLauncher = 1292 {
     CHAR_STRING applicationId = 2;
   }
 
-  attribute(readonly, reportable) INT16U applicationLauncherList[] = 0;
+  attribute(readonly) INT16U applicationLauncherList[] = 0;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct HideAppRequestRequest {
     ApplicationLauncherApplication application = 0;
@@ -185,10 +185,10 @@ client cluster AudioOutput = 1291 {
     CHAR_STRING name = 3;
   }
 
-  attribute(readonly, reportable) OutputInfo audioOutputList[] = 0;
-  attribute(readonly, reportable) int8u currentAudioOutput = 1;
+  attribute(readonly) OutputInfo audioOutputList[] = 0;
+  attribute(readonly) int8u currentAudioOutput = 1;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct RenameOutputRequestRequest {
     INT8U index = 0;
@@ -204,12 +204,12 @@ client cluster AudioOutput = 1291 {
 }
 
 client cluster BarrierControl = 259 {
-  attribute(readonly, reportable) enum8 barrierMovingState = 1;
-  attribute(readonly, reportable) bitmap16 barrierSafetyStatus = 2;
-  attribute(readonly, reportable) bitmap8 barrierCapabilities = 3;
-  attribute(readonly, reportable) int8u barrierPosition = 10;
+  attribute(readonly) enum8 barrierMovingState = 1;
+  attribute(readonly) bitmap16 barrierSafetyStatus = 2;
+  attribute(readonly) bitmap8 barrierCapabilities = 3;
+  attribute(readonly) int8u barrierPosition = 10;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BarrierControlGoToPercentRequest {
     INT8U percentOpen = 0;
@@ -234,42 +234,42 @@ client cluster Basic = 40 {
     boolean reachableNewValue = 0;
   }
 
-  attribute(readonly, reportable) int16u interactionModelVersion = 0;
-  attribute(readonly, reportable) char_string vendorName = 1;
-  attribute(readonly, reportable) vendor_id vendorID = 2;
-  attribute(readonly, reportable) char_string productName = 3;
-  attribute(readonly, reportable) int16u productID = 4;
-  attribute(writable, reportable) char_string nodeLabel = 5;
-  attribute(writable, reportable) char_string location = 6;
-  attribute(readonly, reportable) int16u hardwareVersion = 7;
-  attribute(readonly, reportable) char_string hardwareVersionString = 8;
-  attribute(readonly, reportable) int32u softwareVersion = 9;
-  attribute(readonly, reportable) char_string softwareVersionString = 10;
-  attribute(readonly, reportable) char_string manufacturingDate = 11;
-  attribute(readonly, reportable) char_string partNumber = 12;
-  attribute(readonly, reportable) long_char_string productURL = 13;
-  attribute(readonly, reportable) char_string productLabel = 14;
-  attribute(readonly, reportable) char_string serialNumber = 15;
-  attribute(writable, reportable) boolean localConfigDisabled = 16;
-  attribute(readonly, reportable) boolean reachable = 17;
+  attribute(readonly) int16u interactionModelVersion = 0;
+  attribute(readonly) char_string vendorName = 1;
+  attribute(readonly) vendor_id vendorID = 2;
+  attribute(readonly) char_string productName = 3;
+  attribute(readonly) int16u productID = 4;
+  attribute(writable) char_string nodeLabel = 5;
+  attribute(writable) char_string location = 6;
+  attribute(readonly) int16u hardwareVersion = 7;
+  attribute(readonly) char_string hardwareVersionString = 8;
+  attribute(readonly) int32u softwareVersion = 9;
+  attribute(readonly) char_string softwareVersionString = 10;
+  attribute(readonly) char_string manufacturingDate = 11;
+  attribute(readonly) char_string partNumber = 12;
+  attribute(readonly) long_char_string productURL = 13;
+  attribute(readonly) char_string productLabel = 14;
+  attribute(readonly) char_string serialNumber = 15;
+  attribute(writable) boolean localConfigDisabled = 16;
+  attribute(readonly) boolean reachable = 17;
   attribute(readonly) char_string uniqueID = 18;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command MfgSpecificPing(): DefaultSuccess = 0;
 }
 
 client cluster BinaryInputBasic = 15 {
-  attribute(writable, reportable) boolean outOfService = 81;
-  attribute(writable, reportable) boolean presentValue = 85;
-  attribute(readonly, reportable) bitmap8 statusFlags = 111;
+  attribute(writable) boolean outOfService = 81;
+  attribute(writable) boolean presentValue = 85;
+  attribute(readonly) bitmap8 statusFlags = 111;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster Binding = 30 {
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct BindRequest {
     NODE_ID nodeId = 0;
@@ -294,9 +294,9 @@ client cluster BooleanState = 69 {
     boolean stateValue = 0;
   }
 
-  attribute(readonly, reportable) boolean stateValue = 0;
+  attribute(readonly) boolean stateValue = 0;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster BridgedActions = 37 {
@@ -357,11 +357,11 @@ client cluster BridgedActions = 37 {
     ActionErrorEnum error = 3;
   }
 
-  attribute(readonly, reportable) ActionStruct actionList[] = 0;
-  attribute(readonly, reportable) EndpointListStruct endpointList[] = 1;
-  attribute(readonly, reportable) long_char_string setupUrl = 2;
+  attribute(readonly) ActionStruct actionList[] = 0;
+  attribute(readonly) EndpointListStruct endpointList[] = 1;
+  attribute(readonly) long_char_string setupUrl = 2;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct DisableActionRequest {
     INT16U actionID = 0;
@@ -444,7 +444,7 @@ client cluster BridgedActions = 37 {
 
 client cluster BridgedDeviceBasic = 57 {
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster Channel = 1284 {
@@ -465,9 +465,9 @@ client cluster Channel = 1284 {
     CHAR_STRING affiliateCallSign = 5;
   }
 
-  attribute(readonly, reportable) ChannelInfo channelList[] = 0;
+  attribute(readonly) ChannelInfo channelList[] = 0;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ChangeChannelByNumberRequestRequest {
     INT16U majorNumber = 0;
@@ -539,60 +539,60 @@ client cluster ColorControl = 768 {
     kDown = 3;
   }
 
-  attribute(readonly, reportable) int8u currentHue = 0;
-  attribute(readonly, reportable) int8u currentSaturation = 1;
-  attribute(readonly, reportable) int16u remainingTime = 2;
-  attribute(readonly, reportable) int16u currentX = 3;
-  attribute(readonly, reportable) int16u currentY = 4;
-  attribute(readonly, reportable) enum8 driftCompensation = 5;
-  attribute(readonly, reportable) char_string compensationText = 6;
-  attribute(readonly, reportable) int16u colorTemperature = 7;
-  attribute(readonly, reportable) enum8 colorMode = 8;
-  attribute(writable, reportable) bitmap8 colorControlOptions = 15;
-  attribute(readonly, reportable) int8u numberOfPrimaries = 16;
-  attribute(readonly, reportable) int16u primary1X = 17;
-  attribute(readonly, reportable) int16u primary1Y = 18;
-  attribute(readonly, reportable) int8u primary1Intensity = 19;
-  attribute(readonly, reportable) int16u primary2X = 21;
-  attribute(readonly, reportable) int16u primary2Y = 22;
-  attribute(readonly, reportable) int8u primary2Intensity = 23;
-  attribute(readonly, reportable) int16u primary3X = 25;
-  attribute(readonly, reportable) int16u primary3Y = 26;
-  attribute(readonly, reportable) int8u primary3Intensity = 27;
-  attribute(readonly, reportable) int16u primary4X = 32;
-  attribute(readonly, reportable) int16u primary4Y = 33;
-  attribute(readonly, reportable) int8u primary4Intensity = 34;
-  attribute(readonly, reportable) int16u primary5X = 36;
-  attribute(readonly, reportable) int16u primary5Y = 37;
-  attribute(readonly, reportable) int8u primary5Intensity = 38;
-  attribute(readonly, reportable) int16u primary6X = 40;
-  attribute(readonly, reportable) int16u primary6Y = 41;
-  attribute(readonly, reportable) int8u primary6Intensity = 42;
-  attribute(writable, reportable) int16u whitePointX = 48;
-  attribute(writable, reportable) int16u whitePointY = 49;
-  attribute(writable, reportable) int16u colorPointRX = 50;
-  attribute(writable, reportable) int16u colorPointRY = 51;
-  attribute(writable, reportable) int8u colorPointRIntensity = 52;
-  attribute(writable, reportable) int16u colorPointGX = 54;
-  attribute(writable, reportable) int16u colorPointGY = 55;
-  attribute(writable, reportable) int8u colorPointGIntensity = 56;
-  attribute(writable, reportable) int16u colorPointBX = 58;
-  attribute(writable, reportable) int16u colorPointBY = 59;
-  attribute(writable, reportable) int8u colorPointBIntensity = 60;
-  attribute(readonly, reportable) int16u enhancedCurrentHue = 16384;
-  attribute(readonly, reportable) enum8 enhancedColorMode = 16385;
-  attribute(readonly, reportable) int8u colorLoopActive = 16386;
-  attribute(readonly, reportable) int8u colorLoopDirection = 16387;
-  attribute(readonly, reportable) int16u colorLoopTime = 16388;
-  attribute(readonly, reportable) int16u colorLoopStartEnhancedHue = 16389;
-  attribute(readonly, reportable) int16u colorLoopStoredEnhancedHue = 16390;
-  attribute(readonly, reportable) bitmap16 colorCapabilities = 16394;
-  attribute(readonly, reportable) int16u colorTempPhysicalMin = 16395;
-  attribute(readonly, reportable) int16u colorTempPhysicalMax = 16396;
-  attribute(readonly, reportable) int16u coupleColorTempToLevelMinMireds = 16397;
-  attribute(writable, reportable) int16u startUpColorTemperatureMireds = 16400;
+  attribute(readonly) int8u currentHue = 0;
+  attribute(readonly) int8u currentSaturation = 1;
+  attribute(readonly) int16u remainingTime = 2;
+  attribute(readonly) int16u currentX = 3;
+  attribute(readonly) int16u currentY = 4;
+  attribute(readonly) enum8 driftCompensation = 5;
+  attribute(readonly) char_string compensationText = 6;
+  attribute(readonly) int16u colorTemperature = 7;
+  attribute(readonly) enum8 colorMode = 8;
+  attribute(writable) bitmap8 colorControlOptions = 15;
+  attribute(readonly) int8u numberOfPrimaries = 16;
+  attribute(readonly) int16u primary1X = 17;
+  attribute(readonly) int16u primary1Y = 18;
+  attribute(readonly) int8u primary1Intensity = 19;
+  attribute(readonly) int16u primary2X = 21;
+  attribute(readonly) int16u primary2Y = 22;
+  attribute(readonly) int8u primary2Intensity = 23;
+  attribute(readonly) int16u primary3X = 25;
+  attribute(readonly) int16u primary3Y = 26;
+  attribute(readonly) int8u primary3Intensity = 27;
+  attribute(readonly) int16u primary4X = 32;
+  attribute(readonly) int16u primary4Y = 33;
+  attribute(readonly) int8u primary4Intensity = 34;
+  attribute(readonly) int16u primary5X = 36;
+  attribute(readonly) int16u primary5Y = 37;
+  attribute(readonly) int8u primary5Intensity = 38;
+  attribute(readonly) int16u primary6X = 40;
+  attribute(readonly) int16u primary6Y = 41;
+  attribute(readonly) int8u primary6Intensity = 42;
+  attribute(writable) int16u whitePointX = 48;
+  attribute(writable) int16u whitePointY = 49;
+  attribute(writable) int16u colorPointRX = 50;
+  attribute(writable) int16u colorPointRY = 51;
+  attribute(writable) int8u colorPointRIntensity = 52;
+  attribute(writable) int16u colorPointGX = 54;
+  attribute(writable) int16u colorPointGY = 55;
+  attribute(writable) int8u colorPointGIntensity = 56;
+  attribute(writable) int16u colorPointBX = 58;
+  attribute(writable) int16u colorPointBY = 59;
+  attribute(writable) int8u colorPointBIntensity = 60;
+  attribute(readonly) int16u enhancedCurrentHue = 16384;
+  attribute(readonly) enum8 enhancedColorMode = 16385;
+  attribute(readonly) int8u colorLoopActive = 16386;
+  attribute(readonly) int8u colorLoopDirection = 16387;
+  attribute(readonly) int16u colorLoopTime = 16388;
+  attribute(readonly) int16u colorLoopStartEnhancedHue = 16389;
+  attribute(readonly) int16u colorLoopStoredEnhancedHue = 16390;
+  attribute(readonly) bitmap16 colorCapabilities = 16394;
+  attribute(readonly) int16u colorTempPhysicalMin = 16395;
+  attribute(readonly) int16u colorTempPhysicalMax = 16396;
+  attribute(readonly) int16u coupleColorTempToLevelMinMireds = 16397;
+  attribute(writable) int16u startUpColorTemperatureMireds = 16400;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ColorLoopSetRequest {
     ColorLoopUpdateFlags updateFlags = 0;
@@ -827,10 +827,10 @@ client cluster ContentLauncher = 1290 {
     MetricTypeEnum metric = 3;
   }
 
-  attribute(readonly, reportable) CHAR_STRING acceptHeaderList[] = 0;
-  attribute(writable, reportable) bitmap32 supportedStreamingProtocols = 1;
+  attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
+  attribute(writable) bitmap32 supportedStreamingProtocols = 1;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct LaunchContentRequestRequest {
     BOOLEAN autoPlay = 0;
@@ -859,12 +859,12 @@ client cluster Descriptor = 29 {
     INT16U revision = 2;
   }
 
-  attribute(readonly, reportable) DeviceType deviceList[] = 0;
-  attribute(readonly, reportable) CLUSTER_ID serverList[] = 1;
-  attribute(readonly, reportable) CLUSTER_ID clientList[] = 2;
-  attribute(readonly, reportable) ENDPOINT_NO partsList[] = 3;
+  attribute(readonly) DeviceType deviceList[] = 0;
+  attribute(readonly) CLUSTER_ID serverList[] = 1;
+  attribute(readonly) CLUSTER_ID clientList[] = 2;
+  attribute(readonly) ENDPOINT_NO partsList[] = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster DiagnosticLogs = 50 {
@@ -1141,24 +1141,24 @@ client cluster DoorLock = 257 {
     nullable INT16U dataIndex = 6;
   }
 
-  attribute(readonly, reportable) DlLockState lockState = 0;
-  attribute(readonly, reportable) DlLockType lockType = 1;
-  attribute(readonly, reportable) boolean actuatorEnabled = 2;
-  attribute(readonly, reportable) DlDoorState doorState = 3;
+  attribute(readonly) DlLockState lockState = 0;
+  attribute(readonly) DlLockType lockType = 1;
+  attribute(readonly) boolean actuatorEnabled = 2;
+  attribute(readonly) DlDoorState doorState = 3;
   attribute(readonly) int16u numberOfTotalUsersSupported = 17;
   attribute(readonly) int16u numberOfPINUsersSupported = 18;
   attribute(readonly) int8u maxPINCodeLength = 23;
   attribute(readonly) int8u minPINCodeLength = 24;
-  attribute(writable, reportable) char_string language = 33;
-  attribute(writable, reportable) int32u autoRelockTime = 35;
-  attribute(writable, reportable) int8u soundVolume = 36;
-  attribute(writable, reportable) DlOperatingMode operatingMode = 37;
+  attribute(writable) char_string language = 33;
+  attribute(writable) int32u autoRelockTime = 35;
+  attribute(writable) int8u soundVolume = 36;
+  attribute(writable) DlOperatingMode operatingMode = 37;
   attribute(readonly) bitmap16 supportedOperatingModes = 38;
-  attribute(writable, reportable) boolean enableOneTouchLocking = 41;
-  attribute(writable, reportable) boolean enablePrivacyModeButton = 43;
-  attribute(writable, reportable) int8u wrongCodeEntryLimit = 48;
+  attribute(writable) boolean enableOneTouchLocking = 41;
+  attribute(writable) boolean enablePrivacyModeButton = 43;
+  attribute(writable) int8u wrongCodeEntryLimit = 48;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ClearCredentialRequest {
     DlCredential credential = 0;
@@ -1238,19 +1238,19 @@ client cluster DoorLock = 257 {
 }
 
 client cluster ElectricalMeasurement = 2820 {
-  attribute(readonly, reportable) bitmap32 measurementType = 0;
-  attribute(readonly, reportable) int32s totalActivePower = 772;
-  attribute(readonly, reportable) int16u rmsVoltage = 1285;
-  attribute(readonly, reportable) int16u rmsVoltageMin = 1286;
-  attribute(readonly, reportable) int16u rmsVoltageMax = 1287;
-  attribute(readonly, reportable) int16u rmsCurrent = 1288;
-  attribute(readonly, reportable) int16u rmsCurrentMin = 1289;
-  attribute(readonly, reportable) int16u rmsCurrentMax = 1290;
-  attribute(readonly, reportable) int16s activePower = 1291;
-  attribute(readonly, reportable) int16s activePowerMin = 1292;
-  attribute(readonly, reportable) int16s activePowerMax = 1293;
+  attribute(readonly) bitmap32 measurementType = 0;
+  attribute(readonly) int32s totalActivePower = 772;
+  attribute(readonly) int16u rmsVoltage = 1285;
+  attribute(readonly) int16u rmsVoltageMin = 1286;
+  attribute(readonly) int16u rmsVoltageMax = 1287;
+  attribute(readonly) int16u rmsCurrent = 1288;
+  attribute(readonly) int16u rmsCurrentMin = 1289;
+  attribute(readonly) int16u rmsCurrentMax = 1290;
+  attribute(readonly) int16s activePower = 1291;
+  attribute(readonly) int16s activePowerMin = 1292;
+  attribute(readonly) int16s activePowerMax = 1293;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster EthernetNetworkDiagnostics = 55 {
@@ -1267,35 +1267,35 @@ client cluster EthernetNetworkDiagnostics = 55 {
     k400g = 9;
   }
 
-  attribute(readonly, reportable) enum8 PHYRate = 0;
-  attribute(readonly, reportable) boolean fullDuplex = 1;
-  attribute(readonly, reportable) int64u packetRxCount = 2;
-  attribute(readonly, reportable) int64u packetTxCount = 3;
-  attribute(readonly, reportable) int64u txErrCount = 4;
-  attribute(readonly, reportable) int64u collisionCount = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) boolean carrierDetect = 7;
-  attribute(readonly, reportable) int64u timeSinceReset = 8;
+  attribute(readonly) enum8 PHYRate = 0;
+  attribute(readonly) boolean fullDuplex = 1;
+  attribute(readonly) int64u packetRxCount = 2;
+  attribute(readonly) int64u packetTxCount = 3;
+  attribute(readonly) int64u txErrCount = 4;
+  attribute(readonly) int64u collisionCount = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) boolean carrierDetect = 7;
+  attribute(readonly) int64u timeSinceReset = 8;
   attribute(readonly) attrib_id attributeList[] = 65531;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
 
 client cluster FixedLabel = 64 {
-  attribute(readonly, reportable) LabelStruct labelList[] = 0;
+  attribute(readonly) LabelStruct labelList[] = 0;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster FlowMeasurement = 1028 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster GeneralCommissioning = 48 {
@@ -1316,12 +1316,12 @@ client cluster GeneralCommissioning = 48 {
     INT32U failSafeExpiryLengthMs = 1;
   }
 
-  attribute(writable, reportable) int64u breadcrumb = 0;
-  attribute(readonly, reportable) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
+  attribute(writable) int64u breadcrumb = 0;
+  attribute(readonly) BasicCommissioningInfoType basicCommissioningInfoList[] = 1;
   attribute(readonly) enum8 regulatoryConfig = 2;
   attribute(readonly) enum8 locationCapability = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ArmFailSafeRequest {
     INT16U expiryLengthSeconds = 0;
@@ -1434,16 +1434,16 @@ client cluster GeneralDiagnostics = 51 {
     BootReasonType bootReason = 0;
   }
 
-  attribute(readonly, reportable) NetworkInterfaceType networkInterfaces[] = 0;
-  attribute(readonly, reportable) int16u rebootCount = 1;
-  attribute(readonly, reportable) int64u upTime = 2;
-  attribute(readonly, reportable) int32u totalOperationalHours = 3;
-  attribute(readonly, reportable) enum8 bootReasons = 4;
-  attribute(readonly, reportable) ENUM8 activeHardwareFaults[] = 5;
-  attribute(readonly, reportable) ENUM8 activeRadioFaults[] = 6;
-  attribute(readonly, reportable) ENUM8 activeNetworkFaults[] = 7;
+  attribute(readonly) NetworkInterfaceType networkInterfaces[] = 0;
+  attribute(readonly) int16u rebootCount = 1;
+  attribute(readonly) int64u upTime = 2;
+  attribute(readonly) int32u totalOperationalHours = 3;
+  attribute(readonly) enum8 bootReasons = 4;
+  attribute(readonly) ENUM8 activeHardwareFaults[] = 5;
+  attribute(readonly) ENUM8 activeRadioFaults[] = 6;
+  attribute(readonly) ENUM8 activeNetworkFaults[] = 7;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster GroupKeyManagement = 63 {
@@ -1476,12 +1476,12 @@ client cluster GroupKeyManagement = 63 {
     INT64U epochStartTime2 = 7;
   }
 
-  attribute(readonly, reportable) GroupKey groupKeyMap[] = 0;
-  attribute(readonly, reportable) GroupInfo groupTable[] = 1;
+  attribute(readonly) GroupKey groupKeyMap[] = 0;
+  attribute(readonly) GroupInfo groupTable[] = 1;
   attribute(readonly) int16u maxGroupsPerFabric = 2;
   attribute(readonly) int16u maxGroupKeysPerFabric = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct KeySetReadRequest {
     INT16U groupKeySetID = 0;
@@ -1514,9 +1514,9 @@ client cluster GroupKeyManagement = 63 {
 }
 
 client cluster Groups = 4 {
-  attribute(readonly, reportable) bitmap8 nameSupport = 0;
+  attribute(readonly) bitmap8 nameSupport = 0;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
     INT16U groupId = 0;
@@ -1592,10 +1592,10 @@ client cluster Identify = 3 {
     kActuator = 5;
   }
 
-  attribute(writable, reportable) int16u identifyTime = 0;
-  attribute(readonly, reportable) enum8 identifyType = 1;
+  attribute(writable) int16u identifyTime = 0;
+  attribute(readonly) enum8 identifyType = 1;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct IdentifyRequest {
     INT16U identifyTime = 0;
@@ -1621,13 +1621,13 @@ client cluster IlluminanceMeasurement = 1024 {
     kCmos = 1;
   }
 
-  attribute(readonly, reportable) int16u measuredValue = 0;
-  attribute(readonly, reportable) int16u minMeasuredValue = 1;
-  attribute(readonly, reportable) int16u maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
-  attribute(readonly, reportable) enum8 lightSensorType = 4;
+  attribute(readonly) int16u measuredValue = 0;
+  attribute(readonly) int16u minMeasuredValue = 1;
+  attribute(readonly) int16u maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
+  attribute(readonly) enum8 lightSensorType = 4;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster KeypadInput = 1289 {
@@ -1727,7 +1727,7 @@ client cluster KeypadInput = 1289 {
   }
 
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SendKeyRequestRequest {
     CecKeyCode keyCode = 0;
@@ -1751,23 +1751,23 @@ client cluster LevelControl = 8 {
     kDown = 1;
   }
 
-  attribute(readonly, reportable) int8u currentLevel = 0;
-  attribute(readonly, reportable) int16u remainingTime = 1;
-  attribute(readonly, reportable) int8u minLevel = 2;
-  attribute(readonly, reportable) int8u maxLevel = 3;
-  attribute(readonly, reportable) int16u currentFrequency = 4;
-  attribute(readonly, reportable) int16u minFrequency = 5;
-  attribute(readonly, reportable) int16u maxFrequency = 6;
-  attribute(writable, reportable) bitmap8 options = 15;
-  attribute(writable, reportable) int16u onOffTransitionTime = 16;
-  attribute(writable, reportable) int8u onLevel = 17;
-  attribute(writable, reportable) int16u onTransitionTime = 18;
-  attribute(writable, reportable) int16u offTransitionTime = 19;
-  attribute(writable, reportable) int8u defaultMoveRate = 20;
-  attribute(writable, reportable) int8u startUpCurrentLevel = 16384;
+  attribute(readonly) int8u currentLevel = 0;
+  attribute(readonly) int16u remainingTime = 1;
+  attribute(readonly) int8u minLevel = 2;
+  attribute(readonly) int8u maxLevel = 3;
+  attribute(readonly) int16u currentFrequency = 4;
+  attribute(readonly) int16u minFrequency = 5;
+  attribute(readonly) int16u maxFrequency = 6;
+  attribute(writable) bitmap8 options = 15;
+  attribute(writable) int16u onOffTransitionTime = 16;
+  attribute(writable) int8u onLevel = 17;
+  attribute(writable) int16u onTransitionTime = 18;
+  attribute(writable) int16u offTransitionTime = 19;
+  attribute(writable) int8u defaultMoveRate = 20;
+  attribute(writable) int8u startUpCurrentLevel = 16384;
   attribute(readonly) attrib_id attributeList[] = 65531;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct MoveRequest {
     MoveMode moveMode = 0;
@@ -1829,7 +1829,7 @@ client cluster LocalizationConfiguration = 43 {
 
 client cluster LowPower = 1288 {
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command Sleep(): DefaultSuccess = 0;
 }
@@ -1857,10 +1857,10 @@ client cluster MediaInput = 1287 {
     CHAR_STRING description = 4;
   }
 
-  attribute(readonly, reportable) InputInfo mediaInputList[] = 0;
-  attribute(readonly, reportable) int8u currentMediaInput = 1;
+  attribute(readonly) InputInfo mediaInputList[] = 0;
+  attribute(readonly) int8u currentMediaInput = 1;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct RenameInputRequestRequest {
     INT8U index = 0;
@@ -1894,14 +1894,14 @@ client cluster MediaPlayback = 1286 {
     kSeekOutOfRange = 5;
   }
 
-  attribute(readonly, reportable) PlaybackStateEnum playbackState = 0;
-  attribute(readonly, reportable) epoch_us startTime = 1;
-  attribute(readonly, reportable) int64u duration = 2;
+  attribute(readonly) PlaybackStateEnum playbackState = 0;
+  attribute(readonly) epoch_us startTime = 1;
+  attribute(readonly) int64u duration = 2;
   attribute(readonly) single playbackSpeed = 4;
-  attribute(readonly, reportable) int64u seekRangeEnd = 5;
-  attribute(readonly, reportable) int64u seekRangeStart = 6;
+  attribute(readonly) int64u seekRangeEnd = 5;
+  attribute(readonly) int64u seekRangeStart = 6;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SeekRequestRequest {
     INT64U position = 0;
@@ -1939,13 +1939,13 @@ client cluster ModeSelect = 80 {
     INT32U semanticTag = 3;
   }
 
-  attribute(readonly, reportable) int8u currentMode = 0;
-  attribute(readonly, reportable) ModeOptionStruct supportedModes[] = 1;
-  attribute(writable, reportable) int8u onMode = 2;
-  attribute(readonly, reportable) int8u startUpMode = 3;
-  attribute(readonly, reportable) char_string description = 4;
+  attribute(readonly) int8u currentMode = 0;
+  attribute(readonly) ModeOptionStruct supportedModes[] = 1;
+  attribute(writable) int8u onMode = 2;
+  attribute(readonly) int8u startUpMode = 3;
+  attribute(readonly) char_string description = 4;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ChangeToModeRequest {
     INT8U newMode = 0;
@@ -2012,8 +2012,8 @@ client cluster NetworkCommissioning = 49 {
   attribute(readonly) NetworkCommissioningStatus lastNetworkingStatus = 5;
   attribute(readonly) octet_string lastNetworkID = 6;
   attribute(readonly) int32u lastConnectErrorValue = 7;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
@@ -2095,7 +2095,7 @@ client cluster OtaSoftwareUpdateProvider = 41 {
   }
 
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct ApplyUpdateRequestRequest {
     OCTET_STRING updateToken = 0;
@@ -2191,12 +2191,12 @@ client cluster OtaSoftwareUpdateRequestor = 42 {
     nullable INT64S platformCode = 3;
   }
 
-  attribute(writable, reportable) ProviderLocation defaultOtaProviders[] = 0;
-  attribute(readonly, reportable) boolean updatePossible = 1;
-  attribute(readonly, reportable) OTAUpdateStateEnum updateState = 2;
-  attribute(readonly, reportable) int8u updateStateProgress = 3;
+  attribute(writable) ProviderLocation defaultOtaProviders[] = 0;
+  attribute(readonly) boolean updatePossible = 1;
+  attribute(readonly) OTAUpdateStateEnum updateState = 2;
+  attribute(readonly) int8u updateStateProgress = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AnnounceOtaProviderRequest {
     node_id providerNodeId = 0;
@@ -2210,11 +2210,11 @@ client cluster OtaSoftwareUpdateRequestor = 42 {
 }
 
 client cluster OccupancySensing = 1030 {
-  attribute(readonly, reportable) bitmap8 occupancy = 0;
-  attribute(readonly, reportable) enum8 occupancySensorType = 1;
-  attribute(readonly, reportable) bitmap8 occupancySensorTypeBitmap = 2;
+  attribute(readonly) bitmap8 occupancy = 0;
+  attribute(readonly) enum8 occupancySensorType = 1;
+  attribute(readonly) bitmap8 occupancySensorTypeBitmap = 2;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster OnOff = 6 {
@@ -2233,14 +2233,14 @@ client cluster OnOff = 6 {
     kDyingLight = 1;
   }
 
-  attribute(readonly, reportable) boolean onOff = 0;
-  attribute(readonly, reportable) boolean globalSceneControl = 16384;
-  attribute(writable, reportable) int16u onTime = 16385;
-  attribute(writable, reportable) int16u offWaitTime = 16386;
-  attribute(writable, reportable) enum8 startUpOnOff = 16387;
+  attribute(readonly) boolean onOff = 0;
+  attribute(readonly) boolean globalSceneControl = 16384;
+  attribute(writable) int16u onTime = 16385;
+  attribute(writable) int16u offWaitTime = 16386;
+  attribute(writable) enum8 startUpOnOff = 16387;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct OffWithEffectRequest {
     OnOffEffectIdentifier effectId = 0;
@@ -2262,10 +2262,10 @@ client cluster OnOff = 6 {
 }
 
 client cluster OnOffSwitchConfiguration = 7 {
-  attribute(readonly, reportable) enum8 switchType = 0;
-  attribute(writable, reportable) enum8 switchActions = 16;
+  attribute(readonly) enum8 switchType = 0;
+  attribute(writable) enum8 switchActions = 16;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster OperationalCredentials = 62 {
@@ -2291,13 +2291,13 @@ client cluster OperationalCredentials = 62 {
     CHAR_STRING label = 6;
   }
 
-  attribute(readonly, reportable) FabricDescriptor fabricsList[] = 1;
-  attribute(readonly, reportable) int8u supportedFabrics = 2;
-  attribute(readonly, reportable) int8u commissionedFabrics = 3;
-  attribute(readonly, reportable) OCTET_STRING trustedRootCertificates[] = 4;
-  attribute(readonly, reportable) fabric_idx currentFabricIndex = 5;
+  attribute(readonly) FabricDescriptor fabricsList[] = 1;
+  attribute(readonly) int8u supportedFabrics = 2;
+  attribute(readonly) int8u commissionedFabrics = 3;
+  attribute(readonly) OCTET_STRING trustedRootCertificates[] = 4;
+  attribute(readonly) fabric_idx currentFabricIndex = 5;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddNOCRequest {
     OCTET_STRING NOCValue = 0;
@@ -2372,18 +2372,18 @@ client cluster OperationalCredentials = 62 {
 }
 
 client cluster PowerSource = 47 {
-  attribute(readonly, reportable) enum8 status = 0;
-  attribute(readonly, reportable) int8u order = 1;
-  attribute(readonly, reportable) char_string description = 2;
-  attribute(readonly, reportable) int32u batteryVoltage = 11;
-  attribute(readonly, reportable) int8u batteryPercentRemaining = 12;
-  attribute(readonly, reportable) int32u batteryTimeRemaining = 13;
-  attribute(readonly, reportable) enum8 batteryChargeLevel = 14;
-  attribute(readonly, reportable) ENUM8 activeBatteryFaults[] = 18;
-  attribute(readonly, reportable) enum8 batteryChargeState = 26;
+  attribute(readonly) enum8 status = 0;
+  attribute(readonly) int8u order = 1;
+  attribute(readonly) char_string description = 2;
+  attribute(readonly) int32u batteryVoltage = 11;
+  attribute(readonly) int8u batteryPercentRemaining = 12;
+  attribute(readonly) int32u batteryTimeRemaining = 13;
+  attribute(readonly) enum8 batteryChargeLevel = 14;
+  attribute(readonly) ENUM8 activeBatteryFaults[] = 18;
+  attribute(readonly) enum8 batteryChargeState = 26;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster PowerSourceConfiguration = 46 {
@@ -2393,11 +2393,11 @@ client cluster PowerSourceConfiguration = 46 {
 }
 
 client cluster PressureMeasurement = 1027 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster PumpConfigurationAndControl = 512 {
@@ -2468,42 +2468,42 @@ client cluster PumpConfigurationAndControl = 512 {
   info event TurbineOperation = 16 {
   }
 
-  attribute(readonly, reportable) int16s maxPressure = 0;
-  attribute(readonly, reportable) int16u maxSpeed = 1;
-  attribute(readonly, reportable) int16u maxFlow = 2;
-  attribute(readonly, reportable) int16s minConstPressure = 3;
-  attribute(readonly, reportable) int16s maxConstPressure = 4;
-  attribute(readonly, reportable) int16s minCompPressure = 5;
-  attribute(readonly, reportable) int16s maxCompPressure = 6;
-  attribute(readonly, reportable) int16u minConstSpeed = 7;
-  attribute(readonly, reportable) int16u maxConstSpeed = 8;
-  attribute(readonly, reportable) int16u minConstFlow = 9;
-  attribute(readonly, reportable) int16u maxConstFlow = 10;
-  attribute(readonly, reportable) int16s minConstTemp = 11;
-  attribute(readonly, reportable) int16s maxConstTemp = 12;
-  attribute(readonly, reportable) bitmap16 pumpStatus = 16;
-  attribute(readonly, reportable) enum8 effectiveOperationMode = 17;
-  attribute(readonly, reportable) enum8 effectiveControlMode = 18;
-  attribute(readonly, reportable) int16s capacity = 19;
-  attribute(readonly, reportable) int16u speed = 20;
-  attribute(writable, reportable) int24u lifetimeRunningHours = 21;
-  attribute(readonly, reportable) int24u power = 22;
-  attribute(writable, reportable) int32u lifetimeEnergyConsumed = 23;
-  attribute(writable, reportable) enum8 operationMode = 32;
-  attribute(writable, reportable) enum8 controlMode = 33;
-  attribute(readonly, reportable) bitmap16 alarmMask = 34;
+  attribute(readonly) int16s maxPressure = 0;
+  attribute(readonly) int16u maxSpeed = 1;
+  attribute(readonly) int16u maxFlow = 2;
+  attribute(readonly) int16s minConstPressure = 3;
+  attribute(readonly) int16s maxConstPressure = 4;
+  attribute(readonly) int16s minCompPressure = 5;
+  attribute(readonly) int16s maxCompPressure = 6;
+  attribute(readonly) int16u minConstSpeed = 7;
+  attribute(readonly) int16u maxConstSpeed = 8;
+  attribute(readonly) int16u minConstFlow = 9;
+  attribute(readonly) int16u maxConstFlow = 10;
+  attribute(readonly) int16s minConstTemp = 11;
+  attribute(readonly) int16s maxConstTemp = 12;
+  attribute(readonly) bitmap16 pumpStatus = 16;
+  attribute(readonly) enum8 effectiveOperationMode = 17;
+  attribute(readonly) enum8 effectiveControlMode = 18;
+  attribute(readonly) int16s capacity = 19;
+  attribute(readonly) int16u speed = 20;
+  attribute(writable) int24u lifetimeRunningHours = 21;
+  attribute(readonly) int24u power = 22;
+  attribute(writable) int32u lifetimeEnergyConsumed = 23;
+  attribute(writable) enum8 operationMode = 32;
+  attribute(writable) enum8 controlMode = 33;
+  attribute(readonly) bitmap16 alarmMask = 34;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster RelativeHumidityMeasurement = 1029 {
-  attribute(readonly, reportable) int16u measuredValue = 0;
-  attribute(readonly, reportable) int16u minMeasuredValue = 1;
-  attribute(readonly, reportable) int16u maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
+  attribute(readonly) int16u measuredValue = 0;
+  attribute(readonly) int16u minMeasuredValue = 1;
+  attribute(readonly) int16u maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster Scenes = 5 {
@@ -2513,13 +2513,13 @@ client cluster Scenes = 5 {
     INT8U value = 3;
   }
 
-  attribute(readonly, reportable) int8u sceneCount = 0;
-  attribute(readonly, reportable) int8u currentScene = 1;
-  attribute(readonly, reportable) int16u currentGroup = 2;
-  attribute(readonly, reportable) boolean sceneValid = 3;
-  attribute(readonly, reportable) bitmap8 nameSupport = 4;
+  attribute(readonly) int8u sceneCount = 0;
+  attribute(readonly) int8u currentScene = 1;
+  attribute(readonly) int16u currentGroup = 2;
+  attribute(readonly) boolean sceneValid = 3;
+  attribute(readonly) bitmap8 nameSupport = 4;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct AddSceneRequest {
     INT16U groupId = 0;
@@ -2620,13 +2620,13 @@ client cluster SoftwareDiagnostics = 52 {
     SoftwareFault softwareFault = 0;
   }
 
-  attribute(readonly, reportable) ThreadMetrics threadMetrics[] = 0;
-  attribute(readonly, reportable) int64u currentHeapFree = 1;
-  attribute(readonly, reportable) int64u currentHeapUsed = 2;
-  attribute(readonly, reportable) int64u currentHeapHighWatermark = 3;
+  attribute(readonly) ThreadMetrics threadMetrics[] = 0;
+  attribute(readonly) int64u currentHeapFree = 1;
+  attribute(readonly) int64u currentHeapUsed = 2;
+  attribute(readonly) int64u currentHeapHighWatermark = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetWatermarks(): DefaultSuccess = 0;
 }
@@ -2662,12 +2662,12 @@ client cluster Switch = 59 {
     INT8U totalNumberOfPressesCounted = 1;
   }
 
-  attribute(readonly, reportable) int8u numberOfPositions = 0;
-  attribute(readonly, reportable) int8u currentPosition = 1;
-  attribute(readonly, reportable) int8u multiPressMax = 2;
+  attribute(readonly) int8u numberOfPositions = 0;
+  attribute(readonly) int8u currentPosition = 1;
+  attribute(readonly) int8u multiPressMax = 2;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster TargetNavigator = 1285 {
@@ -2682,10 +2682,10 @@ client cluster TargetNavigator = 1285 {
     CHAR_STRING name = 2;
   }
 
-  attribute(readonly, reportable) TargetInfo targetNavigatorList[] = 0;
-  attribute(readonly, reportable) int8u currentNavigatorTarget = 1;
+  attribute(readonly) TargetInfo targetNavigatorList[] = 0;
+  attribute(readonly) int8u currentNavigatorTarget = 1;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct NavigateTargetRequestRequest {
     INT8U target = 0;
@@ -2701,12 +2701,12 @@ client cluster TargetNavigator = 1285 {
 }
 
 client cluster TemperatureMeasurement = 1026 {
-  attribute(readonly, reportable) int16s measuredValue = 0;
-  attribute(readonly, reportable) int16s minMeasuredValue = 1;
-  attribute(readonly, reportable) int16s maxMeasuredValue = 2;
-  attribute(readonly, reportable) int16u tolerance = 3;
+  attribute(readonly) int16s measuredValue = 0;
+  attribute(readonly) int16s minMeasuredValue = 1;
+  attribute(readonly) int16s maxMeasuredValue = 2;
+  attribute(readonly) int16u tolerance = 3;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster TestCluster = 1295 {
@@ -2773,86 +2773,86 @@ client cluster TestCluster = 1295 {
     SimpleEnum arg6[] = 6;
   }
 
-  attribute(writable, reportable) boolean boolean = 0;
-  attribute(writable, reportable) bitmap8 bitmap8 = 1;
-  attribute(writable, reportable) bitmap16 bitmap16 = 2;
-  attribute(writable, reportable) bitmap32 bitmap32 = 3;
-  attribute(writable, reportable) bitmap64 bitmap64 = 4;
-  attribute(writable, reportable) int8u int8u = 5;
-  attribute(writable, reportable) int16u int16u = 6;
-  attribute(writable, reportable) int24u int24u = 7;
-  attribute(writable, reportable) int32u int32u = 8;
-  attribute(writable, reportable) int40u int40u = 9;
-  attribute(writable, reportable) int48u int48u = 10;
-  attribute(writable, reportable) int56u int56u = 11;
-  attribute(writable, reportable) int64u int64u = 12;
-  attribute(writable, reportable) int8s int8s = 13;
-  attribute(writable, reportable) int16s int16s = 14;
-  attribute(writable, reportable) int24s int24s = 15;
-  attribute(writable, reportable) int32s int32s = 16;
-  attribute(writable, reportable) int40s int40s = 17;
-  attribute(writable, reportable) int48s int48s = 18;
-  attribute(writable, reportable) int56s int56s = 19;
-  attribute(writable, reportable) int64s int64s = 20;
-  attribute(writable, reportable) enum8 enum8 = 21;
-  attribute(writable, reportable) enum16 enum16 = 22;
-  attribute(writable, reportable) single floatSingle = 23;
-  attribute(writable, reportable) double floatDouble = 24;
-  attribute(writable, reportable) octet_string octetString = 25;
-  attribute(writable, reportable) INT8U listInt8u[] = 26;
-  attribute(writable, reportable) OCTET_STRING listOctetString[] = 27;
-  attribute(writable, reportable) TestListStructOctet listStructOctetString[] = 28;
-  attribute(writable, reportable) long_octet_string longOctetString = 29;
-  attribute(writable, reportable) char_string charString = 30;
-  attribute(writable, reportable) long_char_string longCharString = 31;
-  attribute(writable, reportable) epoch_us epochUs = 32;
-  attribute(writable, reportable) epoch_s epochS = 33;
-  attribute(writable, reportable) vendor_id vendorId = 34;
-  attribute(writable, reportable) NullablesAndOptionalsStruct listNullablesAndOptionalsStruct[] = 35;
-  attribute(writable, reportable) SimpleEnum enumAttr = 36;
-  attribute(writable, reportable) SimpleStruct structAttr = 37;
-  attribute(writable, reportable) int8u rangeRestrictedInt8u = 38;
-  attribute(writable, reportable) int8s rangeRestrictedInt8s = 39;
-  attribute(writable, reportable) int16u rangeRestrictedInt16u = 40;
-  attribute(writable, reportable) int16s rangeRestrictedInt16s = 41;
+  attribute(writable) boolean boolean = 0;
+  attribute(writable) bitmap8 bitmap8 = 1;
+  attribute(writable) bitmap16 bitmap16 = 2;
+  attribute(writable) bitmap32 bitmap32 = 3;
+  attribute(writable) bitmap64 bitmap64 = 4;
+  attribute(writable) int8u int8u = 5;
+  attribute(writable) int16u int16u = 6;
+  attribute(writable) int24u int24u = 7;
+  attribute(writable) int32u int32u = 8;
+  attribute(writable) int40u int40u = 9;
+  attribute(writable) int48u int48u = 10;
+  attribute(writable) int56u int56u = 11;
+  attribute(writable) int64u int64u = 12;
+  attribute(writable) int8s int8s = 13;
+  attribute(writable) int16s int16s = 14;
+  attribute(writable) int24s int24s = 15;
+  attribute(writable) int32s int32s = 16;
+  attribute(writable) int40s int40s = 17;
+  attribute(writable) int48s int48s = 18;
+  attribute(writable) int56s int56s = 19;
+  attribute(writable) int64s int64s = 20;
+  attribute(writable) enum8 enum8 = 21;
+  attribute(writable) enum16 enum16 = 22;
+  attribute(writable) single floatSingle = 23;
+  attribute(writable) double floatDouble = 24;
+  attribute(writable) octet_string octetString = 25;
+  attribute(writable) INT8U listInt8u[] = 26;
+  attribute(writable) OCTET_STRING listOctetString[] = 27;
+  attribute(writable) TestListStructOctet listStructOctetString[] = 28;
+  attribute(writable) long_octet_string longOctetString = 29;
+  attribute(writable) char_string charString = 30;
+  attribute(writable) long_char_string longCharString = 31;
+  attribute(writable) epoch_us epochUs = 32;
+  attribute(writable) epoch_s epochS = 33;
+  attribute(writable) vendor_id vendorId = 34;
+  attribute(writable) NullablesAndOptionalsStruct listNullablesAndOptionalsStruct[] = 35;
+  attribute(writable) SimpleEnum enumAttr = 36;
+  attribute(writable) SimpleStruct structAttr = 37;
+  attribute(writable) int8u rangeRestrictedInt8u = 38;
+  attribute(writable) int8s rangeRestrictedInt8s = 39;
+  attribute(writable) int16u rangeRestrictedInt16u = 40;
+  attribute(writable) int16s rangeRestrictedInt16s = 41;
   attribute(readonly) LONG_OCTET_STRING listLongOctetString[] = 42;
   attribute(writable) boolean timedWriteBoolean = 48;
-  attribute(writable, reportable) boolean unsupported = 255;
-  attribute(writable, reportable) boolean nullableBoolean = 32768;
-  attribute(writable, reportable) bitmap8 nullableBitmap8 = 32769;
-  attribute(writable, reportable) bitmap16 nullableBitmap16 = 32770;
-  attribute(writable, reportable) bitmap32 nullableBitmap32 = 32771;
-  attribute(writable, reportable) bitmap64 nullableBitmap64 = 32772;
-  attribute(writable, reportable) int8u nullableInt8u = 32773;
-  attribute(writable, reportable) int16u nullableInt16u = 32774;
-  attribute(writable, reportable) int24u nullableInt24u = 32775;
-  attribute(writable, reportable) int32u nullableInt32u = 32776;
-  attribute(writable, reportable) int40u nullableInt40u = 32777;
-  attribute(writable, reportable) int48u nullableInt48u = 32778;
-  attribute(writable, reportable) int56u nullableInt56u = 32779;
-  attribute(writable, reportable) int64u nullableInt64u = 32780;
-  attribute(writable, reportable) int8s nullableInt8s = 32781;
-  attribute(writable, reportable) int16s nullableInt16s = 32782;
-  attribute(writable, reportable) int24s nullableInt24s = 32783;
-  attribute(writable, reportable) int32s nullableInt32s = 32784;
-  attribute(writable, reportable) int40s nullableInt40s = 32785;
-  attribute(writable, reportable) int48s nullableInt48s = 32786;
-  attribute(writable, reportable) int56s nullableInt56s = 32787;
-  attribute(writable, reportable) int64s nullableInt64s = 32788;
-  attribute(writable, reportable) enum8 nullableEnum8 = 32789;
-  attribute(writable, reportable) enum16 nullableEnum16 = 32790;
-  attribute(writable, reportable) single nullableFloatSingle = 32791;
-  attribute(writable, reportable) double nullableFloatDouble = 32792;
-  attribute(writable, reportable) octet_string nullableOctetString = 32793;
-  attribute(writable, reportable) char_string nullableCharString = 32798;
-  attribute(writable, reportable) SimpleEnum nullableEnumAttr = 32804;
-  attribute(writable, reportable) SimpleStruct nullableStruct = 32805;
-  attribute(writable, reportable) int8u nullableRangeRestrictedInt8u = 32806;
-  attribute(writable, reportable) int8s nullableRangeRestrictedInt8s = 32807;
-  attribute(writable, reportable) int16u nullableRangeRestrictedInt16u = 32808;
-  attribute(writable, reportable) int16s nullableRangeRestrictedInt16s = 32809;
+  attribute(writable) boolean unsupported = 255;
+  attribute(writable) boolean nullableBoolean = 32768;
+  attribute(writable) bitmap8 nullableBitmap8 = 32769;
+  attribute(writable) bitmap16 nullableBitmap16 = 32770;
+  attribute(writable) bitmap32 nullableBitmap32 = 32771;
+  attribute(writable) bitmap64 nullableBitmap64 = 32772;
+  attribute(writable) int8u nullableInt8u = 32773;
+  attribute(writable) int16u nullableInt16u = 32774;
+  attribute(writable) int24u nullableInt24u = 32775;
+  attribute(writable) int32u nullableInt32u = 32776;
+  attribute(writable) int40u nullableInt40u = 32777;
+  attribute(writable) int48u nullableInt48u = 32778;
+  attribute(writable) int56u nullableInt56u = 32779;
+  attribute(writable) int64u nullableInt64u = 32780;
+  attribute(writable) int8s nullableInt8s = 32781;
+  attribute(writable) int16s nullableInt16s = 32782;
+  attribute(writable) int24s nullableInt24s = 32783;
+  attribute(writable) int32s nullableInt32s = 32784;
+  attribute(writable) int40s nullableInt40s = 32785;
+  attribute(writable) int48s nullableInt48s = 32786;
+  attribute(writable) int56s nullableInt56s = 32787;
+  attribute(writable) int64s nullableInt64s = 32788;
+  attribute(writable) enum8 nullableEnum8 = 32789;
+  attribute(writable) enum16 nullableEnum16 = 32790;
+  attribute(writable) single nullableFloatSingle = 32791;
+  attribute(writable) double nullableFloatDouble = 32792;
+  attribute(writable) octet_string nullableOctetString = 32793;
+  attribute(writable) char_string nullableCharString = 32798;
+  attribute(writable) SimpleEnum nullableEnumAttr = 32804;
+  attribute(writable) SimpleStruct nullableStruct = 32805;
+  attribute(writable) int8u nullableRangeRestrictedInt8u = 32806;
+  attribute(writable) int8s nullableRangeRestrictedInt8s = 32807;
+  attribute(writable) int16u nullableRangeRestrictedInt16u = 32808;
+  attribute(writable) int16s nullableRangeRestrictedInt16s = 32809;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct SimpleStructEchoRequestRequest {
     SimpleStruct arg1 = 0;
@@ -2973,26 +2973,26 @@ client cluster Thermostat = 513 {
     kHeatAndCoolSetpoints = 2;
   }
 
-  attribute(readonly, reportable) int16s localTemperature = 0;
-  attribute(readonly, reportable) int16s absMinHeatSetpointLimit = 3;
-  attribute(readonly, reportable) int16s absMaxHeatSetpointLimit = 4;
-  attribute(readonly, reportable) int16s absMinCoolSetpointLimit = 5;
-  attribute(readonly, reportable) int16s absMaxCoolSetpointLimit = 6;
-  attribute(writable, reportable) int16s occupiedCoolingSetpoint = 17;
-  attribute(writable, reportable) int16s occupiedHeatingSetpoint = 18;
-  attribute(writable, reportable) int16s minHeatSetpointLimit = 21;
-  attribute(writable, reportable) int16s maxHeatSetpointLimit = 22;
-  attribute(writable, reportable) int16s minCoolSetpointLimit = 23;
-  attribute(writable, reportable) int16s maxCoolSetpointLimit = 24;
-  attribute(writable, reportable) int8s minSetpointDeadBand = 25;
-  attribute(writable, reportable) enum8 controlSequenceOfOperation = 27;
-  attribute(writable, reportable) enum8 systemMode = 28;
-  attribute(readonly, reportable) enum8 startOfWeek = 32;
-  attribute(readonly, reportable) int8u numberOfWeeklyTransitions = 33;
-  attribute(readonly, reportable) int8u numberOfDailyTransitions = 34;
+  attribute(readonly) int16s localTemperature = 0;
+  attribute(readonly) int16s absMinHeatSetpointLimit = 3;
+  attribute(readonly) int16s absMaxHeatSetpointLimit = 4;
+  attribute(readonly) int16s absMinCoolSetpointLimit = 5;
+  attribute(readonly) int16s absMaxCoolSetpointLimit = 6;
+  attribute(writable) int16s occupiedCoolingSetpoint = 17;
+  attribute(writable) int16s occupiedHeatingSetpoint = 18;
+  attribute(writable) int16s minHeatSetpointLimit = 21;
+  attribute(writable) int16s maxHeatSetpointLimit = 22;
+  attribute(writable) int16s minCoolSetpointLimit = 23;
+  attribute(writable) int16s maxCoolSetpointLimit = 24;
+  attribute(writable) int8s minSetpointDeadBand = 25;
+  attribute(writable) enum8 controlSequenceOfOperation = 27;
+  attribute(writable) enum8 systemMode = 28;
+  attribute(readonly) enum8 startOfWeek = 32;
+  attribute(readonly) int8u numberOfWeeklyTransitions = 33;
+  attribute(readonly) int8u numberOfDailyTransitions = 34;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GetWeeklyScheduleRequest {
     DayOfWeek daysToReturn = 0;
@@ -3035,11 +3035,11 @@ client cluster Thermostat = 513 {
 }
 
 client cluster ThermostatUserInterfaceConfiguration = 516 {
-  attribute(writable, reportable) enum8 temperatureDisplayMode = 0;
-  attribute(writable, reportable) enum8 keypadLockout = 1;
-  attribute(writable, reportable) enum8 scheduleProgrammingVisibility = 2;
+  attribute(writable) enum8 temperatureDisplayMode = 0;
+  attribute(writable) enum8 keypadLockout = 1;
+  attribute(writable) enum8 scheduleProgrammingVisibility = 2;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster ThreadNetworkDiagnostics = 53 {
@@ -3119,72 +3119,72 @@ client cluster ThreadNetworkDiagnostics = 53 {
     ThreadConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) int16u channel = 0;
-  attribute(readonly, reportable) enum8 routingRole = 1;
-  attribute(readonly, reportable) octet_string networkName = 2;
-  attribute(readonly, reportable) int16u panId = 3;
-  attribute(readonly, reportable) int64u extendedPanId = 4;
-  attribute(readonly, reportable) octet_string meshLocalPrefix = 5;
-  attribute(readonly, reportable) int64u overrunCount = 6;
-  attribute(readonly, reportable) NeighborTable neighborTableList[] = 7;
-  attribute(readonly, reportable) RouteTable routeTableList[] = 8;
-  attribute(readonly, reportable) int32u partitionId = 9;
-  attribute(readonly, reportable) int8u weighting = 10;
-  attribute(readonly, reportable) int8u dataVersion = 11;
-  attribute(readonly, reportable) int8u stableDataVersion = 12;
-  attribute(readonly, reportable) int8u leaderRouterId = 13;
-  attribute(readonly, reportable) int16u detachedRoleCount = 14;
-  attribute(readonly, reportable) int16u childRoleCount = 15;
-  attribute(readonly, reportable) int16u routerRoleCount = 16;
-  attribute(readonly, reportable) int16u leaderRoleCount = 17;
-  attribute(readonly, reportable) int16u attachAttemptCount = 18;
-  attribute(readonly, reportable) int16u partitionIdChangeCount = 19;
-  attribute(readonly, reportable) int16u betterPartitionAttachAttemptCount = 20;
-  attribute(readonly, reportable) int16u parentChangeCount = 21;
-  attribute(readonly, reportable) int32u txTotalCount = 22;
-  attribute(readonly, reportable) int32u txUnicastCount = 23;
-  attribute(readonly, reportable) int32u txBroadcastCount = 24;
-  attribute(readonly, reportable) int32u txAckRequestedCount = 25;
-  attribute(readonly, reportable) int32u txAckedCount = 26;
-  attribute(readonly, reportable) int32u txNoAckRequestedCount = 27;
-  attribute(readonly, reportable) int32u txDataCount = 28;
-  attribute(readonly, reportable) int32u txDataPollCount = 29;
-  attribute(readonly, reportable) int32u txBeaconCount = 30;
-  attribute(readonly, reportable) int32u txBeaconRequestCount = 31;
-  attribute(readonly, reportable) int32u txOtherCount = 32;
-  attribute(readonly, reportable) int32u txRetryCount = 33;
-  attribute(readonly, reportable) int32u txDirectMaxRetryExpiryCount = 34;
-  attribute(readonly, reportable) int32u txIndirectMaxRetryExpiryCount = 35;
-  attribute(readonly, reportable) int32u txErrCcaCount = 36;
-  attribute(readonly, reportable) int32u txErrAbortCount = 37;
-  attribute(readonly, reportable) int32u txErrBusyChannelCount = 38;
-  attribute(readonly, reportable) int32u rxTotalCount = 39;
-  attribute(readonly, reportable) int32u rxUnicastCount = 40;
-  attribute(readonly, reportable) int32u rxBroadcastCount = 41;
-  attribute(readonly, reportable) int32u rxDataCount = 42;
-  attribute(readonly, reportable) int32u rxDataPollCount = 43;
-  attribute(readonly, reportable) int32u rxBeaconCount = 44;
-  attribute(readonly, reportable) int32u rxBeaconRequestCount = 45;
-  attribute(readonly, reportable) int32u rxOtherCount = 46;
-  attribute(readonly, reportable) int32u rxAddressFilteredCount = 47;
-  attribute(readonly, reportable) int32u rxDestAddrFilteredCount = 48;
-  attribute(readonly, reportable) int32u rxDuplicatedCount = 49;
-  attribute(readonly, reportable) int32u rxErrNoFrameCount = 50;
-  attribute(readonly, reportable) int32u rxErrUnknownNeighborCount = 51;
-  attribute(readonly, reportable) int32u rxErrInvalidSrcAddrCount = 52;
-  attribute(readonly, reportable) int32u rxErrSecCount = 53;
-  attribute(readonly, reportable) int32u rxErrFcsCount = 54;
-  attribute(readonly, reportable) int32u rxErrOtherCount = 55;
-  attribute(readonly, reportable) int64u activeTimestamp = 56;
-  attribute(readonly, reportable) int64u pendingTimestamp = 57;
-  attribute(readonly, reportable) int32u delay = 58;
-  attribute(readonly, reportable) SecurityPolicy securityPolicy[] = 59;
-  attribute(readonly, reportable) octet_string channelMask = 60;
-  attribute(readonly, reportable) OperationalDatasetComponents operationalDatasetComponents[] = 61;
-  attribute(readonly, reportable) NetworkFault activeNetworkFaultsList[] = 62;
+  attribute(readonly) int16u channel = 0;
+  attribute(readonly) enum8 routingRole = 1;
+  attribute(readonly) octet_string networkName = 2;
+  attribute(readonly) int16u panId = 3;
+  attribute(readonly) int64u extendedPanId = 4;
+  attribute(readonly) octet_string meshLocalPrefix = 5;
+  attribute(readonly) int64u overrunCount = 6;
+  attribute(readonly) NeighborTable neighborTableList[] = 7;
+  attribute(readonly) RouteTable routeTableList[] = 8;
+  attribute(readonly) int32u partitionId = 9;
+  attribute(readonly) int8u weighting = 10;
+  attribute(readonly) int8u dataVersion = 11;
+  attribute(readonly) int8u stableDataVersion = 12;
+  attribute(readonly) int8u leaderRouterId = 13;
+  attribute(readonly) int16u detachedRoleCount = 14;
+  attribute(readonly) int16u childRoleCount = 15;
+  attribute(readonly) int16u routerRoleCount = 16;
+  attribute(readonly) int16u leaderRoleCount = 17;
+  attribute(readonly) int16u attachAttemptCount = 18;
+  attribute(readonly) int16u partitionIdChangeCount = 19;
+  attribute(readonly) int16u betterPartitionAttachAttemptCount = 20;
+  attribute(readonly) int16u parentChangeCount = 21;
+  attribute(readonly) int32u txTotalCount = 22;
+  attribute(readonly) int32u txUnicastCount = 23;
+  attribute(readonly) int32u txBroadcastCount = 24;
+  attribute(readonly) int32u txAckRequestedCount = 25;
+  attribute(readonly) int32u txAckedCount = 26;
+  attribute(readonly) int32u txNoAckRequestedCount = 27;
+  attribute(readonly) int32u txDataCount = 28;
+  attribute(readonly) int32u txDataPollCount = 29;
+  attribute(readonly) int32u txBeaconCount = 30;
+  attribute(readonly) int32u txBeaconRequestCount = 31;
+  attribute(readonly) int32u txOtherCount = 32;
+  attribute(readonly) int32u txRetryCount = 33;
+  attribute(readonly) int32u txDirectMaxRetryExpiryCount = 34;
+  attribute(readonly) int32u txIndirectMaxRetryExpiryCount = 35;
+  attribute(readonly) int32u txErrCcaCount = 36;
+  attribute(readonly) int32u txErrAbortCount = 37;
+  attribute(readonly) int32u txErrBusyChannelCount = 38;
+  attribute(readonly) int32u rxTotalCount = 39;
+  attribute(readonly) int32u rxUnicastCount = 40;
+  attribute(readonly) int32u rxBroadcastCount = 41;
+  attribute(readonly) int32u rxDataCount = 42;
+  attribute(readonly) int32u rxDataPollCount = 43;
+  attribute(readonly) int32u rxBeaconCount = 44;
+  attribute(readonly) int32u rxBeaconRequestCount = 45;
+  attribute(readonly) int32u rxOtherCount = 46;
+  attribute(readonly) int32u rxAddressFilteredCount = 47;
+  attribute(readonly) int32u rxDestAddrFilteredCount = 48;
+  attribute(readonly) int32u rxDuplicatedCount = 49;
+  attribute(readonly) int32u rxErrNoFrameCount = 50;
+  attribute(readonly) int32u rxErrUnknownNeighborCount = 51;
+  attribute(readonly) int32u rxErrInvalidSrcAddrCount = 52;
+  attribute(readonly) int32u rxErrSecCount = 53;
+  attribute(readonly) int32u rxErrFcsCount = 54;
+  attribute(readonly) int32u rxErrOtherCount = 55;
+  attribute(readonly) int64u activeTimestamp = 56;
+  attribute(readonly) int64u pendingTimestamp = 57;
+  attribute(readonly) int32u delay = 58;
+  attribute(readonly) SecurityPolicy securityPolicy[] = 59;
+  attribute(readonly) octet_string channelMask = 60;
+  attribute(readonly) OperationalDatasetComponents operationalDatasetComponents[] = 61;
+  attribute(readonly) NetworkFault activeNetworkFaultsList[] = 62;
   attribute(readonly) attrib_id attributeList[] = 65531;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
@@ -3195,9 +3195,9 @@ client cluster UserLabel = 65 {
 }
 
 client cluster WakeOnLan = 1283 {
-  attribute(readonly, reportable) char_string wakeOnLanMacAddress = 0;
+  attribute(readonly) char_string wakeOnLanMacAddress = 0;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 }
 
 client cluster WiFiNetworkDiagnostics = 54 {
@@ -3244,48 +3244,48 @@ client cluster WiFiNetworkDiagnostics = 54 {
     WiFiConnectionStatus connectionStatus = 0;
   }
 
-  attribute(readonly, reportable) octet_string bssid = 0;
-  attribute(readonly, reportable) enum8 securityType = 1;
-  attribute(readonly, reportable) enum8 wiFiVersion = 2;
-  attribute(readonly, reportable) int16u channelNumber = 3;
-  attribute(readonly, reportable) int8s rssi = 4;
-  attribute(readonly, reportable) int32u beaconLostCount = 5;
-  attribute(readonly, reportable) int32u beaconRxCount = 6;
-  attribute(readonly, reportable) int32u packetMulticastRxCount = 7;
-  attribute(readonly, reportable) int32u packetMulticastTxCount = 8;
-  attribute(readonly, reportable) int32u packetUnicastRxCount = 9;
-  attribute(readonly, reportable) int32u packetUnicastTxCount = 10;
-  attribute(readonly, reportable) int64u currentMaxRate = 11;
-  attribute(readonly, reportable) int64u overrunCount = 12;
+  attribute(readonly) octet_string bssid = 0;
+  attribute(readonly) enum8 securityType = 1;
+  attribute(readonly) enum8 wiFiVersion = 2;
+  attribute(readonly) int16u channelNumber = 3;
+  attribute(readonly) int8s rssi = 4;
+  attribute(readonly) int32u beaconLostCount = 5;
+  attribute(readonly) int32u beaconRxCount = 6;
+  attribute(readonly) int32u packetMulticastRxCount = 7;
+  attribute(readonly) int32u packetMulticastTxCount = 8;
+  attribute(readonly) int32u packetUnicastRxCount = 9;
+  attribute(readonly) int32u packetUnicastTxCount = 10;
+  attribute(readonly) int64u currentMaxRate = 11;
+  attribute(readonly) int64u overrunCount = 12;
   attribute(readonly) attrib_id attributeList[] = 65531;
   attribute(readonly) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   command ResetCounts(): DefaultSuccess = 0;
 }
 
 client cluster WindowCovering = 258 {
-  attribute(readonly, reportable) enum8 type = 0;
-  attribute(readonly, reportable) int16u currentPositionLift = 3;
-  attribute(readonly, reportable) int16u currentPositionTilt = 4;
-  attribute(readonly, reportable) bitmap8 configStatus = 7;
-  attribute(readonly, reportable) Percent currentPositionLiftPercentage = 8;
-  attribute(readonly, reportable) Percent currentPositionTiltPercentage = 9;
-  attribute(readonly, reportable) bitmap8 operationalStatus = 10;
-  attribute(readonly, reportable) Percent100ths targetPositionLiftPercent100ths = 11;
-  attribute(readonly, reportable) Percent100ths targetPositionTiltPercent100ths = 12;
-  attribute(readonly, reportable) enum8 endProductType = 13;
-  attribute(readonly, reportable) Percent100ths currentPositionLiftPercent100ths = 14;
-  attribute(readonly, reportable) Percent100ths currentPositionTiltPercent100ths = 15;
-  attribute(readonly, reportable) int16u installedOpenLimitLift = 16;
-  attribute(readonly, reportable) int16u installedClosedLimitLift = 17;
-  attribute(readonly, reportable) int16u installedOpenLimitTilt = 18;
-  attribute(readonly, reportable) int16u installedClosedLimitTilt = 19;
-  attribute(writable, reportable) bitmap8 mode = 23;
-  attribute(readonly, reportable) bitmap16 safetyStatus = 26;
+  attribute(readonly) enum8 type = 0;
+  attribute(readonly) int16u currentPositionLift = 3;
+  attribute(readonly) int16u currentPositionTilt = 4;
+  attribute(readonly) bitmap8 configStatus = 7;
+  attribute(readonly) Percent currentPositionLiftPercentage = 8;
+  attribute(readonly) Percent currentPositionTiltPercentage = 9;
+  attribute(readonly) bitmap8 operationalStatus = 10;
+  attribute(readonly) Percent100ths targetPositionLiftPercent100ths = 11;
+  attribute(readonly) Percent100ths targetPositionTiltPercent100ths = 12;
+  attribute(readonly) enum8 endProductType = 13;
+  attribute(readonly) Percent100ths currentPositionLiftPercent100ths = 14;
+  attribute(readonly) Percent100ths currentPositionTiltPercent100ths = 15;
+  attribute(readonly) int16u installedOpenLimitLift = 16;
+  attribute(readonly) int16u installedClosedLimitLift = 17;
+  attribute(readonly) int16u installedOpenLimitTilt = 18;
+  attribute(readonly) int16u installedClosedLimitTilt = 19;
+  attribute(writable) bitmap8 mode = 23;
+  attribute(readonly) bitmap16 safetyStatus = 26;
   attribute(readonly) attrib_id attributeList[] = 65531;
-  attribute(readonly, reportable) bitmap32 featureMap = 65532;
-  attribute(readonly, reportable) int16u clusterRevision = 65533;
+  attribute(readonly) bitmap32 featureMap = 65532;
+  attribute(readonly) int16u clusterRevision = 65533;
 
   request struct GoToLiftPercentageRequest {
     Percent liftPercentageValue = 0;


### PR DESCRIPTION
#### Problem
Reportable tag is unstable in idl generation (zap has different settings on reportable for client and server because reportable is generally not used (and reportable is a zcl term: matter has subscriptions and everything is subscribable but some may not generate values)

#### Change overview
Remove the reportable flag. Does not help code review and generates instability.

#### Testing
ZAP gen still works.