### PR TITLE
Op Certs Generation: Support CASE Authenticated Tags and other Attributes

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,14 +95,24 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
                                                                                 MutableByteSpan & rcac, MutableByteSpan & icac,
                                                                                 MutableByteSpan & noc)
 {
+    ChipDN noc_dn;
+    // TODO: Is there a way to make this code less error-prone for consumers?
+    // The consumer doesn't need to know the exact OID value.
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId);
+    // TODO: Add support for the CASE Authenticated Tags attributes
+    ChipDN icac_dn;
+    icac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, mIntermediateIssuerId);
+    ChipDN rcac_dn;
+    rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId);
+
     ChipLogProgress(Controller, "Generating NOC");
-    X509CertRequestParams noc_request = { 1, mIntermediateIssuerId, mNow, mNow + mValidity, true, fabricId, true, nodeId };
-    ReturnErrorOnFailure(
-        NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsIntermediateCA, pubkey, mIntermediateIssuer, noc));
+    X509CertRequestParams noc_request = { 1, mNow, mNow + mValidity, noc_dn, icac_dn };
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, pubkey, mIntermediateIssuer, noc));
 
     ChipLogProgress(Controller, "Generating ICAC");
-    X509CertRequestParams icac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
-    ReturnErrorOnFailure(NewICAX509Cert(icac_request, mIntermediateIssuerId, mIntermediateIssuer.Pubkey(), mIssuer, icac));
+    X509CertRequestParams icac_request = { 0, mNow, mNow + mValidity, icac_dn, rcac_dn };
+    ReturnErrorOnFailure(NewICAX509Cert(icac_request, mIntermediateIssuer.Pubkey(), mIssuer, icac));
 
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
     CHIP_ERROR err      = CHIP_NO_ERROR;
@@ -116,7 +126,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     }
 
     ChipLogProgress(Controller, "Generating RCAC");
-    X509CertRequestParams rcac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
+    X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
     ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2020-2021 Project CHIP Authors
+ *   Copyright (c) 2020-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,10 +67,15 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChainAfterValidation(NodeI
                                                                            MutableByteSpan & rcac, MutableByteSpan & icac,
                                                                            MutableByteSpan & noc)
 {
+    ChipDN noc_dn;
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId);
+    ChipDN rcac_dn;
+    rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId);
+
     ChipLogProgress(Controller, "Generating NOC");
-    chip::Credentials::X509CertRequestParams noc_request = { 1, mIssuerId, mNow, mNow + mValidity, true, fabricId, true, nodeId };
-    ReturnErrorOnFailure(
-        NewNodeOperationalX509Cert(noc_request, chip::Credentials::CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuer, noc));
+    chip::Credentials::X509CertRequestParams noc_request = { 1, mNow, mNow + mValidity, noc_dn, rcac_dn };
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, pubkey, mIssuer, noc));
     icac.reduce_size(0);
 
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
@@ -85,7 +90,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChainAfterValidation(NodeI
     }
 
     ChipLogProgress(Controller, "Generating RCAC");
-    chip::Credentials::X509CertRequestParams rcac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
+    chip::Credentials::X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
     ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
@@ -515,7 +515,8 @@ void ValidationContext::Reset()
 
 bool ChipRDN::IsEqual(const ChipRDN & other) const
 {
-    if (mAttrOID == kOID_Unknown || mAttrOID == kOID_NotSpecified || mAttrOID != other.mAttrOID)
+    if (mAttrOID == kOID_Unknown || mAttrOID == kOID_NotSpecified || mAttrOID != other.mAttrOID ||
+        mAttrIsPrintableString != other.mAttrIsPrintableString)
     {
         return false;
     }
@@ -569,13 +570,14 @@ CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, uint64_t val)
         VerifyOrReturnError(CanCastTo<uint32_t>(val), CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    rdn[rdnCount].mAttrOID = oid;
-    rdn[rdnCount].mChipVal = val;
+    rdn[rdnCount].mAttrOID               = oid;
+    rdn[rdnCount].mChipVal               = val;
+    rdn[rdnCount].mAttrIsPrintableString = false;
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, CharSpan val)
+CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, CharSpan val, bool isPrintableString)
 {
     uint8_t rdnCount = RDNCount();
 
@@ -583,8 +585,9 @@ CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, CharSpan val)
     VerifyOrReturnError(!IsChipDNAttr(oid), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(oid != kOID_NotSpecified, CHIP_ERROR_INVALID_ARGUMENT);
 
-    rdn[rdnCount].mAttrOID = oid;
-    rdn[rdnCount].mString  = val;
+    rdn[rdnCount].mAttrOID               = oid;
+    rdn[rdnCount].mString                = val;
+    rdn[rdnCount].mAttrIsPrintableString = isPrintableString;
 
     return CHIP_NO_ERROR;
 }
