### PR TITLE
Enable building tracing in chip-tool by default

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -37,7 +37,8 @@ automation.
 There are additional flags to chip-tool to control where the traces should go:
 
 -   --trace_file <file> Outputs trace data to the specified file.
--   --trace_log <0/1> Outputs trace data to the console with automation logs if set to 1
+-   --trace_log <0/1> Outputs trace data to the console with automation logs if
+    set to 1
 
 For example:
 

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -29,21 +29,15 @@ scripts/examples/gn_build_example.sh examples/chip-tool SOME-PATH/
 
 which puts the binary at `SOME-PATH/chip-tool`.
 
-### Building with message tracing
+### Using message tracing
 
 Message tracing allows capture of the secure messages which can be used for test
 automation.
 
-```
-gn gen out/with_trace/ --args='import("//with_pw_trace.gni")'
-ninja -C out/with_trace chip-tool
-```
-
-This enables tracing and adds additional flags to chip-tool to control where the
-traces should go:
+There are additional flags to chip-tool to control where the traces should go:
 
 -   --trace_file <file> Outputs trace data to the specified file.
--   --trace_log Outputs trace data to the chip log stream.
+-   --trace_log <0/1> Outputs trace data to the console with automation logs if set to 1
 
 For example:
 

--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/chip-tool/with_pw_trace.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"


### PR DESCRIPTION
#### Problem
- Transport and other tracing is useful for both test automations based
  around chip-tool and for debugging.
- Enabling tracing in chip-tool is already conditional at runtime based on command
  line flags, but requires building with the tracing enabled
- Tracing is very low-touch and is zero cost when disabled at runtime, so having it
  enabled by default in chip-tool build makes it easier to access/use.

Issue #11552

#### Change overview
- This PR enables the build to always include tracing feature
  enabled in chip-tool since it's generally useful.

#### Testing
Testing done:

- Unit tests and integration pass with no change
- Tested that with `--trace_file XXX` and `--trace_log 1`, the tracing works as intended

