### PR TITLE
Do not update FabricIndex of PASE session on AddNoC

### DIFF
--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -28,13 +28,21 @@ Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
         subjectDescriptor.authMode    = Access::AuthMode::kCase;
         subjectDescriptor.subject     = mPeerNodeId;
         subjectDescriptor.cats        = mPeerCATs;
-        subjectDescriptor.fabricIndex = mFabric;
+        VerifyOrDie(mEffectiveFabric == kUndefinedFabricIndex);
+        subjectDescriptor.fabricIndex = mEffectiveFabric;
     }
     else if (IsPAKEKeyId(mPeerNodeId))
     {
         subjectDescriptor.authMode    = Access::AuthMode::kPase;
         subjectDescriptor.subject     = mPeerNodeId;
-        subjectDescriptor.fabricIndex = mFabric;
+        if (mEffectiveFabric == kUndefinedFabricIndex)
+        {
+            subjectDescriptor.fabricIndex = mFabric;
+        }
+        else
+        {
+            subjectDescriptor.fabricIndex = mEffectiveFabric;
+        }
     }
     else
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -126,7 +126,7 @@ public:
             mFabric = fabricIndex;
         }
 #else
-        mFabric = fabricIndex;
+        mEffectiveFabric = fabricIndex;
 #endif
         return CHIP_NO_ERROR;
     }
@@ -156,11 +156,11 @@ private:
     const CATValues mPeerCATs;
     const uint16_t mLocalSessionId;
     const uint16_t mPeerSessionId;
+    const FabricIndex mFabric;
 
     // PASE sessions start with undefined fabric, but are migrated to a newly
     // commissioned fabric after successful OperationalCredentialsCluster::AddNOC
-    FabricIndex mFabric;
-
+    FabricIndex mEffectiveFabric = kUndefinedFabricIndex;
     PeerAddress mPeerAddress;
     System::Clock::Timestamp mLastActivityTime;
     ReliableMessageProtocolConfig mMRPConfig;


### PR DESCRIPTION
#### Problem
AddNoC updates FabricIndex, but which should be a const.

#### Change overview
Add a effective fabric instead of changing the fabric

#### Testing
Unit tests