@@ -693,6 +696,142 @@ CHIP_ERROR ChipDN::GetCertFabricId(uint64_t & fabricId) const
 
     VerifyOrReturnError(fabricId != UINT64_MAX, CHIP_ERROR_WRONG_CERT_TYPE);
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDN::DecodeFromTLV(TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLVType outerContainer;
+
+    static constexpr uint32_t kOID_AttributeIsPrintableString_Flag = 0x00000080;
+    static constexpr uint32_t kOID_AttributeType_Mask              = 0x0000007F;
+
+    VerifyOrReturnError(reader.GetType() == kTLVType_List, CHIP_ERROR_WRONG_TLV_TYPE);
+
+    // Enter the List TLV element that represents the DN in TLV format.
+    ReturnErrorOnFailure(reader.EnterContainer(outerContainer));
+
+    // Read the RDN attributes in the List.
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        // Get the TLV tag, make sure it is a context tag and extract the context tag number.
+        Tag tlvTag = reader.GetTag();
+        VerifyOrReturnError(IsContextTag(tlvTag), CHIP_ERROR_INVALID_TLV_TAG);
+        uint32_t tlvTagNum = TagNumFromTag(tlvTag);
+
+        // Derive the OID of the corresponding ASN.1 attribute from the TLV tag number.
+        // The numeric value of the OID is encoded in the bottom 7 bits of the TLV tag number.
+        // This eliminates the need for a translation table/switch statement but has the
+        // effect of tying the two encodings together.
+        //
+        // NOTE: In the event that the computed OID value is not one that we recognize
+        // (specifically, is not in the table of OIDs defined in ASN1OID.h) then the
+        // macro call below that encodes the attribute's object id (ASN1_ENCODE_OBJECT_ID)
+        // will fail for lack of the OID's encoded representation.  Given this there's no
+        // need to test the validity of the OID here.
+        //
+        OID attrOID = GetOID(kOIDCategory_AttributeType, static_cast<uint8_t>(tlvTagNum & kOID_AttributeType_Mask));
+
+        bool attrIsPrintableString = (tlvTagNum & kOID_AttributeIsPrintableString_Flag) == kOID_AttributeIsPrintableString_Flag;
+
+        // For 64-bit CHIP-defined DN attributes.
+        if (IsChip64bitDNAttr(attrOID))
+        {
+            uint64_t chipAttr;
+            VerifyOrReturnError(attrIsPrintableString == false, CHIP_ERROR_INVALID_TLV_TAG);
+            ReturnErrorOnFailure(reader.Get(chipAttr));
+            ReturnErrorOnFailure(AddAttribute(attrOID, chipAttr));
+        }
+        // For 32-bit CHIP-defined DN attributes.
+        else if (IsChip32bitDNAttr(attrOID))
+        {
+            uint32_t chipAttr;
+            VerifyOrReturnError(attrIsPrintableString == false, CHIP_ERROR_INVALID_TLV_TAG);
+            ReturnErrorOnFailure(reader.Get(chipAttr));
+            ReturnErrorOnFailure(AddAttribute(attrOID, chipAttr));
+        }
+        // Otherwise the attribute is one of the supported X.509 attributes
+        else
+        {
+            CharSpan asn1Attr;
+            ReturnErrorOnFailure(reader.Get(asn1Attr));
+            ReturnErrorOnFailure(AddAttribute(attrOID, asn1Attr, attrIsPrintableString));
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outerContainer));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipDN::EncodeToASN1(ASN1Writer & writer) const
+{
+    CHIP_ERROR err   = CHIP_NO_ERROR;
+    uint8_t rdnCount = RDNCount();
+
+    ASN1_START_SEQUENCE
+    {
+        for (uint8_t i = 0; i < rdnCount; i++)
+        {
+            ASN1_START_SET
+            {
+                char chipAttrStr[kChip64bitAttrUTF8Length + 1];
+                CharSpan asn1Attr;
+                uint8_t asn1Tag;
+                chip::ASN1::OID attrOID = rdn[i].mAttrOID;
+
+                if (IsChip64bitDNAttr(attrOID))
+                {
+                    snprintf(chipAttrStr, sizeof(chipAttrStr), ChipLogFormatX64, ChipLogValueX64(rdn[i].mChipVal));
+                    asn1Attr = CharSpan(chipAttrStr, kChip64bitAttrUTF8Length);
+                    asn1Tag  = kASN1UniversalTag_UTF8String;
+                }
+                else if (IsChip32bitDNAttr(attrOID))
+                {
+                    snprintf(chipAttrStr, sizeof(chipAttrStr), "%08" PRIX32, static_cast<uint32_t>(rdn[i].mChipVal));
+                    asn1Attr = CharSpan(chipAttrStr, kChip32bitAttrUTF8Length);
+                    asn1Tag  = kASN1UniversalTag_UTF8String;
+                }
+                else
+                {
+                    asn1Attr = rdn[i].mString;
+
+                    // Determine the appropriate ASN.1 tag for the DN attribute.
+                    // - DomainComponent is always an IA5String.
+                    // - For all other ASN.1 defined attributes, bit 0x80 in the TLV tag value conveys whether the attribute
+                    //   is a UTF8String or a PrintableString (in some cases the certificate generator has a choice).
+                    if (attrOID == kOID_AttributeType_DomainComponent)
+                    {
+                        asn1Tag = kASN1UniversalTag_IA5String;
+                    }
+                    else
+                    {
+                        asn1Tag = rdn[i].mAttrIsPrintableString ? kASN1UniversalTag_PrintableString : kASN1UniversalTag_UTF8String;
+                    }
+                }
+
+                // AttributeTypeAndValue ::= SEQUENCE
+                ASN1_START_SEQUENCE
+                {
+                    // type AttributeType
+                    // AttributeType ::= OBJECT IDENTIFIER
+                    ASN1_ENCODE_OBJECT_ID(attrOID);
+
+                    VerifyOrReturnError(CanCastTo<uint16_t>(asn1Attr.size()), CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+
+                    // value AttributeValue
+                    // AttributeValue ::= ANY -- DEFINED BY AttributeType
+                    ReturnErrorOnFailure(writer.PutString(asn1Tag, asn1Attr.data(), static_cast<uint16_t>(asn1Attr.size())));
+                }
+                ASN1_END_SEQUENCE;
+            }
+            ASN1_END_SET;
+        }
+    }
+    ASN1_END_SEQUENCE;
+
+exit:
+    return err;
 }
 
 bool ChipDN::IsEqual(const ChipDN & other) const

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
@@ -738,7 +738,10 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
 
     ChipCertificateData certData;
 
-    X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, false, 0, false, 0 };
+    ChipDN root_dn;
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xabcdabcd);
+
+    X509CertRequestParams root_params = { 1234, 631161876, 729942000, root_dn, root_dn };
     MutableByteSpan signed_cert_span(signed_cert);
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span) == CHIP_NO_ERROR);
 
