### PR TITLE
[OTA] Implement event support for OTA Requestor cluster

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1993,7 +1993,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
   info event DownloadError = 2 {
     INT32U softwareVersion = 0;
     INT64U bytesDownloaded = 1;
-    INT8U progressPercent = 2;
+    nullable INT8U progressPercent = 2;
     nullable INT64S platformCode = 3;
   }
 

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -905,7 +905,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
   info event DownloadError = 2 {
     INT32U softwareVersion = 0;
     INT64U bytesDownloaded = 1;
-    INT8U progressPercent = 2;
+    nullable INT8U progressPercent = 2;
     nullable INT64S platformCode = 3;
   }
 

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -337,7 +337,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
   info event DownloadError = 2 {
     INT32U softwareVersion = 0;
     INT64U bytesDownloaded = 1;
-    INT8U progressPercent = 2;
+    nullable INT8U progressPercent = 2;
     nullable INT64S platformCode = 3;
   }
 

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -26,6 +26,7 @@
 
 #include "OTADownloader.h"
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <lib/core/CHIPError.h>
 #include <protocols/bdx/BdxTransferSession.h>
 #include <system/SystemPacketBuffer.h>
@@ -49,10 +50,10 @@ public:
     {
     public:
         // Handle download state change
-        virtual void OnDownloadStateChanged(State state) = 0;
+        virtual void OnDownloadStateChanged(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason) = 0;
         // Handle update progress change
-        virtual void OnUpdateProgressChanged(uint8_t percent) = 0;
-        virtual ~StateDelegate()                              = default;
+        virtual void OnUpdateProgressChanged(app::DataModel::Nullable<uint8_t> percent) = 0;
+        virtual ~StateDelegate()                                                        = default;
     };
 
     // To be called when there is an incoming message to handle (of any protocol type)
@@ -77,7 +78,7 @@ public:
 private:
     void PollTransferSession();
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
-    void SetState(State state);
+    void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
 
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;

--- a/src/app/clusters/ota-requestor/OTADownloader.h
+++ b/src/app/clusters/ota-requestor/OTADownloader.h
@@ -75,7 +75,7 @@ public:
     virtual ~OTADownloader() = default;
 
 protected:
-    OTAImageProcessorInterface * mImageProcessor;
+    OTAImageProcessorInterface * mImageProcessor = nullptr;
     State mState;
 };
 

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -63,12 +63,13 @@ public:
     // Send ApplyImage
     void ApplyUpdate() override;
 
-    // Send NotifyUpdateApplied
-    void NotifyUpdateApplied() override;
+    // Send NotifyUpdateApplied, update Basic cluster SoftwareVersion attribute, log the VersionApplied event
+    void NotifyUpdateApplied(uint32_t version) override;
 
     //////////// BDXDownloader::StateDelegate Implementation ///////////////
-    void OnDownloadStateChanged(OTADownloader::State state) override;
-    void OnUpdateProgressChanged(uint8_t percent) override;
+    void OnDownloadStateChanged(OTADownloader::State state,
+                                app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason) override;
+    void OnUpdateProgressChanged(app::DataModel::Nullable<uint8_t> percent) override;
 
     /**
      * Called to perform some initialization including:
@@ -84,8 +85,14 @@ public:
         mOtaRequestorDriver = driver;
         mBdxDownloader      = downloader;
 
-        OtaRequestorServerSetUpdateState(app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum::kIdle);
-        OtaRequestorServerSetUpdateStateProgress(0);
+        uint32_t version;
+        VerifyOrDie(app::Clusters::Basic::Attributes::SoftwareVersion::Get(kRootEndpointId, &version) == EMBER_ZCL_STATUS_SUCCESS);
+        mCurrentVersion = version;
+
+        OtaRequestorServerSetUpdateState(mCurrentUpdateState);
+        app::DataModel::Nullable<uint8_t> percent;
+        percent.SetNull();
+        OtaRequestorServerSetUpdateStateProgress(percent);
     }
 
     /**
@@ -122,6 +129,8 @@ public:
 private:
     using QueryImageResponseDecodableType  = app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
     using ApplyUpdateResponseDecodableType = app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
+    using OTAUpdateStateEnum               = app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+    using OTAChangeReasonEnum              = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum;
 
     static constexpr size_t kMaxUpdateTokenLen = 32;
 
@@ -193,6 +202,17 @@ private:
     };
 
     /**
+     * Record the new update state by updating the corresponding server attribute and logging a StateTransition event
+     */
+    void RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason);
+
+    /**
+     * Record the error update state by informing the driver of the error and calling `RecordNewUpdateState`
+     */
+    void RecordErrorUpdateState(UpdateFailureState failureState, CHIP_ERROR error,
+                                OTAChangeReasonEnum reason = OTAChangeReasonEnum::kFailure);
+
+    /**
      * Generate an update token using the operational node ID in case of token lost, received in QueryImageResponse
      */
     CHIP_ERROR GenerateUpdateToken();
