### PR TITLE
[zap xml] Align required client/server OTA clusters with device library

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -129,7 +129,7 @@ limitations under the License.
                 <requireAttribute>BINDING</requireAttribute>
             </include>
             <include cluster="OTA Software Update Requestor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="OTA Software Update Provider" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="OTA Software Update Provider" client="true" server="false" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -155,6 +155,7 @@ limitations under the License.
             <include cluster="Binding" client="true" server="false" clientLocked="false" serverLocked="true">
                 <requireAttribute>BINDING</requireAttribute>
             </include>
+            <include cluster="OTA Software Update Requestor" client="true" server="false" clientLocked="true" serverLocked="true"></include>
             <include cluster="OTA Software Update Provider" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>


### PR DESCRIPTION

Signed-off-by: Markus Becker <markus.becker@tridonic.com>

#### Problem

XML specification for ZAP has wrong required clusters for OTA device types.

#### Change overview

Device Library requires OTA Software Update Provider client cluster for device
type OTA Requestor, not the server cluster.

Device Library requires OTA Software Update Requestor client cluster for device
type OTA Provider.

#### Testing

Opened ZAP tool and checked that correct clusters are required when adding new endpoints with the OTA device types.
