### PR TITLE
WindowCovering: fix Limits checks + factorization

### DIFF
--- a/examples/window-app/common/src/ZclCallbacks.cpp
+++ b/examples/window-app/common/src/ZclCallbacks.cpp
@@ -58,6 +58,7 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
 
     chip::app::DataModel::Nullable<chip::Percent100ths> current;
     chip::app::DataModel::Nullable<chip::Percent100ths> target;
+    OperationalState opState;
 
     switch (attributePath.mAttributeId)
     {
@@ -76,32 +77,28 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
     case Attributes::TargetPositionLiftPercent100ths::Id:
         Attributes::TargetPositionLiftPercent100ths::Get(endpoint, target);
         Attributes::CurrentPositionLiftPercent100ths::Get(endpoint, current);
-        if (!current.IsNull() && !target.IsNull())
+        opState = ComputeOperationalState(target, current);
+        if (OperationalState::MovingDownOrClose == opState)
         {
-            if (current.Value() > target.Value())
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftDown, endpoint));
-            }
-            else if (current.Value() < target.Value())
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftUp, endpoint));
-            }
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftDown, endpoint));
+        }
+        else if (OperationalState::MovingUpOrOpen == opState)
+        {
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftUp, endpoint));
         }
         break;
 
     case Attributes::TargetPositionTiltPercent100ths::Id:
         Attributes::TargetPositionTiltPercent100ths::Get(endpoint, target);
         Attributes::CurrentPositionTiltPercent100ths::Get(endpoint, current);
-        if (!current.IsNull() && !target.IsNull())
+        opState = ComputeOperationalState(target, current);
+        if (OperationalState::MovingDownOrClose == opState)
         {
-            if (current.Value() > target.Value())
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltDown, endpoint));
-            }
-            else if (current.Value() < target.Value())
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltUp, endpoint));
-            }
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltDown, endpoint));
+        }
+        else if (OperationalState::MovingUpOrOpen == opState)
+        {
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltUp, endpoint));
         }
         break;
 

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -338,16 +338,26 @@ void WindowAppImpl::UpdateLEDs()
         else { mStatusLED.Blink(50, 950); }
 
         // Action LED
+        NPercent100ths current;
+        LimitStatus liftLimit = LimitStatus::Intermediate;
+
+        Attributes::CurrentPositionLiftPercent100ths::Get(cover.mEndpoint, current);
+
+        if (!current.IsNull())
+        {
+            AbsoluteLimits limits = { .open = WC_PERCENT100THS_MIN_OPEN, .closed = WC_PERCENT100THS_MAX_CLOSED };
+            liftLimit = CheckLimitState(current.Value(), limits);
+        }
 
         if (EventId::None != cover.mLiftAction || EventId::None != cover.mTiltAction)
         {
             mActionLED.Blink(100);
         }
-        else if (IsLiftOpen(cover.mEndpoint))
+        else if (LimitStatus::IsUpOrOpen == liftLimit)
         {
             mActionLED.Set(true);
         }
-        else if (IsLiftClosed(cover.mEndpoint))
+        else if (LimitStatus::IsDownOrClose == liftLimit)
         {
             mActionLED.Set(false);
         }

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -346,7 +346,7 @@ void WindowAppImpl::UpdateLEDs()
         if (!current.IsNull())
         {
             AbsoluteLimits limits = { .open = WC_PERCENT100THS_MIN_OPEN, .closed = WC_PERCENT100THS_MAX_CLOSED };
-            liftLimit = CheckLimitState(current.Value(), limits);
+            liftLimit             = CheckLimitState(current.Value(), limits);
         }
 
         if (EventId::None != cover.mLiftAction || EventId::None != cover.mTiltAction)

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -329,10 +329,10 @@ LimitStatus CheckLimitState(uint16_t position, AbsoluteLimits limits)
         return LimitStatus::IsDownOrClose;
 
     if ((limits.open > 0) && (position < limits.open))
-        return LimitStatus::IsPostUpOrOpen;
+        return LimitStatus::IsPastUpOrOpen;
 
     if ((limits.closed > 0) && (position > limits.closed))