@@ -260,8 +280,10 @@ private:
     BDXMessenger mBdxMessenger;                          // TODO: ideally this is held by the application
     uint8_t mUpdateTokenBuffer[kMaxUpdateTokenLen];
     ByteSpan mUpdateToken;
-    uint32_t mUpdateVersion = 0;
-    Server * mServer        = nullptr;
+    uint32_t mCurrentVersion               = 0;
+    uint32_t mTargetVersion                = 0;
+    OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kIdle;
+    Server * mServer                       = nullptr;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/ota-requestor-server.h
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.h
@@ -21,4 +21,14 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 
 EmberAfStatus OtaRequestorServerSetUpdateState(chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value);
-EmberAfStatus OtaRequestorServerSetUpdateStateProgress(uint8_t value);
+EmberAfStatus OtaRequestorServerSetUpdateStateProgress(chip::app::DataModel::Nullable<uint8_t> value);
+
+void OtaRequestorServerOnStateTransition(
+    chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum> previousState,
+    chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum newState,
+    chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason,
+    chip::app::DataModel::Nullable<uint32_t> const & targetSoftwareVersion);
+void OtaRequestorServerOnVersionApplied(uint32_t softwareVersion, uint16_t productId);
+void OtaRequestorServerOnDownloadError(uint32_t softwareVersion, uint64_t bytesDownloaded,
+                                       chip::app::DataModel::Nullable<uint8_t> progressPercent,
+                                       chip::app::DataModel::Nullable<int64_t> platformCode);

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -73,6 +73,9 @@ struct Nullable : protected Optional<T>
     {
         return true;
     }
+
+    bool operator==(const Nullable & other) const { return Optional<T>::operator==(other); }
+    bool operator!=(const Nullable & other) const { return !(*this == other); }
 };
 
 } // namespace DataModel

--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -150,7 +150,7 @@ limitations under the License.
           <description>This event SHALL be generated whenever an error occurs during OTA Requestor download operation.</description>
           <field id="0" name="SoftwareVersion" type="INT32U"/> 
           <field id="1" name="BytesDownloaded" type="INT64U"/>
-          <field id="2" name="ProgressPercent" type="INT8U" min="0" max="100"/>
+          <field id="2" name="ProgressPercent" type="INT8U" min="0" max="100" isNullable="true"/>
           <field id="3" name="PlatformCode" type="INT64S" isNullable="true"/>
         </event>                     
     </cluster>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2209,7 +2209,7 @@ client cluster OtaSoftwareUpdateRequestor = 42 {
   info event DownloadError = 2 {
     INT32U softwareVersion = 0;
     INT64U bytesDownloaded = 1;
-    INT8U progressPercent = 2;
+    nullable INT8U progressPercent = 2;
     nullable INT64S platformCode = 3;
   }
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -7031,13 +7031,13 @@ class OtaSoftwareUpdateRequestor(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="softwareVersion", Tag=0, Type=uint),
                             ClusterObjectFieldDescriptor(Label="bytesDownloaded", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="progressPercent", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="progressPercent", Tag=2, Type=typing.Union[Nullable, uint]),
                             ClusterObjectFieldDescriptor(Label="platformCode", Tag=3, Type=typing.Union[Nullable, int]),
                     ])
 
             softwareVersion: 'uint' = 0
             bytesDownloaded: 'uint' = 0
-            progressPercent: 'uint' = 0
+            progressPercent: 'typing.Union[Nullable, uint]' = NullValue
             platformCode: 'typing.Union[Nullable, int]' = NullValue
 
 