@@ -749,13 +752,24 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 
-    // Test that root cert cannot be provided a node ID
-    root_params.HasNodeID = true;
+    // Test error case: root cert subject provided ICA OID Attribute.
+    root_params.SubjectDN.Clear();
+    root_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, 0xabcdabcd);
+    root_params.IssuerDN.Clear();
+    root_params.IssuerDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, 0xabcdabcd);
     MutableByteSpan signed_cert_span1(signed_cert);
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 
+    // Test error case: root cert provided different subject and issuer DNs.
+    root_params.SubjectDN.Clear();
+    root_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xabcdabcd);
+    root_params.IssuerDN.Clear();
+    root_params.IssuerDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xffffeeee);
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+
     // Test that serial number cannot be negative
-    root_params.HasNodeID    = false;
+    root_params.IssuerDN.Clear();
+    root_params.IssuerDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xabcdabcd);
     root_params.SerialNumber = -1;
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 }
@@ -773,7 +787,11 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
     uint8_t outCertBuf[kMaxCHIPCertLength];
     MutableByteSpan outCert(outCertBuf);
 
-    X509CertRequestParams root_params_fabric = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0xabcd, false, 0 };
+    ChipDN root_dn;
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xabcdabcd);
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xabcd);
+
+    X509CertRequestParams root_params_fabric = { 1234, 631161876, 729942000, root_dn, root_dn };
 
     MutableByteSpan signed_cert_span(signed_cert);
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params_fabric, keypair, signed_cert_span) == CHIP_NO_ERROR);
@@ -796,28 +814,36 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
 
     ChipCertificateData certData;
 
