### PR TITLE
Adding a base dir structure for the iOS port of the tv-casting-app

### DIFF
--- a/examples/tv-casting-app/darwin/Darwin.xcworkspace/contents.xcworkspacedata
+++ b/examples/tv-casting-app/darwin/Darwin.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:iOSTVCastingApp/iOSTVCastingApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/tv-casting-app/darwin/Darwin.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/tv-casting-app/darwin/Darwin.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/darwin.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/darwin.xcodeproj/project.pbxproj
@@ -1,0 +1,587 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3CB8D82227962E3E00BA4D5D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D82127962E3E00BA4D5D /* AppDelegate.m */; };
+		3CB8D82527962E3E00BA4D5D /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D82427962E3E00BA4D5D /* SceneDelegate.m */; };
+		3CB8D82827962E3E00BA4D5D /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D82727962E3E00BA4D5D /* ViewController.m */; };
+		3CB8D82B27962E3E00BA4D5D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3CB8D82927962E3E00BA4D5D /* Main.storyboard */; };
+		3CB8D82D27962E4800BA4D5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3CB8D82C27962E4800BA4D5D /* Assets.xcassets */; };
+		3CB8D83027962E4800BA4D5D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3CB8D82E27962E4800BA4D5D /* LaunchScreen.storyboard */; };
+		3CB8D83327962E4800BA4D5D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D83227962E4800BA4D5D /* main.m */; };
+		3CB8D83D27962E4900BA4D5D /* darwinTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D83C27962E4900BA4D5D /* darwinTests.m */; };
+		3CB8D84827962E4900BA4D5D /* darwinUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D84727962E4900BA4D5D /* darwinUITests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3CB8D83927962E4900BA4D5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CB8D81527962E3E00BA4D5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CB8D81C27962E3E00BA4D5D;
+			remoteInfo = darwin;
+		};
+		3CB8D84427962E4900BA4D5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CB8D81527962E3E00BA4D5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CB8D81C27962E3E00BA4D5D;
+			remoteInfo = darwin;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3CB8D81D27962E3E00BA4D5D /* darwin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = darwin.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CB8D82027962E3E00BA4D5D /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3CB8D82127962E3E00BA4D5D /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		3CB8D82327962E3E00BA4D5D /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		3CB8D82427962E3E00BA4D5D /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		3CB8D82627962E3E00BA4D5D /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		3CB8D82727962E3E00BA4D5D /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		3CB8D82A27962E3E00BA4D5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3CB8D82C27962E4800BA4D5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3CB8D82F27962E4800BA4D5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3CB8D83127962E4800BA4D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3CB8D83227962E4800BA4D5D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3CB8D83827962E4900BA4D5D /* darwinTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = darwinTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CB8D83C27962E4900BA4D5D /* darwinTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = darwinTests.m; sourceTree = "<group>"; };
+		3CB8D83E27962E4900BA4D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3CB8D84327962E4900BA4D5D /* darwinUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = darwinUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CB8D84727962E4900BA4D5D /* darwinUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = darwinUITests.m; sourceTree = "<group>"; };
+		3CB8D84927962E4900BA4D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3CB8D81A27962E3E00BA4D5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D83527962E4900BA4D5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D84027962E4900BA4D5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3CB8D81427962E3E00BA4D5D = {
+			isa = PBXGroup;
+			children = (
+				3CB8D81F27962E3E00BA4D5D /* darwin */,
+				3CB8D83B27962E4900BA4D5D /* darwinTests */,
+				3CB8D84627962E4900BA4D5D /* darwinUITests */,
+				3CB8D81E27962E3E00BA4D5D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3CB8D81E27962E3E00BA4D5D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D81D27962E3E00BA4D5D /* darwin.app */,
+				3CB8D83827962E4900BA4D5D /* darwinTests.xctest */,
+				3CB8D84327962E4900BA4D5D /* darwinUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3CB8D81F27962E3E00BA4D5D /* darwin */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D82027962E3E00BA4D5D /* AppDelegate.h */,
+				3CB8D82127962E3E00BA4D5D /* AppDelegate.m */,
+				3CB8D82327962E3E00BA4D5D /* SceneDelegate.h */,
+				3CB8D82427962E3E00BA4D5D /* SceneDelegate.m */,
+				3CB8D82627962E3E00BA4D5D /* ViewController.h */,
+				3CB8D82727962E3E00BA4D5D /* ViewController.m */,
+				3CB8D82927962E3E00BA4D5D /* Main.storyboard */,
+				3CB8D82C27962E4800BA4D5D /* Assets.xcassets */,
+				3CB8D82E27962E4800BA4D5D /* LaunchScreen.storyboard */,
+				3CB8D83127962E4800BA4D5D /* Info.plist */,
+				3CB8D83227962E4800BA4D5D /* main.m */,
+			);
+			path = darwin;
+			sourceTree = "<group>";
+		};
+		3CB8D83B27962E4900BA4D5D /* darwinTests */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D83C27962E4900BA4D5D /* darwinTests.m */,
+				3CB8D83E27962E4900BA4D5D /* Info.plist */,
+			);
+			path = darwinTests;
+			sourceTree = "<group>";
+		};
+		3CB8D84627962E4900BA4D5D /* darwinUITests */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D84727962E4900BA4D5D /* darwinUITests.m */,
+				3CB8D84927962E4900BA4D5D /* Info.plist */,
+			);
+			path = darwinUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3CB8D81C27962E3E00BA4D5D /* darwin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3CB8D84C27962E4900BA4D5D /* Build configuration list for PBXNativeTarget "darwin" */;
+			buildPhases = (
+				3CB8D81927962E3E00BA4D5D /* Sources */,
+				3CB8D81A27962E3E00BA4D5D /* Frameworks */,
+				3CB8D81B27962E3E00BA4D5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = darwin;
+			productName = darwin;
+			productReference = 3CB8D81D27962E3E00BA4D5D /* darwin.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3CB8D83727962E4900BA4D5D /* darwinTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3CB8D84F27962E4900BA4D5D /* Build configuration list for PBXNativeTarget "darwinTests" */;
+			buildPhases = (
+				3CB8D83427962E4900BA4D5D /* Sources */,
+				3CB8D83527962E4900BA4D5D /* Frameworks */,
+				3CB8D83627962E4900BA4D5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3CB8D83A27962E4900BA4D5D /* PBXTargetDependency */,
+			);
+			name = darwinTests;
+			productName = darwinTests;
+			productReference = 3CB8D83827962E4900BA4D5D /* darwinTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		3CB8D84227962E4900BA4D5D /* darwinUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3CB8D85227962E4900BA4D5D /* Build configuration list for PBXNativeTarget "darwinUITests" */;
+			buildPhases = (
+				3CB8D83F27962E4900BA4D5D /* Sources */,
+				3CB8D84027962E4900BA4D5D /* Frameworks */,
+				3CB8D84127962E4900BA4D5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3CB8D84527962E4900BA4D5D /* PBXTargetDependency */,
+			);
+			name = darwinUITests;
+			productName = darwinUITests;
+			productReference = 3CB8D84327962E4900BA4D5D /* darwinUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3CB8D81527962E3E00BA4D5D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					3CB8D81C27962E3E00BA4D5D = {
+						CreatedOnToolsVersion = 12.4;
+					};
+					3CB8D83727962E4900BA4D5D = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = 3CB8D81C27962E3E00BA4D5D;
+					};
+					3CB8D84227962E4900BA4D5D = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = 3CB8D81C27962E3E00BA4D5D;
+					};
+				};
+			};
+			buildConfigurationList = 3CB8D81827962E3E00BA4D5D /* Build configuration list for PBXProject "darwin" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3CB8D81427962E3E00BA4D5D;
+			productRefGroup = 3CB8D81E27962E3E00BA4D5D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3CB8D81C27962E3E00BA4D5D /* darwin */,
+				3CB8D83727962E4900BA4D5D /* darwinTests */,
+				3CB8D84227962E4900BA4D5D /* darwinUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3CB8D81B27962E3E00BA4D5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D83027962E4800BA4D5D /* LaunchScreen.storyboard in Resources */,
+				3CB8D82D27962E4800BA4D5D /* Assets.xcassets in Resources */,
+				3CB8D82B27962E3E00BA4D5D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D83627962E4900BA4D5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D84127962E4900BA4D5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3CB8D81927962E3E00BA4D5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D82827962E3E00BA4D5D /* ViewController.m in Sources */,
+				3CB8D82227962E3E00BA4D5D /* AppDelegate.m in Sources */,
+				3CB8D83327962E4800BA4D5D /* main.m in Sources */,
+				3CB8D82527962E3E00BA4D5D /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D83427962E4900BA4D5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D83D27962E4900BA4D5D /* darwinTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D83F27962E4900BA4D5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D84827962E4900BA4D5D /* darwinUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3CB8D83A27962E4900BA4D5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CB8D81C27962E3E00BA4D5D /* darwin */;
+			targetProxy = 3CB8D83927962E4900BA4D5D /* PBXContainerItemProxy */;
+		};
+		3CB8D84527962E4900BA4D5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CB8D81C27962E3E00BA4D5D /* darwin */;
+			targetProxy = 3CB8D84427962E4900BA4D5D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		3CB8D82927962E3E00BA4D5D /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3CB8D82A27962E3E00BA4D5D /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3CB8D82E27962E4800BA4D5D /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3CB8D82F27962E4800BA4D5D /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		3CB8D84A27962E4900BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		3CB8D84B27962E4900BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3CB8D84D27962E4900BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = darwin/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.darwin;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3CB8D84E27962E4900BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = darwin/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.darwin;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3CB8D85027962E4900BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = darwinTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.darwinTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/darwin.app/darwin";
+			};
+			name = Debug;
+		};
+		3CB8D85127962E4900BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = darwinTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.darwinTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/darwin.app/darwin";
+			};
+			name = Release;
+		};
+		3CB8D85327962E4900BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = darwinUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.darwinUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = darwin;
+			};
+			name = Debug;
+		};
+		3CB8D85427962E4900BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = darwinUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.darwinUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = darwin;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3CB8D81827962E3E00BA4D5D /* Build configuration list for PBXProject "darwin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D84A27962E4900BA4D5D /* Debug */,
+				3CB8D84B27962E4900BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3CB8D84C27962E4900BA4D5D /* Build configuration list for PBXNativeTarget "darwin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D84D27962E4900BA4D5D /* Debug */,
+				3CB8D84E27962E4900BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3CB8D84F27962E4900BA4D5D /* Build configuration list for PBXNativeTarget "darwinTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D85027962E4900BA4D5D /* Debug */,
+				3CB8D85127962E4900BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3CB8D85227962E4900BA4D5D /* Build configuration list for PBXNativeTarget "darwinUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D85327962E4900BA4D5D /* Debug */,
+				3CB8D85427962E4900BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3CB8D81527962E3E00BA4D5D /* Project object */;
+}