--- a/src/include/platform/OTAImageProcessor.h
+++ b/src/include/platform/OTAImageProcessor.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/data-model/Nullable.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
@@ -30,6 +31,21 @@ struct OTAImageProcessorParams
     CharSpan imageFile;
     uint64_t downloadedBytes = 0;
     uint64_t totalFileBytes  = 0;
+};
+
+// TODO: Parse the header when the image is received
+struct OTAImageProcessorHeader
+{
+    uint16_t vendorId;
+    uint16_t productId;
+    uint32_t softwareVersion;
+    CharSpan softwareVersionString;
+    uint64_t payloadSize;
+    uint16_t minApplicableSoftwareVersion;
+    uint16_t maxApplicableSoftwareVersion;
+    CharSpan releaseNotesUrl;
+    uint8_t imageDigestType;
+    ByteSpan imageDigest;
 };
 
 /**
@@ -83,20 +99,26 @@ public:
     /**
      * Called to check the current download status of the OTA image download.
      */
-    virtual uint8_t GetPercentComplete()
+    virtual void GetPercentComplete(app::DataModel::Nullable<uint8_t> & percent)
     {
         if (mParams.totalFileBytes == 0)
         {
-            return 0;
+            percent.SetNull();
         }
         else
         {
-            return static_cast<uint8_t>((mParams.downloadedBytes * 100) / mParams.totalFileBytes);
+            percent.SetNonNull(static_cast<uint8_t>((mParams.downloadedBytes * 100) / mParams.totalFileBytes));
         }
     }
 
+    /**
+     * Called to check the current number of bytes that have been downloaded of the OTA image
+     */
+    virtual uint64_t GetBytesDownloaded() { return mParams.downloadedBytes; }
+
 protected:
     OTAImageProcessorParams mParams;
+    OTAImageProcessorHeader mHeader;
 };
 
 } // namespace chip

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -65,7 +65,7 @@ public:
     virtual void ApplyUpdate() = 0;
 
     // Send NotifyUpdateApplied command
-    virtual void NotifyUpdateApplied() = 0;
+    virtual void NotifyUpdateApplied(uint32_t version) = 0;
 
     // Manually set OTA Provider parameters
     virtual void TestModeSetProviderParameters(NodeId nodeId, FabricIndex fabIndex, EndpointId endpointId) = 0;

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -125,10 +125,16 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
 
 void OTAImageProcessorImpl::HandleApply(intptr_t context)
 {
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        return;
+    }
+
     OTARequestorInterface * requestor = chip::GetRequestorInstance();
     if (requestor != nullptr)
     {
-        requestor->NotifyUpdateApplied();
+        requestor->NotifyUpdateApplied(imageProcessor->mHeader.softwareVersion);
     }
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -8919,7 +8919,7 @@ public:
 
     uint32_t softwareVersion = static_cast<uint32_t>(0);
     uint64_t bytesDownloaded = static_cast<uint64_t>(0);
-    uint8_t progressPercent  = static_cast<uint8_t>(0);
+    DataModel::Nullable<uint8_t> progressPercent;
     DataModel::Nullable<int64_t> platformCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -8934,7 +8934,7 @@ public:
 
     uint32_t softwareVersion = static_cast<uint32_t>(0);
     uint64_t bytesDownloaded = static_cast<uint64_t>(0);
-    uint8_t progressPercent  = static_cast<uint8_t>(0);
+    DataModel::Nullable<uint8_t> progressPercent;
     DataModel::Nullable<int64_t> platformCode;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);


### PR DESCRIPTION
#### Problem
Events are not logged for OTA Requestor cluster

Fixes: https://github.com/project-chip/connectedhomeip/issues/13006

#### Change overview
- Add mechanism to log the following events OTA Requestor cluster events:
-- StateTransition
-- VersionApplied
-- DownloadError
- Log the events throughout OTA Requestor core logic

#### Testing
Manual testing for Linux provider/requestor and verify that messages like the following are seen:
```
[1642621838874] [72717:6427314] CHIP: [EVL] LogEvent event number: 0x0000000000000000 priority: 1, endpoint id:  0x0 cluster id: 0x0000_002A event id: 0x0 Sys timestamp: 0x000000003E39F24B
[1642621842882] [72717:6427314] CHIP: [EVL] LogEvent event number: 0x0000000000000003 priority: 2, endpoint id:  0x0 cluster id: 0x0000_002A event id: 0x1 Sys timestamp: 0x000000003E3A01F3
```