### PR TITLE
Remove x86/x64 builds in Android CI

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -57,7 +57,7 @@ jobs:
             - name: Build Android CHIPTool and CHIPTest
               run: |
                 ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-{arm,arm64,x64,x86}-chip-*' build"
+                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-{arm,arm64}-chip-*' build"
             # - name: Build Android Studio build (arm64 only)
             #   run: |
             #     ./scripts/run_in_build_env.sh \


### PR DESCRIPTION
#### Problem
* Android CI is always close to running out of memory recently
* #13686 helped a bit, but I'm again running into "Error 137" problems for `android-x64` on #13609, which adds a lot of code.

#### Change overview
* Remove x86/x64 builds. These go through the exact same Java code paths, so don't provide a ton of extra coverage here. #13609 passes with this change.

#### Testing
* CI
