### PR TITLE
Fix sizing on thread data set

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -29,7 +29,7 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
     if (params.HasThreadOperationalDataset())
     {
         ByteSpan dataset = params.GetThreadOperationalDataset().Value();
-        if (dataset.size() > CommissioningParameters::kMaxCredentialsLen)
+        if (dataset.size() > CommissioningParameters::kMaxThreadDatasetLen)
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }


### PR DESCRIPTION
#### Problem
Thread operational data set size check is incorrect.

#### Change overview
Use correct check on thread operational data set size

#### Testing
Cirque test uses thread.