-    X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, false, 0, false, 0 };
+    ChipDN ica_dn;
+    ica_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, 0xABCDABCDABCDABCD);
+    ChipDN issuer_dn;
+    issuer_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0x43215678FEDCABCD);
+
+    X509CertRequestParams ica_params = { 1234, 631161876, 729942000, ica_dn, issuer_dn };
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 
-    // Test that ICA cert cannot be provided a node ID
-    ica_params.HasNodeID = true;
+    // Test error case: ICA cert subject provided a node ID attribute
+    ica_params.SubjectDN.Clear();
+    ica_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xABCDABCDABCDABCD);
+    ica_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
     MutableByteSpan signed_cert_span1(signed_cert);
-    NL_TEST_ASSERT(
-        inSuite, NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that serial number cannot be negative
-    ica_params.HasNodeID    = false;
+    ica_params.SubjectDN.Clear();
+    ica_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, 0xABCDABCDABCDABCD);
     ica_params.SerialNumber = -1;
-    NL_TEST_ASSERT(
-        inSuite, NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext)
@@ -833,39 +859,51 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
 
     ChipCertificateData certData;
 
-    X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
+    ChipDN noc_dn;
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xABCDABCDABCDABCD);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
+    ChipDN issuer_dn;
+    issuer_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0x8888999944442222);
+
+    X509CertRequestParams noc_params = { 123456, 631161876, 729942000, noc_dn, issuer_dn };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span) ==
-                       CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 
-    // Test that NOC cert must be provided a node ID
-    noc_params.HasNodeID = false;
+    // Test error case: NOC cert subject doesn't have NodeId attribute
+    noc_params.SubjectDN.Clear();
+    noc_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
+
     MutableByteSpan signed_cert_span1(signed_cert, sizeof(signed_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
+                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
                        CHIP_ERROR_INVALID_ARGUMENT);
 
-    // Test that NOC cert must be provided a fabric ID
-    noc_params.HasNodeID   = true;
-    noc_params.HasFabricID = false;
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    // Test error case: NOC cert subject doesn't have fabric ID attribute
+    noc_params.SubjectDN.Clear();
+    noc_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xABCDABCDABCDABCD);
 
-    // Test that serial number cannot be negative
-    noc_params.HasNodeID    = true;
-    noc_params.HasFabricID  = true;
-    noc_params.SerialNumber = -1;
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
+                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
+                       CHIP_ERROR_WRONG_CERT_TYPE);
+
+    // Test error case: issuer cert DN type is Node certificate
+    noc_params.SubjectDN.Clear();
+    noc_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xABCDABCDABCDABCD);
+    noc_params.SubjectDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
+    noc_params.IssuerDN.Clear();
+    noc_params.IssuerDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0x8888999944442222);
+    noc_params.IssuerDN.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
+
+    NL_TEST_ASSERT(inSuite,
+                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
                        CHIP_ERROR_INVALID_ARGUMENT);
 }
 
@@ -880,18 +918,38 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
     uint8_t outCertBuf[kMaxCHIPCertLength];
     MutableByteSpan outCert(outCertBuf);
 
+    uint8_t outCertDERBuf[kMaxDERCertLength];
+    MutableByteSpan outCertDER(outCertDERBuf);
+
     ChipCertificateData certData;
 