--- a/examples/tv-casting-app/darwin/darwin/AppDelegate.h
+++ b/examples/tv-casting-app/darwin/darwin/AppDelegate.h
@@ -1,0 +1,22 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@end

--- a/examples/tv-casting-app/darwin/darwin/AppDelegate.m
+++ b/examples/tv-casting-app/darwin/darwin/AppDelegate.m
@@ -1,0 +1,51 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    // Override point for customization after application launch.
+    return YES;
+}
+
+#pragma mark - UISceneSession lifecycle
+
+- (UISceneConfiguration *)application:(UIApplication *)application
+    configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession
+                                   options:(UISceneConnectionOptions *)options
+{
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions
+{
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after
+    // application:didFinishLaunchingWithOptions. Use this method to release any resources that were specific to the discarded
+    // scenes, as they will not return.
+}
+
+@end

--- a/examples/tv-casting-app/darwin/darwin/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/tv-casting-app/darwin/darwin/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+    "colors": [
+        {
+            "idiom": "universal"
+        }
+    ],
+    "info": {
+        "author": "xcode",
+        "version": 1
+    }
+}

--- a/examples/tv-casting-app/darwin/darwin/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/tv-casting-app/darwin/darwin/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+    "images": [
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "60x60"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "60x60"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "76x76"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "76x76"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "83.5x83.5"
+        },
+        {
+            "idiom": "ios-marketing",
+            "scale": "1x",
+            "size": "1024x1024"
+        }
+    ],
+    "info": {
+        "author": "xcode",
+        "version": 1
+    }
+}