-        return LimitStatus::IsPostDownOrClose;
+        return LimitStatus::IsPastDownOrClose;
 
     return LimitStatus::Intermediate;
 }

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -43,7 +43,7 @@ using namespace chip::app::Clusters::WindowCovering;
 #define CHECK_BOUNDS_VALID(MIN, VAL, MAX) (!CHECK_BOUNDS_INVALID(MIN, VAL, MAX))
 
 /*
- * ConvertValue: Permits to convert values from one range to another
+ * ConvertValue: Converts values from one range to another
  * Range In  -> from  inputLowValue to   inputHighValue
  * Range Out -> from outputLowValue to outputtHighValue
  * offset true  -> allows to take into account the minimum of each range in the conversion

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -419,6 +419,26 @@ void TiltPositionSet(chip::EndpointId endpoint, uint16_t percent100ths)
     emberAfWindowCoveringClusterPrint("Tilt Position Set: %u%%", percent);
 }
 
+OperationalState ComputeOperationalState(uint16_t target, uint16_t current)
+{
+    OperationalState opState = OperationalState::Stall;
+
+    if (current != target)
+    {
+        opState = (current < target) ? OperationalState::MovingDownOrClose : OperationalState::MovingUpOrOpen;
+    }
+    return opState;
+}
+
+OperationalState ComputeOperationalState(NPercent100ths target, NPercent100ths current)
+{
+    if (!current.IsNull() && !target.IsNull())
+    {
+        return ComputeOperationalState(target.Value(), current.Value());
+    }
+    return OperationalState::Stall;
+}
+
 } // namespace WindowCovering
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -42,6 +42,13 @@ using namespace chip::app::Clusters::WindowCovering;
 #define CHECK_BOUNDS_INVALID(MIN, VAL, MAX) ((VAL < MIN) || (VAL > MAX))
 #define CHECK_BOUNDS_VALID(MIN, VAL, MAX) (!CHECK_BOUNDS_INVALID(MIN, VAL, MAX))
 
+/*
+ * ConvertValue: Permits to convert values from one range to another
+ * Range In  -> from  inputLowValue to   inputHighValue
+ * Range Out -> from outputLowValue to outputtHighValue
+ * offset true  -> allows to take into account the minimum of each range in the conversion
+ * offset false -> applies only the basic "rule of three" for the conversion
+ */
 static uint16_t ConvertValue(uint16_t inputLowValue, uint16_t inputHighValue, uint16_t outputLowValue, uint16_t outputHighValue,
                              uint16_t value, bool offset)
 {

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -323,10 +323,10 @@ LimitStatus CheckLimitState(uint16_t position, AbsoluteLimits limits)
         return LimitStatus::IsDownOrClose;
 
     if ((limits.open > 0) && (position < limits.open))
-        return LimitStatus::IsOverUpOrOpen;
+        return LimitStatus::IsPostUpOrOpen;
 
     if ((limits.closed > 0) && (position > limits.closed))
-        return LimitStatus::IsOverDownOrClose;
+        return LimitStatus::IsPostDownOrClose;
 
     return LimitStatus::Intermediate;
 }

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -40,9 +40,10 @@ using namespace chip;
 using namespace chip::app::Clusters::WindowCovering;
 
 #define CHECK_BOUNDS_INVALID(MIN, VAL, MAX) ((VAL < MIN) || (VAL > MAX))
-#define CHECK_BOUNDS_VALID(MIN, VAL, MAX)   (!CHECK_BOUNDS_INVALID(MIN, VAL, MAX))
+#define CHECK_BOUNDS_VALID(MIN, VAL, MAX) (!CHECK_BOUNDS_INVALID(MIN, VAL, MAX))
 
