### PR TITLE
[hotfix] Fix gdb version in cirque image

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
   avahi-utils=0.7-4ubuntu7.1 \
   ca-certificates=20210119~20.04.2 \
   dhcpcd5=7.1.0-2build1 \
-  gdb=9.2-0ubuntu1~20.04 \
+  gdb=9.2-0ubuntu1~20.04.1 \
   git=1:2.25.1-1ubuntu3.2 \
   iproute2=5.5.0-1ubuntu1 \
   libavahi-client3=0.7-4ubuntu7.1 \


### PR DESCRIPTION
#### Problem
Cirque bootstrap is failing

#### Change overview
`gdb=9.2-0ubuntu1~20.04` -> `gdb=9.2-0ubuntu1~20.04.1`

Note: I have checked the original PR (https://github.com/project-chip/connectedhomeip/pull/12186) for adding the version pin, and it does do the step for rebuilding the image (i.e. not using the cache) Seems ubuntu upstream changed the version number.

#### Testing
No code changes