### PR TITLE
Remove WriteClientHandle leftovers (followup of #13248)

### DIFF
--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -42,7 +42,6 @@
 namespace chip {
 namespace app {
 
-class WriteClientHandle;
 class InteractionModelEngine;
 
 /**
@@ -168,7 +167,6 @@ public:
 private:
     friend class TestWriteInteraction;
     friend class InteractionModelEngine;
-    friend class WriteClientHandle;
 
     enum class State
     {


### PR DESCRIPTION
#### Problem

After #13248 `WriteClientHandle` is gone. I was using it locally and when updating it was complaining about the fact that the class was incomplete due to the forward declaration.


#### Change overview
 * Remove the leftovers...
 