### PR TITLE
[Group] Add GroupDataProvider Persistence

### DIFF
--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -31,6 +31,13 @@ config("server_config") {
   if (chip_enable_group_messaging_tests) {
     defines += [ "CHIP_ENABLE_GROUP_MESSAGING_TESTS" ]
   }
+
+  if (current_os == "mac" || current_os == "ios") {
+    # Using Non persistent storage delegate since
+    # persistence is also disable in Unit test for linux and MacOS
+    # Issue #12174 for Darwin
+    defines += [ "CHIP_USE_NON_PERSISTENT_STORAGE_DELEGATE" ]
+  }
 }
 
 static_library("server") {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -92,8 +92,8 @@ Server::Server() :
         .dnsCache          = nullptr,
         .devicePool        = &mDevicePool,
         .dnsResolver       = nullptr,
-    }), mCommissioningWindowManager(this), mGroupsProvider(mGroupsStorage),
-    mAttributePersister(mServerStorage)
+    }), mCommissioningWindowManager(this), mGroupsProvider(mDeviceStorage),
+    mAttributePersister(mDeviceStorage)
 {}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort)
@@ -121,10 +121,10 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 
     InitDataModelHandler(&mExchangeMgr);
 
-    err = mFabrics.Init(&mServerStorage);
+    err = mFabrics.Init(&mDeviceStorage);
     SuccessOrExit(err);
 
-    // Group data provider must be initialized after mServerStorage
+    // Group data provider must be initialized after mDeviceStorage
     err = mGroupsProvider.Init();
     SuccessOrExit(err);
     SetGroupDataProvider(&mGroupsProvider);

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -96,7 +96,7 @@ private:
 
     static Server sServer;
 
-    class ServerStorageDelegate : public PersistentStorageDelegate, public FabricStorage
+    class DeviceStorageDelegate : public PersistentStorageDelegate, public FabricStorage
     {
         CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
         {
@@ -114,16 +114,12 @@ private:
 
         CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
         {
-            ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size));
-            ChipLogProgress(AppServer, "Saved into server storage: %s", key);
-            return CHIP_NO_ERROR;
+            return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
         }
 
         CHIP_ERROR SyncDeleteKeyValue(const char * key) override
         {
-            ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key));
-            ChipLogProgress(AppServer, "Deleted from server storage: %s", key);
-            return CHIP_NO_ERROR;
+            return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
         }
 
         CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
@@ -163,10 +159,13 @@ private:
 
     // Both PersistentStorageDelegate, and GroupDataProvider should be injected by the applications
     // See: https://github.com/project-chip/connectedhomeip/issues/12276
-    ServerStorageDelegate mServerStorage;
     // Currently, the GroupDataProvider cannot use KeyValueStoreMgr() due to
     // (https://github.com/project-chip/connectedhomeip/issues/12174)
-    TestPersistentStorageDelegate mGroupsStorage;
+#ifdef CHIP_USE_NON_PERSISTENT_STORAGE_DELEGATE
+    TestPersistentStorageDelegate mDeviceStorage;
+#else
+    DeviceStorageDelegate mDeviceStorage;
+#endif
     Credentials::GroupDataProviderImpl mGroupsProvider;
     app::DefaultAttributePersistenceProvider mAttributePersister;
 

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <algorithm>
+#include <credentials/FabricTable.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/DLLUtil.h>
@@ -28,7 +29,7 @@
 
 namespace chip {
 
-class TestPersistentStorageDelegate : public PersistentStorageDelegate
+class TestPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
 {
 public:
     TestPersistentStorageDelegate() {}
@@ -59,6 +60,18 @@ public:
         mStorage.erase(key);
         return CHIP_NO_ERROR;
     }
+
+    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
+    {
+        return SyncSetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
+    {
+        return SyncGetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
 
 protected:
     std::map<std::string, std::vector<uint8_t>> mStorage;

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -28,7 +28,7 @@
 #include <vector>
 
 namespace chip {
-
+// TODO : Remove FabricStorage dependency
 class TestPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
 {
 public:


### PR DESCRIPTION
#### Problem
GroupDataProvider is not persistent. Group membership doesn't survive a device reset/power cycle.

#### Change overview
Added the `GroupStorageDelegate` class to replace the `TestPersistentStorageDelegate` which stored the data in RAM.

#### Testing
Tested with an EFR32. Group membership did survive a power cycle.
Excluded from test suite since persistence unit test are already excluded from CI.
