### PR TITLE
Fix build breakage from OTA Requestor event support

### DIFF
--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -62,14 +62,16 @@ CHIP_ERROR ApplyImageHandler(int argc, char ** argv)
 CHIP_ERROR NotifyImageHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(GetRequestorInstance() != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(argc == 4, CHIP_ERROR_INVALID_ARGUMENT);
 
     const FabricIndex fabricIndex       = static_cast<FabricIndex>(strtoul(argv[0], nullptr, 10));
     const NodeId providerNodeId         = static_cast<NodeId>(strtoull(argv[1], nullptr, 10));
     const EndpointId providerEndpointId = static_cast<EndpointId>(strtoul(argv[2], nullptr, 10));
+    const intptr_t version              = static_cast<intptr_t>(strtoul(argv[3], nullptr, 10));
 
     GetRequestorInstance()->TestModeSetProviderParameters(providerNodeId, fabricIndex, providerEndpointId);
-    PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->NotifyUpdateApplied(); });
+    PlatformMgr().ScheduleWork([](intptr_t arg) { GetRequestorInstance()->NotifyUpdateApplied(static_cast<uint32_t>(arg)); },
+                               version);
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem

This commit failed to update Ota.cpp, resulting in a breakage for
builds that include the OTA shell:

commit d0d6dda77fed3b38864553e85b29465d6a32e56a
Date:   Thu Jan 20 05:37:01 2022 -0800

    [OTA] Implement event support for OTA Requestor cluster (#13727)

#### Change overview

This commit fixes the issue by adding the now necessary version argument
to the NotifyImageHandler shell command.

Fixes #13803

#### Testing

Local m5stack all-clusters-app build now succeeds.
