### PR TITLE
[OTA] Update matter-devices.xml for OTA devices, update README for the OTA Requestor

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -414,6 +414,7 @@ fsl
 fstab
 fsync
 fullclean
+gbl
 gcloud
 GDB
 GeneralCommissioning

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -1,4 +1,4 @@
-#CHIP EFR32 OTA Requestor Example
+# CHIP EFR32 OTA Requestor Example
 
 An example showing the use of the Matter OTA Requestor functionality on the
 Silicon Labs EFR32 MG12.
@@ -9,7 +9,7 @@ Silicon Labs EFR32 MG12.
 
 The EFR32 OTA Requestor example provides a baseline demonstration the Matter OTA
 Requestor functionality built with the Silicon Labs gecko SDK. It can be
-controlled by a Chip controller over Openthread network..
+controlled by a Chip controller over Open thread network..
 
 <a name="building"></a>
 
@@ -48,6 +48,8 @@ examples/lighting-app/efr32/README.md
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
 
+<a name="Flashing the Application"></a>
+
 ## Flashing the Application
 
 -   On the command line:
@@ -61,7 +63,9 @@ examples/lighting-app/efr32/README.md
 
 ## Viewing Logging Output
 
-See examples/lighting-app/efr32/README.md
+See `examples/lighting-app/efr32/README.md`
+
+<a name="Running the OTA Download scenario"></a>
 
 ## Running the OTA Download scenario
 
@@ -74,10 +78,14 @@ See examples/lighting-app/efr32/README.md
            scripts/examples/gn_build_example.sh examples/chip-tool out/
            scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false
 
--   In a terminal start the provider app passing to it the path to the image
-    file that the Requestor is supposed to download (for example /tmp/ota.out):
+-   Create a bootable image file:
 
-                ./out/debug/chip-ota-provider-app -f /tmp/ota.out
+           commander gbl create chip-efr32-ota-requestor-example.gbl --app chip-efr32-ota-requestor-example.s37
+
+-   In a terminal start the provider app passing to it the path to the bootable image
+    file created in the previous step:
+
+           ./out/debug/chip-ota-provider-app -f chip-efr32-ota-requestor-example.gbl
 
 -   In a separate terminal run the chip-tool commands to provision the Provider:
 
@@ -97,4 +105,5 @@ where operationalDataset is obtained from the Open Thread Border Router.
 
             ./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0
 
--   The Requestor will connect to the Provider and start the image download.
+-   The Requestor will connect to the Provider and start the image download. Once the image is downloaded
+    the Requestor will reboot into the downloaded image.

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -9,7 +9,7 @@ Silicon Labs EFR32 MG12.
 
 The EFR32 OTA Requestor example provides a baseline demonstration the Matter OTA
 Requestor functionality built with the Silicon Labs gecko SDK. It can be
-controlled by a Chip controller over Open thread network..
+controlled by a Chip controller over OpenThread network.
 
 <a name="building"></a>
 
@@ -69,7 +69,7 @@ See `examples/lighting-app/efr32/README.md`
 
 ## Running the OTA Download scenario
 
--   Bring up the Open Thread Border Router as discussed in
+-   Bring up the OpenThread Border Router as discussed in
     examples/lighting-app/efr32/README.md and get its operational dataset.
 
 -   On a Linux or Darwin platform build the chip-tool and the ota-provider-app
@@ -99,7 +99,7 @@ See `examples/lighting-app/efr32/README.md`
 
             ./out/chip-tool pairing ble-thread 2 hex:<operationalDataset> 73141520   3840
 
-where operationalDataset is obtained from the Open Thread Border Router.
+where operationalDataset is obtained from the OpenThread Border Router.
 
 -   Once the commissioning process completes enter:
 

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -82,8 +82,8 @@ See `examples/lighting-app/efr32/README.md`
 
            commander gbl create chip-efr32-ota-requestor-example.gbl --app chip-efr32-ota-requestor-example.s37
 
--   In a terminal start the provider app passing to it the path to the bootable image
-    file created in the previous step:
+-   In a terminal start the provider app passing to it the path to the bootable
+    image file created in the previous step:
 
            ./out/debug/chip-ota-provider-app -f chip-efr32-ota-requestor-example.gbl
 
