### PR TITLE
Set IPV6_PKTINFO socket option for UDP endpoint

### DIFF
--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -530,6 +530,17 @@ CHIP_ERROR UDPEndPointImplSockets::GetSocket(IPAddressType addressType)
 #endif // defined(IP_PKTINFO)
 #endif // INET_CONFIG_ENABLE_IPV4
 
+#ifdef IPV6_PKTINFO
+        if (addressType == IPAddressType::kIPv6)
+        {
+            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_PKTINFO, &one, sizeof(one));
+            if (res != 0)
+            {
+                ChipLogError(Inet, "IPV6_PKTINFO failed: %d", errno);
+            }
+        }
+#endif // defined(IPV6_PKTINFO)
+
 #ifdef IPV6_RECVPKTINFO
         if (addressType == IPAddressType::kIPv6)
         {


### PR DESCRIPTION
#### Problem
The Mbed POSIX layer uses IPV6_PKTINFO socket option for socket configuration. We need to set this option in the UDP endpoint initialization to properly receive IPv6 messages. 

#### Change overview
Set IPV6_PKTINFO socket option for udp endpoint

#### Testing
Build and run Mbed examples. Check node's communication via IPv6.
