### PR TITLE
Update the ACL event fields to align with the spec

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -48,18 +48,18 @@ server cluster AccessControl = 31 {
 
   info event AccessControlEntryChanged = 0 {
     fabric_idx adminFabricIndex = 0;
-    node_id adminNodeID = 1;
-    INT16U adminPasscodeID = 2;
+    nullable node_id adminNodeID = 1;
+    nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
-    AccessControlEntry latestValue = 4;
+    nullable AccessControlEntry latestValue = 4;
   }
 
   info event AccessControlExtensionChanged = 1 {
     fabric_idx adminFabricIndex = 0;
-    node_id adminNodeID = 1;
-    INT16U adminPasscodeID = 2;
+    nullable node_id adminNodeID = 1;
+    nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
-    ExtensionEntry latestValue = 4;
+    nullable ExtensionEntry latestValue = 4;
   }
 
   attribute AccessControlEntry acl[] = 0;

--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -89,18 +89,18 @@ limitations under the License.
     <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" optional="false">
       <description>The cluster SHALL send AccessControlEntryChanged events whenever its ACL attribute data is changed by an Administrator.</description>
       <field id="0" name="AdminFabricIndex" type="fabric_idx"/>
-      <field id="1" name="AdminNodeID" type="node_id"/>
-      <field id="2" name="AdminPasscodeID" type="INT16U"/>
+      <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
+      <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
       <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
-      <field id="4" name="LatestValue" type="AccessControlEntry"/>
+      <field id="4" name="LatestValue" type="AccessControlEntry" isNullable="true"/>
     </event>
     <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" optional="false">
       <description>The cluster SHALL send AccessControlExtensionChanged events whenever its extension attribute data is changed by an Administrator.</description>
       <field id="0" name="AdminFabricIndex" type="fabric_idx"/>
-      <field id="1" name="AdminNodeID" type="node_id"/>
-      <field id="2" name="AdminPasscodeID" type="INT16U"/>
+      <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
+      <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
       <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
-      <field id="4" name="LatestValue" type="ExtensionEntry"/>
+      <field id="4" name="LatestValue" type="ExtensionEntry" isNullable="true"/>
     </event>    
   </cluster>
 </configurator>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -48,18 +48,18 @@ client cluster AccessControl = 31 {
 
   info event AccessControlEntryChanged = 0 {
     fabric_idx adminFabricIndex = 0;
-    node_id adminNodeID = 1;
-    INT16U adminPasscodeID = 2;
+    nullable node_id adminNodeID = 1;
+    nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
-    AccessControlEntry latestValue = 4;
+    nullable AccessControlEntry latestValue = 4;
   }
 
   info event AccessControlExtensionChanged = 1 {
     fabric_idx adminFabricIndex = 0;
-    node_id adminNodeID = 1;
-    INT16U adminPasscodeID = 2;
+    nullable node_id adminNodeID = 1;
+    nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
-    ExtensionEntry latestValue = 4;
+    nullable ExtensionEntry latestValue = 4;
   }
 
   attribute AccessControlEntry acl[] = 0;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -5297,17 +5297,17 @@ class AccessControl(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="adminFabricIndex", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="adminNodeID", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="adminNodeID", Tag=1, Type=typing.Union[Nullable, uint]),
+                            ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=typing.Union[Nullable, uint]),
                             ClusterObjectFieldDescriptor(Label="changeType", Tag=3, Type=AccessControl.Enums.ChangeTypeEnum),
-                            ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=AccessControl.Structs.AccessControlEntry),
+                            ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=typing.Union[Nullable, AccessControl.Structs.AccessControlEntry]),
                     ])
 
             adminFabricIndex: 'uint' = 0
-            adminNodeID: 'uint' = 0
-            adminPasscodeID: 'uint' = 0
+            adminNodeID: 'typing.Union[Nullable, uint]' = NullValue
+            adminPasscodeID: 'typing.Union[Nullable, uint]' = NullValue
             changeType: 'AccessControl.Enums.ChangeTypeEnum' = 0
-            latestValue: 'AccessControl.Structs.AccessControlEntry' = field(default_factory=lambda: AccessControl.Structs.AccessControlEntry())
+            latestValue: 'typing.Union[Nullable, AccessControl.Structs.AccessControlEntry]' = NullValue
 
         @dataclass
         class AccessControlExtensionChanged(ClusterEvent):
@@ -5324,17 +5324,17 @@ class AccessControl(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="adminFabricIndex", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="adminNodeID", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="adminNodeID", Tag=1, Type=typing.Union[Nullable, uint]),
+                            ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=typing.Union[Nullable, uint]),
                             ClusterObjectFieldDescriptor(Label="changeType", Tag=3, Type=AccessControl.Enums.ChangeTypeEnum),
-                            ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=AccessControl.Structs.ExtensionEntry),
+                            ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=typing.Union[Nullable, AccessControl.Structs.ExtensionEntry]),
                     ])
 
             adminFabricIndex: 'uint' = 0
-            adminNodeID: 'uint' = 0
-            adminPasscodeID: 'uint' = 0
+            adminNodeID: 'typing.Union[Nullable, uint]' = NullValue
+            adminPasscodeID: 'typing.Union[Nullable, uint]' = NullValue
             changeType: 'AccessControl.Enums.ChangeTypeEnum' = 0
-            latestValue: 'AccessControl.Structs.ExtensionEntry' = field(default_factory=lambda: AccessControl.Structs.ExtensionEntry())
+            latestValue: 'typing.Union[Nullable, AccessControl.Structs.ExtensionEntry]' = NullValue
 
 
 @dataclass

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -6605,10 +6605,10 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
 
     chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
-    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
-    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
-    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
-    Structs::AccessControlEntry::Type latestValue;
+    DataModel::Nullable<chip::NodeId> adminNodeID;
+    DataModel::Nullable<uint16_t> adminPasscodeID;
+    ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
+    DataModel::Nullable<Structs::AccessControlEntry::Type> latestValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6621,10 +6621,10 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
 
     chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
-    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
-    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
-    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
-    Structs::AccessControlEntry::DecodableType latestValue;
+    DataModel::Nullable<chip::NodeId> adminNodeID;
+    DataModel::Nullable<uint16_t> adminPasscodeID;
+    ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
+    DataModel::Nullable<Structs::AccessControlEntry::DecodableType> latestValue;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -6650,10 +6650,10 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
 
     chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
-    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
-    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
-    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
-    Structs::ExtensionEntry::Type latestValue;
+    DataModel::Nullable<chip::NodeId> adminNodeID;
+    DataModel::Nullable<uint16_t> adminPasscodeID;
+    ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
+    DataModel::Nullable<Structs::ExtensionEntry::Type> latestValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6666,10 +6666,10 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
 
     chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
-    chip::NodeId adminNodeID           = static_cast<chip::NodeId>(0);
-    uint16_t adminPasscodeID           = static_cast<uint16_t>(0);
-    ChangeTypeEnum changeType          = static_cast<ChangeTypeEnum>(0);
-    Structs::ExtensionEntry::DecodableType latestValue;
+    DataModel::Nullable<chip::NodeId> adminNodeID;
+    DataModel::Nullable<uint16_t> adminPasscodeID;
+    ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
+    DataModel::Nullable<Structs::ExtensionEntry::DecodableType> latestValue;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Some fields of AccessControlEntryChanged and AccessControlExtensionChanged should be marked as nullable per spec

#### Change overview
Update the ACL event fields to align with the spec

#### Testing
How was this tested? (at least one bullet point required)
* xml update only, no source code change
