### PR TITLE
Fix pairing via the SetupCodePairer

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1628,7 +1628,6 @@ void DeviceCommissioner::OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & 
 
     if (mDeviceBeingCommissioned != nullptr && mDeviceBeingCommissioned->GetDeviceId() == nodeData.mPeerId.GetNodeId())
     {
-        RendezvousCleanup(CHIP_NO_ERROR);
         // Let's release the device that's being paired, if pairing was successful,
         // and the device is available on the operational network.
         ReleaseCommissioneeDevice(mDeviceBeingCommissioned);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverSoftAP()
 
 void SetUpCodePairer::OnDeviceDiscovered(RendezvousParameters & params)
 {
-    LogErrorOnFailure(mCommissioner->pairDevice(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
+    LogErrorOnFailure(mCommissioner->PairDevice(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
 }
 
 #if CONFIG_NETWORK_LAYER_BLE

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverSoftAP()
 
 void SetUpCodePairer::OnDeviceDiscovered(RendezvousParameters & params)
 {
-    LogErrorOnFailure(mCommissioner->EstablishPASEConnection(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
+    LogErrorOnFailure(mCommissioner->pairDevice(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
 }
 
 #if CONFIG_NETWORK_LAYER_BLE
@@ -146,7 +146,7 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
 
     Transport::PeerAddress peerAddress = Transport::PeerAddress::BLE();
     RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress).SetConnectionObject(connObj);
-    OnDeviceDiscovered(params);
+    LogErrorOnFailure(mCommissioner->EstablishPASEConnection(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
 }
 
 void SetUpCodePairer::OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -146,6 +146,8 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
 
     Transport::PeerAddress peerAddress = Transport::PeerAddress::BLE();
     RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress).SetConnectionObject(connObj);
+    // We don't have network credentials, so can't do the entire pairing flow.  Just establish a PASE session to the
+    //  device and let our consumer deal with the rest.
     LogErrorOnFailure(mCommissioner->EstablishPASEConnection(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
 }
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverSoftAP()
 
 void SetUpCodePairer::OnDeviceDiscovered(RendezvousParameters & params)
 {
-    LogErrorOnFailure(mCommissioner->PairDevice(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
+    LogErrorOnFailure(mCommissioner->EstablishPASEConnection(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
 }
 
 #if CONFIG_NETWORK_LAYER_BLE

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -637,7 +637,7 @@
 - (void)commissionWithSSID:(NSString *)ssid password:(NSString *)password
 {
 
-    NSError *error;
+    NSError * error;
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     // create commissioning params in ObjC. Pass those in here with network credentials.
     // maybe this just becomes the new norm
@@ -647,8 +647,7 @@
 
     uint64_t deviceId = CHIPGetNextAvailableDeviceID() - 1;
 
-    if (![controller commissionDevice:deviceId commissioningParams:params error:&error])
-    {
+    if (![controller commissionDevice:deviceId commissioningParams:params error:&error]) {
         NSLog(@"Failed to commission Device %llu, with error %@", deviceId, error);
     }
 }

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -68,7 +68,9 @@
 		998F286D26D55E10001846C6 /* CHIPKeypair.h in Headers */ = {isa = PBXBuildFile; fileRef = 998F286C26D55E10001846C6 /* CHIPKeypair.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		998F286F26D55EC5001846C6 /* CHIPP256KeypairBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 998F286E26D55EC5001846C6 /* CHIPP256KeypairBridge.h */; };
 		998F287126D56940001846C6 /* CHIPP256KeypairBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 998F287026D56940001846C6 /* CHIPP256KeypairBridge.mm */; };
+		99AECC802798A57F00B6355B /* CHIPCommissioningParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 99AECC7F2798A57E00B6355B /* CHIPCommissioningParameters.m */; };
 		99C65E10267282F1003402F6 /* CHIPControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 99C65E0F267282F1003402F6 /* CHIPControllerTests.m */; };
+		99D466E12798936D0089A18F /* CHIPCommissioningParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 99D466E02798936D0089A18F /* CHIPCommissioningParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B20252972459E34F00F97062 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B202528D2459E34F00F97062 /* CHIP.framework */; };
 		B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */ = {isa = PBXBuildFile; fileRef = B289D4202639C0D300D4E314 /* CHIPOnboardingPayloadParser.m */; };
@@ -157,7 +159,9 @@
 		998F286C26D55E10001846C6 /* CHIPKeypair.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPKeypair.h; sourceTree = "<group>"; };
 		998F286E26D55EC5001846C6 /* CHIPP256KeypairBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPP256KeypairBridge.h; sourceTree = "<group>"; };
 		998F287026D56940001846C6 /* CHIPP256KeypairBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPP256KeypairBridge.mm; sourceTree = "<group>"; };
+		99AECC7F2798A57E00B6355B /* CHIPCommissioningParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPCommissioningParameters.m; sourceTree = "<group>"; };
 		99C65E0F267282F1003402F6 /* CHIPControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPControllerTests.m; sourceTree = "<group>"; };
+		99D466E02798936D0089A18F /* CHIPCommissioningParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPCommissioningParameters.h; sourceTree = "<group>"; };
 		B202528D2459E34F00F97062 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20252912459E34F00F97062 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B20252962459E34F00F97062 /* CHIPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CHIPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -285,6 +289,8 @@
 				997DED172695344800975E97 /* CHIPThreadOperationalDataset.h */,
 				2C8C8FBD253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h */,
 				2C8C8FBF253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm */,
+				99D466E02798936D0089A18F /* CHIPCommissioningParameters.h */,
+				99AECC7F2798A57E00B6355B /* CHIPCommissioningParameters.m */,
 				2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */,
 				2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */,
 				2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */,
@@ -345,6 +351,7 @@
 				2CB7163B252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h in Headers */,
 				1E16A90326B98AF100683C53 /* CHIPTestClustersObjc.h in Headers */,
 				2C1B027B2641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h in Headers */,
+				99D466E12798936D0089A18F /* CHIPCommissioningParameters.h in Headers */,
 				B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */,
 				513DDB862761F69300DAA01A /* CHIPAttributeTLVValueDecoder_Internal.h in Headers */,
 				2CB7163F252F731E0026E2BB /* CHIPDevicePairingDelegate.h in Headers */,
@@ -492,6 +499,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C8C8FC2253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.mm in Sources */,
+				99AECC802798A57F00B6355B /* CHIPCommissioningParameters.m in Sources */,
 				2CB7163C252E8A7C0026E2BB /* CHIPDevicePairingDelegateBridge.mm in Sources */,
 				997DED162695343400975E97 /* CHIPThreadOperationalDataset.mm in Sources */,
 				998F287126D56940001846C6 /* CHIPP256KeypairBridge.mm in Sources */,

--- a/src/darwin/Framework/CHIP/CHIP.h
+++ b/src/darwin/Framework/CHIP/CHIP.h
@@ -19,6 +19,7 @@
 #import <CHIP/CHIPCluster.h>
 #import <CHIP/CHIPClustersObjc.h>
 #import <CHIP/CHIPCommandPayloadsObjc.h>
+#import <CHIP/CHIPCommissioningParameters.h>
 #import <CHIP/CHIPDevice.h>
 #import <CHIP/CHIPDeviceController.h>
 #import <CHIP/CHIPDevicePairingDelegate.h>

--- a/src/darwin/Framework/CHIP/CHIPCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/CHIPCommissioningParameters.h
@@ -1,0 +1,51 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The class definition for the CHIPCommissioningParameters
+ *
+ */
+@interface CHIPCommissioningParameters : NSObject
+
+/**
+ *  The CSRNonce
+ */
+@property (nonatomic, nullable, copy, readwrite) NSData * CSRNonce;
+/**
+ *  The AttestationNonce
+ */
+@property (nonatomic, nullable, copy, readwrite) NSData * attestationNonce;
+/**
+ *  The Wi-Fi SSID
+ */
+@property (nonatomic, nullable, copy, readwrite) NSData * wifiSSID;
+/**
+ *  The Wi-Fi Credentials
+ */
+@property (nonatomic, nullable, copy, readwrite) NSData * wifiCredentials;
+/**
+ *  The Thread operational dataset
+ */
+@property (nonatomic, nullable, copy, readwrite) NSData * threadOperationalDataset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPCommissioningParameters.m
+++ b/src/darwin/Framework/CHIP/CHIPCommissioningParameters.m
@@ -1,0 +1,26 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPCommissioningParameters.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation CHIPCommissioningParameters : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -50,7 +50,9 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
              error:(NSError * __autoreleasing *)error;
 
 - (BOOL)pairDevice:(uint64_t)deviceID onboardingPayload:(NSString *)onboardingPayload error:(NSError * __autoreleasing *)error;
-- (BOOL)commissionDevice:(uint64_t)deviceId commissioningParams:(CHIPCommissioningParameters *)commissioningParams error:(NSError * __autoreleasing *)error;
+- (BOOL)commissionDevice:(uint64_t)deviceId
+     commissioningParams:(CHIPCommissioningParameters *)commissioningParams
+                   error:(NSError * __autoreleasing *)error;
 
 - (void)setListenPort:(uint16_t)port;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSError * _Nullable error);
 
+@class CHIPCommissioningParameters;
 @protocol CHIPDevicePairingDelegate;
 @protocol CHIPPersistentStorageDelegate;
 @protocol CHIPKeypair;
@@ -49,6 +50,7 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
              error:(NSError * __autoreleasing *)error;
 
 - (BOOL)pairDevice:(uint64_t)deviceID onboardingPayload:(NSString *)onboardingPayload error:(NSError * __autoreleasing *)error;
+- (BOOL)commissionDevice:(uint64_t)deviceId commissioningParams:(CHIPCommissioningParameters *)commissioningParams error:(NSError * __autoreleasing *)error;
 
 - (void)setListenPort:(uint16_t)port;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -353,7 +353,9 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     return success;
 }
 
-- (BOOL)commissionDevice:(uint64_t)deviceId commissioningParams:(CHIPCommissioningParameters *)commissioningParams error:(NSError * __autoreleasing *)error
+- (BOOL)commissionDevice:(uint64_t)deviceId
+     commissioningParams:(CHIPCommissioningParameters *)commissioningParams
+                   error:(NSError * __autoreleasing *)error
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     __block BOOL success = NO;
@@ -364,22 +366,22 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     dispatch_sync(_chipWorkQueue, ^{
         if ([self isRunning]) {
             chip::Controller::CommissioningParameters params;
-            if (commissioningParams.CSRNonce)
-            {
-                params.SetCSRNonce(chip::ByteSpan ((uint8_t *) commissioningParams.CSRNonce.bytes, commissioningParams.CSRNonce.length));
+            if (commissioningParams.CSRNonce) {
+                params.SetCSRNonce(
+                    chip::ByteSpan((uint8_t *) commissioningParams.CSRNonce.bytes, commissioningParams.CSRNonce.length));
             }
-            if (commissioningParams.attestationNonce)
-            {
-                params.SetAttestationNonce(chip::ByteSpan ((uint8_t *) commissioningParams.attestationNonce.bytes, commissioningParams.attestationNonce.length));
+            if (commissioningParams.attestationNonce) {
+                params.SetAttestationNonce(chip::ByteSpan(
+                    (uint8_t *) commissioningParams.attestationNonce.bytes, commissioningParams.attestationNonce.length));
             }
-            if (commissioningParams.threadOperationalDataset)
-            {
-                params.SetThreadOperationalDataset(chip::ByteSpan ((uint8_t *) commissioningParams.threadOperationalDataset.bytes, commissioningParams.threadOperationalDataset.length));
+            if (commissioningParams.threadOperationalDataset) {
+                params.SetThreadOperationalDataset(chip::ByteSpan((uint8_t *) commissioningParams.threadOperationalDataset.bytes,
+                    commissioningParams.threadOperationalDataset.length));
             }
-            if (commissioningParams.wifiSSID && commissioningParams.wifiCredentials)
-            {
+            if (commissioningParams.wifiSSID && commissioningParams.wifiCredentials) {
                 chip::ByteSpan ssid((uint8_t *) commissioningParams.wifiSSID.bytes, commissioningParams.wifiSSID.length);
-                chip::ByteSpan credentials((uint8_t *) commissioningParams.wifiCredentials.bytes, commissioningParams.wifiCredentials.length);
+                chip::ByteSpan credentials(
+                    (uint8_t *) commissioningParams.wifiCredentials.bytes, commissioningParams.wifiCredentials.length);
                 chip::Controller::WiFiCredentials wifiCreds(ssid, credentials);
                 params.SetWiFiCredentials(wifiCreds);
             }

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegate.h
@@ -45,16 +45,16 @@ typedef NS_ENUM(NSUInteger, CHIPPairingStatus) {
 - (void)onPairingComplete:(nullable NSError *)error;
 
 /**
+ * Notify the delegate when commissioning is completed
+ *
+ */
+- (void)onCommissioningComplete:(nullable NSError *)error;
+
+/**
  * Notify the delegate when pairing is deleted
  *
  */
 - (void)onPairingDeleted:(nullable NSError *)error;
-
-/**
- * Notify the delegate when address is updated
- *
- */
-- (void)onAddressUpdated:(nullable NSError *)error;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
@@ -38,6 +38,8 @@ public:
 
     void OnPairingDeleted(CHIP_ERROR error) override;
 
+    void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
+
     void OnAddressUpdateComplete(chip::NodeId nodeId, CHIP_ERROR error) override;
 
 private:

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
@@ -95,17 +95,23 @@ void CHIPDevicePairingDelegateBridge::OnPairingDeleted(CHIP_ERROR error)
     }
 }
 
-void CHIPDevicePairingDelegateBridge::OnAddressUpdateComplete(chip::NodeId nodeId, CHIP_ERROR error)
+void CHIPDevicePairingDelegateBridge::OnCommissioningComplete(chip::NodeId nodeId, CHIP_ERROR error)
 {
-    NSLog(@"OnAddressUpdateComplete. Status %s", chip::ErrorStr(error));
+    NSLog(@"DevicePairingDelegate Commissioning complete. NodeId %llu Status %s", nodeId, chip::ErrorStr(error));
 
     id<CHIPDevicePairingDelegate> strongDelegate = mDelegate;
-    if ([strongDelegate respondsToSelector:@selector(onAddressUpdated:)]) {
+    if ([strongDelegate respondsToSelector:@selector(onCommissioningComplete:)]) {
         if (strongDelegate && mQueue) {
             dispatch_async(mQueue, ^{
                 NSError * nsError = [CHIPError errorForCHIPErrorCode:error];
-                [strongDelegate onAddressUpdated:nsError];
+                [strongDelegate onCommissioningComplete:nsError];
             });
         }
     }
+}
+
+void CHIPDevicePairingDelegateBridge::OnAddressUpdateComplete(chip::NodeId nodeId, CHIP_ERROR error)
+{
+    // Todo, is there any benefit of exposing this anymore?
+    NSLog(@"OnAddressUpdateComplete. Status %s", chip::ErrorStr(error));
 }

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -90,6 +90,13 @@ CHIPDevice * GetConnectedDevice(void)
     _expectation = nil;
 }
 
+- (void)onCommissioningComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
 - (void)onAddressUpdated:(NSError *)error
 {
     XCTAssertEqual(error.code, 0);

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -106,6 +106,13 @@ CHIPDevice * GetConnectedDevice(void)
     _expectation = nil;
 }
 
+- (void)onCommissioningComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
 - (void)onAddressUpdated:(NSError *)error
 {
     XCTAssertEqual(error.code, 0);


### PR DESCRIPTION
#### Problem
SetupCodePairer doesn't need to use the BLE auto commissioning mechanism. 

Instead its purpose is to establish PASE by parsing the onboarding payload and figuring out whether the commissionee is on BLE or IP. 


#### Change overview
Only establish a PASE session inside the SetupCodePairer when the node was discovered over BLE and perform a full commissioning when it's on-network.

Also fixed iOS CHIPTool and exposed the Commission API to ObjC. 

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Verified that chip-tool qrcode/manualcode pairing is no longer broken.
```
./out/host/chip-tool pairing qrcode 1 'MT:C8XA0SRB00KA0648G00'
```