--- a/examples/tv-casting-app/darwin/darwin/Assets.xcassets/Contents.json
+++ b/examples/tv-casting-app/darwin/darwin/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+    "info": {
+        "author": "xcode",
+        "version": 1
+    }
+}

--- a/examples/tv-casting-app/darwin/darwin/Base.lproj/LaunchScreen.storyboard
+++ b/examples/tv-casting-app/darwin/darwin/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/tv-casting-app/darwin/darwin/Base.lproj/Main.storyboard
+++ b/examples/tv-casting-app/darwin/darwin/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/tv-casting-app/darwin/darwin/Info.plist
+++ b/examples/tv-casting-app/darwin/darwin/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/darwin/SceneDelegate.h
+++ b/examples/tv-casting-app/darwin/darwin/SceneDelegate.h
@@ -1,0 +1,24 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow * window;
+
+@end

--- a/examples/tv-casting-app/darwin/darwin/SceneDelegate.m
+++ b/examples/tv-casting-app/darwin/darwin/SceneDelegate.m
@@ -1,0 +1,68 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "SceneDelegate.h"
+
+@interface SceneDelegate ()
+
+@end
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see
+    // `application:configurationForConnectingSceneSession` instead).
+}
+
+- (void)sceneDidDisconnect:(UIScene *)scene
+{
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions`
+    // instead).
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene
+{
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene
+{
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene
+{
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+}
+
+@end

--- a/examples/tv-casting-app/darwin/darwin/ViewController.h
+++ b/examples/tv-casting-app/darwin/darwin/ViewController.h
@@ -1,0 +1,22 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end

--- a/examples/tv-casting-app/darwin/darwin/ViewController.m
+++ b/examples/tv-casting-app/darwin/darwin/ViewController.m
@@ -1,0 +1,32 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+@end

--- a/examples/tv-casting-app/darwin/darwin/main.m
+++ b/examples/tv-casting-app/darwin/darwin/main.m
@@ -1,0 +1,29 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "AppDelegate.h"
+#import <UIKit/UIKit.h>
+
+int main(int argc, char * argv[])
+{
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/examples/tv-casting-app/darwin/darwinTests/Info.plist
+++ b/examples/tv-casting-app/darwin/darwinTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/darwinTests/darwinTests.m
+++ b/examples/tv-casting-app/darwin/darwinTests/darwinTests.m
@@ -1,0 +1,50 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@interface darwinTests : XCTestCase
+
+@end
+
+@implementation darwinTests
+
+- (void)setUp
+{
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample
+{
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample
+{
+    // This is an example of a performance test case.
+    [self measureBlock:^ {
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/examples/tv-casting-app/darwin/darwinUITests/Info.plist
+++ b/examples/tv-casting-app/darwin/darwinUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/darwinUITests/darwinUITests.m
+++ b/examples/tv-casting-app/darwin/darwinUITests/darwinUITests.m
@@ -1,0 +1,63 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@interface darwinUITests : XCTestCase
+
+@end
+
+@implementation darwinUITests
+
+- (void)setUp
+{
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    self.continueAfterFailure = NO;
+
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they
+    // run. The setUp method is a good place to do this.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample
+{
+    // UI tests must launch the application that they test.
+    XCUIApplication * app = [[XCUIApplication alloc] init];
+    [app launch];
+
+    // Use recording to get started writing UI tests.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testLaunchPerformance
+{
+    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
+        // This measures how long it takes to launch your application.
+        [self measureWithMetrics:@[ [[XCTApplicationLaunchMetric alloc] init] ]
+                           block:^{
+                               [[[XCUIApplication alloc] init] launch];
+                           }];
+    }
+}
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp.xcodeproj/project.pbxproj
@@ -1,0 +1,587 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3CB8D86627962FD100BA4D5D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D86527962FD100BA4D5D /* AppDelegate.m */; };
+		3CB8D86927962FD100BA4D5D /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D86827962FD100BA4D5D /* SceneDelegate.m */; };
+		3CB8D86C27962FD100BA4D5D /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D86B27962FD100BA4D5D /* ViewController.m */; };
+		3CB8D86F27962FD100BA4D5D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3CB8D86D27962FD100BA4D5D /* Main.storyboard */; };
+		3CB8D87127962FDA00BA4D5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3CB8D87027962FDA00BA4D5D /* Assets.xcassets */; };
+		3CB8D87427962FDA00BA4D5D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3CB8D87227962FDA00BA4D5D /* LaunchScreen.storyboard */; };
+		3CB8D87727962FDA00BA4D5D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D87627962FDA00BA4D5D /* main.m */; };
+		3CB8D88127962FDA00BA4D5D /* iOSTVCastingAppTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D88027962FDA00BA4D5D /* iOSTVCastingAppTests.m */; };
+		3CB8D88C27962FDB00BA4D5D /* iOSTVCastingAppUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB8D88B27962FDB00BA4D5D /* iOSTVCastingAppUITests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3CB8D87D27962FDA00BA4D5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CB8D85927962FD100BA4D5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CB8D86027962FD100BA4D5D;
+			remoteInfo = iOSTVCastingApp;
+		};
+		3CB8D88827962FDB00BA4D5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CB8D85927962FD100BA4D5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3CB8D86027962FD100BA4D5D;
+			remoteInfo = iOSTVCastingApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3CB8D86127962FD100BA4D5D /* iOSTVCastingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSTVCastingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CB8D86427962FD100BA4D5D /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3CB8D86527962FD100BA4D5D /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		3CB8D86727962FD100BA4D5D /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		3CB8D86827962FD100BA4D5D /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		3CB8D86A27962FD100BA4D5D /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		3CB8D86B27962FD100BA4D5D /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		3CB8D86E27962FD100BA4D5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3CB8D87027962FDA00BA4D5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3CB8D87327962FDA00BA4D5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3CB8D87527962FDA00BA4D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3CB8D87627962FDA00BA4D5D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3CB8D87C27962FDA00BA4D5D /* iOSTVCastingAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSTVCastingAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CB8D88027962FDA00BA4D5D /* iOSTVCastingAppTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOSTVCastingAppTests.m; sourceTree = "<group>"; };
+		3CB8D88227962FDA00BA4D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3CB8D88727962FDB00BA4D5D /* iOSTVCastingAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSTVCastingAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CB8D88B27962FDB00BA4D5D /* iOSTVCastingAppUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOSTVCastingAppUITests.m; sourceTree = "<group>"; };
+		3CB8D88D27962FDB00BA4D5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3CB8D85E27962FD100BA4D5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D87927962FDA00BA4D5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D88427962FDB00BA4D5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3CB8D85827962FD100BA4D5D = {
+			isa = PBXGroup;
+			children = (
+				3CB8D86327962FD100BA4D5D /* iOSTVCastingApp */,
+				3CB8D87F27962FDA00BA4D5D /* iOSTVCastingAppTests */,
+				3CB8D88A27962FDB00BA4D5D /* iOSTVCastingAppUITests */,
+				3CB8D86227962FD100BA4D5D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3CB8D86227962FD100BA4D5D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D86127962FD100BA4D5D /* iOSTVCastingApp.app */,
+				3CB8D87C27962FDA00BA4D5D /* iOSTVCastingAppTests.xctest */,
+				3CB8D88727962FDB00BA4D5D /* iOSTVCastingAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3CB8D86327962FD100BA4D5D /* iOSTVCastingApp */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D86427962FD100BA4D5D /* AppDelegate.h */,
+				3CB8D86527962FD100BA4D5D /* AppDelegate.m */,
+				3CB8D86727962FD100BA4D5D /* SceneDelegate.h */,
+				3CB8D86827962FD100BA4D5D /* SceneDelegate.m */,
+				3CB8D86A27962FD100BA4D5D /* ViewController.h */,
+				3CB8D86B27962FD100BA4D5D /* ViewController.m */,
+				3CB8D86D27962FD100BA4D5D /* Main.storyboard */,
+				3CB8D87027962FDA00BA4D5D /* Assets.xcassets */,
+				3CB8D87227962FDA00BA4D5D /* LaunchScreen.storyboard */,
+				3CB8D87527962FDA00BA4D5D /* Info.plist */,
+				3CB8D87627962FDA00BA4D5D /* main.m */,
+			);
+			path = iOSTVCastingApp;
+			sourceTree = "<group>";
+		};
+		3CB8D87F27962FDA00BA4D5D /* iOSTVCastingAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D88027962FDA00BA4D5D /* iOSTVCastingAppTests.m */,
+				3CB8D88227962FDA00BA4D5D /* Info.plist */,
+			);
+			path = iOSTVCastingAppTests;
+			sourceTree = "<group>";
+		};
+		3CB8D88A27962FDB00BA4D5D /* iOSTVCastingAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				3CB8D88B27962FDB00BA4D5D /* iOSTVCastingAppUITests.m */,
+				3CB8D88D27962FDB00BA4D5D /* Info.plist */,
+			);
+			path = iOSTVCastingAppUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3CB8D86027962FD100BA4D5D /* iOSTVCastingApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3CB8D89027962FDB00BA4D5D /* Build configuration list for PBXNativeTarget "iOSTVCastingApp" */;
+			buildPhases = (
+				3CB8D85D27962FD100BA4D5D /* Sources */,
+				3CB8D85E27962FD100BA4D5D /* Frameworks */,
+				3CB8D85F27962FD100BA4D5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOSTVCastingApp;
+			productName = iOSTVCastingApp;
+			productReference = 3CB8D86127962FD100BA4D5D /* iOSTVCastingApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3CB8D87B27962FDA00BA4D5D /* iOSTVCastingAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3CB8D89327962FDB00BA4D5D /* Build configuration list for PBXNativeTarget "iOSTVCastingAppTests" */;
+			buildPhases = (
+				3CB8D87827962FDA00BA4D5D /* Sources */,
+				3CB8D87927962FDA00BA4D5D /* Frameworks */,
+				3CB8D87A27962FDA00BA4D5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3CB8D87E27962FDA00BA4D5D /* PBXTargetDependency */,
+			);
+			name = iOSTVCastingAppTests;
+			productName = iOSTVCastingAppTests;
+			productReference = 3CB8D87C27962FDA00BA4D5D /* iOSTVCastingAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		3CB8D88627962FDB00BA4D5D /* iOSTVCastingAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3CB8D89627962FDB00BA4D5D /* Build configuration list for PBXNativeTarget "iOSTVCastingAppUITests" */;
+			buildPhases = (
+				3CB8D88327962FDB00BA4D5D /* Sources */,
+				3CB8D88427962FDB00BA4D5D /* Frameworks */,
+				3CB8D88527962FDB00BA4D5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3CB8D88927962FDB00BA4D5D /* PBXTargetDependency */,
+			);
+			name = iOSTVCastingAppUITests;
+			productName = iOSTVCastingAppUITests;
+			productReference = 3CB8D88727962FDB00BA4D5D /* iOSTVCastingAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3CB8D85927962FD100BA4D5D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					3CB8D86027962FD100BA4D5D = {
+						CreatedOnToolsVersion = 12.4;
+					};
+					3CB8D87B27962FDA00BA4D5D = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = 3CB8D86027962FD100BA4D5D;
+					};
+					3CB8D88627962FDB00BA4D5D = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = 3CB8D86027962FD100BA4D5D;
+					};
+				};
+			};
+			buildConfigurationList = 3CB8D85C27962FD100BA4D5D /* Build configuration list for PBXProject "iOSTVCastingApp" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3CB8D85827962FD100BA4D5D;
+			productRefGroup = 3CB8D86227962FD100BA4D5D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3CB8D86027962FD100BA4D5D /* iOSTVCastingApp */,
+				3CB8D87B27962FDA00BA4D5D /* iOSTVCastingAppTests */,
+				3CB8D88627962FDB00BA4D5D /* iOSTVCastingAppUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3CB8D85F27962FD100BA4D5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D87427962FDA00BA4D5D /* LaunchScreen.storyboard in Resources */,
+				3CB8D87127962FDA00BA4D5D /* Assets.xcassets in Resources */,
+				3CB8D86F27962FD100BA4D5D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D87A27962FDA00BA4D5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D88527962FDB00BA4D5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3CB8D85D27962FD100BA4D5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D86C27962FD100BA4D5D /* ViewController.m in Sources */,
+				3CB8D86627962FD100BA4D5D /* AppDelegate.m in Sources */,
+				3CB8D87727962FDA00BA4D5D /* main.m in Sources */,
+				3CB8D86927962FD100BA4D5D /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D87827962FDA00BA4D5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D88127962FDA00BA4D5D /* iOSTVCastingAppTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3CB8D88327962FDB00BA4D5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CB8D88C27962FDB00BA4D5D /* iOSTVCastingAppUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3CB8D87E27962FDA00BA4D5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CB8D86027962FD100BA4D5D /* iOSTVCastingApp */;
+			targetProxy = 3CB8D87D27962FDA00BA4D5D /* PBXContainerItemProxy */;
+		};
+		3CB8D88927962FDB00BA4D5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3CB8D86027962FD100BA4D5D /* iOSTVCastingApp */;
+			targetProxy = 3CB8D88827962FDB00BA4D5D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		3CB8D86D27962FD100BA4D5D /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3CB8D86E27962FD100BA4D5D /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3CB8D87227962FDA00BA4D5D /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3CB8D87327962FDA00BA4D5D /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		3CB8D88E27962FDB00BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		3CB8D88F27962FDB00BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3CB8D89127962FDB00BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = iOSTVCastingApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.iOSTVCastingApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3CB8D89227962FDB00BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = iOSTVCastingApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.iOSTVCastingApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3CB8D89427962FDB00BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = iOSTVCastingAppTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.iOSTVCastingAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSTVCastingApp.app/iOSTVCastingApp";
+			};
+			name = Debug;
+		};
+		3CB8D89527962FDB00BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = iOSTVCastingAppTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.iOSTVCastingAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSTVCastingApp.app/iOSTVCastingApp";
+			};
+			name = Release;
+		};
+		3CB8D89727962FDB00BA4D5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = iOSTVCastingAppUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.iOSTVCastingAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iOSTVCastingApp;
+			};
+			name = Debug;
+		};
+		3CB8D89827962FDB00BA4D5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = iOSTVCastingAppUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = darwin.iOSTVCastingAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iOSTVCastingApp;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3CB8D85C27962FD100BA4D5D /* Build configuration list for PBXProject "iOSTVCastingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D88E27962FDB00BA4D5D /* Debug */,
+				3CB8D88F27962FDB00BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3CB8D89027962FDB00BA4D5D /* Build configuration list for PBXNativeTarget "iOSTVCastingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D89127962FDB00BA4D5D /* Debug */,
+				3CB8D89227962FDB00BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3CB8D89327962FDB00BA4D5D /* Build configuration list for PBXNativeTarget "iOSTVCastingAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D89427962FDB00BA4D5D /* Debug */,
+				3CB8D89527962FDB00BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3CB8D89627962FDB00BA4D5D /* Build configuration list for PBXNativeTarget "iOSTVCastingAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3CB8D89727962FDB00BA4D5D /* Debug */,
+				3CB8D89827962FDB00BA4D5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3CB8D85927962FD100BA4D5D /* Project object */;
+}

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/AppDelegate.h
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/AppDelegate.h
@@ -1,0 +1,22 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/AppDelegate.m
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/AppDelegate.m
@@ -1,0 +1,51 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    // Override point for customization after application launch.
+    return YES;
+}
+
+#pragma mark - UISceneSession lifecycle
+
+- (UISceneConfiguration *)application:(UIApplication *)application
+    configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession
+                                   options:(UISceneConnectionOptions *)options
+{
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions
+{
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after
+    // application:didFinishLaunchingWithOptions. Use this method to release any resources that were specific to the discarded
+    // scenes, as they will not return.
+}
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+    "colors": [
+        {
+            "idiom": "universal"
+        }
+    ],
+    "info": {
+        "author": "xcode",
+        "version": 1
+    }
+}

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+    "images": [
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "2x",
+            "size": "60x60"
+        },
+        {
+            "idiom": "iphone",
+            "scale": "3x",
+            "size": "60x60"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "20x20"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "29x29"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "40x40"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "1x",
+            "size": "76x76"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "76x76"
+        },
+        {
+            "idiom": "ipad",
+            "scale": "2x",
+            "size": "83.5x83.5"
+        },
+        {
+            "idiom": "ios-marketing",
+            "scale": "1x",
+            "size": "1024x1024"
+        }
+    ],
+    "info": {
+        "author": "xcode",
+        "version": 1
+    }
+}

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Assets.xcassets/Contents.json
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+    "info": {
+        "author": "xcode",
+        "version": 1
+    }
+}

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Base.lproj/LaunchScreen.storyboard
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Base.lproj/Main.storyboard
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Info.plist
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/SceneDelegate.h
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/SceneDelegate.h
@@ -1,0 +1,24 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow * window;
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/SceneDelegate.m
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/SceneDelegate.m
@@ -1,0 +1,68 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "SceneDelegate.h"
+
+@interface SceneDelegate ()
+
+@end
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see
+    // `application:configurationForConnectingSceneSession` instead).
+}
+
+- (void)sceneDidDisconnect:(UIScene *)scene
+{
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions`
+    // instead).
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene
+{
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene
+{
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene
+{
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+}
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/ViewController.h
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/ViewController.h
@@ -1,0 +1,22 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/ViewController.m
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/ViewController.m
@@ -1,0 +1,32 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/main.m
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingApp/main.m
@@ -1,0 +1,29 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "AppDelegate.h"
+#import <UIKit/UIKit.h>
+
+int main(int argc, char * argv[])
+{
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppTests/Info.plist
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppTests/iOSTVCastingAppTests.m
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppTests/iOSTVCastingAppTests.m
@@ -1,0 +1,50 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@interface iOSTVCastingAppTests : XCTestCase
+
+@end
+
+@implementation iOSTVCastingAppTests
+
+- (void)setUp
+{
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample
+{
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample
+{
+    // This is an example of a performance test case.
+    [self measureBlock:^ {
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppUITests/Info.plist
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppUITests/iOSTVCastingAppUITests.m
+++ b/examples/tv-casting-app/darwin/iOSTVCastingApp/iOSTVCastingAppUITests/iOSTVCastingAppUITests.m
@@ -1,0 +1,63 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@interface iOSTVCastingAppUITests : XCTestCase
+
+@end
+
+@implementation iOSTVCastingAppUITests
+
+- (void)setUp
+{
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    self.continueAfterFailure = NO;
+
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they
+    // run. The setUp method is a good place to do this.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample
+{
+    // UI tests must launch the application that they test.
+    XCUIApplication * app = [[XCUIApplication alloc] init];
+    [app launch];
+
+    // Use recording to get started writing UI tests.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testLaunchPerformance
+{
+    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
+        // This measures how long it takes to launch your application.
+        [self measureWithMetrics:@[ [[XCTApplicationLaunchMetric alloc] init] ]
+                           block:^{
+                               [[[XCUIApplication alloc] init] launch];
+                           }];
+    }
+}
+
+@end


### PR DESCRIPTION
#### Problem
This PR adds the basic directory/build structure for an iOS port of the tv-casting-app.

#### Change overview
Boilerplate files for an iOS app in the examples/tv-casting-app directory

#### Testing
Successfully launched the basic iOS app on the iPhone Simulator.