### PR TITLE
Fix compilation errors in scenes-client and groups-client

### DIFF
--- a/src/app/clusters/groups-client/groups-client.cpp
+++ b/src/app/clusters/groups-client/groups-client.cpp
@@ -76,7 +76,7 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(app::CommandHandler 
     {
         emberAfGroupsClusterPrint(" [0x%2x]", emberAfGetInt16u(groupList + (i << 1), 0, 2));
     }
-    emberAfGroupsClusterPrintln("");
+    emberAfGroupsClusterPrintln("%s", "");
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }

--- a/src/app/clusters/scenes-client/scenes-client.cpp
+++ b/src/app/clusters/scenes-client/scenes-client.cpp
@@ -42,7 +42,7 @@
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
 
-#include <zap-generated/command-id.h>
+#include <app-common/zap-generated/command-id.h>
 
 using namespace chip;
 
@@ -100,7 +100,7 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(app::CommandHandler 
         }
     }
 
-    emberAfScenesClusterPrintln("");
+    emberAfScenesClusterPrintln("%s", "");
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
@@ -157,7 +157,7 @@ bool emberAfPluginScenesClientParseViewSceneResponse(const EmberAfClusterCommand
         }
     }
 
-    emberAfScenesClusterPrintln("");
+    emberAfScenesClusterPrintln("%s", "");
     emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }


### PR DESCRIPTION
#### Problem
* Compilation errors when the scenes-client or groups-client cluster is included from src/app/clusters/ like:
```
error: zero-length gnu_printf format string [-Werror=format-zero-length]: emberAfGroupsClusterPrintln("");
```

#### Change overview
* Updated the error lines similar to how it is done in other clusters
* Also fixed an include error in scenes-client

#### Testing
* Compilation worked fine when including these clusters