### PR TITLE
Surface a NetworkLocation on Android for ChipDeviceController

### DIFF
--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -81,6 +81,7 @@ android_library("java") {
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
     "src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java",
     "src/chip/devicecontroller/NetworkCredentials.java",
+    "src/chip/devicecontroller/NetworkLocation.java",
     "src/chip/devicecontroller/PaseVerifierParams.java",
     "zap-generated/chip/devicecontroller/ChipClusters.java",
     "zap-generated/chip/devicecontroller/ClusterInfoMapping.java",

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -259,6 +259,16 @@ public class ChipDeviceController {
     return getIpAddress(deviceControllerPtr, deviceId);
   }
 
+  /**
+   * Returns the {@link NetworkLocation} at which the given {@code deviceId} has been found.
+   *
+   * @param deviceId the 64-bit node ID of the device
+   * @throws ChipDeviceControllerException if the device location could not be resolved
+   */
+  public NetworkLocation getNetworkLocation(long deviceId) {
+    return getNetworkLocation(deviceControllerPtr, deviceId);
+  }
+
   public long getCompressedFabricId() {
     return getCompressedFabricId(deviceControllerPtr);
   }
@@ -345,6 +355,8 @@ public class ChipDeviceController {
   private native void deleteDeviceController(long deviceControllerPtr);
 
   private native String getIpAddress(long deviceControllerPtr, long deviceId);
+
+  private native NetworkLocation getNetworkLocation(long deviceControllerPtr, long deviceId);
 
   private native long getCompressedFabricId(long deviceControllerPtr);
 

--- a/src/controller/java/src/chip/devicecontroller/NetworkLocation.java
+++ b/src/controller/java/src/chip/devicecontroller/NetworkLocation.java
@@ -1,0 +1,28 @@
+package chip.devicecontroller;
+
+import java.util.Locale;
+
+/** Represents a location on an operational network. */
+public final class NetworkLocation {
+  private final String ipAddress;
+  private final int port;
+
+  public NetworkLocation(String ipAddress, int port) {
+    this.ipAddress = ipAddress;
+    this.port = port;
+  }
+
+  /** Returns the IP address (e.g. fe80::3e61:5ff:fe0c:89f8). */
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(Locale.ROOT, "%s[%d]", ipAddress, port);
+  }
+}


### PR DESCRIPTION
Currently there is a method to getIpAddress(), but we also need to know
the port. This adds a Java wrapper class that combines both properties,
and the JNI bindings to resolve.

Tested:
- Commissioned an m5stack, and verified that the resolved
  NetworkLocation on the Java side matched Addr 0 logged from DIS after
  mDNS discovery completed.