### PR TITLE
Allow null NetworkCredentials in commissionDevice()

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -187,8 +187,11 @@ JNI_METHOD(void, commissionDevice)
     ChipLogProgress(Controller, "commissionDevice() called");
 
     CommissioningParameters commissioningParams = CommissioningParameters();
-    err                                         = wrapper->ApplyNetworkCredentials(commissioningParams, networkCredentials);
-    VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_INVALID_ARGUMENT);
+    if (networkCredentials != nullptr)
+    {
+        err = wrapper->ApplyNetworkCredentials(commissioningParams, networkCredentials);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_INVALID_ARGUMENT);
+    }
 
     if (csrNonce != nullptr)
     {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -141,7 +141,7 @@ public class ChipDeviceController {
    * @param deviceId the ID of the node to be commissioned
    * @param networkCredentials the credentials (Wi-Fi or Thread) to be provisioned
    */
-  public void commissionDevice(long deviceId, NetworkCredentials networkCredentials) {
+  public void commissionDevice(long deviceId, @Nullable NetworkCredentials networkCredentials) {
     commissionDevice(deviceControllerPtr, deviceId, /* csrNonce= */ null, networkCredentials);
   }
 
@@ -155,7 +155,7 @@ public class ChipDeviceController {
    * @param networkCredentials the credentials (Wi-Fi or Thread) to be provisioned
    */
   public void commissionDevice(
-      long deviceId, @Nullable byte[] csrNonce, NetworkCredentials networkCredentials) {
+      long deviceId, @Nullable byte[] csrNonce, @Nullable NetworkCredentials networkCredentials) {
     commissionDevice(deviceControllerPtr, deviceId, csrNonce, networkCredentials);
   }
 
@@ -331,7 +331,7 @@ public class ChipDeviceController {
       long deviceControllerPtr,
       long deviceId,
       @Nullable byte[] csrNonce,
-      NetworkCredentials networkCredentials);
+      @Nullable NetworkCredentials networkCredentials);
 
   private native void unpairDevice(long deviceControllerPtr, long deviceId);
 


### PR DESCRIPTION
For IP commissioning, no credentials should be added, but currently the
Java layer requires either a Thread or Wi-Fi network. The underlying
commissioner logic already has safeguards to ensure that a network is
provided unless we are doing IP commissioning.

#### Testing

Tested locally, providing null credentials during IP commissioning on Android