-static uint16_t ConvertValue(uint16_t inputLowValue, uint16_t inputHighValue, uint16_t outputLowValue, uint16_t outputHighValue, uint16_t value, bool offset)
+static uint16_t ConvertValue(uint16_t inputLowValue, uint16_t inputHighValue, uint16_t outputLowValue, uint16_t outputHighValue,
+                             uint16_t value, bool offset)
 {
     uint16_t inputMin = inputLowValue, inputMax = inputHighValue, inputRange = UINT16_MAX;
     uint16_t outputMin = outputLowValue, outputMax = outputHighValue, outputRange = UINT16_MAX;
@@ -59,9 +60,8 @@ static uint16_t ConvertValue(uint16_t inputLowValue, uint16_t inputHighValue, ui
         outputMax = outputLowValue;
     }
 
-    inputRange = static_cast<uint16_t>(inputMax - inputMin);
+    inputRange  = static_cast<uint16_t>(inputMax - inputMin);
     outputRange = static_cast<uint16_t>(outputMax - outputMin);
-
 
     if (offset)
     {
@@ -74,7 +74,6 @@ static uint16_t ConvertValue(uint16_t inputLowValue, uint16_t inputHighValue, ui
         {
             return outputMax;
         }
-
 
         if (inputRange > 0)
         {
@@ -90,7 +89,6 @@ static uint16_t ConvertValue(uint16_t inputLowValue, uint16_t inputHighValue, ui
     }
 
     return outputMax;
-
 }
 
 static Percent100ths ValueToPercent100ths(AbsoluteLimits limits, uint16_t absolute)
@@ -102,8 +100,6 @@ static uint16_t Percent100thsToValue(AbsoluteLimits limits, Percent100ths relati
 {
     return ConvertValue(WC_PERCENT100THS_MIN_OPEN, WC_PERCENT100THS_MAX_CLOSED, limits.open, limits.closed, relative, true);
 }
-
-
 
 static OperationalState ValueToOperationalState(uint8_t value)
 {
@@ -143,7 +139,7 @@ namespace WindowCovering {
 
 bool HasFeature(chip::EndpointId endpoint, WcFeature feature)
 {
-    bool hasFeature = false;
+    bool hasFeature     = false;
     uint32_t FeatureMap = 0;
     if (EMBER_ZCL_STATUS_SUCCESS ==
         emberAfReadServerAttribute(endpoint, chip::app::Clusters::WindowCovering::Id,
@@ -208,13 +204,15 @@ const ConfigStatus ConfigStatusGet(chip::EndpointId endpoint)
     return status;
 }
 
-
 void OperationalStatusSetWithGlobalUpdated(chip::EndpointId endpoint, OperationalStatus & status)
 {
     /* Global Always follow Lift by priority and then fallback to Tilt */
-    if (OperationalState::Stall != status.lift) {
+    if (OperationalState::Stall != status.lift)
+    {
         status.global = status.lift;
-    } else {
+    }
+    else
+    {
         status.global = status.tilt;
     }
 
@@ -324,7 +322,7 @@ LimitStatus CheckLimitState(uint16_t position, AbsoluteLimits limits)
     if (position == limits.closed)
         return LimitStatus::IsDownOrClose;
 
-    if ((limits.open   > 0) && (position < limits.open  ))
+    if ((limits.open > 0) && (position < limits.open))
         return LimitStatus::IsOverUpOrOpen;
 
     if ((limits.closed > 0) && (position > limits.closed))

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -208,6 +208,19 @@ const ConfigStatus ConfigStatusGet(chip::EndpointId endpoint)
     return status;
 }
 
+
+void OperationalStatusSetWithGlobalUpdated(chip::EndpointId endpoint, OperationalStatus & status)
+{
+    /* Global Always follow Lift by priority and then fallback to Tilt */
+    if (OperationalState::Stall != status.lift) {
+        status.global = status.lift;
+    } else {
+        status.global = status.tilt;
+    }
+
+    OperationalStatusSet(endpoint, status);
+}
+
 void OperationalStatusSet(chip::EndpointId endpoint, const OperationalStatus & status)
 {
     uint8_t global = OperationalStateToValue(status.global);

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -140,13 +140,12 @@ namespace WindowCovering {
 bool HasFeature(chip::EndpointId endpoint, WcFeature feature)
 {
     bool hasFeature     = false;
-    uint32_t FeatureMap = 0;
-    if (EMBER_ZCL_STATUS_SUCCESS ==
-        emberAfReadServerAttribute(endpoint, chip::app::Clusters::WindowCovering::Id,
-                                   chip::app::Clusters::WindowCovering::Attributes::FeatureMap::Id,
-                                   reinterpret_cast<uint8_t *>(&FeatureMap), sizeof(FeatureMap)))
+    uint32_t featureMap = 0;
+
+    EmberAfStatus status = Attributes::FeatureMap::Get(endpoint, &featureMap);
+    if (EMBER_ZCL_STATUS_SUCCESS == status)
     {
-        hasFeature = (FeatureMap & chip::to_underlying(feature));
+        hasFeature = (featureMap & chip::to_underlying(feature));
     }
 
     return hasFeature;

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -40,29 +40,12 @@ using namespace chip;
 using namespace chip::app::Clusters::WindowCovering;
 
 
-static bool HasFeature(chip::EndpointId endpoint, WcFeature feature)
 {
-    uint32_t FeatureMap = 0;
-    if (EMBER_ZCL_STATUS_SUCCESS ==
-        emberAfReadServerAttribute(endpoint, chip::app::Clusters::WindowCovering::Id,
-                                   chip::app::Clusters::WindowCovering::Attributes::FeatureMap::Id,
-                                   reinterpret_cast<uint8_t *>(&FeatureMap), sizeof(FeatureMap)))
     {
-        return (FeatureMap & chip::to_underlying(feature)) != 0;
     }
 
-    return false;
-}
 
-static bool HasFeaturePaLift(chip::EndpointId endpoint)
-{
-    return (HasFeature(endpoint, WcFeature::kLift) && HasFeature(endpoint, WcFeature::kPositionAwareLift));
-}
 
-static bool HasFeaturePaTilt(chip::EndpointId endpoint)
-{
-    return (HasFeature(endpoint, WcFeature::kTilt) && HasFeature(endpoint, WcFeature::kPositionAwareTilt));
-}
 
 static uint16_t ValueToPercent100ths(uint16_t openLimit, uint16_t closedLimit, uint16_t value)
 {
@@ -153,14 +136,29 @@ namespace app {
 namespace Clusters {
 namespace WindowCovering {
 
+bool HasFeature(chip::EndpointId endpoint, WcFeature feature)
 {
+    bool hasFeature = false;
+    uint32_t FeatureMap = 0;
+    if (EMBER_ZCL_STATUS_SUCCESS ==
+        emberAfReadServerAttribute(endpoint, chip::app::Clusters::WindowCovering::Id,
+                                   chip::app::Clusters::WindowCovering::Attributes::FeatureMap::Id,
+                                   reinterpret_cast<uint8_t *>(&FeatureMap), sizeof(FeatureMap)))
+    {
+        hasFeature = (FeatureMap & chip::to_underlying(feature));
+    }
 
+    return hasFeature;
 }
 
+static bool HasFeaturePaLift(chip::EndpointId endpoint)
 {
+    return (HasFeature(endpoint, WcFeature::kLift) && HasFeature(endpoint, WcFeature::kPositionAwareLift));
 }
 
+static bool HasFeaturePaTilt(chip::EndpointId endpoint)
 {
+    return (HasFeature(endpoint, WcFeature::kTilt) && HasFeature(endpoint, WcFeature::kPositionAwareTilt));
 }
 
 void TypeSet(chip::EndpointId endpoint, EmberAfWcType type)

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -24,7 +24,7 @@
 
 #include <app/data-model/Nullable.h>
 
-#define WC_PERCENT100THS_MIN_OPEN   0
+#define WC_PERCENT100THS_MIN_OPEN 0
 #define WC_PERCENT100THS_MAX_CLOSED 10000
 
 namespace chip {

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -121,6 +121,9 @@ void OperationalStatusSet(chip::EndpointId endpoint, const OperationalStatus & s
 void OperationalStatusSetWithGlobalUpdated(chip::EndpointId endpoint, OperationalStatus & status);
 const OperationalStatus OperationalStatusGet(chip::EndpointId endpoint);
 
+OperationalState ComputeOperationalState(uint16_t target, uint16_t current);
+OperationalState ComputeOperationalState(NPercent100ths target, NPercent100ths current);
+
 void EndProductTypeSet(chip::EndpointId endpoint, EmberAfWcEndProductType type);
 EmberAfWcEndProductType EndProductTypeGet(chip::EndpointId endpoint);
 

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -131,6 +131,9 @@ const SafetyStatus SafetyStatusGet(chip::EndpointId endpoint);
 
 LimitStatus CheckLimitState(uint16_t position, AbsoluteLimits limits);
 
+bool IsPercent100thsValid(Percent100ths percent100ths);
+bool IsPercent100thsValid(NPercent100ths npercent100ths);
+
 uint16_t LiftToPercent100ths(chip::EndpointId endpoint, uint16_t lift);
 uint16_t Percent100thsToLift(chip::EndpointId endpoint, uint16_t percent100ths);
 void LiftPositionSet(chip::EndpointId endpoint, uint16_t percent100ths);

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -98,8 +98,8 @@ enum class LimitStatus : uint8_t
     IsUpOrOpen        = 0x01,
     IsDownOrClose     = 0x02,
     Inverted          = 0x03,
-    IsPostUpOrOpen    = 0x04,
-    IsPostDownOrClose = 0x05,
+    IsPastUpOrOpen    = 0x04,
+    IsPastDownOrClose = 0x05,
 };
 static_assert(sizeof(LimitStatus) == sizeof(uint8_t), "LimitStatus Size is not correct");
 

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -98,8 +98,8 @@ enum class LimitStatus : uint8_t
     IsUpOrOpen        = 0x01,
     IsDownOrClose     = 0x02,
     Inverted          = 0x03,
-    IsOverUpOrOpen    = 0x04,
-    IsOverDownOrClose = 0x05,
+    IsPostUpOrOpen    = 0x04,
+    IsPostDownOrClose = 0x05,
 };
 static_assert(sizeof(LimitStatus) == sizeof(uint8_t), "LimitStatus Size is not correct");
 

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -21,10 +21,19 @@
 #include <app-common/zap-generated/enums.h>
 #include <app/util/af-types.h>
 
+#include <app/data-model/Nullable.h>
+
+#define WC_PERCENT100THS_MIN_OPEN   0
+#define WC_PERCENT100THS_MAX_CLOSED 10000
+
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace WindowCovering {
+
+typedef DataModel::Nullable<Percent> NPercent;
+typedef DataModel::Nullable<Percent100ths> NPercent100ths;
+typedef DataModel::Nullable<uint16_t> NAbsolute;
 
 struct Mode
 {
@@ -81,11 +90,24 @@ struct SafetyStatus
 };
 static_assert(sizeof(SafetyStatus) == sizeof(uint16_t), "SafetyStatus Size is not correct");
 
-bool IsLiftOpen(chip::EndpointId endpoint);
-bool IsLiftClosed(chip::EndpointId endpoint);
+// Declare Position Limit Status
+enum class LimitStatus : uint8_t
+{
+    Intermediate      = 0x00,
+    IsUpOrOpen        = 0x01,
+    IsDownOrClose     = 0x02,
+    Inverted          = 0x03,
+    IsOverUpOrOpen    = 0x04,
+    IsOverDownOrClose = 0x05,
+};
+static_assert(sizeof(LimitStatus) == sizeof(uint8_t), "LimitStatus Size is not correct");
 
-bool IsTiltOpen(chip::EndpointId endpoint);
-bool IsTiltClosed(chip::EndpointId endpoint);
+struct AbsoluteLimits
+{
+    uint16_t open;
+    uint16_t closed;
+};
+
 
 void TypeSet(chip::EndpointId endpoint, EmberAfWcType type);
 EmberAfWcType TypeGet(chip::EndpointId endpoint);
@@ -104,6 +126,8 @@ const Mode ModeGet(chip::EndpointId endpoint);
 
 void SafetyStatusSet(chip::EndpointId endpoint, SafetyStatus & status);
 const SafetyStatus SafetyStatusGet(chip::EndpointId endpoint);
+
+LimitStatus CheckLimitState(uint16_t position, AbsoluteLimits limits);
 
 uint16_t LiftToPercent100ths(chip::EndpointId endpoint, uint16_t lift);
 uint16_t Percent100thsToLift(chip::EndpointId endpoint, uint16_t percent100ths);

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app-common/zap-generated/attribute-id.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/enums.h>
 #include <app/util/af-types.h>
 
@@ -108,6 +109,7 @@ struct AbsoluteLimits
     uint16_t closed;
 };
 
+bool HasFeature(chip::EndpointId endpoint, WcFeature feature);
 
 void TypeSet(chip::EndpointId endpoint, EmberAfWcType type);
 EmberAfWcType TypeGet(chip::EndpointId endpoint);

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -118,6 +118,7 @@ void ConfigStatusSet(chip::EndpointId endpoint, const ConfigStatus & status);
 const ConfigStatus ConfigStatusGet(chip::EndpointId endpoint);
 
 void OperationalStatusSet(chip::EndpointId endpoint, const OperationalStatus & status);
+void OperationalStatusSetWithGlobalUpdated(chip::EndpointId endpoint, OperationalStatus & status);
 const OperationalStatus OperationalStatusGet(chip::EndpointId endpoint);
 
 void EndProductTypeSet(chip::EndpointId endpoint, EmberAfWcEndProductType type);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

Goal: Lay down some small changes for next PRs

* Fix : Limits checks for invalid Percenth100s
* Simplification and factorization for incoming other PRs

#### Change overview
Add some Helper methods : 
 - to check a Percenth100
 - compute a movement comparing target and current
 - factorize the conversion function using AbsolutLimits
+ Move HasFeature functions

#### Testing
How was this tested? (at least one bullet point required)
* Test on EFR32 Window-app example
* Passing actual YAML tests
