### PR TITLE
Add tracing instructions in ESP32 README.md

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -988,6 +988,7 @@ TLV
 tmp
 tngvndl
 TODO
+tokenized
 toolchain
 toolchains
 topologies

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -136,6 +136,7 @@ ifeq ($(is_debug),false)
 endif
 	if [[ "$(CONFIG_ENABLE_PW_RPC)" = "y" ]]; then                        \
 	  echo "chip_build_pw_rpc_lib = true" >> $(OUTPUT_DIR)/args.gn       ;\
+	  echo "chip_build_pw_trace_lib = true" >> $(OUTPUT_DIR)/args.gn       ;\
 	  echo "remove_default_configs = [\"//third_party/connectedhomeip/third_party/pigweed/repo/pw_build:cpp17\"]" >> $(OUTPUT_DIR)/args.gn		;\
 	  echo "pw_log_BACKEND = \"//third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic\"" >> $(OUTPUT_DIR)/args.gn     ;\
 	  echo "pw_assert_BACKEND = \"//third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log\"" >> $(OUTPUT_DIR)/args.gn ;\

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -299,8 +299,9 @@ From within the console you can then invoke rpcs:
 
 ## Device Tracing
 
-Device tracing is available to analyze the device performance. To turn on tracing, build with RPC enabled.
-See [Using the RPC console](#using-the-rpc-console).
+Device tracing is available to analyze the device performance. To turn on
+tracing, build with RPC enabled. See
+[Using the RPC console](#using-the-rpc-console).
 
 Obtain tracing json file.
 
@@ -308,4 +309,3 @@ Obtain tracing json file.
     $ ./{PIGWEED_REPO}/pw_trace_tokenized/py/pw_trace_tokenized/get_trace.py -d {PORT} -o {OUTPUT_FILE} \
     -t {ELF_FILE} {PIGWEED_REPO}/pw_trace_tokenized/pw_trace_protos/trace_rpc.proto
 ```
-

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -15,6 +15,7 @@ control.
         -   [Flashing app using script](#flashing-app-using-script)
         -   [Note](#note)
     -   [Using the RPC console](#using-the-rpc-console)
+    -   [Device Tracing](#device-tracing)
 
 ---
 
@@ -295,3 +296,16 @@ From within the console you can then invoke rpcs:
 
     rpcs.chip.rpc.Lighting.Get()
     rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))
+
+## Device Tracing
+
+Device tracing is available to analyze the device performance. To turn on tracing, build with RPC enabled.
+See [Using the RPC console](#using-the-rpc-console).
+
+Obtain tracing json file.
+
+```
+    $ ./{PIGWEED_REPO}/pw_trace_tokenized/py/pw_trace_tokenized/get_trace.py -d {PORT} -o {OUTPUT_FILE} \
+    -t {ELF_FILE} {PIGWEED_REPO}/pw_trace_tokenized/pw_trace_protos/trace_rpc.proto
+```
+

--- a/src/trace/BUILD.gn
+++ b/src/trace/BUILD.gn
@@ -19,7 +19,7 @@ declare_args() {
 }
 
 config("config") {
-  defines = [ "PW_TRACE_BACKEND_SET=1" ]
+  defines = [ "PW_TRACE_BACKEND_SET" ]
 }
 
 source_set("trace") {

--- a/src/trace/BUILD.gn
+++ b/src/trace/BUILD.gn
@@ -18,11 +18,16 @@ declare_args() {
   chip_build_pw_trace_lib = false
 }
 
+config("config") {
+  defines = [
+    "PW_TRACE_BACKEND_SET=1",
+  ]
+}
+
 source_set("trace") {
   sources = [ "trace.h" ]
-
   if (chip_build_pw_trace_lib) {
-    cflags = [ "-DPW_TRACE_BACKEND_SET=1" ]
+    public_configs = [ ":config" ]
     public_deps = [ "${dir_pigweed}/pw_trace" ]
   }
 }

--- a/src/trace/BUILD.gn
+++ b/src/trace/BUILD.gn
@@ -19,9 +19,7 @@ declare_args() {
 }
 
 config("config") {
-  defines = [
-    "PW_TRACE_BACKEND_SET=1",
-  ]
+  defines = [ "PW_TRACE_BACKEND_SET=1" ]
 }
 
 source_set("trace") {


### PR DESCRIPTION
#### Problem
Add tracing instructions to README.md and update tracing related flags.

#### Testing
Build and tested on esp32 M5Stack and obtain commissioning traces in CASE and PASE Session.
