### PR TITLE
Update ZAP to tip.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AccessControl = 31 {
@@ -133,8 +133,8 @@ server cluster ApplicationLauncher = 1292 {
   }
 
   struct ApplicationLauncherApplication {
-    INT16U catalogVendorId = 1;
-    CHAR_STRING applicationId = 2;
+    INT16U catalogVendorId = 0;
+    CHAR_STRING applicationId = 1;
   }
 
   attribute(readonly) INT16U applicationLauncherList[] = 0;
@@ -152,9 +152,9 @@ server cluster AudioOutput = 1291 {
   }
 
   struct OutputInfo {
-    INT8U index = 1;
-    OutputTypeEnum outputType = 2;
-    CHAR_STRING name = 3;
+    INT8U index = 0;
+    OutputTypeEnum outputType = 1;
+    CHAR_STRING name = 2;
   }
 
   attribute(readonly) OutputInfo audioOutputList[] = 0;
@@ -283,19 +283,19 @@ server cluster BridgedActions = 37 {
   }
 
   struct ActionStruct {
-    INT16U actionID = 1;
-    CHAR_STRING name = 2;
-    ActionTypeEnum type = 3;
-    INT16U endpointListID = 4;
-    INT16U supportedCommands = 5;
-    ActionStateEnum status = 6;
+    INT16U actionID = 0;
+    CHAR_STRING name = 1;
+    ActionTypeEnum type = 2;
+    INT16U endpointListID = 3;
+    INT16U supportedCommands = 4;
+    ActionStateEnum status = 5;
   }
 
   struct EndpointListStruct {
-    INT16U endpointListID = 1;
-    CHAR_STRING name = 2;
-    EndpointListTypeEnum type = 3;
-    ENDPOINT_NO endpoints[] = 4;
+    INT16U endpointListID = 0;
+    CHAR_STRING name = 1;
+    EndpointListTypeEnum type = 2;
+    ENDPOINT_NO endpoints[] = 3;
   }
 
   info event StateChanged = 0 {
@@ -332,11 +332,11 @@ server cluster Channel = 1284 {
   }
 
   struct ChannelInfo {
-    INT16U majorNumber = 1;
-    INT16U minorNumber = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING callSign = 4;
-    CHAR_STRING affiliateCallSign = 5;
+    INT16U majorNumber = 0;
+    INT16U minorNumber = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING callSign = 3;
+    CHAR_STRING affiliateCallSign = 4;
   }
 
   attribute(readonly) ChannelInfo channelList[] = 0;
@@ -642,39 +642,39 @@ server cluster ContentLauncher = 1290 {
   }
 
   struct ContentSearch {
-    Parameter parameterList[] = 1;
+    Parameter parameterList[] = 0;
   }
 
   struct Parameter {
-    ParameterEnum type = 1;
-    CHAR_STRING value = 2;
-    AdditionalInfo externalIDList[] = 3;
+    ParameterEnum type = 0;
+    CHAR_STRING value = 1;
+    AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
-    CHAR_STRING name = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING name = 0;
+    CHAR_STRING value = 1;
   }
 
   struct BrandingInformation {
-    CHAR_STRING providerName = 1;
-    StyleInformation background = 2;
-    StyleInformation logo = 3;
-    StyleInformation progressBar = 4;
-    StyleInformation splash = 5;
-    StyleInformation waterMark = 6;
+    CHAR_STRING providerName = 0;
+    StyleInformation background = 1;
+    StyleInformation logo = 2;
+    StyleInformation progressBar = 3;
+    StyleInformation splash = 4;
+    StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 1;
-    CHAR_STRING color = 2;
-    Dimension size = 3;
+    CHAR_STRING imageUrl = 0;
+    CHAR_STRING color = 1;
+    Dimension size = 2;
   }
 
   struct Dimension {
-    double width = 1;
-    double height = 2;
-    MetricTypeEnum metric = 3;
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
   }
 
   attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
@@ -684,8 +684,8 @@ server cluster ContentLauncher = 1290 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -920,8 +920,8 @@ server cluster DoorLock = 257 {
   }
 
   struct DlCredential {
-    DlCredentialType credentialType = 1;
-    INT16U credentialIndex = 2;
+    DlCredentialType credentialType = 0;
+    INT16U credentialIndex = 1;
   }
 
   critical event DoorLockAlarm = 0 {
@@ -1139,7 +1139,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -1233,12 +1233,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -1714,10 +1714,10 @@ server cluster MediaInput = 1287 {
   }
 
   struct InputInfo {
-    INT8U index = 1;
-    InputTypeEnum inputType = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING description = 4;
+    INT8U index = 0;
+    InputTypeEnum inputType = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING description = 3;
   }
 
   attribute(readonly) InputInfo mediaInputList[] = 0;
@@ -1753,9 +1753,9 @@ server cluster MediaPlayback = 1286 {
 
 server cluster ModeSelect = 80 {
   struct ModeOptionStruct {
-    CHAR_STRING label = 1;
-    INT8U mode = 2;
-    INT32U semanticTag = 3;
+    CHAR_STRING label = 0;
+    INT8U mode = 1;
+    INT32U semanticTag = 2;
   }
 
   attribute(readonly) int8u currentMode = 0;
@@ -1798,28 +1798,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -2085,12 +2085,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -2304,9 +2304,9 @@ server cluster RelativeHumidityMeasurement = 1029 {
 
 server cluster Scenes = 5 {
   struct SceneExtensionFieldSet {
-    CLUSTER_ID clusterId = 1;
-    INT8U length = 2;
-    INT8U value = 3;
+    CLUSTER_ID clusterId = 0;
+    INT8U length = 1;
+    INT8U value = 2;
   }
 
   attribute(readonly) int8u sceneCount = 0;
@@ -2404,11 +2404,11 @@ server cluster Scenes = 5 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -2471,8 +2471,8 @@ server cluster TargetNavigator = 1285 {
   }
 
   struct TargetInfo {
-    INT8U identifier = 1;
-    CHAR_STRING name = 2;
+    INT8U identifier = 0;
+    CHAR_STRING name = 1;
   }
 
   attribute(readonly) TargetInfo targetNavigatorList[] = 0;
@@ -2497,50 +2497,50 @@ server cluster TestCluster = 1295 {
   }
 
   struct TestListStructOctet {
-    INT64U fabricIndex = 1;
-    OCTET_STRING operationalCert = 2;
+    INT64U fabricIndex = 0;
+    OCTET_STRING operationalCert = 1;
   }
 
   struct NullablesAndOptionalsStruct {
-    nullable INT16U nullableInt = 1;
-    optional INT16U optionalInt = 2;
-    optional nullable INT16U nullableOptionalInt = 3;
-    nullable CHAR_STRING nullableString = 4;
-    optional CHAR_STRING optionalString = 5;
-    optional nullable CHAR_STRING nullableOptionalString = 6;
-    nullable SimpleStruct nullableStruct = 7;
-    optional SimpleStruct optionalStruct = 8;
-    optional nullable SimpleStruct nullableOptionalStruct = 9;
-    nullable SimpleEnum nullableList[] = 10;
-    optional SimpleEnum optionalList[] = 11;
-    optional nullable SimpleEnum nullableOptionalList[] = 12;
+    nullable INT16U nullableInt = 0;
+    optional INT16U optionalInt = 1;
+    optional nullable INT16U nullableOptionalInt = 2;
+    nullable CHAR_STRING nullableString = 3;
+    optional CHAR_STRING optionalString = 4;
+    optional nullable CHAR_STRING nullableOptionalString = 5;
+    nullable SimpleStruct nullableStruct = 6;
+    optional SimpleStruct optionalStruct = 7;
+    optional nullable SimpleStruct nullableOptionalStruct = 8;
+    nullable SimpleEnum nullableList[] = 9;
+    optional SimpleEnum optionalList[] = 10;
+    optional nullable SimpleEnum nullableOptionalList[] = 11;
   }
 
   struct SimpleStruct {
-    INT8U a = 1;
-    BOOLEAN b = 2;
-    SimpleEnum c = 3;
-    OCTET_STRING d = 4;
-    CHAR_STRING e = 5;
-    SimpleBitmap f = 6;
-    single g = 7;
-    double h = 8;
+    INT8U a = 0;
+    BOOLEAN b = 1;
+    SimpleEnum c = 2;
+    OCTET_STRING d = 3;
+    CHAR_STRING e = 4;
+    SimpleBitmap f = 5;
+    single g = 6;
+    double h = 7;
   }
 
   struct NestedStructList {
-    INT8U a = 1;
-    BOOLEAN b = 2;
-    SimpleStruct c = 3;
-    SimpleStruct d[] = 4;
-    INT32U e[] = 5;
-    OCTET_STRING f[] = 6;
-    INT8U g[] = 7;
+    INT8U a = 0;
+    BOOLEAN b = 1;
+    SimpleStruct c = 2;
+    SimpleStruct d[] = 3;
+    INT32U e[] = 4;
+    OCTET_STRING f[] = 5;
+    INT8U g[] = 6;
   }
 
   struct NestedStruct {
-    INT8U a = 1;
-    BOOLEAN b = 2;
-    SimpleStruct c = 3;
+    INT8U a = 0;
+    BOOLEAN b = 1;
+    SimpleStruct c = 2;
   }
 
   info event TestEvent = 1 {
@@ -2797,53 +2797,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -73,8 +73,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -161,7 +161,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -255,12 +255,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -405,28 +405,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -537,12 +537,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -626,11 +626,11 @@ server cluster OperationalCredentials = 62 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -707,53 +707,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/door-lock-app/door-lock-common/door-lock-app.matter
+++ b/examples/door-lock-app/door-lock-common/door-lock-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -73,8 +73,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -309,8 +309,8 @@ server cluster DoorLock = 257 {
   }
 
   struct DlCredential {
-    DlCredentialType credentialType = 1;
-    INT16U credentialIndex = 2;
+    DlCredentialType credentialType = 0;
+    INT16U credentialIndex = 1;
   }
 
   critical event DoorLockAlarm = 0 {
@@ -494,7 +494,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -588,12 +588,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -657,28 +657,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -765,12 +765,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -872,11 +872,11 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -915,53 +915,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -320,8 +320,8 @@ server cluster ColorControl = 768 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -410,7 +410,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -504,12 +504,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -699,28 +699,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -1022,12 +1022,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -1111,11 +1111,11 @@ server cluster OperationalCredentials = 62 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -1189,53 +1189,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -73,8 +73,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -161,7 +161,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -255,12 +255,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -324,28 +324,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -461,12 +461,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -568,11 +568,11 @@ server cluster PowerSourceConfiguration = 46 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -611,53 +611,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -75,7 +75,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -141,23 +141,23 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int16u clusterRevision = 65533;
@@ -235,12 +235,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster FixedLabel = 64 {
@@ -26,7 +26,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -100,28 +100,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -273,12 +273,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster Basic = 40 {
@@ -57,7 +57,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -131,28 +131,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -373,12 +373,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -122,8 +122,8 @@ server cluster ColorControl = 768 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -148,7 +148,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -375,28 +375,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -507,12 +507,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -596,9 +596,9 @@ server cluster OperationalCredentials = 62 {
 
 server cluster Scenes = 5 {
   struct SceneExtensionFieldSet {
-    CLUSTER_ID clusterId = 1;
-    INT8U length = 2;
-    INT8U value = 3;
+    CLUSTER_ID clusterId = 0;
+    INT8U length = 1;
+    INT8U value = 2;
   }
 
   attribute(readonly) int8u sceneCount = 0;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -122,8 +122,8 @@ server cluster ColorControl = 768 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -148,7 +148,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -375,28 +375,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -507,12 +507,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -596,9 +596,9 @@ server cluster OperationalCredentials = 62 {
 
 server cluster Scenes = 5 {
   struct SceneExtensionFieldSet {
-    CLUSTER_ID clusterId = 1;
-    INT8U length = 2;
-    INT8U value = 3;
+    CLUSTER_ID clusterId = 0;
+    INT8U length = 1;
+    INT8U value = 2;
   }
 
   attribute(readonly) int8u sceneCount = 0;

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -75,8 +75,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -150,7 +150,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -244,12 +244,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -380,28 +380,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -512,12 +512,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -711,11 +711,11 @@ server cluster PumpConfigurationAndControl = 512 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -768,53 +768,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -75,8 +75,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -170,7 +170,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -264,12 +264,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -400,28 +400,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -532,12 +532,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -706,11 +706,11 @@ client cluster PumpConfigurationAndControl = 512 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -756,53 +756,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -73,8 +73,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -161,7 +161,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -255,12 +255,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -324,28 +324,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -426,12 +426,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -104,8 +104,8 @@ server cluster Binding = 30 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -192,7 +192,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -286,12 +286,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -512,28 +512,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -685,12 +685,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -774,9 +774,9 @@ server cluster OperationalCredentials = 62 {
 
 server cluster Scenes = 5 {
   struct SceneExtensionFieldSet {
-    CLUSTER_ID clusterId = 1;
-    INT8U length = 2;
-    INT8U value = 3;
+    CLUSTER_ID clusterId = 0;
+    INT8U length = 1;
+    INT8U value = 2;
   }
 
   attribute(readonly) int8u sceneCount = 0;
@@ -874,11 +874,11 @@ server cluster Scenes = 5 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -984,53 +984,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AccountLogin = 1294 {
@@ -72,8 +72,8 @@ server cluster ApplicationBasic = 1293 {
   }
 
   struct ApplicationBasicApplication {
-    INT16U catalogVendorId = 1;
-    CHAR_STRING applicationId = 2;
+    INT16U catalogVendorId = 0;
+    CHAR_STRING applicationId = 1;
   }
 
   attribute(readonly) char_string vendorName = 0;
@@ -95,13 +95,13 @@ server cluster ApplicationLauncher = 1292 {
   }
 
   struct ApplicationEP {
-    ApplicationLauncherApplication application = 1;
-    CHAR_STRING endpoint = 2;
+    ApplicationLauncherApplication application = 0;
+    CHAR_STRING endpoint = 1;
   }
 
   struct ApplicationLauncherApplication {
-    INT16U catalogVendorId = 1;
-    CHAR_STRING applicationId = 2;
+    INT16U catalogVendorId = 0;
+    CHAR_STRING applicationId = 1;
   }
 
   attribute(readonly) INT16U applicationLauncherList[] = 0;
@@ -142,9 +142,9 @@ server cluster AudioOutput = 1291 {
   }
 
   struct OutputInfo {
-    INT8U index = 1;
-    OutputTypeEnum outputType = 2;
-    CHAR_STRING name = 3;
+    INT8U index = 0;
+    OutputTypeEnum outputType = 1;
+    CHAR_STRING name = 2;
   }
 
   attribute(readonly) OutputInfo audioOutputList[] = 0;
@@ -255,18 +255,18 @@ server cluster Channel = 1284 {
   }
 
   struct ChannelInfo {
-    INT16U majorNumber = 1;
-    INT16U minorNumber = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING callSign = 4;
-    CHAR_STRING affiliateCallSign = 5;
+    INT16U majorNumber = 0;
+    INT16U minorNumber = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING callSign = 3;
+    CHAR_STRING affiliateCallSign = 4;
   }
 
   struct LineupInfo {
-    CHAR_STRING operatorName = 1;
-    CHAR_STRING lineupName = 2;
-    CHAR_STRING postalCode = 3;
-    LineupInfoTypeEnum lineupInfoType = 4;
+    CHAR_STRING operatorName = 0;
+    CHAR_STRING lineupName = 1;
+    CHAR_STRING postalCode = 2;
+    LineupInfoTypeEnum lineupInfoType = 3;
   }
 
   attribute(readonly) ChannelInfo channelList[] = 0;
@@ -326,39 +326,39 @@ server cluster ContentLauncher = 1290 {
   }
 
   struct ContentSearch {
-    Parameter parameterList[] = 1;
+    Parameter parameterList[] = 0;
   }
 
   struct Parameter {
-    ParameterEnum type = 1;
-    CHAR_STRING value = 2;
-    AdditionalInfo externalIDList[] = 3;
+    ParameterEnum type = 0;
+    CHAR_STRING value = 1;
+    AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
-    CHAR_STRING name = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING name = 0;
+    CHAR_STRING value = 1;
   }
 
   struct BrandingInformation {
-    CHAR_STRING providerName = 1;
-    StyleInformation background = 2;
-    StyleInformation logo = 3;
-    StyleInformation progressBar = 4;
-    StyleInformation splash = 5;
-    StyleInformation waterMark = 6;
+    CHAR_STRING providerName = 0;
+    StyleInformation background = 1;
+    StyleInformation logo = 2;
+    StyleInformation progressBar = 3;
+    StyleInformation splash = 4;
+    StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 1;
-    CHAR_STRING color = 2;
-    Dimension size = 3;
+    CHAR_STRING imageUrl = 0;
+    CHAR_STRING color = 1;
+    Dimension size = 2;
   }
 
   struct Dimension {
-    double width = 1;
-    double height = 2;
-    MetricTypeEnum metric = 3;
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
   }
 
   attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
@@ -388,8 +388,8 @@ server cluster ContentLauncher = 1290 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -476,7 +476,7 @@ client cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -534,7 +534,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -628,12 +628,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -904,10 +904,10 @@ server cluster MediaInput = 1287 {
   }
 
   struct InputInfo {
-    INT8U index = 1;
-    InputTypeEnum inputType = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING description = 4;
+    INT8U index = 0;
+    InputTypeEnum inputType = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING description = 3;
   }
 
   attribute(readonly) InputInfo mediaInputList[] = 0;
@@ -947,8 +947,8 @@ server cluster MediaPlayback = 1286 {
   }
 
   struct PlaybackPosition {
-    INT64U updatedAt = 1;
-    INT64U position = 2;
+    INT64U updatedAt = 0;
+    INT64U position = 1;
   }
 
   attribute(readonly) PlaybackStateEnum playbackState = 0;
@@ -1015,28 +1015,28 @@ client cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -1134,28 +1134,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -1331,12 +1331,12 @@ client cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -1422,12 +1422,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -1518,11 +1518,11 @@ server cluster RelativeHumidityMeasurement = 1029 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -1545,8 +1545,8 @@ server cluster TargetNavigator = 1285 {
   }
 
   struct TargetInfo {
-    INT8U identifier = 1;
-    CHAR_STRING name = 2;
+    INT8U identifier = 0;
+    CHAR_STRING name = 1;
   }
 
   attribute(readonly) TargetInfo targetNavigatorList[] = 0;
@@ -1590,53 +1590,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 client cluster AccountLogin = 1294 {
@@ -84,8 +84,8 @@ client cluster ApplicationLauncher = 1292 {
   }
 
   struct ApplicationLauncherApplication {
-    INT16U catalogVendorId = 1;
-    CHAR_STRING applicationId = 2;
+    INT16U catalogVendorId = 0;
+    CHAR_STRING applicationId = 1;
   }
 
   attribute(readonly) INT16U applicationLauncherList[] = 0;
@@ -120,9 +120,9 @@ client cluster AudioOutput = 1291 {
   }
 
   struct OutputInfo {
-    INT8U index = 1;
-    OutputTypeEnum outputType = 2;
-    CHAR_STRING name = 3;
+    INT8U index = 0;
+    OutputTypeEnum outputType = 1;
+    CHAR_STRING name = 2;
   }
 
   attribute(readonly) OutputInfo audioOutputList[] = 0;
@@ -257,18 +257,18 @@ client cluster Channel = 1284 {
   }
 
   struct ChannelInfo {
-    INT16U majorNumber = 1;
-    INT16U minorNumber = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING callSign = 4;
-    CHAR_STRING affiliateCallSign = 5;
+    INT16U majorNumber = 0;
+    INT16U minorNumber = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING callSign = 3;
+    CHAR_STRING affiliateCallSign = 4;
   }
 
   struct LineupInfo {
-    CHAR_STRING operatorName = 1;
-    CHAR_STRING lineupName = 2;
-    CHAR_STRING postalCode = 3;
-    LineupInfoTypeEnum lineupInfoType = 4;
+    CHAR_STRING operatorName = 0;
+    CHAR_STRING lineupName = 1;
+    CHAR_STRING postalCode = 2;
+    LineupInfoTypeEnum lineupInfoType = 3;
   }
 
   attribute(readonly) ChannelInfo channelList[] = 0;
@@ -545,39 +545,39 @@ client cluster ContentLauncher = 1290 {
   }
 
   struct ContentSearch {
-    Parameter parameterList[] = 1;
+    Parameter parameterList[] = 0;
   }
 
   struct Parameter {
-    ParameterEnum type = 1;
-    CHAR_STRING value = 2;
-    AdditionalInfo externalIDList[] = 3;
+    ParameterEnum type = 0;
+    CHAR_STRING value = 1;
+    AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
-    CHAR_STRING name = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING name = 0;
+    CHAR_STRING value = 1;
   }
 
   struct BrandingInformation {
-    CHAR_STRING providerName = 1;
-    StyleInformation background = 2;
-    StyleInformation logo = 3;
-    StyleInformation progressBar = 4;
-    StyleInformation splash = 5;
-    StyleInformation waterMark = 6;
+    CHAR_STRING providerName = 0;
+    StyleInformation background = 1;
+    StyleInformation logo = 2;
+    StyleInformation progressBar = 3;
+    StyleInformation splash = 4;
+    StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 1;
-    CHAR_STRING color = 2;
-    Dimension size = 3;
+    CHAR_STRING imageUrl = 0;
+    CHAR_STRING color = 1;
+    Dimension size = 2;
   }
 
   struct Dimension {
-    double width = 1;
-    double height = 2;
-    MetricTypeEnum metric = 3;
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
   }
 
   attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
@@ -602,8 +602,8 @@ client cluster ContentLauncher = 1290 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -838,8 +838,8 @@ server cluster DoorLock = 257 {
   }
 
   struct DlCredential {
-    DlCredentialType credentialType = 1;
-    INT16U credentialIndex = 2;
+    DlCredentialType credentialType = 0;
+    INT16U credentialIndex = 1;
   }
 
   critical event DoorLockAlarm = 0 {
@@ -1039,7 +1039,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -1133,12 +1133,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -1550,10 +1550,10 @@ client cluster MediaInput = 1287 {
   }
 
   struct InputInfo {
-    INT8U index = 1;
-    InputTypeEnum inputType = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING description = 4;
+    INT8U index = 0;
+    InputTypeEnum inputType = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING description = 3;
   }
 
   attribute(readonly) InputInfo mediaInputList[] = 0;
@@ -1644,28 +1644,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -1853,12 +1853,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -1956,9 +1956,9 @@ server cluster RelativeHumidityMeasurement = 1029 {
 
 server cluster Scenes = 5 {
   struct SceneExtensionFieldSet {
-    CLUSTER_ID clusterId = 1;
-    INT8U length = 2;
-    INT8U value = 3;
+    CLUSTER_ID clusterId = 0;
+    INT8U length = 1;
+    INT8U value = 2;
   }
 
   attribute(readonly) int8u sceneCount = 0;
@@ -2056,11 +2056,11 @@ server cluster Scenes = 5 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -2119,8 +2119,8 @@ client cluster TargetNavigator = 1285 {
   }
 
   struct TargetInfo {
-    INT8U identifier = 1;
-    CHAR_STRING name = 2;
+    INT8U identifier = 0;
+    CHAR_STRING name = 1;
   }
 
   attribute(readonly) TargetInfo targetNavigatorList[] = 0;
@@ -2150,8 +2150,8 @@ server cluster TestCluster = 1295 {
   }
 
   struct TestListStructOctet {
-    INT64U fabricIndex = 1;
-    OCTET_STRING operationalCert = 2;
+    INT64U fabricIndex = 0;
+    OCTET_STRING operationalCert = 1;
   }
 
   info event TestEvent = 1 {
@@ -2244,53 +2244,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 server cluster AdministratorCommissioning = 60 {
@@ -80,8 +80,8 @@ server cluster Basic = 40 {
 
 server cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -138,7 +138,7 @@ server cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -232,12 +232,12 @@ server cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -346,28 +346,28 @@ server cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -454,12 +454,12 @@ server cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -557,11 +557,11 @@ server cluster PowerSource = 47 {
 
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -600,53 +600,53 @@ server cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -54,7 +54,7 @@ while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
   switch (currentDecodeTagId)
   {
 {{#zcl_command_arguments}}
-    case {{index}}:
+    case {{fieldIdentifier}}:
 {{#if isArray}}
       // Just for compatibility, we will add array type support in IM later.
       TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>({{asSymbol label}}));

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -99,7 +99,7 @@ namespace Commands {
 namespace {{asUpperCamelCase name}} {
 enum class Fields {
     {{#zcl_command_arguments}}
-    k{{asUpperCamelCase label}} = {{index}},
+    k{{asUpperCamelCase label}} = {{fieldIdentifier}},
     {{/zcl_command_arguments}}
 };
 

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -250,8 +250,7 @@ function chip_cluster_command_arguments(options)
   const commands  = getCommands.call(this.parent, 'chip_cluster_commands_argments');
 
   const filter = command => command.id == commandId;
-  return asBlocks.call(this,
-      commands.then(items => items.find(filter).arguments.map((value, index) => ({...value, fieldIdentifier : index }))), options);
+  return asBlocks.call(this, commands.then(items => items.find(filter).arguments), options);
 }
 
 /**
@@ -300,8 +299,7 @@ function chip_cluster_response_arguments(options)
   const responses = getResponses.call(this.parent, 'chip_cluster_responses_argments');
 
   const filter = command => command.id == commandId;
-  return asBlocks.call(this,
-      responses.then(items => items.find(filter).arguments.map((value, index) => ({...value, fieldIdentifier : index }))), options);
+  return asBlocks.call(this, responses.then(items => items.find(filter).arguments), options);
 }
 
 /**

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2,8 +2,8 @@
 // It is for view/code review purposes only.
 
 struct LabelStruct {
-    CHAR_STRING label = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING label = 0;
+    CHAR_STRING value = 1;
 }
 
 client cluster AccessControl = 31 {
@@ -136,8 +136,8 @@ client cluster ApplicationBasic = 1293 {
   }
 
   struct ApplicationBasicApplication {
-    INT16U catalogVendorId = 1;
-    CHAR_STRING applicationId = 2;
+    INT16U catalogVendorId = 0;
+    CHAR_STRING applicationId = 1;
   }
 
   attribute(readonly) char_string vendorName = 0;
@@ -160,8 +160,8 @@ client cluster ApplicationLauncher = 1292 {
   }
 
   struct ApplicationLauncherApplication {
-    INT16U catalogVendorId = 1;
-    CHAR_STRING applicationId = 2;
+    INT16U catalogVendorId = 0;
+    CHAR_STRING applicationId = 1;
   }
 
   attribute(readonly) INT16U applicationLauncherList[] = 0;
@@ -202,9 +202,9 @@ client cluster AudioOutput = 1291 {
   }
 
   struct OutputInfo {
-    INT8U index = 1;
-    OutputTypeEnum outputType = 2;
-    CHAR_STRING name = 3;
+    INT8U index = 0;
+    OutputTypeEnum outputType = 1;
+    CHAR_STRING name = 2;
   }
 
   attribute(readonly) OutputInfo audioOutputList[] = 0;
@@ -351,19 +351,19 @@ client cluster BridgedActions = 37 {
   }
 
   struct ActionStruct {
-    INT16U actionID = 1;
-    CHAR_STRING name = 2;
-    ActionTypeEnum type = 3;
-    INT16U endpointListID = 4;
-    INT16U supportedCommands = 5;
-    ActionStateEnum status = 6;
+    INT16U actionID = 0;
+    CHAR_STRING name = 1;
+    ActionTypeEnum type = 2;
+    INT16U endpointListID = 3;
+    INT16U supportedCommands = 4;
+    ActionStateEnum status = 5;
   }
 
   struct EndpointListStruct {
-    INT16U endpointListID = 1;
-    CHAR_STRING name = 2;
-    EndpointListTypeEnum type = 3;
-    ENDPOINT_NO endpoints[] = 4;
+    INT16U endpointListID = 0;
+    CHAR_STRING name = 1;
+    EndpointListTypeEnum type = 2;
+    ENDPOINT_NO endpoints[] = 3;
   }
 
   info event StateChanged = 0 {
@@ -480,11 +480,11 @@ client cluster Channel = 1284 {
   }
 
   struct ChannelInfo {
-    INT16U majorNumber = 1;
-    INT16U minorNumber = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING callSign = 4;
-    CHAR_STRING affiliateCallSign = 5;
+    INT16U majorNumber = 0;
+    INT16U minorNumber = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING callSign = 3;
+    CHAR_STRING affiliateCallSign = 4;
   }
 
   attribute(readonly) ChannelInfo channelList[] = 0;
@@ -814,39 +814,39 @@ client cluster ContentLauncher = 1290 {
   }
 
   struct ContentSearch {
-    Parameter parameterList[] = 1;
+    Parameter parameterList[] = 0;
   }
 
   struct Parameter {
-    ParameterEnum type = 1;
-    CHAR_STRING value = 2;
-    AdditionalInfo externalIDList[] = 3;
+    ParameterEnum type = 0;
+    CHAR_STRING value = 1;
+    AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
-    CHAR_STRING name = 1;
-    CHAR_STRING value = 2;
+    CHAR_STRING name = 0;
+    CHAR_STRING value = 1;
   }
 
   struct BrandingInformation {
-    CHAR_STRING providerName = 1;
-    StyleInformation background = 2;
-    StyleInformation logo = 3;
-    StyleInformation progressBar = 4;
-    StyleInformation splash = 5;
-    StyleInformation waterMark = 6;
+    CHAR_STRING providerName = 0;
+    StyleInformation background = 1;
+    StyleInformation logo = 2;
+    StyleInformation progressBar = 3;
+    StyleInformation splash = 4;
+    StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 1;
-    CHAR_STRING color = 2;
-    Dimension size = 3;
+    CHAR_STRING imageUrl = 0;
+    CHAR_STRING color = 1;
+    Dimension size = 2;
   }
 
   struct Dimension {
-    double width = 1;
-    double height = 2;
-    MetricTypeEnum metric = 3;
+    double width = 0;
+    double height = 1;
+    MetricTypeEnum metric = 2;
   }
 
   attribute(readonly) CHAR_STRING acceptHeaderList[] = 0;
@@ -877,8 +877,8 @@ client cluster ContentLauncher = 1290 {
 
 client cluster Descriptor = 29 {
   struct DeviceType {
-    DEVTYPE_ID type = 1;
-    INT16U revision = 2;
+    DEVTYPE_ID type = 0;
+    INT16U revision = 1;
   }
 
   attribute(readonly) DeviceType deviceList[] = 0;
@@ -1122,8 +1122,8 @@ client cluster DoorLock = 257 {
   }
 
   struct DlCredential {
-    DlCredentialType credentialType = 1;
-    INT16U credentialIndex = 2;
+    DlCredentialType credentialType = 0;
+    INT16U credentialIndex = 1;
   }
 
   critical event DoorLockAlarm = 0 {
@@ -1335,7 +1335,7 @@ client cluster GeneralCommissioning = 48 {
   }
 
   struct BasicCommissioningInfoType {
-    INT32U failSafeExpiryLengthMs = 1;
+    INT32U failSafeExpiryLengthMs = 0;
   }
 
   attribute(writable) int64u breadcrumb = 0;
@@ -1429,12 +1429,12 @@ client cluster GeneralDiagnostics = 51 {
   }
 
   struct NetworkInterfaceType {
-    CHAR_STRING name = 1;
-    BOOLEAN fabricConnected = 2;
-    BOOLEAN offPremiseServicesReachableIPv4 = 3;
-    BOOLEAN offPremiseServicesReachableIPv6 = 4;
-    OCTET_STRING hardwareAddress = 5;
-    InterfaceType type = 6;
+    CHAR_STRING name = 0;
+    BOOLEAN fabricConnected = 1;
+    BOOLEAN offPremiseServicesReachableIPv4 = 2;
+    BOOLEAN offPremiseServicesReachableIPv6 = 3;
+    OCTET_STRING hardwareAddress = 4;
+    InterfaceType type = 5;
   }
 
   critical event HardwareFaultChange = 0 {
@@ -1873,10 +1873,10 @@ client cluster MediaInput = 1287 {
   }
 
   struct InputInfo {
-    INT8U index = 1;
-    InputTypeEnum inputType = 2;
-    CHAR_STRING name = 3;
-    CHAR_STRING description = 4;
+    INT8U index = 0;
+    InputTypeEnum inputType = 1;
+    CHAR_STRING name = 2;
+    CHAR_STRING description = 3;
   }
 
   attribute(readonly) InputInfo mediaInputList[] = 0;
@@ -1956,9 +1956,9 @@ client cluster MediaPlayback = 1286 {
 
 client cluster ModeSelect = 80 {
   struct ModeOptionStruct {
-    CHAR_STRING label = 1;
-    INT8U mode = 2;
-    INT32U semanticTag = 3;
+    CHAR_STRING label = 0;
+    INT8U mode = 1;
+    INT32U semanticTag = 2;
   }
 
   attribute(readonly) int8u currentMode = 0;
@@ -2002,28 +2002,28 @@ client cluster NetworkCommissioning = 49 {
   }
 
   struct NetworkInfo {
-    OCTET_STRING networkID = 1;
-    BOOLEAN connected = 2;
+    OCTET_STRING networkID = 0;
+    BOOLEAN connected = 1;
   }
 
   struct WiFiInterfaceScanResult {
-    BITMAP8 security = 1;
-    OCTET_STRING ssid = 2;
-    OCTET_STRING bssid = 3;
-    INT16U channel = 4;
-    WiFiBand wiFiBand = 5;
-    INT8S rssi = 6;
+    BITMAP8 security = 0;
+    OCTET_STRING ssid = 1;
+    OCTET_STRING bssid = 2;
+    INT16U channel = 3;
+    WiFiBand wiFiBand = 4;
+    INT8S rssi = 5;
   }
 
   struct ThreadInterfaceScanResult {
-    INT64U panId = 1;
-    INT64U extendedPanId = 2;
-    CHAR_STRING networkName = 3;
-    INT16U channel = 4;
-    INT8U version = 5;
-    INT64U extendedAddress = 6;
-    INT8S rssi = 7;
-    INT8U lqi = 8;
+    INT64U panId = 0;
+    INT64U extendedPanId = 1;
+    CHAR_STRING networkName = 2;
+    INT16U channel = 3;
+    INT8U version = 4;
+    INT64U extendedAddress = 5;
+    INT8S rssi = 6;
+    INT8U lqi = 7;
   }
 
   attribute(readonly) int8u maxNetworks = 0;
@@ -2305,12 +2305,12 @@ client cluster OperationalCredentials = 62 {
   }
 
   struct FabricDescriptor {
-    INT8U fabricIndex = 1;
-    OCTET_STRING rootPublicKey = 2;
-    INT16U vendorId = 3;
-    FABRIC_ID fabricId = 4;
-    NODE_ID nodeId = 5;
-    CHAR_STRING label = 6;
+    INT8U fabricIndex = 0;
+    OCTET_STRING rootPublicKey = 1;
+    INT16U vendorId = 2;
+    FABRIC_ID fabricId = 3;
+    NODE_ID nodeId = 4;
+    CHAR_STRING label = 5;
   }
 
   attribute(readonly) FabricDescriptor fabricsList[] = 1;
@@ -2530,9 +2530,9 @@ client cluster RelativeHumidityMeasurement = 1029 {
 
 client cluster Scenes = 5 {
   struct SceneExtensionFieldSet {
-    CLUSTER_ID clusterId = 1;
-    INT8U length = 2;
-    INT8U value = 3;
+    CLUSTER_ID clusterId = 0;
+    INT8U length = 1;
+    INT8U value = 2;
   }
 
   attribute(readonly) int8u sceneCount = 0;
@@ -2631,11 +2631,11 @@ client cluster Scenes = 5 {
 
 client cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
-    INT64U id = 1;
-    CHAR_STRING name = 2;
-    INT32U stackFreeCurrent = 3;
-    INT32U stackFreeMinimum = 4;
-    INT32U stackSize = 5;
+    INT64U id = 0;
+    CHAR_STRING name = 1;
+    INT32U stackFreeCurrent = 2;
+    INT32U stackFreeMinimum = 3;
+    INT32U stackSize = 4;
   }
 
   info event SoftwareFault = 0 {
@@ -2700,8 +2700,8 @@ client cluster TargetNavigator = 1285 {
   }
 
   struct TargetInfo {
-    INT8U identifier = 1;
-    CHAR_STRING name = 2;
+    INT8U identifier = 0;
+    CHAR_STRING name = 1;
   }
 
   attribute(readonly) TargetInfo targetNavigatorList[] = 0;
@@ -2740,50 +2740,50 @@ client cluster TestCluster = 1295 {
   }
 
   struct TestListStructOctet {
-    INT64U fabricIndex = 1;
-    OCTET_STRING operationalCert = 2;
+    INT64U fabricIndex = 0;
+    OCTET_STRING operationalCert = 1;
   }
 
   struct NullablesAndOptionalsStruct {
-    nullable INT16U nullableInt = 1;
-    optional INT16U optionalInt = 2;
-    optional nullable INT16U nullableOptionalInt = 3;
-    nullable CHAR_STRING nullableString = 4;
-    optional CHAR_STRING optionalString = 5;
-    optional nullable CHAR_STRING nullableOptionalString = 6;
-    nullable SimpleStruct nullableStruct = 7;
-    optional SimpleStruct optionalStruct = 8;
-    optional nullable SimpleStruct nullableOptionalStruct = 9;
-    nullable SimpleEnum nullableList[] = 10;
-    optional SimpleEnum optionalList[] = 11;
-    optional nullable SimpleEnum nullableOptionalList[] = 12;
+    nullable INT16U nullableInt = 0;
+    optional INT16U optionalInt = 1;
+    optional nullable INT16U nullableOptionalInt = 2;
+    nullable CHAR_STRING nullableString = 3;
+    optional CHAR_STRING optionalString = 4;
+    optional nullable CHAR_STRING nullableOptionalString = 5;
+    nullable SimpleStruct nullableStruct = 6;
+    optional SimpleStruct optionalStruct = 7;
+    optional nullable SimpleStruct nullableOptionalStruct = 8;
+    nullable SimpleEnum nullableList[] = 9;
+    optional SimpleEnum optionalList[] = 10;
+    optional nullable SimpleEnum nullableOptionalList[] = 11;
   }
 
   struct SimpleStruct {
-    INT8U a = 1;
-    BOOLEAN b = 2;
-    SimpleEnum c = 3;
-    OCTET_STRING d = 4;
-    CHAR_STRING e = 5;
-    SimpleBitmap f = 6;
-    single g = 7;
-    double h = 8;
+    INT8U a = 0;
+    BOOLEAN b = 1;
+    SimpleEnum c = 2;
+    OCTET_STRING d = 3;
+    CHAR_STRING e = 4;
+    SimpleBitmap f = 5;
+    single g = 6;
+    double h = 7;
   }
 
   struct NestedStructList {
-    INT8U a = 1;
-    BOOLEAN b = 2;
-    SimpleStruct c = 3;
-    SimpleStruct d[] = 4;
-    INT32U e[] = 5;
-    OCTET_STRING f[] = 6;
-    INT8U g[] = 7;
+    INT8U a = 0;
+    BOOLEAN b = 1;
+    SimpleStruct c = 2;
+    SimpleStruct d[] = 3;
+    INT32U e[] = 4;
+    OCTET_STRING f[] = 5;
+    INT8U g[] = 6;
   }
 
   struct NestedStruct {
-    INT8U a = 1;
-    BOOLEAN b = 2;
-    SimpleStruct c = 3;
+    INT8U a = 0;
+    BOOLEAN b = 1;
+    SimpleStruct c = 2;
   }
 
   info event TestEvent = 1 {
@@ -3088,53 +3088,53 @@ client cluster ThreadNetworkDiagnostics = 53 {
   }
 
   struct NeighborTable {
-    INT64U extAddress = 1;
-    INT32U age = 2;
-    INT16U rloc16 = 3;
-    INT32U linkFrameCounter = 4;
-    INT32U mleFrameCounter = 5;
-    INT8U lqi = 6;
-    INT8S averageRssi = 7;
-    INT8S lastRssi = 8;
-    INT8U frameErrorRate = 9;
-    INT8U messageErrorRate = 10;
-    BOOLEAN rxOnWhenIdle = 11;
-    BOOLEAN fullThreadDevice = 12;
-    BOOLEAN fullNetworkData = 13;
-    BOOLEAN isChild = 14;
+    INT64U extAddress = 0;
+    INT32U age = 1;
+    INT16U rloc16 = 2;
+    INT32U linkFrameCounter = 3;
+    INT32U mleFrameCounter = 4;
+    INT8U lqi = 5;
+    INT8S averageRssi = 6;
+    INT8S lastRssi = 7;
+    INT8U frameErrorRate = 8;
+    INT8U messageErrorRate = 9;
+    BOOLEAN rxOnWhenIdle = 10;
+    BOOLEAN fullThreadDevice = 11;
+    BOOLEAN fullNetworkData = 12;
+    BOOLEAN isChild = 13;
   }
 
   struct RouteTable {
-    INT64U extAddress = 1;
-    INT16U rloc16 = 2;
-    INT8U routerId = 3;
-    INT8U nextHop = 4;
-    INT8U pathCost = 5;
-    INT8U LQIIn = 6;
-    INT8U LQIOut = 7;
-    INT8U age = 8;
-    BOOLEAN allocated = 9;
-    BOOLEAN linkEstablished = 10;
+    INT64U extAddress = 0;
+    INT16U rloc16 = 1;
+    INT8U routerId = 2;
+    INT8U nextHop = 3;
+    INT8U pathCost = 4;
+    INT8U LQIIn = 5;
+    INT8U LQIOut = 6;
+    INT8U age = 7;
+    BOOLEAN allocated = 8;
+    BOOLEAN linkEstablished = 9;
   }
 
   struct SecurityPolicy {
-    INT16U rotationTime = 1;
-    BITMAP16 flags = 2;
+    INT16U rotationTime = 0;
+    BITMAP16 flags = 1;
   }
 
   struct OperationalDatasetComponents {
-    BOOLEAN activeTimestampPresent = 1;
-    BOOLEAN pendingTimestampPresent = 2;
-    BOOLEAN masterKeyPresent = 3;
-    BOOLEAN networkNamePresent = 4;
-    BOOLEAN extendedPanIdPresent = 5;
-    BOOLEAN meshLocalPrefixPresent = 6;
-    BOOLEAN delayPresent = 7;
-    BOOLEAN panIdPresent = 8;
-    BOOLEAN channelPresent = 9;
-    BOOLEAN pskcPresent = 10;
-    BOOLEAN securityPolicyPresent = 11;
-    BOOLEAN channelMaskPresent = 12;
+    BOOLEAN activeTimestampPresent = 0;
+    BOOLEAN pendingTimestampPresent = 1;
+    BOOLEAN masterKeyPresent = 2;
+    BOOLEAN networkNamePresent = 3;
+    BOOLEAN extendedPanIdPresent = 4;
+    BOOLEAN meshLocalPrefixPresent = 5;
+    BOOLEAN delayPresent = 6;
+    BOOLEAN panIdPresent = 7;
+    BOOLEAN channelPresent = 8;
+    BOOLEAN pskcPresent = 9;
+    BOOLEAN securityPolicyPresent = 10;
+    BOOLEAN channelMaskPresent = 11;
   }
 
   info event ConnectionStatus = 0 {

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -1839,9 +1839,9 @@ class Scenes(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="clusterId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="length", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="value", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="clusterId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="length", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="value", Tag=2, Type=uint),
                     ])
 
             clusterId: 'uint' = 0
@@ -3924,10 +3924,10 @@ class PowerProfile(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="powerProfileId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="energyPhaseId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="powerProfileRemoteControl", Tag=3, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="powerProfileState", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="powerProfileId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="energyPhaseId", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="powerProfileRemoteControl", Tag=2, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="powerProfileState", Tag=3, Type=uint),
                     ])
 
             powerProfileId: 'uint' = 0
@@ -3941,8 +3941,8 @@ class PowerProfile(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="energyPhaseId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="scheduledTime", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="energyPhaseId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="scheduledTime", Tag=1, Type=uint),
                     ])
 
             energyPhaseId: 'uint' = 0
@@ -3954,12 +3954,12 @@ class PowerProfile(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="energyPhaseId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="macroPhaseId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="expectedDuration", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="peakPower", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="energy", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="maxActivationDelay", Tag=6, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="energyPhaseId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="macroPhaseId", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="expectedDuration", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="peakPower", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="energy", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="maxActivationDelay", Tag=5, Type=uint),
                     ])
 
             energyPhaseId: 'uint' = 0
@@ -4869,8 +4869,8 @@ class Descriptor(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="type", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="revision", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="type", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="revision", Tag=1, Type=uint),
                     ])
 
             type: 'uint' = 0
@@ -5664,12 +5664,12 @@ class BridgedActions(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="actionID", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="type", Tag=3, Type=BridgedActions.Enums.ActionTypeEnum),
-                            ClusterObjectFieldDescriptor(Label="endpointListID", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="supportedCommands", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="status", Tag=6, Type=BridgedActions.Enums.ActionStateEnum),
+                            ClusterObjectFieldDescriptor(Label="actionID", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="type", Tag=2, Type=BridgedActions.Enums.ActionTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="endpointListID", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="supportedCommands", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=5, Type=BridgedActions.Enums.ActionStateEnum),
                     ])
 
             actionID: 'uint' = 0
@@ -5685,10 +5685,10 @@ class BridgedActions(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="endpointListID", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="type", Tag=3, Type=BridgedActions.Enums.EndpointListTypeEnum),
-                            ClusterObjectFieldDescriptor(Label="endpoints", Tag=4, Type=typing.List[uint]),
+                            ClusterObjectFieldDescriptor(Label="endpointListID", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="type", Tag=2, Type=BridgedActions.Enums.EndpointListTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="endpoints", Tag=3, Type=typing.List[uint]),
                     ])
 
             endpointListID: 'uint' = 0
@@ -8055,7 +8055,7 @@ class GeneralCommissioning(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="failSafeExpiryLengthMs", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="failSafeExpiryLengthMs", Tag=0, Type=uint),
                     ])
 
             failSafeExpiryLengthMs: 'uint' = 0
@@ -8347,8 +8347,8 @@ class NetworkCommissioning(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="networkID", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="connected", Tag=2, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="networkID", Tag=0, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="connected", Tag=1, Type=bool),
                     ])
 
             networkID: 'bytes' = b""
@@ -8360,14 +8360,14 @@ class NetworkCommissioning(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="panId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="extendedPanId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="networkName", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="channel", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="version", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="extendedAddress", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="rssi", Tag=7, Type=int),
-                            ClusterObjectFieldDescriptor(Label="lqi", Tag=8, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="panId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="extendedPanId", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="networkName", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="channel", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="version", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="extendedAddress", Tag=5, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="rssi", Tag=6, Type=int),
+                            ClusterObjectFieldDescriptor(Label="lqi", Tag=7, Type=uint),
                     ])
 
             panId: 'uint' = 0
@@ -8385,12 +8385,12 @@ class NetworkCommissioning(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="security", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ssid", Tag=2, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="bssid", Tag=3, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="channel", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="wiFiBand", Tag=5, Type=NetworkCommissioning.Enums.WiFiBand),
-                            ClusterObjectFieldDescriptor(Label="rssi", Tag=6, Type=int),
+                            ClusterObjectFieldDescriptor(Label="security", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="ssid", Tag=1, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="bssid", Tag=2, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="channel", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="wiFiBand", Tag=4, Type=NetworkCommissioning.Enums.WiFiBand),
+                            ClusterObjectFieldDescriptor(Label="rssi", Tag=5, Type=int),
                     ])
 
             security: 'uint' = 0
@@ -8961,12 +8961,12 @@ class GeneralDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="fabricConnected", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="offPremiseServicesReachableIPv4", Tag=3, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="offPremiseServicesReachableIPv6", Tag=4, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="hardwareAddress", Tag=5, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="type", Tag=6, Type=GeneralDiagnostics.Enums.InterfaceType),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="fabricConnected", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="offPremiseServicesReachableIPv4", Tag=2, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="offPremiseServicesReachableIPv6", Tag=3, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="hardwareAddress", Tag=4, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="type", Tag=5, Type=GeneralDiagnostics.Enums.InterfaceType),
                     ])
 
             name: 'str' = ""
@@ -9274,9 +9274,9 @@ class SoftwareDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="id", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="faultRecording", Tag=3, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="id", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="faultRecording", Tag=2, Type=bytes),
                     ])
 
             id: 'uint' = 0
@@ -9289,11 +9289,11 @@ class SoftwareDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="id", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="stackFreeCurrent", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="stackFreeMinimum", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="stackSize", Tag=5, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="id", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="stackFreeCurrent", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="stackFreeMinimum", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="stackSize", Tag=4, Type=uint),
                     ])
 
             id: 'uint' = 0
@@ -9625,20 +9625,20 @@ class ThreadNetworkDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="extAddress", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="age", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="rloc16", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="linkFrameCounter", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="mleFrameCounter", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="lqi", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="averageRssi", Tag=7, Type=int),
-                            ClusterObjectFieldDescriptor(Label="lastRssi", Tag=8, Type=int),
-                            ClusterObjectFieldDescriptor(Label="frameErrorRate", Tag=9, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="messageErrorRate", Tag=10, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="rxOnWhenIdle", Tag=11, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="fullThreadDevice", Tag=12, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="fullNetworkData", Tag=13, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="isChild", Tag=14, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="extAddress", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="age", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="rloc16", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="linkFrameCounter", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="mleFrameCounter", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="lqi", Tag=5, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="averageRssi", Tag=6, Type=int),
+                            ClusterObjectFieldDescriptor(Label="lastRssi", Tag=7, Type=int),
+                            ClusterObjectFieldDescriptor(Label="frameErrorRate", Tag=8, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="messageErrorRate", Tag=9, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="rxOnWhenIdle", Tag=10, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="fullThreadDevice", Tag=11, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="fullNetworkData", Tag=12, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="isChild", Tag=13, Type=bool),
                     ])
 
             extAddress: 'uint' = 0
@@ -9662,18 +9662,18 @@ class ThreadNetworkDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="activeTimestampPresent", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="pendingTimestampPresent", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="masterKeyPresent", Tag=3, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="networkNamePresent", Tag=4, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="extendedPanIdPresent", Tag=5, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="meshLocalPrefixPresent", Tag=6, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="delayPresent", Tag=7, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="panIdPresent", Tag=8, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="channelPresent", Tag=9, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="pskcPresent", Tag=10, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="securityPolicyPresent", Tag=11, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="channelMaskPresent", Tag=12, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="activeTimestampPresent", Tag=0, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="pendingTimestampPresent", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="masterKeyPresent", Tag=2, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="networkNamePresent", Tag=3, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="extendedPanIdPresent", Tag=4, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="meshLocalPrefixPresent", Tag=5, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="delayPresent", Tag=6, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="panIdPresent", Tag=7, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="channelPresent", Tag=8, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="pskcPresent", Tag=9, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="securityPolicyPresent", Tag=10, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="channelMaskPresent", Tag=11, Type=bool),
                     ])
 
             activeTimestampPresent: 'bool' = False
@@ -9695,16 +9695,16 @@ class ThreadNetworkDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="extAddress", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="rloc16", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="routerId", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="nextHop", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="pathCost", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LQIIn", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LQIOut", Tag=7, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="age", Tag=8, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="allocated", Tag=9, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="linkEstablished", Tag=10, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="extAddress", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="rloc16", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="routerId", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="nextHop", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="pathCost", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="LQIIn", Tag=5, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="LQIOut", Tag=6, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="age", Tag=7, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="allocated", Tag=8, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="linkEstablished", Tag=9, Type=bool),
                     ])
 
             extAddress: 'uint' = 0
@@ -9724,8 +9724,8 @@ class ThreadNetworkDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="rotationTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="flags", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="rotationTime", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="flags", Tag=1, Type=uint),
                     ])
 
             rotationTime: 'uint' = 0
@@ -12459,12 +12459,12 @@ class OperationalCredentials(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="rootPublicKey", Tag=2, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="vendorId", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="fabricId", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="nodeId", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="label", Tag=6, Type=str),
+                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="rootPublicKey", Tag=1, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="vendorId", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="fabricId", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="nodeId", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="label", Tag=5, Type=str),
                     ])
 
             fabricIndex: 'uint' = 0
@@ -12480,8 +12480,8 @@ class OperationalCredentials(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="noc", Tag=2, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="noc", Tag=1, Type=bytes),
                     ])
 
             fabricIndex: 'uint' = 0
@@ -13160,8 +13160,8 @@ class FixedLabel(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="label", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="value", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="label", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="value", Tag=1, Type=str),
                     ])
 
             label: 'str' = ""
@@ -13264,8 +13264,8 @@ class UserLabel(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="label", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="value", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="label", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="value", Tag=1, Type=str),
                     ])
 
             label: 'str' = ""
@@ -13698,9 +13698,9 @@ class ModeSelect(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="label", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="mode", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="semanticTag", Tag=3, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="label", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="mode", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="semanticTag", Tag=2, Type=uint),
                     ])
 
             label: 'str' = ""
@@ -13713,8 +13713,8 @@ class ModeSelect(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="mfgCode", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="value", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="mfgCode", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="value", Tag=1, Type=uint),
                     ])
 
             mfgCode: 'uint' = 0
@@ -14319,8 +14319,8 @@ class DoorLock(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="credentialType", Tag=1, Type=DoorLock.Enums.DlCredentialType),
-                            ClusterObjectFieldDescriptor(Label="credentialIndex", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="credentialType", Tag=0, Type=DoorLock.Enums.DlCredentialType),
+                            ClusterObjectFieldDescriptor(Label="credentialIndex", Tag=1, Type=uint),
                     ])
 
             credentialType: 'DoorLock.Enums.DlCredentialType' = 0
@@ -26817,8 +26817,8 @@ class IasAce(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="zoneId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="zoneStatus", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="zoneId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="zoneStatus", Tag=1, Type=uint),
                     ])
 
             zoneId: 'uint' = 0
@@ -27482,11 +27482,11 @@ class Channel(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="majorNumber", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="minorNumber", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="callSign", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="affiliateCallSign", Tag=5, Type=str),
+                            ClusterObjectFieldDescriptor(Label="majorNumber", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="minorNumber", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="callSign", Tag=3, Type=str),
+                            ClusterObjectFieldDescriptor(Label="affiliateCallSign", Tag=4, Type=str),
                     ])
 
             majorNumber: 'uint' = 0
@@ -27501,10 +27501,10 @@ class Channel(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="operatorName", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="lineupName", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="postalCode", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="lineupInfoType", Tag=4, Type=Channel.Enums.LineupInfoTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="operatorName", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="lineupName", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="postalCode", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="lineupInfoType", Tag=3, Type=Channel.Enums.LineupInfoTypeEnum),
                     ])
 
             operatorName: 'str' = ""
@@ -27714,8 +27714,8 @@ class TargetNavigator(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="identifier", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="identifier", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
                     ])
 
             identifier: 'uint' = 0
@@ -27896,8 +27896,8 @@ class MediaPlayback(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="updatedAt", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="position", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="updatedAt", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="position", Tag=1, Type=uint),
                     ])
 
             updatedAt: 'uint' = 0
@@ -28278,10 +28278,10 @@ class MediaInput(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="index", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="inputType", Tag=2, Type=MediaInput.Enums.InputTypeEnum),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="description", Tag=4, Type=str),
+                            ClusterObjectFieldDescriptor(Label="index", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="inputType", Tag=1, Type=MediaInput.Enums.InputTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="description", Tag=3, Type=str),
                     ])
 
             index: 'uint' = 0
@@ -28769,9 +28769,9 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="width", Tag=1, Type=float),
-                            ClusterObjectFieldDescriptor(Label="height", Tag=2, Type=float),
-                            ClusterObjectFieldDescriptor(Label="metric", Tag=3, Type=ContentLauncher.Enums.MetricTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="width", Tag=0, Type=float),
+                            ClusterObjectFieldDescriptor(Label="height", Tag=1, Type=float),
+                            ClusterObjectFieldDescriptor(Label="metric", Tag=2, Type=ContentLauncher.Enums.MetricTypeEnum),
                     ])
 
             width: 'float' = 0.0
@@ -28784,8 +28784,8 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="value", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="value", Tag=1, Type=str),
                     ])
 
             name: 'str' = ""
@@ -28797,9 +28797,9 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="type", Tag=1, Type=ContentLauncher.Enums.ParameterEnum),
-                            ClusterObjectFieldDescriptor(Label="value", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="externalIDList", Tag=3, Type=typing.List[ContentLauncher.Structs.AdditionalInfo]),
+                            ClusterObjectFieldDescriptor(Label="type", Tag=0, Type=ContentLauncher.Enums.ParameterEnum),
+                            ClusterObjectFieldDescriptor(Label="value", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="externalIDList", Tag=2, Type=typing.List[ContentLauncher.Structs.AdditionalInfo]),
                     ])
 
             type: 'ContentLauncher.Enums.ParameterEnum' = 0
@@ -28812,7 +28812,7 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="parameterList", Tag=1, Type=typing.List[ContentLauncher.Structs.Parameter]),
+                            ClusterObjectFieldDescriptor(Label="parameterList", Tag=0, Type=typing.List[ContentLauncher.Structs.Parameter]),
                     ])
 
             parameterList: 'typing.List[ContentLauncher.Structs.Parameter]' = field(default_factory=lambda: [])
@@ -28823,9 +28823,9 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="imageUrl", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="color", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="size", Tag=3, Type=ContentLauncher.Structs.Dimension),
+                            ClusterObjectFieldDescriptor(Label="imageUrl", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="color", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="size", Tag=2, Type=ContentLauncher.Structs.Dimension),
                     ])
 
             imageUrl: 'str' = ""
@@ -28838,12 +28838,12 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="providerName", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="background", Tag=2, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="logo", Tag=3, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="progressBar", Tag=4, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="splash", Tag=5, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="waterMark", Tag=6, Type=ContentLauncher.Structs.StyleInformation),
+                            ClusterObjectFieldDescriptor(Label="providerName", Tag=0, Type=str),
+                            ClusterObjectFieldDescriptor(Label="background", Tag=1, Type=ContentLauncher.Structs.StyleInformation),
+                            ClusterObjectFieldDescriptor(Label="logo", Tag=2, Type=ContentLauncher.Structs.StyleInformation),
+                            ClusterObjectFieldDescriptor(Label="progressBar", Tag=3, Type=ContentLauncher.Structs.StyleInformation),
+                            ClusterObjectFieldDescriptor(Label="splash", Tag=4, Type=ContentLauncher.Structs.StyleInformation),
+                            ClusterObjectFieldDescriptor(Label="waterMark", Tag=5, Type=ContentLauncher.Structs.StyleInformation),
                     ])
 
             providerName: 'str' = ""
@@ -29033,9 +29033,9 @@ class AudioOutput(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="index", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="outputType", Tag=2, Type=AudioOutput.Enums.OutputTypeEnum),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=3, Type=str),
+                            ClusterObjectFieldDescriptor(Label="index", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="outputType", Tag=1, Type=AudioOutput.Enums.OutputTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
                     ])
 
             index: 'uint' = 0
@@ -29196,8 +29196,8 @@ class ApplicationLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="catalogVendorId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="applicationId", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="catalogVendorId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="applicationId", Tag=1, Type=str),
                     ])
 
             catalogVendorId: 'uint' = 0
@@ -29209,8 +29209,8 @@ class ApplicationLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="application", Tag=1, Type=ApplicationLauncher.Structs.ApplicationLauncherApplication),
-                            ClusterObjectFieldDescriptor(Label="endpoint", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.ApplicationLauncherApplication),
+                            ClusterObjectFieldDescriptor(Label="endpoint", Tag=1, Type=str),
                     ])
 
             application: 'ApplicationLauncher.Structs.ApplicationLauncherApplication' = field(default_factory=lambda: ApplicationLauncher.Structs.ApplicationLauncherApplication())
@@ -29415,8 +29415,8 @@ class ApplicationBasic(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="catalogVendorId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="applicationId", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="catalogVendorId", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="applicationId", Tag=1, Type=str),
                     ])
 
             catalogVendorId: 'uint' = 0
@@ -29936,14 +29936,14 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="a", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="b", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="c", Tag=3, Type=TestCluster.Enums.SimpleEnum),
-                            ClusterObjectFieldDescriptor(Label="d", Tag=4, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="e", Tag=5, Type=str),
-                            ClusterObjectFieldDescriptor(Label="f", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="g", Tag=7, Type=float),
-                            ClusterObjectFieldDescriptor(Label="h", Tag=8, Type=float),
+                            ClusterObjectFieldDescriptor(Label="a", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="b", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="c", Tag=2, Type=TestCluster.Enums.SimpleEnum),
+                            ClusterObjectFieldDescriptor(Label="d", Tag=3, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="e", Tag=4, Type=str),
+                            ClusterObjectFieldDescriptor(Label="f", Tag=5, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="g", Tag=6, Type=float),
+                            ClusterObjectFieldDescriptor(Label="h", Tag=7, Type=float),
                     ])
 
             a: 'uint' = 0
@@ -29961,18 +29961,18 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="nullableInt", Tag=1, Type=typing.Union[Nullable, uint]),
-                            ClusterObjectFieldDescriptor(Label="optionalInt", Tag=2, Type=typing.Optional[uint]),
-                            ClusterObjectFieldDescriptor(Label="nullableOptionalInt", Tag=3, Type=typing.Union[None, Nullable, uint]),
-                            ClusterObjectFieldDescriptor(Label="nullableString", Tag=4, Type=typing.Union[Nullable, str]),
-                            ClusterObjectFieldDescriptor(Label="optionalString", Tag=5, Type=typing.Optional[str]),
-                            ClusterObjectFieldDescriptor(Label="nullableOptionalString", Tag=6, Type=typing.Union[None, Nullable, str]),
-                            ClusterObjectFieldDescriptor(Label="nullableStruct", Tag=7, Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct]),
-                            ClusterObjectFieldDescriptor(Label="optionalStruct", Tag=8, Type=typing.Optional[TestCluster.Structs.SimpleStruct]),
-                            ClusterObjectFieldDescriptor(Label="nullableOptionalStruct", Tag=9, Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]),
-                            ClusterObjectFieldDescriptor(Label="nullableList", Tag=10, Type=typing.Union[Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
-                            ClusterObjectFieldDescriptor(Label="optionalList", Tag=11, Type=typing.Optional[typing.List[TestCluster.Enums.SimpleEnum]]),
-                            ClusterObjectFieldDescriptor(Label="nullableOptionalList", Tag=12, Type=typing.Union[None, Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
+                            ClusterObjectFieldDescriptor(Label="nullableInt", Tag=0, Type=typing.Union[Nullable, uint]),
+                            ClusterObjectFieldDescriptor(Label="optionalInt", Tag=1, Type=typing.Optional[uint]),
+                            ClusterObjectFieldDescriptor(Label="nullableOptionalInt", Tag=2, Type=typing.Union[None, Nullable, uint]),
+                            ClusterObjectFieldDescriptor(Label="nullableString", Tag=3, Type=typing.Union[Nullable, str]),
+                            ClusterObjectFieldDescriptor(Label="optionalString", Tag=4, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="nullableOptionalString", Tag=5, Type=typing.Union[None, Nullable, str]),
+                            ClusterObjectFieldDescriptor(Label="nullableStruct", Tag=6, Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct]),
+                            ClusterObjectFieldDescriptor(Label="optionalStruct", Tag=7, Type=typing.Optional[TestCluster.Structs.SimpleStruct]),
+                            ClusterObjectFieldDescriptor(Label="nullableOptionalStruct", Tag=8, Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]),
+                            ClusterObjectFieldDescriptor(Label="nullableList", Tag=9, Type=typing.Union[Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
+                            ClusterObjectFieldDescriptor(Label="optionalList", Tag=10, Type=typing.Optional[typing.List[TestCluster.Enums.SimpleEnum]]),
+                            ClusterObjectFieldDescriptor(Label="nullableOptionalList", Tag=11, Type=typing.Union[None, Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
                     ])
 
             nullableInt: 'typing.Union[Nullable, uint]' = NullValue
@@ -29994,9 +29994,9 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="a", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="b", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="c", Tag=3, Type=TestCluster.Structs.SimpleStruct),
+                            ClusterObjectFieldDescriptor(Label="a", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="b", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="c", Tag=2, Type=TestCluster.Structs.SimpleStruct),
                     ])
 
             a: 'uint' = 0
@@ -30009,13 +30009,13 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="a", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="b", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="c", Tag=3, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="d", Tag=4, Type=typing.List[TestCluster.Structs.SimpleStruct]),
-                            ClusterObjectFieldDescriptor(Label="e", Tag=5, Type=typing.List[uint]),
-                            ClusterObjectFieldDescriptor(Label="f", Tag=6, Type=typing.List[bytes]),
-                            ClusterObjectFieldDescriptor(Label="g", Tag=7, Type=typing.List[uint]),
+                            ClusterObjectFieldDescriptor(Label="a", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="b", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="c", Tag=2, Type=TestCluster.Structs.SimpleStruct),
+                            ClusterObjectFieldDescriptor(Label="d", Tag=3, Type=typing.List[TestCluster.Structs.SimpleStruct]),
+                            ClusterObjectFieldDescriptor(Label="e", Tag=4, Type=typing.List[uint]),
+                            ClusterObjectFieldDescriptor(Label="f", Tag=5, Type=typing.List[bytes]),
+                            ClusterObjectFieldDescriptor(Label="g", Tag=6, Type=typing.List[uint]),
                     ])
 
             a: 'uint' = 0
@@ -30032,7 +30032,7 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="a", Tag=1, Type=typing.List[TestCluster.Structs.NestedStructList]),
+                            ClusterObjectFieldDescriptor(Label="a", Tag=0, Type=typing.List[TestCluster.Structs.NestedStructList]),
                     ])
 
             a: 'typing.List[TestCluster.Structs.NestedStructList]' = field(default_factory=lambda: [])
@@ -30043,8 +30043,8 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="operationalCert", Tag=2, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="operationalCert", Tag=1, Type=bytes),
                     ])
 
             fabricIndex: 'uint' = 0

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -43,8 +43,8 @@ namespace Structs {
 namespace LabelStruct {
 enum class Fields
 {
-    kLabel = 1,
-    kValue = 2,
+    kLabel = 0,
+    kValue = 1,
 };
 
 struct Type
@@ -1791,9 +1791,9 @@ namespace Structs {
 namespace SceneExtensionFieldSet {
 enum class Fields
 {
-    kClusterId = 1,
-    kLength    = 2,
-    kValue     = 3,
+    kClusterId = 0,
+    kLength    = 1,
+    kValue     = 2,
 };
 
 struct Type
@@ -4534,10 +4534,10 @@ namespace Structs {
 namespace PowerProfileRecord {
 enum class Fields
 {
-    kPowerProfileId            = 1,
-    kEnergyPhaseId             = 2,
-    kPowerProfileRemoteControl = 3,
-    kPowerProfileState         = 4,
+    kPowerProfileId            = 0,
+    kEnergyPhaseId             = 1,
+    kPowerProfileRemoteControl = 2,
+    kPowerProfileState         = 3,
 };
 
 struct Type
@@ -4558,8 +4558,8 @@ using DecodableType = Type;
 namespace ScheduledPhase {
 enum class Fields
 {
-    kEnergyPhaseId = 1,
-    kScheduledTime = 2,
+    kEnergyPhaseId = 0,
+    kScheduledTime = 1,
 };
 
 struct Type
@@ -4578,12 +4578,12 @@ using DecodableType = Type;
 namespace TransferredPhase {
 enum class Fields
 {
-    kEnergyPhaseId      = 1,
-    kMacroPhaseId       = 2,
-    kExpectedDuration   = 3,
-    kPeakPower          = 4,
-    kEnergy             = 5,
-    kMaxActivationDelay = 6,
+    kEnergyPhaseId      = 0,
+    kMacroPhaseId       = 1,
+    kExpectedDuration   = 2,
+    kPeakPower          = 3,
+    kEnergy             = 4,
+    kMaxActivationDelay = 5,
 };
 
 struct Type
@@ -6112,8 +6112,8 @@ namespace Structs {
 namespace DeviceType {
 enum class Fields
 {
-    kType     = 1,
-    kRevision = 2,
+    kType     = 0,
+    kRevision = 1,
 };
 
 struct Type
@@ -7066,12 +7066,12 @@ namespace Structs {
 namespace ActionStruct {
 enum class Fields
 {
-    kActionID          = 1,
-    kName              = 2,
-    kType              = 3,
-    kEndpointListID    = 4,
-    kSupportedCommands = 5,
-    kStatus            = 6,
+    kActionID          = 0,
+    kName              = 1,
+    kType              = 2,
+    kEndpointListID    = 3,
+    kSupportedCommands = 4,
+    kStatus            = 5,
 };
 
 struct Type
@@ -7094,10 +7094,10 @@ using DecodableType = Type;
 namespace EndpointListStruct {
 enum class Fields
 {
-    kEndpointListID = 1,
-    kName           = 2,
-    kType           = 3,
-    kEndpoints      = 4,
+    kEndpointListID = 0,
+    kName           = 1,
+    kType           = 2,
+    kEndpoints      = 3,
 };
 
 struct Type
@@ -9699,7 +9699,7 @@ namespace Structs {
 namespace BasicCommissioningInfoType {
 enum class Fields
 {
-    kFailSafeExpiryLengthMs = 1,
+    kFailSafeExpiryLengthMs = 0,
 };
 
 struct Type
@@ -10107,8 +10107,8 @@ namespace Structs {
 namespace NetworkInfo {
 enum class Fields
 {
-    kNetworkID = 1,
-    kConnected = 2,
+    kNetworkID = 0,
+    kConnected = 1,
 };
 
 struct Type
@@ -10127,14 +10127,14 @@ using DecodableType = Type;
 namespace ThreadInterfaceScanResult {
 enum class Fields
 {
-    kPanId           = 1,
-    kExtendedPanId   = 2,
-    kNetworkName     = 3,
-    kChannel         = 4,
-    kVersion         = 5,
-    kExtendedAddress = 6,
-    kRssi            = 7,
-    kLqi             = 8,
+    kPanId           = 0,
+    kExtendedPanId   = 1,
+    kNetworkName     = 2,
+    kChannel         = 3,
+    kVersion         = 4,
+    kExtendedAddress = 5,
+    kRssi            = 6,
+    kLqi             = 7,
 };
 
 struct Type
@@ -10159,12 +10159,12 @@ using DecodableType = Type;
 namespace WiFiInterfaceScanResult {
 enum class Fields
 {
-    kSecurity = 1,
-    kSsid     = 2,
-    kBssid    = 3,
-    kChannel  = 4,
-    kWiFiBand = 5,
-    kRssi     = 6,
+    kSecurity = 0,
+    kSsid     = 1,
+    kBssid    = 2,
+    kChannel  = 3,
+    kWiFiBand = 4,
+    kRssi     = 5,
 };
 
 struct Type
@@ -10994,12 +10994,12 @@ namespace Structs {
 namespace NetworkInterfaceType {
 enum class Fields
 {
-    kName                            = 1,
-    kFabricConnected                 = 2,
-    kOffPremiseServicesReachableIPv4 = 3,
-    kOffPremiseServicesReachableIPv6 = 4,
-    kHardwareAddress                 = 5,
-    kType                            = 6,
+    kName                            = 0,
+    kFabricConnected                 = 1,
+    kOffPremiseServicesReachableIPv4 = 2,
+    kOffPremiseServicesReachableIPv6 = 3,
+    kHardwareAddress                 = 4,
+    kType                            = 5,
 };
 
 struct Type
@@ -11330,9 +11330,9 @@ namespace Structs {
 namespace SoftwareFault {
 enum class Fields
 {
-    kId             = 1,
-    kName           = 2,
-    kFaultRecording = 3,
+    kId             = 0,
+    kName           = 1,
+    kFaultRecording = 2,
 };
 
 struct Type
@@ -11352,11 +11352,11 @@ using DecodableType = Type;
 namespace ThreadMetrics {
 enum class Fields
 {
-    kId               = 1,
-    kName             = 2,
-    kStackFreeCurrent = 3,
-    kStackFreeMinimum = 4,
-    kStackSize        = 5,
+    kId               = 0,
+    kName             = 1,
+    kStackFreeCurrent = 2,
+    kStackFreeMinimum = 3,
+    kStackSize        = 4,
 };
 
 struct Type
@@ -11598,20 +11598,20 @@ namespace Structs {
 namespace NeighborTable {
 enum class Fields
 {
-    kExtAddress       = 1,
-    kAge              = 2,
-    kRloc16           = 3,
-    kLinkFrameCounter = 4,
-    kMleFrameCounter  = 5,
-    kLqi              = 6,
-    kAverageRssi      = 7,
-    kLastRssi         = 8,
-    kFrameErrorRate   = 9,
-    kMessageErrorRate = 10,
-    kRxOnWhenIdle     = 11,
-    kFullThreadDevice = 12,
-    kFullNetworkData  = 13,
-    kIsChild          = 14,
+    kExtAddress       = 0,
+    kAge              = 1,
+    kRloc16           = 2,
+    kLinkFrameCounter = 3,
+    kMleFrameCounter  = 4,
+    kLqi              = 5,
+    kAverageRssi      = 6,
+    kLastRssi         = 7,
+    kFrameErrorRate   = 8,
+    kMessageErrorRate = 9,
+    kRxOnWhenIdle     = 10,
+    kFullThreadDevice = 11,
+    kFullNetworkData  = 12,
+    kIsChild          = 13,
 };
 
 struct Type
@@ -11642,18 +11642,18 @@ using DecodableType = Type;
 namespace OperationalDatasetComponents {
 enum class Fields
 {
-    kActiveTimestampPresent  = 1,
-    kPendingTimestampPresent = 2,
-    kMasterKeyPresent        = 3,
-    kNetworkNamePresent      = 4,
-    kExtendedPanIdPresent    = 5,
-    kMeshLocalPrefixPresent  = 6,
-    kDelayPresent            = 7,
-    kPanIdPresent            = 8,
-    kChannelPresent          = 9,
-    kPskcPresent             = 10,
-    kSecurityPolicyPresent   = 11,
-    kChannelMaskPresent      = 12,
+    kActiveTimestampPresent  = 0,
+    kPendingTimestampPresent = 1,
+    kMasterKeyPresent        = 2,
+    kNetworkNamePresent      = 3,
+    kExtendedPanIdPresent    = 4,
+    kMeshLocalPrefixPresent  = 5,
+    kDelayPresent            = 6,
+    kPanIdPresent            = 7,
+    kChannelPresent          = 8,
+    kPskcPresent             = 9,
+    kSecurityPolicyPresent   = 10,
+    kChannelMaskPresent      = 11,
 };
 
 struct Type
@@ -11682,16 +11682,16 @@ using DecodableType = Type;
 namespace RouteTable {
 enum class Fields
 {
-    kExtAddress      = 1,
-    kRloc16          = 2,
-    kRouterId        = 3,
-    kNextHop         = 4,
-    kPathCost        = 5,
-    kLQIIn           = 6,
-    kLQIOut          = 7,
-    kAge             = 8,
-    kAllocated       = 9,
-    kLinkEstablished = 10,
+    kExtAddress      = 0,
+    kRloc16          = 1,
+    kRouterId        = 2,
+    kNextHop         = 3,
+    kPathCost        = 4,
+    kLQIIn           = 5,
+    kLQIOut          = 6,
+    kAge             = 7,
+    kAllocated       = 8,
+    kLinkEstablished = 9,
 };
 
 struct Type
@@ -11718,8 +11718,8 @@ using DecodableType = Type;
 namespace SecurityPolicy {
 enum class Fields
 {
-    kRotationTime = 1,
-    kFlags        = 2,
+    kRotationTime = 0,
+    kFlags        = 1,
 };
 
 struct Type
@@ -14399,12 +14399,12 @@ namespace Structs {
 namespace FabricDescriptor {
 enum class Fields
 {
-    kFabricIndex   = 1,
-    kRootPublicKey = 2,
-    kVendorId      = 3,
-    kFabricId      = 4,
-    kNodeId        = 5,
-    kLabel         = 6,
+    kFabricIndex   = 0,
+    kRootPublicKey = 1,
+    kVendorId      = 2,
+    kFabricId      = 3,
+    kNodeId        = 4,
+    kLabel         = 5,
 };
 
 struct Type
@@ -14427,8 +14427,8 @@ using DecodableType = Type;
 namespace NOCStruct {
 enum class Fields
 {
-    kFabricIndex = 1,
-    kNoc         = 2,
+    kFabricIndex = 0,
+    kNoc         = 1,
 };
 
 struct Type
@@ -15946,9 +15946,9 @@ namespace Structs {
 namespace ModeOptionStruct {
 enum class Fields
 {
-    kLabel       = 1,
-    kMode        = 2,
-    kSemanticTag = 3,
+    kLabel       = 0,
+    kMode        = 1,
+    kSemanticTag = 2,
 };
 
 struct Type
@@ -15968,8 +15968,8 @@ using DecodableType = Type;
 namespace SemanticTag {
 enum class Fields
 {
-    kMfgCode = 1,
-    kValue   = 2,
+    kMfgCode = 0,
+    kValue   = 1,
 };
 
 struct Type
@@ -16675,8 +16675,8 @@ namespace Structs {
 namespace DlCredential {
 enum class Fields
 {
-    kCredentialType  = 1,
-    kCredentialIndex = 2,
+    kCredentialType  = 0,
+    kCredentialIndex = 1,
 };
 
 struct Type
@@ -29258,8 +29258,8 @@ namespace Structs {
 namespace IasAceZoneStatusResult {
 enum class Fields
 {
-    kZoneId     = 1,
-    kZoneStatus = 2,
+    kZoneId     = 0,
+    kZoneStatus = 1,
 };
 
 struct Type
@@ -30394,11 +30394,11 @@ namespace Structs {
 namespace ChannelInfo {
 enum class Fields
 {
-    kMajorNumber       = 1,
-    kMinorNumber       = 2,
-    kName              = 3,
-    kCallSign          = 4,
-    kAffiliateCallSign = 5,
+    kMajorNumber       = 0,
+    kMinorNumber       = 1,
+    kName              = 2,
+    kCallSign          = 3,
+    kAffiliateCallSign = 4,
 };
 
 struct Type
@@ -30420,10 +30420,10 @@ using DecodableType = Type;
 namespace LineupInfo {
 enum class Fields
 {
-    kOperatorName   = 1,
-    kLineupName     = 2,
-    kPostalCode     = 3,
-    kLineupInfoType = 4,
+    kOperatorName   = 0,
+    kLineupName     = 1,
+    kPostalCode     = 2,
+    kLineupInfoType = 3,
 };
 
 struct Type
@@ -30712,8 +30712,8 @@ namespace Structs {
 namespace TargetInfo {
 enum class Fields
 {
-    kIdentifier = 1,
-    kName       = 2,
+    kIdentifier = 0,
+    kName       = 1,
 };
 
 struct Type
@@ -30925,8 +30925,8 @@ namespace Structs {
 namespace PlaybackPosition {
 enum class Fields
 {
-    kUpdatedAt = 1,
-    kPosition  = 2,
+    kUpdatedAt = 0,
+    kPosition  = 1,
 };
 
 struct Type
@@ -31537,10 +31537,10 @@ namespace Structs {
 namespace InputInfo {
 enum class Fields
 {
-    kIndex       = 1,
-    kInputType   = 2,
-    kName        = 3,
-    kDescription = 4,
+    kIndex       = 0,
+    kInputType   = 1,
+    kName        = 2,
+    kDescription = 3,
 };
 
 struct Type
@@ -32182,9 +32182,9 @@ namespace Structs {
 namespace Dimension {
 enum class Fields
 {
-    kWidth  = 1,
-    kHeight = 2,
-    kMetric = 3,
+    kWidth  = 0,
+    kHeight = 1,
+    kMetric = 2,
 };
 
 struct Type
@@ -32204,8 +32204,8 @@ using DecodableType = Type;
 namespace AdditionalInfo {
 enum class Fields
 {
-    kName  = 1,
-    kValue = 2,
+    kName  = 0,
+    kValue = 1,
 };
 
 struct Type
@@ -32224,9 +32224,9 @@ using DecodableType = Type;
 namespace Parameter {
 enum class Fields
 {
-    kType           = 1,
-    kValue          = 2,
-    kExternalIDList = 3,
+    kType           = 0,
+    kValue          = 1,
+    kExternalIDList = 2,
 };
 
 struct Type
@@ -32252,7 +32252,7 @@ public:
 namespace ContentSearch {
 enum class Fields
 {
-    kParameterList = 1,
+    kParameterList = 0,
 };
 
 struct Type
@@ -32274,9 +32274,9 @@ public:
 namespace StyleInformation {
 enum class Fields
 {
-    kImageUrl = 1,
-    kColor    = 2,
-    kSize     = 3,
+    kImageUrl = 0,
+    kColor    = 1,
+    kSize     = 2,
 };
 
 struct Type
@@ -32296,12 +32296,12 @@ using DecodableType = Type;
 namespace BrandingInformation {
 enum class Fields
 {
-    kProviderName = 1,
-    kBackground   = 2,
-    kLogo         = 3,
-    kProgressBar  = 4,
-    kSplash       = 5,
-    kWaterMark    = 6,
+    kProviderName = 0,
+    kBackground   = 1,
+    kLogo         = 2,
+    kProgressBar  = 3,
+    kSplash       = 4,
+    kWaterMark    = 5,
 };
 
 struct Type
@@ -32559,9 +32559,9 @@ namespace Structs {
 namespace OutputInfo {
 enum class Fields
 {
-    kIndex      = 1,
-    kOutputType = 2,
-    kName       = 3,
+    kIndex      = 0,
+    kOutputType = 1,
+    kName       = 2,
 };
 
 struct Type
@@ -32772,8 +32772,8 @@ namespace Structs {
 namespace ApplicationLauncherApplication {
 enum class Fields
 {
-    kCatalogVendorId = 1,
-    kApplicationId   = 2,
+    kCatalogVendorId = 0,
+    kApplicationId   = 1,
 };
 
 struct Type
@@ -32792,8 +32792,8 @@ using DecodableType = Type;
 namespace ApplicationEP {
 enum class Fields
 {
-    kApplication = 1,
-    kEndpoint    = 2,
+    kApplication = 0,
+    kEndpoint    = 1,
 };
 
 struct Type
@@ -33067,8 +33067,8 @@ namespace Structs {
 namespace ApplicationBasicApplication {
 enum class Fields
 {
-    kCatalogVendorId = 1,
-    kApplicationId   = 2,
+    kCatalogVendorId = 0,
+    kApplicationId   = 1,
 };
 
 struct Type
@@ -33477,14 +33477,14 @@ namespace Structs {
 namespace SimpleStruct {
 enum class Fields
 {
-    kA = 1,
-    kB = 2,
-    kC = 3,
-    kD = 4,
-    kE = 5,
-    kF = 6,
-    kG = 7,
-    kH = 8,
+    kA = 0,
+    kB = 1,
+    kC = 2,
+    kD = 3,
+    kE = 4,
+    kF = 5,
+    kG = 6,
+    kH = 7,
 };
 
 struct Type
@@ -33509,18 +33509,18 @@ using DecodableType = Type;
 namespace NullablesAndOptionalsStruct {
 enum class Fields
 {
-    kNullableInt            = 1,
-    kOptionalInt            = 2,
-    kNullableOptionalInt    = 3,
-    kNullableString         = 4,
-    kOptionalString         = 5,
-    kNullableOptionalString = 6,
-    kNullableStruct         = 7,
-    kOptionalStruct         = 8,
-    kNullableOptionalStruct = 9,
-    kNullableList           = 10,
-    kOptionalList           = 11,
-    kNullableOptionalList   = 12,
+    kNullableInt            = 0,
+    kOptionalInt            = 1,
+    kNullableOptionalInt    = 2,
+    kNullableString         = 3,
+    kOptionalString         = 4,
+    kNullableOptionalString = 5,
+    kNullableStruct         = 6,
+    kOptionalStruct         = 7,
+    kNullableOptionalStruct = 8,
+    kNullableList           = 9,
+    kOptionalList           = 10,
+    kNullableOptionalList   = 11,
 };
 
 struct Type
@@ -33564,9 +33564,9 @@ public:
 namespace NestedStruct {
 enum class Fields
 {
-    kA = 1,
-    kB = 2,
-    kC = 3,
+    kA = 0,
+    kB = 1,
+    kC = 2,
 };
 
 struct Type
@@ -33586,13 +33586,13 @@ using DecodableType = Type;
 namespace NestedStructList {
 enum class Fields
 {
-    kA = 1,
-    kB = 2,
-    kC = 3,
-    kD = 4,
-    kE = 5,
-    kF = 6,
-    kG = 7,
+    kA = 0,
+    kB = 1,
+    kC = 2,
+    kD = 3,
+    kE = 4,
+    kF = 5,
+    kG = 6,
 };
 
 struct Type
@@ -33626,7 +33626,7 @@ public:
 namespace DoubleNestedStructList {
 enum class Fields
 {
-    kA = 1,
+    kA = 0,
 };
 
 struct Type
@@ -33648,8 +33648,8 @@ public:
 namespace TestListStructOctet {
 enum class Fields
 {
-    kFabricIndex     = 1,
-    kOperationalCert = 2,
+    kFabricIndex     = 0,
+    kOperationalCert = 1,
 };
 
 struct Type


### PR DESCRIPTION
The changes to the field ids of structs are intended, and were
verified to all match the spec now.

The change to use fieldIdentifier for command fields is because ZAP
now exposes it.

#### Problem
Wrong field ids for structs, not matching spec.

#### Change overview
Fix the field ids.

#### Testing
Manually inspected the generated structs.