### PR TITLE
ota-requestor: Handle QueryImageResponse status and ApplyUpdateResponse status

### DIFF
--- a/src/platform/GenericOTARequestorDriver.cpp
+++ b/src/platform/GenericOTARequestorDriver.cpp
@@ -32,6 +32,8 @@ GenericOTARequestorDriver * ToDriver(void * context)
     return static_cast<GenericOTARequestorDriver *>(context);
 }
 
+constexpr System::Clock::Seconds32 kDefaultDelayedActionTime = System::Clock::Seconds32(120);
+
 } // namespace
 
 bool GenericOTARequestorDriver::CanConsent()
@@ -60,13 +62,12 @@ void GenericOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason, Syst
 {
     VerifyOrDie(mRequestor != nullptr);
 
-    System::Clock::Seconds32 delayedActionTime = System::Clock::Seconds32(120);
-    if (delay > delayedActionTime)
+    if (delay < kDefaultDelayedActionTime)
     {
-        delayedActionTime = delay;
+        delay = kDefaultDelayedActionTime;
     }
 
-    ScheduleDelayedAction(UpdateFailureState::kQuerying, delayedActionTime,
+    ScheduleDelayedAction(UpdateFailureState::kQuerying, delay,
                           [](System::Layer *, void * context) { ToDriver(context)->mRequestor->TriggerImmediateQuery(); });
 }
 
@@ -87,13 +88,12 @@ void GenericOTARequestorDriver::UpdateSuspended(System::Clock::Seconds32 delay)
 {
     VerifyOrDie(mRequestor != nullptr);
 
-    System::Clock::Seconds32 delayedActionTime = System::Clock::Seconds32(120);
-    if (delay > delayedActionTime)
+    if (delay < kDefaultDelayedActionTime)
     {
-        delayedActionTime = delay;
+        delay = kDefaultDelayedActionTime;
     }
 
-    ScheduleDelayedAction(UpdateFailureState::kAwaitingNextAction, delayedActionTime,
+    ScheduleDelayedAction(UpdateFailureState::kAwaitingNextAction, delay,
                           [](System::Layer *, void * context) { ToDriver(context)->mRequestor->ApplyUpdate(); });
 }
 

--- a/src/platform/GenericOTARequestorDriver.cpp
+++ b/src/platform/GenericOTARequestorDriver.cpp
@@ -58,7 +58,16 @@ void GenericOTARequestorDriver::UpdateAvailable(const UpdateDescription & update
 
 void GenericOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason, System::Clock::Seconds32 delay)
 {
-    // TODO: Schedule the next QueryImage
+    VerifyOrDie(mRequestor != nullptr);
+
+    System::Clock::Seconds32 delayedActionTime = System::Clock::Seconds32(120);
+    if (delay > delayedActionTime)
+    {
+        delayedActionTime = delay;
+    }
+
+    ScheduleDelayedAction(UpdateFailureState::kQuerying, delayedActionTime,
+                          [](System::Layer *, void * context) { ToDriver(context)->mRequestor->TriggerImmediateQuery(); });
 }
 
 void GenericOTARequestorDriver::UpdateDownloaded()
@@ -77,7 +86,14 @@ void GenericOTARequestorDriver::UpdateConfirmed(System::Clock::Seconds32 delay)
 void GenericOTARequestorDriver::UpdateSuspended(System::Clock::Seconds32 delay)
 {
     VerifyOrDie(mRequestor != nullptr);
-    ScheduleDelayedAction(UpdateFailureState::kAwaitingNextAction, delay,
+
+    System::Clock::Seconds32 delayedActionTime = System::Clock::Seconds32(120);
+    if (delay > delayedActionTime)
+    {
+        delayedActionTime = delay;
+    }
+
+    ScheduleDelayedAction(UpdateFailureState::kAwaitingNextAction, delayedActionTime,
                           [](System::Layer *, void * context) { ToDriver(context)->mRequestor->ApplyUpdate(); });
 }
 


### PR DESCRIPTION
#### Problem
- Busy and NotAvailable status is not handled in QueryImageResponse
- Delays used are not aligned with the specifications for scheduling the next action
- Fixes #9524

#### Change overview
- Schedule next QueryImage as per delay specified in Specification
- Schedule next ApplyUpdateRequest as per delay specified in Specification

#### Testing
- Tested using linux ota provider and requestor app
- `./chip-ota-provider-app -f test.bin -d 60 -q Busy`
- Requestor waited for 120 seconds before Querying again