@@ -105,5 +105,6 @@ where operationalDataset is obtained from the Open Thread Border Router.
 
             ./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0
 
--   The Requestor will connect to the Provider and start the image download. Once the image is downloaded
-    the Requestor will reboot into the downloaded image.
+-   The Requestor will connect to the Provider and start the image download.
+    Once the image is downloaded the Requestor will reboot into the downloaded
+    image.

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -78,6 +78,10 @@ See `examples/lighting-app/efr32/README.md`
            scripts/examples/gn_build_example.sh examples/chip-tool out/
            scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false
 
+-   Build or download the Gecko Bootloader binary. Bootloader should be built with the Gecko SDK version 3.2.1 or earlier,
+    type "external SPI" configured with a single slot of at least 1000 KB. Using the commander tool upload the bootloader to
+    the device running the requestor application.
+
 -   Create a bootable image file:
 
            commander gbl create chip-efr32-ota-requestor-example.gbl --app chip-efr32-ota-requestor-example.s37

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -78,9 +78,10 @@ See `examples/lighting-app/efr32/README.md`
            scripts/examples/gn_build_example.sh examples/chip-tool out/
            scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false
 
--   Build or download the Gecko Bootloader binary. Bootloader should be built with the Gecko SDK version 3.2.1 or earlier,
-    type "external SPI" configured with a single slot of at least 1000 KB. Using the commander tool upload the bootloader to
-    the device running the requestor application.
+-   Build or download the Gecko Bootloader binary. Bootloader should be built
+    with the Gecko SDK version 3.2.1 or earlier, type "external SPI" configured
+    with a single slot of at least 1000 KB. Using the commander tool upload the
+    bootloader to the device running the requestor application.
 
 -   Create a bootable image file:
 

--- a/examples/ota-requestor-app/linux/README.md
+++ b/examples/ota-requestor-app/linux/README.md
@@ -63,16 +63,21 @@ In terminal 2:
 
 ## Note
 
-When the Provider, Requestor and chip-tool are run on the same Linux node the user must issue `rm -r /tmp/chip_*` before starting the Provider and `rm /tmp/chip_kvs` before starting the Requestor. These commands reset the shared Key Value Store to a consistent state. 
+When the Provider, Requestor and chip-tool are run on the same Linux node the
+user must issue `rm -r /tmp/chip_*` before starting the Provider and
+`rm /tmp/chip_kvs` before starting the Requestor. These commands reset the
+shared Key Value Store to a consistent state.
 
 ## Example
 
 Building:
+
 ```
 scripts/examples/gn_build_example.sh examples/chip-tool out/ chip_config_network_layer_ble=false && scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false  && scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug chip_config_network_layer_ble=false
 ```
 
 Running (in separate terminals as described above):
+
 ```
 rm -r /tmp/chip_*
 ./out/debug/chip-ota-provider-app -f /tmp/ota.txt
@@ -82,6 +87,7 @@ rm /tmp/chip_kvs
 ./out/chip-tool pairing onnetwork-long 2 20202021 42
 ./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0
 ```
+
 ## Current Features / Limitations
 
 ### Features

--- a/examples/ota-requestor-app/linux/README.md
+++ b/examples/ota-requestor-app/linux/README.md
@@ -60,8 +60,11 @@ In terminal 2:
 ```
 ./chip-tool otasoftwareupdaterequestor announce-ota-provider ${PROVIDER_NODE_ID} 0 0 0 ${REQUESTOR_NODE_ID} 0
 ```
--   `${PROVIDER_NODE_ID}` is the node ID of the ota-provider-app assigned to it during the pairing step above
--   `${REQUESTOR_NODE_ID}` is the node ID of the ota-requestor-app assigned to it during the pairing step above
+
+-   `${PROVIDER_NODE_ID}` is the node ID of the ota-provider-app assigned to it
+    during the pairing step above
+-   `${REQUESTOR_NODE_ID}` is the node ID of the ota-requestor-app assigned to
+    it during the pairing step above
 
 ## Note
 