-    X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
+    const static char noc_cn_rdn[]        = "Test NOC";
+    const static char noc_givenname_rdn[] = "John";
+    const static char noc_name_rdn[]      = "Smith";
+
+    ChipDN noc_dn;
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_CommonName, CharSpan(noc_cn_rdn, strlen(noc_cn_rdn)), false);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xAAAABBBBCCCCDDDD);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_GivenName, CharSpan(noc_givenname_rdn, strlen(noc_givenname_rdn)), true);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_Name, CharSpan(noc_name_rdn, strlen(noc_name_rdn)), true);
+
+    ChipDN ica_dn;
+    ica_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, 0x8888999944442222);
+    ica_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB00000FAB00001);
+
+    X509CertRequestParams noc_params = { 12348765, 631161876, 729942000, noc_dn, ica_dn };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert);
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), keypair,
-                                              signed_cert_span) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, ConvertChipCertToX509Cert(outCert, outCertDER) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, signed_cert_span.data_equal(outCertDER));
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 }
@@ -904,29 +962,40 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
 
     static uint8_t root_cert[kMaxDERCertLength];
 
-    X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
+    ChipDN root_dn;
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xAAAABBBBCCCCDDDD);
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB0000000008888);
+
+    X509CertRequestParams root_params = { 1234, 631161876, 729942000, root_dn, root_dn };
     MutableByteSpan root_cert_span(root_cert);
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t ica_cert[kMaxDERCertLength];
 
-    X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
+    ChipDN ica_dn;
+    ica_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, 0xAABBCCDDAABBCCDD);
+    ica_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB0000000008888);
+
+    X509CertRequestParams ica_params = { 12345, 631161876, 729942000, ica_dn, root_dn };
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
     MutableByteSpan ica_cert_span(ica_cert);
-    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
 
-    X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
+    ChipDN noc_dn;
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xAABBCCDDAABBCCDD);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB0000000008888);
+
+    X509CertRequestParams noc_params = { 123456, 631161876, 729942000, noc_dn, ica_dn };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
     MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair,
-                                              noc_cert_span) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), ica_keypair, noc_cert_span) == CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
     NL_TEST_ASSERT(inSuite, certSet.Init(3) == CHIP_NO_ERROR);
@@ -971,20 +1040,33 @@ static void TestChipCert_VerifyGeneratedCertsNoICA(nlTestSuite * inSuite, void *
 
     static uint8_t root_cert[kMaxDERCertLength];
 
-    X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
+    const static char root_cn_rdn[] = "Test Root Operational Cert";
+
+    ChipDN root_dn;
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_CommonName, CharSpan(root_cn_rdn, strlen(root_cn_rdn)), false);
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, 0xAAAABBBBCCCCDDDD);
+    root_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB0000000008888);
+
+    X509CertRequestParams root_params = { 1234, 631161876, 729942000, root_dn, root_dn };
     MutableByteSpan root_cert_span(root_cert);
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
 
-    X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
+    const static char noc_cn_rdn[] = "Test NOC";
+
+    ChipDN noc_dn;
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_CommonName, CharSpan(noc_cn_rdn, strlen(noc_cn_rdn)), true);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, 0xAABBCCDDAABBCCDD);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, 0xFAB0000000008888);
+    noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipCASEAuthenticatedTag, 0xABCD0010);
+
+    X509CertRequestParams noc_params = { 1234, 631161876, 729942000, noc_dn, root_dn };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
     MutableByteSpan noc_cert_span(noc_cert);
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert_span) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, noc_cert_span) == CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
     NL_TEST_ASSERT(inSuite, certSet.Init(2) == CHIP_NO_ERROR);

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -299,7 +299,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'c':
-        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, chip::CharSpan::fromCharString(arg));
+        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, chip::CharSpan::fromCharString(arg), false);
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add Common Name attribute to the subject DN: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
Currently implemented code only supports NodeId and FabricId DN attributes. 

Ticket: #6435

#### Change overview
  - Added support for the subject and issuer DNs in the X509CertRequestParams structure.
  - Factored out ChipDN encoding and decoding into separate functions.
  - Other updates and cleanups.

#### Testing
Unit tests and top level tests that use OpCert generation. 