### PR TITLE
Add event definitions in Access Control Cluster xml 

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -13,6 +13,12 @@ server cluster AccessControl = 31 {
     kGroup = 3;
   }
 
+  enum ChangeTypeEnum : ENUM8 {
+    kChanged = 0;
+    kAdded = 1;
+    kRemoved = 2;
+  }
+
   enum Privilege : ENUM8 {
     kView = 1;
     kProxyView = 2;
@@ -38,6 +44,22 @@ server cluster AccessControl = 31 {
   struct ExtensionEntry {
     fabric_idx fabricIndex = 0;
     OCTET_STRING data = 1;
+  }
+
+  info event AccessControlEntryChanged = 0 {
+    fabric_idx adminFabricIndex = 0;
+    node_id adminNodeID = 1;
+    INT16U adminPasscodeID = 2;
+    ChangeTypeEnum changeType = 3;
+    AccessControlEntry latestValue = 4;
+  }
+
+  info event AccessControlExtensionChanged = 1 {
+    fabric_idx adminFabricIndex = 0;
+    node_id adminNodeID = 1;
+    INT16U adminPasscodeID = 2;
+    ChangeTypeEnum changeType = 3;
+    ExtensionEntry latestValue = 4;
   }
 
   attribute(writable) AccessControlEntry acl[] = 0;

--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -33,6 +33,13 @@ limitations under the License.
     <item name="Group" value="0x03"/>
   </enum>
 
+  <enum name="ChangeTypeEnum" type="ENUM8">
+    <cluster code="0x001F"/>
+    <item name="Changed" value="0x00"/>
+    <item name="Added" value="0x01"/>
+    <item name="Removed" value="0x02"/>
+  </enum>  
+
   <struct name="Target">
     <cluster code="0x001F"/>
     <item fieldId="0" name="Cluster" type="cluster_id" isNullable="true"/>
@@ -79,5 +86,21 @@ limitations under the License.
         <access op="write" privilege="administer"/>        
         <access modifier="fabric-scoped"/>
     </attribute>
+    <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" optional="false">
+      <description>The cluster SHALL send AccessControlEntryChanged events whenever its ACL attribute data is changed by an Administrator.</description>
+      <field id="0" name="AdminFabricIndex" type="fabric_idx"/>
+      <field id="1" name="AdminNodeID" type="node_id"/>
+      <field id="2" name="AdminPasscodeID" type="INT16U"/>
+      <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
+      <field id="4" name="LatestValue" type="AccessControlEntry"/>
+    </event>
+    <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" optional="false">
+      <description>The cluster SHALL send AccessControlExtensionChanged events whenever its extension attribute data is changed by an Administrator.</description>
+      <field id="0" name="AdminFabricIndex" type="fabric_idx"/>
+      <field id="1" name="AdminNodeID" type="node_id"/>
+      <field id="2" name="AdminPasscodeID" type="INT16U"/>
+      <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
+      <field id="4" name="LatestValue" type="ExtensionEntry"/>
+    </event>    
   </cluster>
 </configurator>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -13,6 +13,12 @@ client cluster AccessControl = 31 {
     kGroup = 3;
   }
 
+  enum ChangeTypeEnum : ENUM8 {
+    kChanged = 0;
+    kAdded = 1;
+    kRemoved = 2;
+  }
+
   enum Privilege : ENUM8 {
     kView = 1;
     kProxyView = 2;
@@ -38,6 +44,22 @@ client cluster AccessControl = 31 {
   struct ExtensionEntry {
     fabric_idx fabricIndex = 0;
     OCTET_STRING data = 1;
+  }
+
+  info event AccessControlEntryChanged = 0 {
+    fabric_idx adminFabricIndex = 0;
+    node_id adminNodeID = 1;
+    INT16U adminPasscodeID = 2;
+    ChangeTypeEnum changeType = 3;
+    AccessControlEntry latestValue = 4;
+  }
+
+  info event AccessControlExtensionChanged = 1 {
+    fabric_idx adminFabricIndex = 0;
+    node_id adminNodeID = 1;
+    INT16U adminPasscodeID = 2;
+    ChangeTypeEnum changeType = 3;
+    ExtensionEntry latestValue = 4;
   }
 
   attribute(writable) AccessControlEntry acl[] = 0;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -5135,6 +5135,11 @@ class AccessControl(Cluster):
             kCase = 0x02
             kGroup = 0x03
 
+        class ChangeTypeEnum(IntEnum):
+            kChanged = 0x00
+            kAdded = 0x01
+            kRemoved = 0x02
+
         class Privilege(IntEnum):
             kView = 0x01
             kProxyView = 0x02
@@ -5275,6 +5280,61 @@ class AccessControl(Cluster):
 
             value: 'uint' = 0
 
+
+    class Events:
+        @dataclass
+        class AccessControlEntryChanged(ClusterEvent):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x001F
+
+            @ChipUtility.classproperty
+            def event_id(cls) -> int:
+                return 0x00000000
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields = [
+                            ClusterObjectFieldDescriptor(Label="adminFabricIndex", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="adminNodeID", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="changeType", Tag=3, Type=AccessControl.Enums.ChangeTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=AccessControl.Structs.AccessControlEntry),
+                    ])
+
+            adminFabricIndex: 'uint' = 0
+            adminNodeID: 'uint' = 0
+            adminPasscodeID: 'uint' = 0
+            changeType: 'AccessControl.Enums.ChangeTypeEnum' = 0
+            latestValue: 'AccessControl.Structs.AccessControlEntry' = field(default_factory=lambda: AccessControl.Structs.AccessControlEntry())
+
+        @dataclass
+        class AccessControlExtensionChanged(ClusterEvent):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x001F
+
+            @ChipUtility.classproperty
+            def event_id(cls) -> int:
+                return 0x00000001
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields = [
+                            ClusterObjectFieldDescriptor(Label="adminFabricIndex", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="adminNodeID", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="changeType", Tag=3, Type=AccessControl.Enums.ChangeTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=AccessControl.Structs.ExtensionEntry),
+                    ])
+
+            adminFabricIndex: 'uint' = 0
+            adminNodeID: 'uint' = 0
+            adminPasscodeID: 'uint' = 0
+            changeType: 'AccessControl.Enums.ChangeTypeEnum' = 0
+            latestValue: 'AccessControl.Structs.ExtensionEntry' = field(default_factory=lambda: AccessControl.Structs.ExtensionEntry())
 
 
 @dataclass

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -6724,6 +6724,58 @@ void CHIPNullableAccessControlClusterAuthModeAttributeCallbackSubscriptionBridge
     }
 }
 
+void CHIPAccessControlClusterChangeTypeEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::AccessControl::ChangeTypeEnum value)
+{
+    NSNumber * _Nonnull objCValue;
+    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+{
+    auto * self = static_cast<CHIPAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
+void CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::AccessControl::ChangeTypeEnum> & value)
+{
+    NSNumber * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
+    }
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+{
+    auto * self = static_cast<CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
 void CHIPAccessControlClusterPrivilegeAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::AccessControl::Privilege value)
 {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -165,6 +165,9 @@ typedef void (*NullableApplianceControlClusterWarningEventAttributeCallback)(
 typedef void (*AccessControlClusterAuthModeAttributeCallback)(void *, chip::app::Clusters::AccessControl::AuthMode);
 typedef void (*NullableAccessControlClusterAuthModeAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::AccessControl::AuthMode> &);
+typedef void (*AccessControlClusterChangeTypeEnumAttributeCallback)(void *, chip::app::Clusters::AccessControl::ChangeTypeEnum);
+typedef void (*NullableAccessControlClusterChangeTypeEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::AccessControl::ChangeTypeEnum> &);
 typedef void (*AccessControlClusterPrivilegeAttributeCallback)(void *, chip::app::Clusters::AccessControl::Privilege);
 typedef void (*NullableAccessControlClusterPrivilegeAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::AccessControl::Privilege> &);
@@ -5394,6 +5397,64 @@ public:
                                                                                 CHIPActionBlock action,
                                                                                 SubscriptionEstablishedHandler establishedHandler) :
         CHIPNullableAccessControlClusterAuthModeAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPAccessControlClusterChangeTypeEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<AccessControlClusterChangeTypeEnumAttributeCallback>
+{
+public:
+    CHIPAccessControlClusterChangeTypeEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                  CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<AccessControlClusterChangeTypeEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+
+    static void OnSuccessFn(void * context, chip::app::Clusters::AccessControl::ChangeTypeEnum value);
+};
+
+class CHIPAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge
+    : public CHIPAccessControlClusterChangeTypeEnumAttributeCallbackBridge
+{
+public:
+    CHIPAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                              CHIPActionBlock action,
+                                                                              SubscriptionEstablishedHandler establishedHandler) :
+        CHIPAccessControlClusterChangeTypeEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableAccessControlClusterChangeTypeEnumAttributeCallback>
+{
+public:
+    CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                          CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<NullableAccessControlClusterChangeTypeEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                        keepAlive){};
+
+    static void OnSuccessFn(void * context,
+                            const chip::app::DataModel::Nullable<chip::app::Clusters::AccessControl::ChangeTypeEnum> & value);
+};
+
+class CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge
+{
+public:
+    CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableAccessControlClusterChangeTypeEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -4635,6 +4635,106 @@ CHIP_ERROR TypeInfo::DecodableType::Decode(TLV::TLVReader & reader, const Concre
 } // namespace Attributes
 
 namespace Events {
+namespace AccessControlEntryChanged {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminFabricIndex)), adminFabricIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminNodeID)), adminNodeID));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminPasscodeID)), adminPasscodeID));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kChangeType)), changeType));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLatestValue)), latestValue));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kAdminFabricIndex):
+            ReturnErrorOnFailure(DataModel::Decode(reader, adminFabricIndex));
+            break;
+        case to_underlying(Fields::kAdminNodeID):
+            ReturnErrorOnFailure(DataModel::Decode(reader, adminNodeID));
+            break;
+        case to_underlying(Fields::kAdminPasscodeID):
+            ReturnErrorOnFailure(DataModel::Decode(reader, adminPasscodeID));
+            break;
+        case to_underlying(Fields::kChangeType):
+            ReturnErrorOnFailure(DataModel::Decode(reader, changeType));
+            break;
+        case to_underlying(Fields::kLatestValue):
+            ReturnErrorOnFailure(DataModel::Decode(reader, latestValue));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace AccessControlEntryChanged.
+namespace AccessControlExtensionChanged {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminFabricIndex)), adminFabricIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminNodeID)), adminNodeID));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminPasscodeID)), adminPasscodeID));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kChangeType)), changeType));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLatestValue)), latestValue));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kAdminFabricIndex):
+            ReturnErrorOnFailure(DataModel::Decode(reader, adminFabricIndex));
+            break;
+        case to_underlying(Fields::kAdminNodeID):
+            ReturnErrorOnFailure(DataModel::Decode(reader, adminNodeID));
+            break;
+        case to_underlying(Fields::kAdminPasscodeID):
+            ReturnErrorOnFailure(DataModel::Decode(reader, adminPasscodeID));
+            break;
+        case to_underlying(Fields::kChangeType):
+            ReturnErrorOnFailure(DataModel::Decode(reader, changeType));
+            break;
+        case to_underlying(Fields::kLatestValue):
+            ReturnErrorOnFailure(DataModel::Decode(reader, latestValue));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace AccessControlExtensionChanged.
 } // namespace Events
 
 } // namespace AccessControl

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -6402,6 +6402,13 @@ enum class AuthMode : uint8_t
     kCase  = 0x02,
     kGroup = 0x03,
 };
