### PR TITLE
[QPG] Adopt new qpg SDK directory structure

### DIFF
--- a/examples/lighting-app/qpg/BUILD.gn
+++ b/examples/lighting-app/qpg/BUILD.gn
@@ -79,7 +79,7 @@ qpg_executable("lighting_app") {
     "${chip_root}/examples/lighting-app/lighting-common/color_format",
   ]
 
-  ldscript = "${qpg_sdk_root}/${qpg_target_ic}/ldscripts/chip-${qpg_target_ic}-example.ld"
+  ldscript = "${qpg_sdk_root}/Libraries/Qorvo/QorvoStack/gen/QorvoStack_${qpg_target_ic}/QorvoStack_${qpg_target_ic}.ld"
 
   inputs = [ ldscript ]
 

--- a/examples/lock-app/qpg/BUILD.gn
+++ b/examples/lock-app/qpg/BUILD.gn
@@ -75,7 +75,7 @@ qpg_executable("lock_app") {
 
   cflags = [ "-Wconversion" ]
 
-  ldscript = "${qpg_sdk_root}/${qpg_target_ic}/ldscripts/chip-${qpg_target_ic}-example.ld"
+  ldscript = "${qpg_sdk_root}/Libraries/Qorvo/QorvoStack/gen/QorvoStack_${qpg_target_ic}/QorvoStack_${qpg_target_ic}.ld"
 
   inputs = [ ldscript ]
 

--- a/examples/persistent-storage/qpg/BUILD.gn
+++ b/examples/persistent-storage/qpg/BUILD.gn
@@ -63,7 +63,7 @@ qpg_executable("persistent_storage") {
 
   output_dir = root_out_dir
 
-  ldscript = "${qpg_sdk_root}/${qpg_target_ic}/ldscripts/chip-${qpg_target_ic}-example.ld"
+  ldscript = "${qpg_sdk_root}/Libraries/Qorvo/QorvoStack/gen/QorvoStack_${qpg_target_ic}/QorvoStack_${qpg_target_ic}.ld"
 
   inputs = [ ldscript ]
 

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -99,14 +99,13 @@ if (current_os == "zephyr" || current_os == "mbed") {
 
   lwip_target("lwip") {
     public = [
-      "${qpg_sdk_build_root}/repo/${qpg_target_ic}/comps/lwip/arch/cc.h",
-      "${qpg_sdk_build_root}/repo/${qpg_target_ic}/comps/lwip/arch/perf.h",
-      "${qpg_sdk_build_root}/repo/${qpg_target_ic}/comps/lwip/lwipopts.h",
-      "${qpg_sdk_build_root}/repo/${qpg_target_ic}/comps/lwip/lwippools.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Lwip/arch/cc.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Lwip/arch/perf.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Lwip/lwipopts.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Lwip/lwippools.h",
       "freertos/arch/sys_arch.h",
     ]
-    sources =
-        [ "${qpg_sdk_build_root}/repo/${qpg_target_ic}/comps/lwip/sys_arch.c" ]
+    sources = [ "${qpg_sdk_root}/Components/ThirdParty/Lwip/sys_arch.c" ]
 
     public_deps = [ ":lwip_buildconfig" ]
     public_deps += [ "${qpg_sdk_build_root}:qpg_sdk" ]

--- a/third_party/openthread/platforms/qpg/BUILD.gn
+++ b/third_party/openthread/platforms/qpg/BUILD.gn
@@ -64,7 +64,9 @@ source_set("libopenthread-qpg") {
   ]
   include_dirs += [ "${openthread_root}/examples/apps" ]
 
-  libs = [ "${qpg_sdk_root}/${qpg_target_ic}/lib/libOpenThreadQorvoGlue_${qpg_target_ic}_mtd.a" ]
+  if (qpg_sdk_include_platform_libs) {
+    libs = [ "${qpg_sdk_root}/${qpg_sdk_lib_dir}/OpenThreadQorvoGlue_${qpg_target_ic}_mtd/libOpenThreadQorvoGlue_${qpg_target_ic}_mtd.a" ]
+  }
 
   public_deps = [
     ":openthread_core_config_qpg",

--- a/third_party/qpg_sdk/BUILD.gn
+++ b/third_party/qpg_sdk/BUILD.gn
@@ -33,8 +33,8 @@ group("qpg_sdk") {
 
 config("qpg_freertos_config") {
   include_dirs = [
-    "${qpg_sdk_root}/${qpg_target_ic}/comps/gpFreeRTOS/config",
-    "${chip_root}/third_party/qpg_sdk/repo/${qpg_target_ic}/comps/lwip",
+    "${qpg_sdk_root}/Applications/Matter/shared/config/inc",
+    "${qpg_sdk_root}/Components/ThirdParty/Lwip",
     "${freertos_root}/repo/portable/GCC/ARM_CM3",
   ]
 }

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -22,8 +22,16 @@ declare_args() {
   # Location of the QPG SDK.
   qpg_sdk_root = "${chip_root}/third_party/qpg_sdk/repo"
 
+  # subdirectory in qpg_sdk_root where the binary library builds (.a) are to be found
+  # for connectedhomeip-qpg: Binaries (default)
+  # for matter endnodes sdk: Work
+  qpg_sdk_lib_dir = "Binaries"
+
   # Target IC for QPG SDK
   qpg_target_ic = "qpg6105"
+
+  # an option to disable referencing qorvo object archive files (*.a)
+  qpg_sdk_include_platform_libs = true
 }
 
 assert(qpg_sdk_root != "", "qpg_sdk_root must be specified")
@@ -57,21 +65,25 @@ template("qpg_sdk") {
     }
 
     include_dirs += [
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/qvCHIP/inc",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/qvIO/inc",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/gpFreeRTOS/config",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls",
+      "${qpg_sdk_root}/Components/Qorvo/Matter/qvCHIP/inc",
+      "${qpg_sdk_root}/Components/Qorvo/BSP/qvIO/inc",
+      "${qpg_sdk_root}/Libraries/Qorvo/mbedtls_alt/inc",
+      "${qpg_sdk_root}/Components/ThirdParty/Silex/cryptosoc/mbedtls_alt",
+      "${qpg_sdk_root}/Components/ThirdParty/Lwip",
+      "${qpg_sdk_root}/Components/ThirdParty/Lwip/arch",
       "${mbedtls_root}/repo/include",
       "${openthread_root}/include",
     ]
 
     lib_dirs = []
 
-    libs += [
-      "${qpg_sdk_root}/${qpg_target_ic}/lib/libMatterQorvoGlue_${qpg_target_ic}_libbuild.a",
-      "${qpg_sdk_root}/${qpg_target_ic}/lib/libQorvoStack_${qpg_target_ic}.a",
-      "${qpg_sdk_root}/${qpg_target_ic}/lib/libmbedtls_alt_${qpg_target_ic}.a",
-    ]
+    if (qpg_sdk_include_platform_libs) {
+      libs += [
+        "${qpg_sdk_root}/${qpg_sdk_lib_dir}/MatterQorvoGlue_${qpg_target_ic}_libbuild/libMatterQorvoGlue_${qpg_target_ic}_libbuild.a",
+        "${qpg_sdk_root}/${qpg_sdk_lib_dir}/QorvoStack_${qpg_target_ic}/libQorvoStack_${qpg_target_ic}.a",
+        "${qpg_sdk_root}/${qpg_sdk_lib_dir}/mbedtls_alt_${qpg_target_ic}/libmbedtls_alt_${qpg_target_ic}.a",
+      ]
+    }
 
     #MBed TLS built from third_party/mbedtls tree - OT config not used
     defines = [
@@ -177,18 +189,19 @@ template("qpg_sdk") {
       "${chip_root}/third_party/mbedtls/repo/library/x509write_crt.c",
       "${chip_root}/third_party/mbedtls/repo/library/x509write_csr.c",
       "${chip_root}/third_party/mbedtls/repo/library/xtea.c",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/gpFreeRTOS/config/FreeRTOSConfig.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/gpFreeRTOS/config/hooks.c",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/${qpg_target_ic}-mbedtls-config.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/aes_alt.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/ccm_alt.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/ecjpake_alt.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/ecp_alt.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/sha256_alt.h",
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/libmbedtls/trng.c",  #add this for
+      "${qpg_sdk_root}/Applications/Matter/shared/config/inc/FreeRTOSConfig.h",
+      "${qpg_sdk_root}/Applications/Matter/shared/config/src/hooks.c",
+      "${qpg_sdk_root}/Components/ThirdParty/Silex/cryptosoc/mbedtls_alt/aes_alt.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Silex/cryptosoc/mbedtls_alt/ccm_alt.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Silex/cryptosoc/mbedtls_alt/ecjpake_alt.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Silex/cryptosoc/mbedtls_alt/ecp_alt.h",
+      "${qpg_sdk_root}/Components/ThirdParty/Silex/cryptosoc/mbedtls_alt/sha256_alt.h",
+      "${qpg_sdk_root}/Libraries/Qorvo/mbedtls_alt/inc/${qpg_target_ic}-mbedtls-config.h",
+      "${qpg_sdk_root}/Libraries/Qorvo/mbedtls_alt/src/trng.c",
 
       # mbedtls_hardware_poll
-      "${qpg_sdk_root}/${qpg_target_ic}/comps/qvCHIP/inc/qvCHIP.h",
+      "${qpg_sdk_root}/Components/Qorvo/BSP/qvIO/inc/qvIO.h",
+      "${qpg_sdk_root}/Components/Qorvo/Matter/qvCHIP/inc/qvCHIP.h",
     ]
 
     if (defined(invoker.sources)) {


### PR DESCRIPTION

#### Problem
The Qorvo QPG61xx SDK adopts a new directory structure, our third_party/repo/qpg_sdk needs to be updated

#### Change overview
Update third_party/qpg_sdk/repo to a commit with the new directory
structure.

Introduce qpg_sdk_lib_dir to override the subdirectory in qpg_sdk_root
where the Qorvo platform libraries (.a) are to be found.

Add an option (qpg_sdk_include_platform_libs) to disable referencing
Qorvo platform libraries (useful to avoid missing unneeded paths when
building //config/qpg/chip-gn).

#### Testing
* manual build test of example apps
