### PR TITLE
Access control default delegates no longer error

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -85,8 +85,8 @@ CHIP_ERROR AccessControl::Finish()
 CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
                                 Privilege requestPrivilege)
 {
-    // During development, allow access if delegate is transitional
-    ReturnErrorCodeIf(mDelegate.IsTransitional(), CHIP_NO_ERROR);
+    // Don't check if using default delegate (e.g. test code that isn't testing access control)
+    ReturnErrorCodeIf(&mDelegate == &mDefaultDelegate, CHIP_NO_ERROR);
 
     EntryIterator iterator;
     ReturnErrorOnFailure(Entries(iterator, &subjectDescriptor.fabricIndex));

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -63,28 +63,36 @@ public:
             virtual void Release() {}
 
             // Simple getters
-            virtual CHIP_ERROR GetAuthMode(AuthMode & authMode) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR GetFabricIndex(FabricIndex & fabricIndex) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR GetPrivilege(Privilege & privilege) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
+            virtual CHIP_ERROR GetAuthMode(AuthMode & authMode) const { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR GetFabricIndex(FabricIndex & fabricIndex) const { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR GetPrivilege(Privilege & privilege) const { return CHIP_NO_ERROR; }
 
             // Simple setters
-            virtual CHIP_ERROR SetAuthMode(AuthMode authMode) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR SetFabricIndex(FabricIndex fabricIndex) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR SetPrivilege(Privilege privilege) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+            virtual CHIP_ERROR SetAuthMode(AuthMode authMode) { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR SetFabricIndex(FabricIndex fabricIndex) { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR SetPrivilege(Privilege privilege) { return CHIP_NO_ERROR; }
 
             // Subjects
-            virtual CHIP_ERROR GetSubjectCount(size_t & count) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR GetSubject(size_t index, NodeId & subject) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR SetSubject(size_t index, NodeId subject) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR AddSubject(size_t * index, NodeId subject) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR RemoveSubject(size_t index) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+            virtual CHIP_ERROR GetSubjectCount(size_t & count) const
+            {
+                count = 0;
+                return CHIP_NO_ERROR;
+            }
+            virtual CHIP_ERROR GetSubject(size_t index, NodeId & subject) const { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR SetSubject(size_t index, NodeId subject) { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR AddSubject(size_t * index, NodeId subject) { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR RemoveSubject(size_t index) { return CHIP_NO_ERROR; }
 
             // Targets
-            virtual CHIP_ERROR GetTargetCount(size_t & count) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR GetTarget(size_t index, Target & target) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR SetTarget(size_t index, const Target & target) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR AddTarget(size_t * index, const Target & target) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-            virtual CHIP_ERROR RemoveTarget(size_t index) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+            virtual CHIP_ERROR GetTargetCount(size_t & count) const
+            {
+                count = 0;
+                return CHIP_NO_ERROR;
+            }
+            virtual CHIP_ERROR GetTarget(size_t index, Target & target) const { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR SetTarget(size_t index, const Target & target) { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR AddTarget(size_t * index, const Target & target) { return CHIP_NO_ERROR; }
+            virtual CHIP_ERROR RemoveTarget(size_t index) { return CHIP_NO_ERROR; }
         };
 
         Entry() = default;
@@ -301,42 +309,36 @@ public:
 
         virtual void Release() {}
 
-        virtual CHIP_ERROR Init() { return CHIP_ERROR_NOT_IMPLEMENTED; }
-        virtual CHIP_ERROR Finish() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+        virtual CHIP_ERROR Init() { return CHIP_NO_ERROR; }
+        virtual CHIP_ERROR Finish() { return CHIP_NO_ERROR; }
 
         // Capabilities
-        virtual CHIP_ERROR GetMaxEntryCount(size_t & value) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
-        // TODO: more capabilities
+        virtual CHIP_ERROR GetMaxEntryCount(size_t & value) const
+        {
+            value = 0;
+            return CHIP_NO_ERROR;
+        }
+
+        // TODO: add more capabilities
 
         // Actualities
-        virtual CHIP_ERROR GetEntryCount(size_t & value) const { return CHIP_ERROR_NOT_IMPLEMENTED; }
+        virtual CHIP_ERROR GetEntryCount(size_t & value) const
+        {
+            value = 0;
+            return CHIP_NO_ERROR;
+        }
 
         // Preparation
-        virtual CHIP_ERROR PrepareEntry(Entry & entry) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+        virtual CHIP_ERROR PrepareEntry(Entry & entry) { return CHIP_NO_ERROR; }
 
         // CRUD
-        virtual CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex)
-        {
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        }
-        virtual CHIP_ERROR ReadEntry(size_t index, Entry & entry, const FabricIndex * fabricIndex) const
-        {
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        }
-        virtual CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex)
-        {
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        }
-        virtual CHIP_ERROR DeleteEntry(size_t index, const FabricIndex * fabricIndex) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+        virtual CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex) { return CHIP_NO_ERROR; }
+        virtual CHIP_ERROR ReadEntry(size_t index, Entry & entry, const FabricIndex * fabricIndex) const { return CHIP_NO_ERROR; }
+        virtual CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex) { return CHIP_NO_ERROR; }
+        virtual CHIP_ERROR DeleteEntry(size_t index, const FabricIndex * fabricIndex) { return CHIP_NO_ERROR; }
 
         // Iteration
-        virtual CHIP_ERROR Entries(EntryIterator & iterator, const FabricIndex * fabricIndex) const
-        {
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        }
-
-        // Transitional (during development, will be removed later)
-        virtual bool IsTransitional() const { return true; }
+        virtual CHIP_ERROR Entries(EntryIterator & iterator, const FabricIndex * fabricIndex) const { return CHIP_NO_ERROR; }
 
         // Listening
         virtual void SetListener(Listener & listener) { mListener = &listener; }

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -1095,8 +1095,6 @@ public:
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    bool IsTransitional() const override { return false; }
-
 private:
     CHIP_ERROR LoadFromFlash() { return CHIP_NO_ERROR; }
 


### PR DESCRIPTION
#### Problem
A lot of non-production code doesn't like access control.

Production code will have a proper functional access control
module configured. But non-production code will by default
have non-functional components configured in the access
control module. These return CHIP_ERROR_NOT_IMPLEMENTED
which is strictly correct, but troublesome.

This isn't a problem for production code, which properly
configures a working system, or for test code for access
control, which at least configures enough to test access
control properly.

But we have a lot of other test code that tries to test other
modules (e.g. IM) that interact with access control, but don't care
about access control because they aren't testing access control.
This test code fails right now, but it's not a meaningful failure.

#### Change overview
Change the default delegates in access control to return
CHIP_NO_ERROR. Also return zero counts for anything that
is a count. Also remove the IsTransitional development flag,
since we can just allow the default delegate to pass the access
control check, since that's what we want. (It's not a functional
delegate, so if we wanted a functional check, we should have
installed a functional delegate to have a functional system.)

#### Testing
- Built and ran all-clusters-app with chip-repl on Linux
- Ran unit tests
- Seeing if CI passes...