### PR TITLE
TestCluster: Add attribute resets during Test cmd.

### DIFF
--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -411,6 +411,43 @@ CHIP_ERROR TestAttrAccess::WriteStructAttribute(AttributeValueDecoder & aDecoder
 bool emberAfTestClusterClusterTestCallback(app::CommandHandler *, const app::ConcreteCommandPath & commandPath,
                                            const Test::DecodableType & commandData)
 {
+    // Setup the test variables
+    emAfLoadAttributeDefaults(commandPath.mEndpointId, true, MakeOptional(commandPath.mClusterId));
+    for (int i = 0; i < kAttributeListLength; ++i)
+    {
+        gListUint8Data[i] = 0;
+        gListOctetStringData[i].SetLength(0);
+        gListOperationalCert[i].SetLength(0);
+        listStructOctetStringData[i].fabricIndex     = 0;
+        listStructOctetStringData[i].operationalCert = ByteSpan();
+        gSimpleEnums[i]                              = SimpleEnum::kUnspecified;
+    }
+    gSimpleEnumCount = 0;
+
+    gStructAttributeValue.a = 0;
+    gStructAttributeValue.b = false;
+    gStructAttributeValue.c = SimpleEnum::kValueA;
+    gStructAttributeValue.d = ByteSpan();
+    gStructAttributeValue.e = CharSpan();
+    gStructAttributeValue.f = BitFlags<SimpleBitmap>();
+    gStructAttributeValue.g = 0;
+    gStructAttributeValue.h = 0;
+
+    gNullableStructAttributeValue.SetNull();
+
+    gNullablesAndOptionalsStruct.nullableInt.SetNull();
+    gNullablesAndOptionalsStruct.optionalInt         = NullOptional;
+    gNullablesAndOptionalsStruct.nullableOptionalInt = NullOptional;
+    gNullablesAndOptionalsStruct.nullableString.SetNull();
+    gNullablesAndOptionalsStruct.optionalString         = NullOptional;
+    gNullablesAndOptionalsStruct.nullableOptionalString = NullOptional;
+    gNullablesAndOptionalsStruct.nullableStruct.SetNull();
+    gNullablesAndOptionalsStruct.optionalStruct         = NullOptional;
+    gNullablesAndOptionalsStruct.nullableOptionalStruct = NullOptional;
+    gNullablesAndOptionalsStruct.nullableList.SetNull();
+    gNullablesAndOptionalsStruct.optionalList         = NullOptional;
+    gNullablesAndOptionalsStruct.nullableOptionalList = NullOptional;
+
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1111,7 +1111,7 @@ void emberAfResetAttributes(EndpointId endpoint)
     emAfLoadAttributeDefaults(endpoint, true);
 }
 
-void emAfLoadAttributeDefaults(EndpointId endpoint, bool ignoreStorage)
+void emAfLoadAttributeDefaults(EndpointId endpoint, bool ignoreStorage, Optional<ClusterId> clusterId)
 {
     uint16_t ep;
     uint8_t clusterI, curNetwork = 0 /* emberGetCurrentNetwork() */;
@@ -1142,6 +1142,13 @@ void emAfLoadAttributeDefaults(EndpointId endpoint, bool ignoreStorage)
         for (clusterI = 0; clusterI < de->endpointType->clusterCount; clusterI++)
         {
             EmberAfCluster * cluster = &(de->endpointType->cluster[clusterI]);
+            if (clusterId.HasValue())
+            {
+                if (clusterId.Value() != cluster->clusterId)
+                {
+                    continue;
+                }
+            }
 
             // when the attributeCount is high, the loop takes too long to run and a
             // watchdog kicks in causing a reset. As a workaround, we'll

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -197,7 +197,7 @@ void emberAfResetAttributes(chip::EndpointId endpoint);
 // Loads the attributes from built-in default and / or storage.  If
 // ignoreStorage is true, only defaults will be read, and the storage for
 // non-volatile attributes will be overwritten with those defaults.
-void emAfLoadAttributeDefaults(chip::EndpointId endpoint, bool ignoreStorage);
+void emAfLoadAttributeDefaults(chip::EndpointId endpoint, bool ignoreStorage, chip::Optional<chip::ClusterId> = chip::NullOptional);
 
 // After the RAM value has changed, code should call this function. If this
 // attribute has been tagged as non-volatile, its value will be stored.


### PR DESCRIPTION
#### Problem
The test assumes that we start with the default values, which means
the test will fail the second time around. This fixes that.
Fixes #13434
Fixes #13435

#### Change overview
Adds an attribute reset to the Test command that is run at the start of the test.

#### Testing
Ran TestCluster tests using chip-tool 2x on linux and M5.
