### PR TITLE
apply keepSubscription logic for subscription only

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -232,6 +232,9 @@ private:
 
     bool HasActiveRead();
 
+    CHIP_ERROR ShutdownExistingSubscriptionsIfNeeded(Messaging::ExchangeContext * apExchangeContext,
+                                                     System::PacketBufferHandle && aPayload);
+
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
 


### PR DESCRIPTION
#### Problem
The logic regarding check if  Keep the existing Subscription has been run when receive read request in responder side, we should not run that logic for read request.

#### Change overview
Move the KeepSubscription logic inside one new function called, CheckWhetherKeepExistingSubscription, and run it when receiving subscribe request.

#### Testing
Manual test. 
