### PR TITLE
Disambiguate type names in cluster-objects initializers.

### DIFF
--- a/src/app/zap-templates/partials/cluster-objects-field-init.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-field-init.zapt
@@ -8,7 +8,7 @@
           {{~#if_is_struct type}}
             {{! Structs have their own initializers }}
           {{~else~}}
-          = static_cast<{{zapTypeToEncodableClusterObjectType type}}>(0)
+          = static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>(0)
           {{~/if_is_struct}}
         {{~/unless}}
       {{~/unless}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -176,7 +176,7 @@ struct TypeInfo
 {{#zcl_attributes_server}}
         {{! isOptional=false because optional attributes don't get represented
             as Optional types here. }}
-        Attributes::{{asUpperCamelCase label}}::TypeInfo::DecodableType {{asLowerCamelCase label}}{{> cluster_objects_field_init isOptional=false}};
+        Attributes::{{asUpperCamelCase label}}::TypeInfo::DecodableType {{asLowerCamelCase label}}{{> cluster_objects_field_init ns=parent.name isOptional=false}};
 {{/zcl_attributes_server}}
     };
 };

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -8811,7 +8811,8 @@ struct TypeInfo
 
         Attributes::DefaultOtaProviders::TypeInfo::DecodableType defaultOtaProviders;
         Attributes::UpdatePossible::TypeInfo::DecodableType updatePossible = static_cast<bool>(0);
-        Attributes::UpdateState::TypeInfo::DecodableType updateState       = static_cast<OTAUpdateStateEnum>(0);
+        Attributes::UpdateState::TypeInfo::DecodableType updateState =
+            static_cast<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum>(0);
         Attributes::UpdateStateProgress::TypeInfo::DecodableType updateStateProgress;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
         Attributes::FeatureMap::TypeInfo::DecodableType featureMap           = static_cast<uint32_t>(0);
@@ -10719,7 +10720,8 @@ struct TypeInfo
         Attributes::ScanMaxTimeSeconds::TypeInfo::DecodableType scanMaxTimeSeconds       = static_cast<uint8_t>(0);
         Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType connectMaxTimeSeconds = static_cast<uint8_t>(0);
         Attributes::InterfaceEnabled::TypeInfo::DecodableType interfaceEnabled           = static_cast<bool>(0);
-        Attributes::LastNetworkingStatus::TypeInfo::DecodableType lastNetworkingStatus = static_cast<NetworkCommissioningStatus>(0);
+        Attributes::LastNetworkingStatus::TypeInfo::DecodableType lastNetworkingStatus =
+            static_cast<chip::app::Clusters::NetworkCommissioning::NetworkCommissioningStatus>(0);
         Attributes::LastNetworkID::TypeInfo::DecodableType lastNetworkID;
         Attributes::LastConnectErrorValue::TypeInfo::DecodableType lastConnectErrorValue = static_cast<uint32_t>(0);
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
@@ -19177,7 +19179,7 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::LockState::TypeInfo::DecodableType lockState;
-        Attributes::LockType::TypeInfo::DecodableType lockType               = static_cast<DlLockType>(0);
+        Attributes::LockType::TypeInfo::DecodableType lockType = static_cast<chip::app::Clusters::DoorLock::DlLockType>(0);
         Attributes::ActuatorEnabled::TypeInfo::DecodableType actuatorEnabled = static_cast<bool>(0);
         Attributes::DoorState::TypeInfo::DecodableType doorState;
         Attributes::DoorOpenEvents::TypeInfo::DecodableType doorOpenEvents                           = static_cast<uint32_t>(0);
@@ -19200,11 +19202,12 @@ struct TypeInfo
         Attributes::CredentialRulesSupport::TypeInfo::DecodableType credentialRulesSupport = static_cast<uint8_t>(0);
         Attributes::EnableLogging::TypeInfo::DecodableType enableLogging                   = static_cast<bool>(0);
         Attributes::Language::TypeInfo::DecodableType language;
-        Attributes::LEDSettings::TypeInfo::DecodableType LEDSettings                         = static_cast<uint8_t>(0);
-        Attributes::AutoRelockTime::TypeInfo::DecodableType autoRelockTime                   = static_cast<uint32_t>(0);
-        Attributes::SoundVolume::TypeInfo::DecodableType soundVolume                         = static_cast<uint8_t>(0);
-        Attributes::OperatingMode::TypeInfo::DecodableType operatingMode                     = static_cast<DlOperatingMode>(0);
-        Attributes::SupportedOperatingModes::TypeInfo::DecodableType supportedOperatingModes = static_cast<uint16_t>(0);
+        Attributes::LEDSettings::TypeInfo::DecodableType LEDSettings       = static_cast<uint8_t>(0);
+        Attributes::AutoRelockTime::TypeInfo::DecodableType autoRelockTime = static_cast<uint32_t>(0);
+        Attributes::SoundVolume::TypeInfo::DecodableType soundVolume       = static_cast<uint8_t>(0);
+        Attributes::OperatingMode::TypeInfo::DecodableType operatingMode =
+            static_cast<chip::app::Clusters::DoorLock::DlOperatingMode>(0);
+        Attributes::SupportedOperatingModes::TypeInfo::DecodableType supportedOperatingModes           = static_cast<uint16_t>(0);
         Attributes::DefaultConfigurationRegister::TypeInfo::DecodableType defaultConfigurationRegister = static_cast<uint16_t>(0);
         Attributes::EnableLocalProgramming::TypeInfo::DecodableType enableLocalProgramming             = static_cast<bool>(0);
         Attributes::EnableOneTouchLocking::TypeInfo::DecodableType enableOneTouchLocking               = static_cast<bool>(0);
@@ -31495,9 +31498,10 @@ struct TypeInfo
 
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
-        Attributes::PlaybackState::TypeInfo::DecodableType playbackState = static_cast<PlaybackStateEnum>(0);
-        Attributes::StartTime::TypeInfo::DecodableType startTime         = static_cast<uint64_t>(0);
-        Attributes::Duration::TypeInfo::DecodableType duration           = static_cast<uint64_t>(0);
+        Attributes::PlaybackState::TypeInfo::DecodableType playbackState =
+            static_cast<chip::app::Clusters::MediaPlayback::PlaybackStateEnum>(0);
+        Attributes::StartTime::TypeInfo::DecodableType startTime = static_cast<uint64_t>(0);
+        Attributes::Duration::TypeInfo::DecodableType duration   = static_cast<uint64_t>(0);
         Attributes::Position::TypeInfo::DecodableType position;
         Attributes::PlaybackSpeed::TypeInfo::DecodableType playbackSpeed   = static_cast<float>(0);
         Attributes::SeekRangeEnd::TypeInfo::DecodableType seekRangeEnd     = static_cast<uint64_t>(0);
@@ -33234,7 +33238,8 @@ struct TypeInfo
         Attributes::ApplicationName::TypeInfo::DecodableType applicationName;
         Attributes::ProductId::TypeInfo::DecodableType productId = static_cast<uint16_t>(0);
         Attributes::ApplicationApp::TypeInfo::DecodableType applicationApp;
-        Attributes::ApplicationStatus::TypeInfo::DecodableType applicationStatus = static_cast<ApplicationStatusEnum>(0);
+        Attributes::ApplicationStatus::TypeInfo::DecodableType applicationStatus =
+            static_cast<chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum>(0);
         Attributes::ApplicationVersion::TypeInfo::DecodableType applicationVersion;
         Attributes::AllowedVendorList::TypeInfo::DecodableType allowedVendorList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
@@ -36031,7 +36036,7 @@ struct TypeInfo
         Attributes::EpochS::TypeInfo::DecodableType epochS     = static_cast<uint32_t>(0);
         Attributes::VendorId::TypeInfo::DecodableType vendorId = static_cast<chip::VendorId>(0);
         Attributes::ListNullablesAndOptionalsStruct::TypeInfo::DecodableType listNullablesAndOptionalsStruct;
-        Attributes::EnumAttr::TypeInfo::DecodableType enumAttr = static_cast<SimpleEnum>(0);
+        Attributes::EnumAttr::TypeInfo::DecodableType enumAttr = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(0);
         Attributes::StructAttr::TypeInfo::DecodableType structAttr;
         Attributes::RangeRestrictedInt8u::TypeInfo::DecodableType rangeRestrictedInt8u   = static_cast<uint8_t>(0);
         Attributes::RangeRestrictedInt8s::TypeInfo::DecodableType rangeRestrictedInt8s   = static_cast<int8_t>(0);


### PR DESCRIPTION
In most places, where we are assigning to something of type {{zapTypeToDecodableClusterObjectType type}} to start with, what we had was not a problem.

But in the DecodableType for the cluster-wide struct, which is inside
namespace chip::app::Clusters::ClusterName::Attributes, we could get
an ambiguity when an attribute and an enum had the same name
(e.g. HourFormat).  Then the bareword HourFormat instead of being
treated as ClusterName::HourFormat would get treated as
ClusterName::Attributes::HourFormat, which is a namespace, not a type
name, and after that things would fail to compile.

The fix is to, at this one callsite, pass in the cluster name as the
namespace, so we generate fully qualified names for enums.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ensured that I can compile with the HourFormat attribute defined to be of HourFormat type.