+// Enum for ChangeTypeEnum
+enum class ChangeTypeEnum : uint8_t
+{
+    kChanged = 0x00,
+    kAdded   = 0x01,
+    kRemoved = 0x02,
+};
 // Enum for Privilege
 enum class Privilege : uint8_t
 {
@@ -6576,6 +6583,98 @@ struct TypeInfo
     };
 };
 } // namespace Attributes
+namespace Events {
+namespace AccessControlEntryChanged {
+static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
+static constexpr EventId kEventId             = 0x00000000;
+
+enum class Fields
+{
+    kAdminFabricIndex = 0,
+    kAdminNodeID      = 1,
+    kAdminPasscodeID  = 2,
+    kChangeType       = 3,
+    kLatestValue      = 4,
+};
+
+struct Type
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
+
+    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
+    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
+    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
+    Structs::AccessControlEntry::Type latestValue;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+};
+
+struct DecodableType
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
+
+    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
+    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
+    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
+    Structs::AccessControlEntry::DecodableType latestValue;
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+} // namespace AccessControlEntryChanged
+namespace AccessControlExtensionChanged {
+static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
+static constexpr EventId kEventId             = 0x00000001;
+
+enum class Fields
+{
+    kAdminFabricIndex = 0,
+    kAdminNodeID      = 1,
+    kAdminPasscodeID  = 2,
+    kChangeType       = 3,
+    kLatestValue      = 4,
+};
+
+struct Type
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
+
+    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
+    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
+    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
+    Structs::ExtensionEntry::Type latestValue;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+};
+
+struct DecodableType
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
+
+    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
+    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
+    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
+    Structs::ExtensionEntry::DecodableType latestValue;
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+} // namespace AccessControlExtensionChanged
+} // namespace Events
 } // namespace AccessControl
 namespace PollControl {
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -149,6 +149,10 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
                     const chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType & value);
 
 CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
                     chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType value);
 CHIP_ERROR LogValue(const char * label, size_t indent,
                     chip::app::Clusters::BridgedActions::Events::ActionFailed::DecodableType value);
