### PR TITLE
Fix compilation when a response command argument name-collides with a struct.

### DIFF
--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -171,7 +171,7 @@ bool emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Call
     GET_CLUSTER_RESPONSE_CALLBACKS("{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback");
 
     Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback> * cb = Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext{{#chip_cluster_response_arguments}}, {{#if isArray}}{{asSymbol label}}{{else}}{{#if_is_struct type}}{{asUnderlyingZclType type}}(){{else}}{{asSymbol label}}{{/if_is_struct}}{{/if}}{{/chip_cluster_response_arguments}});
+    cb->mCall(cb->mContext{{#chip_cluster_response_arguments}}, {{#if isArray}}{{asSymbol label}}{{else}}{{#if_is_struct type}}::{{asUnderlyingZclType type}}(){{else}}{{asSymbol label}}{{/if_is_struct}}{{/if}}{{/chip_cluster_response_arguments}});
     return true;
 }
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -2331,7 +2331,7 @@ bool emberAfChannelClusterChangeChannelResponseCallback(
 
     Callback::Callback<ChannelClusterChangeChannelResponseCallback> * cb =
         Callback::Callback<ChannelClusterChangeChannelResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, ChannelInfo(), errorType);
+    cb->mCall(cb->mContext, ::ChannelInfo(), errorType);
     return true;
 }
 
@@ -2498,7 +2498,7 @@ bool emberAfGroupKeyManagementClusterKeySetReadResponseCallback(
 
     Callback::Callback<GroupKeyManagementClusterKeySetReadResponseCallback> * cb =
         Callback::Callback<GroupKeyManagementClusterKeySetReadResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, GroupKeySet());
+    cb->mCall(cb->mContext, ::GroupKeySet());
     return true;
 }
 
@@ -2897,7 +2897,7 @@ bool emberAfTestClusterClusterSimpleStructResponseCallback(
 
     Callback::Callback<TestClusterClusterSimpleStructResponseCallback> * cb =
         Callback::Callback<TestClusterClusterSimpleStructResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, SimpleStruct());
+    cb->mCall(cb->mContext, ::SimpleStruct());
     return true;
 }
 


### PR DESCRIPTION
#### Problem
Code fails to compile in some cases.

#### Change overview
Explicitly say I we want the global-scope names so the right types are found.

#### Testing
Should not have behavior changes.