--- a/examples/ota-requestor-app/linux/README.md
+++ b/examples/ota-requestor-app/linux/README.md
@@ -57,6 +57,31 @@ In terminal 2:
 -   `${REQUESTOR_LONG_DISCRIMINATOR}` is the long discriminator of the
     ota-requestor-app specified in terminal 3 above
 
+```
+./chip-tool otasoftwareupdaterequestor announce-ota-provider  ${NODE_ID_TO_ASSIGN_PROVIDER} 0 0 0 ${NODE_ID_TO_ASSIGN_REQUESTOR} 0
+```
+
+## Note
+
+When the Provider, Requestor and chip-tool are run on the same Linux node the user must issue `rm -r /tmp/chip_*` before starting the Provider and `rm /tmp/chip_kvs` before starting the Requestor. These commands reset the shared Key Value Store to a consistent state. 
+
+## Example
+
+Building:
+```
+scripts/examples/gn_build_example.sh examples/chip-tool out/ chip_config_network_layer_ble=false && scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false  && scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug chip_config_network_layer_ble=false
+```
+
+Running (in separate terminals as described above):
+```
+rm -r /tmp/chip_*
+./out/debug/chip-ota-provider-app -f /tmp/ota.txt
+./out/chip-tool pairing onnetwork 1 20202021
+rm /tmp/chip_kvs
+./out/debug/chip-ota-requestor-app -u 5560 -d 42
+./out/chip-tool pairing onnetwork-long 2 20202021 42
+./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0
+```
 ## Current Features / Limitations
 
 ### Features
@@ -68,10 +93,5 @@ In terminal 2:
 
 ### Limitations
 
--   Needs chip-tool to commission the OTA Provider device first because the Node
-    ID and IP Address of the OTA Provider must be supplied to this reference
-    application
--   Does not verify QueryImageResponse message contents
 -   Stores the downloaded file in the directory this reference app is launched
     from
--   Does not support AnnounceOTAProvider command or OTA Requestor attributes

--- a/examples/ota-requestor-app/linux/README.md
+++ b/examples/ota-requestor-app/linux/README.md
@@ -58,8 +58,10 @@ In terminal 2:
     ota-requestor-app specified in terminal 3 above
 
 ```
-./chip-tool otasoftwareupdaterequestor announce-ota-provider  ${NODE_ID_TO_ASSIGN_PROVIDER} 0 0 0 ${NODE_ID_TO_ASSIGN_REQUESTOR} 0
+./chip-tool otasoftwareupdaterequestor announce-ota-provider ${PROVIDER_NODE_ID} 0 0 0 ${REQUESTOR_NODE_ID} 0
 ```
+-   `${PROVIDER_NODE_ID}` is the node ID of the ota-provider-app assigned to it during the pairing step above
+-   `${REQUESTOR_NODE_ID}` is the node ID of the ota-requestor-app assigned to it during the pairing step above
 
 ## Note
 

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -106,9 +106,9 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
-        <name>MA-otarequester</name>
+        <name>MA-otarequestor</name>
         <domain>CHIP</domain>
-        <typeName>Matter OTA Requester</typeName>
+        <typeName>Matter OTA Requestor</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0012</deviceId>
         <clusters lockOthers="true">
@@ -129,7 +129,7 @@ limitations under the License.
                 <requireAttribute>BINDING</requireAttribute>
             </include>
             <include cluster="OTA Software Update Requestor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="OTA Software Update Provider" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Provider" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -156,6 +156,7 @@ limitations under the License.
                 <requireAttribute>BINDING</requireAttribute>
             </include>
             <include cluster="OTA Software Update Provider" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Requestor" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>


### PR DESCRIPTION
#### Problem
Need correct definitions of the OTA device types: https://github.com/project-chip/connectedhomeip/issues/9598

#### Change overview
- Reference correct OTA clusters in matter-devices.xml
- Unrelated to the above, update README for the OTA Requestor app on Linux and EFR32

#### Testing
No executable code changes. Verified that README files are displayed correctly. 