### PR TITLE
[chip-tool] When sending a command fails for some reasons, chip-tool …

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -33,7 +33,9 @@ void ModelCommand::OnDeviceConnectedFn(void * context, ChipDevice * device)
 {
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
-    command->SendCommand(device, command->mEndPointId);
+
+    CHIP_ERROR err = command->SendCommand(device, command->mEndPointId);
+    VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 
 void ModelCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR err)


### PR DESCRIPTION
…ignore the error

#### Problem

When something went wrong building a command for sending, `chip-tool` silently ignores the issue and will timeout.
It happens to me while manually crafting incorrect commands...

#### Change overview
 * Use `SetCommandExitStatus` is something went wrong sending it
