### PR TITLE
[Darwin] Further strip CHIPFramework in release builds

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -821,6 +821,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chip.CHIP;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				STRIP_STYLE = "non-global";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
#### Change overview
Remove more symbols from the CHIPFramework in release configuration. This further reduces the size of the framework.

#### Testing
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Manually tested to make sure functionality is not impacted. CI uses debug builds and won't necessarily exercise this.
