### PR TITLE
Fix src/lib/support/StateMachine pattern matching

### DIFF
--- a/src/lib/support/StateMachine.h
+++ b/src/lib/support/StateMachine.h
@@ -48,19 +48,21 @@ struct VariantState : Variant<Ts...>
 
 private:
     template <typename T>
-    void Enter()
+    void Enter(bool & ever)
     {
-        if (chip::Variant<Ts...>::template Is<T>())
+        if (!ever && chip::Variant<Ts...>::template Is<T>())
         {
+            ever = true;
             chip::Variant<Ts...>::template Get<T>().Enter();
         }
     }
 
     template <typename T>
-    void Exit()
+    void Exit(bool & ever)
     {
-        if (chip::Variant<Ts...>::template Is<T>())
+        if (!ever && chip::Variant<Ts...>::template Is<T>())
         {
+            ever = true;
             chip::Variant<Ts...>::template Get<T>().Exit();
         }
     }
@@ -68,17 +70,18 @@ private:
     template <typename T>
     void GetName(const char ** name)
     {
-        if (name && chip::Variant<Ts...>::template Is<T>())
+        if (name && !*name && chip::Variant<Ts...>::template Is<T>())
         {
             *name = chip::Variant<Ts...>::template Get<T>().GetName();
         }
     }
 
     template <typename T>
-    void LogTransition(const char * previous)
+    void LogTransition(bool & ever, const char * previous)
     {
-        if (chip::Variant<Ts...>::template Is<T>())
+        if (!ever && chip::Variant<Ts...>::template Is<T>())
         {
+            ever = true;
             chip::Variant<Ts...>::template Get<T>().LogTransition(previous);
         }
     }
@@ -94,12 +97,14 @@ public:
 
     void Enter()
     {
-        [](...) {}((this->template Enter<Ts>(), 0)...);
+        bool ever = false;
+        [](...) {}((this->template Enter<Ts>(ever), 0)...);
     }
 
     void Exit()
     {
-        [](...) {}((this->template Exit<Ts>(), 0)...);
+        bool ever = false;
+        [](...) {}((this->template Exit<Ts>(ever), 0)...);
     }
 
     const char * GetName()
@@ -111,7 +116,8 @@ public:
 
     void LogTransition(const char * previous)
     {
-        [](...) {}((this->template LogTransition<Ts>(previous), 0)...);
+        bool ever = false;
+        [](...) {}((this->template LogTransition<Ts>(ever, previous), 0)...);
     }
 };
 
@@ -215,10 +221,10 @@ public:
         auto newState = mTransitions(mCurrentState, evt);
         if (newState.HasValue())
         {
-            auto oldState = mCurrentState;
-            oldState.Exit();
+            auto oldState = mCurrentState.GetName();
+            mCurrentState.Exit();
             mCurrentState = newState.Value();
-            mCurrentState.LogTransition(oldState.GetName());
+            mCurrentState.LogTransition(oldState);
             // It is impermissible to dispatch events from Exit() or
             // LogTransition(), or from the transitions table when a transition
             // has also been returned.  Verify that this hasn't occurred.


### PR DESCRIPTION
#### Problem

The variant state Enter method can rewrite state objects during pattern matching traversal if Dispatch is called and a state transition occurs.  We therefore need to ensure that the Enter method pattern matching can only evaluate true once.  Without a check for this, the pattern matching may continue accessing the state object after its destructor has been called.

#### Change overview
 
Add a one-shot bool to ensure that Enter is only executed once.  And although state changes from Exit, LogTransition and GetName aren't expected, checks are added for these too.  In all cases, the pattern match should only execute once.

#### Testing

A new unit test has been added to check for the bug that is fixed by this PR.