### PR TITLE
Stop trying to commission devices that are not in commissioning mode.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -167,6 +167,11 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR
 
 bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData)
 {
+    if (nodeData.commissioningMode == 0)
+    {
+        return false;
+    }
+
     switch (currentFilter.type)
     {
     case Dnssd::DiscoveryFilterType::kShortDiscriminator:


### PR DESCRIPTION
SetUpCodePairer was filtering devices by discriminator, but not
checking for a nonzero CM value, so could end up trying to commission
a device that's not commissionable and miss a device with a colliding
discriminator that is.

#### Problem
See above.

#### Change overview
Check the `commissioningMode` of the returned data before deciding it's OK to use.

#### Testing
Manually tested that without this change we end up trying to commission a device that is not in commissioning mode, and with this change we skip it and discover another device that is.