### PR TITLE
cli: lock Thread stack when calling OpenThread API

### DIFF
--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -105,11 +105,13 @@ CHIP_ERROR cmd_otcli_dispatch(int argc, char ** argv)
         }
     }
     buff_ptr = 0;
+    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
 #if OPENTHREAD_API_VERSION >= 85
     otCliInputLine(buff);
 #else
     otCliConsoleInputLine(buff, buff_ptr - buff);
 #endif
+    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
 exit:
     return error;
 }


### PR DESCRIPTION
#### Problem

The OpenThread cli does not lock the Thread stack when calling `otCliConsoleInputLine`.
The shell and the OpenThread stack are running in different tasks. Calling OpenThread APIs without a lock will cause data race and unexpected context switch.


#### Change overview

Lock the Thread stack when calling OpenThread API

#### Testing

* Manual run

