### PR TITLE
[OTA] Remove setting of Basic cluster SoftwareVersion attribute in OTA Requestor

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -318,6 +318,101 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     }
 }
 
+EmberAfStatus BasicClusterServerGetVendorIdAttribute(chip::EndpointId endpointId, chip::VendorId & value)
+{
+    return Attributes::VendorID::Get(endpointId, &value);
+}
+
+EmberAfStatus BasicClusterServerSetVendorIdAttribute(chip::EndpointId endpointId, chip::VendorId value)
+{
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+
+    chip::VendorId currentValue;
+    status = Attributes::VendorID::Get(endpointId, &currentValue);
+    VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+
+    if (currentValue != value)
+    {
+        status = Attributes::VendorID::Set(endpointId, value);
+        VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+    }
+
+    return status;
+}
+
+EmberAfStatus BasicClusterServerGetProductIdAttribute(chip::EndpointId endpointId, uint16_t & value)
+{
+    return Attributes::ProductID::Get(endpointId, &value);
+}
+
+EmberAfStatus BasicClusterServerSetProductIdAttribute(chip::EndpointId endpointId, uint16_t value)
+{
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+
+    uint16_t currentValue;
+    status = Attributes::ProductID::Get(endpointId, &currentValue);
+    VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+
+    if (currentValue != value)
+    {
+        status = Attributes::ProductID::Set(endpointId, value);
+        VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+    }
+
+    return status;
+}
+
+EmberAfStatus BasicClusterServerGetLocationAttribute(chip::EndpointId endpointId, chip::MutableCharSpan value)
+{
+    return Attributes::Location::Get(endpointId, value);
+}
+
+// EmberAfStatus BasicClusterServerSetLocationAttribute(chip::EndpointId endpointId, chip::CharSpan value)
+
+EmberAfStatus BasicClusterServerGetHardwareVersionAttribute(chip::EndpointId endpointId, uint16_t & value)
+{
+    return Attributes::HardwareVersion::Get(endpointId, &value);
+}
+
+EmberAfStatus BasicClusterServerSetHardtwareVersionAttribute(chip::EndpointId endpointId, uint16_t value)
+{
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+
+    uint16_t currentValue;
+    status = Attributes::HardwareVersion::Get(endpointId, &currentValue);
+    VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+
+    if (currentValue != value)
+    {
+        status = Attributes::HardwareVersion::Set(endpointId, value);
+        VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+    }
+
+    return status;
+}
+
+EmberAfStatus BasicClusterServerGetSoftwareVersionAttribute(chip::EndpointId endpointId, uint32_t & value)
+{
+    return Attributes::SoftwareVersion::Get(endpointId, &value);
+}
+
+EmberAfStatus BasicClusterServerSetSoftwareVersionAttribute(chip::EndpointId endpointId, uint32_t value)
+{
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+
+    uint32_t currentValue;
+    status = Attributes::SoftwareVersion::Get(endpointId, &currentValue);
+    VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+
+    if (currentValue != value)
+    {
+        status = Attributes::SoftwareVersion::Set(endpointId, value);
+        VerifyOrDie(EMBER_ZCL_STATUS_SUCCESS == status);
+    }
+
+    return status;
+}
+
 void MatterBasicPluginServerInitCallback()
 {
     PlatformMgr().SetDelegate(&gPlatformMgrDelegate);

--- a/src/app/clusters/basic/basic.h
+++ b/src/app/clusters/basic/basic.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <app/util/af-enums.h>
 #include <app/util/basic-types.h>
+#include <lib/support/Span.h>
 
 /** @brief Basic Cluster Server Init
  *
@@ -27,3 +29,19 @@
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
 void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint);
+
+// Global getter/setter for Basic cluster attributes
+EmberAfStatus BasicClusterServerGetVendorIdAttribute(chip::EndpointId endpointId, chip::VendorId & value);
+EmberAfStatus BasicClusterServerSetVendorIdAttribute(chip::EndpointId endpointId, chip::VendorId value);
+
+EmberAfStatus BasicClusterServerGetProductIdAttribute(chip::EndpointId endpointId, uint16_t & value);
+EmberAfStatus BasicClusterServerSetProductIdAttribute(chip::EndpointId endpointId, uint16_t value);
+
+EmberAfStatus BasicClusterServerGetLocationAttribute(chip::EndpointId endpointId, chip::MutableCharSpan value);
+EmberAfStatus BasicClusterServerSetLocationAttribute(chip::EndpointId endpointId, chip::CharSpan value);
+
+EmberAfStatus BasicClusterServerGetHardwareVersionAttribute(chip::EndpointId endpointId, uint16_t & value);
+EmberAfStatus BasicClusterServerSetHardtwareVersionAttribute(chip::EndpointId endpointId, uint16_t value);
+
+EmberAfStatus BasicClusterServerGetSoftwareVersionAttribute(chip::EndpointId endpointId, uint32_t & value);
+EmberAfStatus BasicClusterServerSetSoftwareVersionAttribute(chip::EndpointId endpointId, uint32_t value);

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -63,8 +63,8 @@ public:
     // Send ApplyImage
     void ApplyUpdate() override;
 
-    // Send NotifyUpdateApplied, update Basic cluster SoftwareVersion attribute, log the VersionApplied event
-    void NotifyUpdateApplied(uint32_t version) override;
+    // Send NotifyUpdateApplied and log the VersionApplied event
+    void NotifyUpdateApplied() override;
 
     //////////// BDXDownloader::StateDelegate Implementation ///////////////
     void OnDownloadStateChanged(OTADownloader::State state,

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -65,7 +65,7 @@ public:
     virtual void ApplyUpdate() = 0;
 
     // Send NotifyUpdateApplied command
-    virtual void NotifyUpdateApplied(uint32_t version) = 0;
+    virtual void NotifyUpdateApplied() = 0;
 
     // Manually set OTA Provider parameters
     virtual void TestModeSetProviderParameters(NodeId nodeId, FabricIndex fabIndex, EndpointId endpointId) = 0;

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -62,16 +62,14 @@ CHIP_ERROR ApplyImageHandler(int argc, char ** argv)
 CHIP_ERROR NotifyImageHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(GetRequestorInstance() != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(argc == 4, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
     const FabricIndex fabricIndex       = static_cast<FabricIndex>(strtoul(argv[0], nullptr, 10));
     const NodeId providerNodeId         = static_cast<NodeId>(strtoull(argv[1], nullptr, 10));
     const EndpointId providerEndpointId = static_cast<EndpointId>(strtoul(argv[2], nullptr, 10));
-    const intptr_t version              = static_cast<intptr_t>(strtoul(argv[3], nullptr, 10));
 
     GetRequestorInstance()->TestModeSetProviderParameters(providerNodeId, fabricIndex, providerEndpointId);
-    PlatformMgr().ScheduleWork([](intptr_t arg) { GetRequestorInstance()->NotifyUpdateApplied(static_cast<uint32_t>(arg)); },
-                               version);
+    PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->NotifyUpdateApplied(); });
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -78,6 +78,9 @@ static_library("Darwin") {
 
   if (chip_enable_ota_requestor) {
     sources += [
+      "${chip_root}/src/app/clusters/basic/basic.h",
+      "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h",
+
       # using the implements from Linux platform
       "../Linux/OTAImageProcessorImpl.cpp",
       "../Linux/OTAImageProcessorImpl.h",

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <app/clusters/basic/basic.h>
 #include <app/clusters/ota-requestor/OTADownloader.h>
 #include <platform/OTARequestorInterface.h>
 
@@ -131,10 +132,12 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
         return;
     }
 
+    BasicClusterServerSetSoftwareVersionAttribute(kRootEndpointId, imageProcessor->mHeader.softwareVersion);
+
     OTARequestorInterface * requestor = chip::GetRequestorInstance();
     if (requestor != nullptr)
     {
-        requestor->NotifyUpdateApplied(imageProcessor->mHeader.softwareVersion);
+        requestor->NotifyUpdateApplied();
     }
 }
 


### PR DESCRIPTION
#### Problem
The OTA Requestor core is currently updating the Basic cluster SoftwareVersion attribute. This should be done by the platform when it boots into a new image. The OTA Requestor should only be a consumer of this attribute.

Also, non-cluster code should not directly call the getter/setter of the attributes.

#### Change overview
- Exposed APIs to get/set some Basic cluster attributes to be used by the OTA Requestor
- Update the `NotifyUpdateApplied` API to not take version as this should be read/obtained from the Basic cluster attribute

#### Testing
- Manually tested with Linux provider/requestor to ensure that the Basic cluster attributes are the same as before when called directly from Accessors.h
- Also make sure that OTA Requestor is reading the version set by the Linux Image Processor