### PR TITLE
[third-party] Add third_party/jsoncpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -162,3 +162,6 @@
 [submodule "p6/lwip"]
 	path = third_party/p6/p6_sdk/libs/lwip
 	url = https://github.com/lwip-tcpip/lwip.git
+[submodule "third_party/jsoncpp/repo"]
+	path = third_party/jsoncpp/repo
+	url = https://github.com/open-source-parsers/jsoncpp.git

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -71,6 +71,7 @@ static_library("chip-tool-utils") {
     "${chip_root}/src/lib",
     "${chip_root}/src/platform",
     "${chip_root}/third_party/inipp",
+    "${chip_root}/third_party/jsoncpp",
   ]
 
   cflags = [ "-Wconversion" ]
@@ -96,6 +97,7 @@ executable("chip-tool") {
     "${chip_root}/src/lib",
     "${chip_root}/src/platform",
     "${chip_root}/third_party/inipp",
+    "${chip_root}/third_party/jsoncpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/third_party/jsoncpp/BUILD.gn
+++ b/third_party/jsoncpp/BUILD.gn
@@ -1,0 +1,50 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+config("jsoncpp_config") {
+  include_dirs = [ "repo/include" ]
+
+  cflags = [ "-Wno-implicit-fallthrough" ]
+}
+
+source_set("jsoncpp") {
+  sources = [
+    "repo/include/json/allocator.h",
+    "repo/include/json/assertions.h",
+    "repo/include/json/config.h",
+    "repo/include/json/forwards.h",
+    "repo/include/json/json.h",
+    "repo/include/json/json_features.h",
+    "repo/include/json/reader.h",
+    "repo/include/json/value.h",
+    "repo/include/json/version.h",
+    "repo/include/json/writer.h",
+    "repo/src/lib_json/json_reader.cpp",
+    "repo/src/lib_json/json_tool.h",
+    "repo/src/lib_json/json_value.cpp",
+    "repo/src/lib_json/json_writer.cpp",
+  ]
+
+  public_configs = [ ":jsoncpp_config" ]
+
+  defines = [
+    "JSON_USE_EXCEPTION=0",
+    "JSON_USE_NULLREF=0",
+  ]
+
+  include_dirs = [ "repo/src/lib_json" ]
+}


### PR DESCRIPTION
#### Problem

Instead of building a complex parser in #13240  for complex attributes types, let's use `jsoncpp`. 
For the record I have an implementation for complex types at https://github.com/vivien-apple/connectedhomeip-1/tree/ChipTool_WildcardsAndComplexTypesAndReadWriteById but I need to break down this branch into a few different PRs...

#### Change overview
 * Add `third_party/jsoncpp`
 * Add it to be built along `chip-tool`