@@ -2544,6 +2548,104 @@ CHIP_ERROR LogValue(const char * label, size_t indent,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("AdminFabricIndex", indent + 1, value.adminFabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AdminFabricIndex'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("AdminNodeID", indent + 1, value.adminNodeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AdminNodeID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("AdminPasscodeID", indent + 1, value.adminPasscodeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AdminPasscodeID'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ChangeType", indent + 1, value.changeType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ChangeType'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LatestValue", indent + 1, value.latestValue);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'LatestValue'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("AdminFabricIndex", indent + 1, value.adminFabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AdminFabricIndex'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("AdminNodeID", indent + 1, value.adminNodeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AdminNodeID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("AdminPasscodeID", indent + 1, value.adminPasscodeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'AdminPasscodeID'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ChangeType", indent + 1, value.changeType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'ChangeType'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LatestValue", indent + 1, value.latestValue);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sEvent truncated due to invalid value for 'LatestValue'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
                     chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType value)
 {
     ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
@@ -4516,7 +4618,156 @@ static void OnThermostatGetWeeklyScheduleResponseSuccess(
 | * ClusterRevision                                                   | 0xFFFD |
 |------------------------------------------------------------------------------|
 | Events:                                                             |        |
+| * AccessControlEntryChanged                                         | 0x0000 |
+| * AccessControlExtensionChanged                                     | 0x0001 |
 \*----------------------------------------------------------------------------*/
+
+/*
+ * Event AccessControlEntryChanged
+ */
+class ReadAccessControlAccessControlEntryChanged : public ModelCommand
+{
+public:
+    ReadAccessControlAccessControlEntryChanged() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "access-control-entry-changed");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadAccessControlAccessControlEntryChanged() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::AccessControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "AccessControl.AccessControlEntryChanged response", value);
+    }
+};
+
+class ReportAccessControlAccessControlEntryChanged : public ModelCommand
+{
+public:
+    ReportAccessControlAccessControlEntryChanged() : ModelCommand("report-event")
+    {
+        AddArgument("event-name", "access-control-entry-changed");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("wait", 0, 1, &mWait);
+        ModelCommand::AddArguments();
+    }
+
+    ~ReportAccessControlAccessControlEntryChanged() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReportEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::AccessControlCluster cluster;
+        cluster.Associate(device, endpointId);
+
+        auto subscriptionEstablishedCallback = mWait ? OnDefaultSuccessResponseWithoutExit : OnDefaultSuccessResponse;
+        return cluster.SubscribeEvent<chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType>(
+            this, OnValueReport, OnDefaultFailure, mMinInterval, mMaxInterval, subscriptionEstablishedCallback);
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
+    }
+
+    static void OnValueReport(void * context,
+                              chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType value)
+    {
+        LogValue("AccessControl.AccessControlEntryChanged report", 0, value);
+    }
+
+private:
+    uint16_t mMinInterval;
+    uint16_t mMaxInterval;
+    bool mWait;
+};
+/*
+ * Event AccessControlExtensionChanged
+ */
+class ReadAccessControlAccessControlExtensionChanged : public ModelCommand
+{
+public:
+    ReadAccessControlAccessControlExtensionChanged() : ModelCommand("read-event")
+    {
+        AddArgument("event-name", "access-control-extension-changed");
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadAccessControlAccessControlExtensionChanged() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReadEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::AccessControlCluster cluster;
+        cluster.Associate(device, endpointId);
+        return cluster.ReadEvent<chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType>(
+            this, OnEventResponse, OnDefaultFailure);
+    }
+
+    static void OnEventResponse(void * context,
+                                chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType value)
+    {
+        OnGeneralAttributeEventResponse(context, "AccessControl.AccessControlExtensionChanged response", value);
+    }
+};
+
+class ReportAccessControlAccessControlExtensionChanged : public ModelCommand
+{
+public:
+    ReportAccessControlAccessControlExtensionChanged() : ModelCommand("report-event")
+    {
+        AddArgument("event-name", "access-control-extension-changed");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("wait", 0, 1, &mWait);
+        ModelCommand::AddArguments();
+    }
+
+    ~ReportAccessControlAccessControlExtensionChanged() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x001F) ReportEvent on endpoint %" PRIu8, endpointId);
+
+        chip::Controller::AccessControlCluster cluster;
+        cluster.Associate(device, endpointId);
+
+        auto subscriptionEstablishedCallback = mWait ? OnDefaultSuccessResponseWithoutExit : OnDefaultSuccessResponse;
+        return cluster.SubscribeEvent<chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType>(
+            this, OnValueReport, OnDefaultFailure, mMinInterval, mMaxInterval, subscriptionEstablishedCallback);
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
+    }
+
+    static void OnValueReport(void * context,
+                              chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType value)
+    {
+        LogValue("AccessControl.AccessControlExtensionChanged report", 0, value);
+    }
+
+private:
+    uint16_t mMinInterval;
+    uint16_t mMaxInterval;
+    bool mWait;
+};
 
 /*
  * Attribute Acl
@@ -59892,11 +60143,15 @@ void registerClusterAccessControl(Commands & commands)
     const char * clusterName = "AccessControl";
 
     commands_list clusterCommands = {
-        make_unique<ReadAccessControlAcl>(),               //
-        make_unique<ReadAccessControlExtension>(),         //
-        make_unique<ReadAccessControlAttributeList>(),     //
-        make_unique<ReadAccessControlClusterRevision>(),   //
-        make_unique<ReportAccessControlClusterRevision>(), //
+        make_unique<ReadAccessControlAcl>(),                             //
+        make_unique<ReadAccessControlExtension>(),                       //
+        make_unique<ReadAccessControlAttributeList>(),                   //
+        make_unique<ReadAccessControlClusterRevision>(),                 //
+        make_unique<ReportAccessControlClusterRevision>(),               //
+        make_unique<ReadAccessControlAccessControlEntryChanged>(),       //
+        make_unique<ReportAccessControlAccessControlEntryChanged>(),     //
+        make_unique<ReadAccessControlAccessControlExtensionChanged>(),   //
+        make_unique<ReportAccessControlAccessControlExtensionChanged>(), //
     };
 
     commands.Register(clusterName, clusterCommands);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Missing event definition in Access Control Cluster 


#### Change overview
Add event definitions in Access Control Cluster xml.
Work towards issue #10255.

#### Testing
How was this tested? (at least one bullet point required)
* Only xml updated, regression is covered by CI
