### PR TITLE
[controller] Fixed error handling on session establishment failure

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -845,7 +845,17 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        RendezvousCleanup(err);
+        // Delete the current rendezvous session only if a device is not currently being paired.
+        if (mDeviceBeingCommissioned == nullptr)
+        {
+            FreeRendezvousSession();
+        }
+
+        if (device != nullptr)
+        {
+            ReleaseCommissioneeDevice(device);
+            mDeviceBeingCommissioned = nullptr;
+        }
     }
 
     return err;


### PR DESCRIPTION
#### Problem
In https://github.com/project-chip/connectedhomeip/pull/13287 the regression was introduced that starting commissioning,
while an existing commissioning is in progress will cancel it.

The previous PR was related to the other problem that also is considered in this change. When calling `Pair()` method (https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CHIPDeviceController.cpp#L837) the `device` and `mDeviceBeingCommissioned` are not null, so in case of pairing failure only `ReleaseCommissioneeDevice(device);` will be called and `mDeviceBeingCommissioned` will stay not equal to nullptr and not allowing to start another commissioning (https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CHIPDeviceController.cpp#L769). Normally the PASE session timeout should result in calling `RendezvousCleanup`, but timer is started at the very bottom of `Pair()` method (https://github.com/project-chip/connectedhomeip/blob/master/src/protocols/secure_channel/PASESession.cpp#L351) and it won't be done in case of earlier failure (e.g in `SendPBKDFParamRequest`).

#### Change overview
Brought back previous error handling and added clearing `mDeviceBeingCommissioned` to allow starting new commissioning
after previous ones fail.
