### PR TITLE
Remove unused include from Globals.cpp

### DIFF
--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -21,7 +21,6 @@
 
 #include <inet/TCPEndPointImpl.h>
 #include <inet/UDPEndPointImpl.h>
-#include <platform/internal/BLEManager.h>
 #include <system/SystemLayerImpl.h>
 
 namespace chip {


### PR DESCRIPTION
#### Problem

#include <platform/internal/BLEManager.h> is not used in Globals.cpp

#### Change overview

Remove it.

#### Testing

Compile.