### PR TITLE
Update ZAP to pick up reportability changes.

### DIFF
--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -88,5 +88,5 @@
             "commandDiscovery": true
         }
     },
-    "defaultReportable": true
+    "defaultReportingPolicy": "mandatory"
 }

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2319,7 +2319,7 @@ client cluster OperationalCredentials = 62 {
     CHAR_STRING label = 5;
   }
 
-  readonly nosubscribe attribute NOCStruct NOCs[] = 0;
+  readonly attribute NOCStruct NOCs[] = 0;
   readonly attribute FabricDescriptor fabricsList[] = 1;
   readonly attribute int8u supportedFabrics = 2;
   readonly attribute int8u commissionedFabrics = 3;

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -3321,6 +3321,7 @@ class ChipClusters:
                     "attributeName": "NOCs",
                     "attributeId": 0x00000000,
                     "type": "",
+                    "reportable": True,
                 },
                 0x00000001: {
                     "attributeName": "FabricsList",

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -3104,6 +3104,10 @@ NS_ASSUME_NONNULL_BEGIN
                                 NSError * _Nullable error))completionHandler;
 
 - (void)readAttributeNOCsWithCompletionHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completionHandler;
+- (void)subscribeAttributeNOCsWithMinInterval:(uint16_t)minInterval
+                                  maxInterval:(uint16_t)maxInterval
+                      subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
+                                reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler;
 
 - (void)readAttributeFabricsListWithCompletionHandler:(void (^)(
                                                           NSArray * _Nullable value, NSError * _Nullable error))completionHandler;

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -12969,6 +12969,24 @@ using namespace chip::app::Clusters;
         });
 }
 
+- (void)subscribeAttributeNOCsWithMinInterval:(uint16_t)minInterval
+                                  maxInterval:(uint16_t)maxInterval
+                      subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
+                                reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
+{
+    new CHIPOperationalCredentialsNOCsListAttributeCallbackSubscriptionBridge(
+        self.callbackQueue, reportHandler,
+        ^(Cancelable * success, Cancelable * failure) {
+            using TypeInfo = OperationalCredentials::Attributes::NOCs::TypeInfo;
+            auto successFn = Callback<OperationalCredentialsNOCsListAttributeCallback>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.SubscribeAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall,
+                minInterval, maxInterval,
+                CHIPOperationalCredentialsNOCsListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
+        },
+        subscriptionEstablishedHandler);
+}
+
 - (void)readAttributeFabricsListWithCompletionHandler:(void (^)(
                                                           NSArray * _Nullable value, NSError * _Nullable error))completionHandler
 {


### PR DESCRIPTION
We can now explicitly default all attributes to "reportable".  XML
files will be able to set reportingPolicy="prohibited" for things that
the Matter spec decides are not subscribable.

#### Problem
ZAP UI controls whether things are marked as "reportable".

#### Change overview
Ignore the UI.  Set things to default to "reportable" globally, with an affordance to mark things that are non-reportable (non-subscribable) accordingly in XML.

#### Testing
Ran codegen, and a non-reportable attribute that had gotten added is now being treated as reportable.