### PR TITLE
Make sure we don't advertise with CM=1 when we're not accepting PASE connections.

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -73,8 +73,13 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
 
 void CommissioningWindowManager::Shutdown()
 {
-    StopAdvertisement();
+    StopAdvertisement(/* aShuttingDown = */ true);
 
+    ResetState();
+}
+
+void CommissioningWindowManager::ResetState()
+{
     mUseECM = false;
 
     mECMDiscriminator = 0;
@@ -88,10 +93,9 @@ void CommissioningWindowManager::Shutdown()
 
 void CommissioningWindowManager::Cleanup()
 {
-    Shutdown();
+    StopAdvertisement(/* aShuttingDown = */ false);
 
-    // reset all advertising
-    app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kDisabled);
+    ResetState();
 }
 
 void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
@@ -151,7 +155,7 @@ void CommissioningWindowManager::OnSessionEstablished()
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 
-    StopAdvertisement();
+    StopAdvertisement(/* aShuttingDown = */ true);
     ChipLogProgress(AppServer, "Device completed Rendezvous process");
 }
 
@@ -171,17 +175,12 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow()
     ReturnErrorOnFailure(mServer->GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
         Protocols::SecureChannel::MsgType::PBKDFParamRequest, &mPairingSession));
 
-    ReturnErrorOnFailure(StartAdvertisement());
-
     if (mUseECM)
     {
         ReturnErrorOnFailure(SetTemporaryDiscriminator(mECMDiscriminator));
         ReturnErrorOnFailure(
             mPairingSession.WaitForPairing(mECMPASEVerifier, mECMIterations, ByteSpan(mECMSalt, mECMSaltLength), mECMPasscodeID,
                                            keyID, Optional<ReliableMessageProtocolConfig>::Value(gDefaultMRPConfig), this));
-
-        // reset all advertising, indicating we are in commissioningMode
-        app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kEnabledEnhanced);
     }
     else
     {
@@ -192,10 +191,9 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow()
             pinCode, kSpake2p_Iteration_Count,
             ByteSpan(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt)), keyID,
             Optional<ReliableMessageProtocolConfig>::Value(gDefaultMRPConfig), this));
-
-        // reset all advertising, indicating we are in commissioningMode
-        app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kEnabledBasic);
     }
+
+    ReturnErrorOnFailure(StartAdvertisement());
 
     return CHIP_NO_ERROR;
 }
@@ -284,14 +282,20 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
         mAppDelegate->OnPairingWindowOpened();
     }
 
+    Dnssd::CommissioningMode commissioningMode;
     if (mUseECM)
     {
-        mWindowStatus = app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kEnhancedWindowOpen;
+        mWindowStatus     = app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kEnhancedWindowOpen;
+        commissioningMode = Dnssd::CommissioningMode::kEnabledEnhanced;
     }
     else
     {
-        mWindowStatus = app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kBasicWindowOpen;
+        mWindowStatus     = app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kBasicWindowOpen;
+        commissioningMode = Dnssd::CommissioningMode::kEnabledBasic;
     }
+
+    // reset all advertising, indicating we are in commissioningMode
+    app::DnssdServer::Instance().StartServer(commissioningMode);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(true);
@@ -300,7 +304,7 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CommissioningWindowManager::StopAdvertisement()
+CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
 {
     RestoreDiscriminator();
 
@@ -312,6 +316,15 @@ CHIP_ERROR CommissioningWindowManager::StopAdvertisement()
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(false);
 #endif
+
+    // If aShuttingDown, don't try to change our DNS-SD advertisements.
+    if (!aShuttingDown)
+    {
+        // Stop advertising commissioning mode, since we're not accepting PASE
+        // connections right now.  If we start accepting them again (via
+        // OpenCommissioningWindow) that will call StartAdvertisement as needed.
+        app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kDisabled);
+    }
 
     if (mIsBLE)
     {

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -78,9 +78,14 @@ private:
 
     CHIP_ERROR StartAdvertisement();
 
-    CHIP_ERROR StopAdvertisement();
+    CHIP_ERROR StopAdvertisement(bool aShuttingDown);
 
     CHIP_ERROR OpenCommissioningWindow();
+
+    // Helper for Shutdown and Cleanup.  Does not do anything with
+    // advertisements, because Shutdown and Cleanup want to handle those
+    // differently.
+    void ResetState();
 
     AppDelegate * mAppDelegate = nullptr;
     Server * mServer           = nullptr;

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
 #include <lib/dnssd/Advertiser.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <stddef.h>
@@ -79,8 +80,11 @@ public:
 
     /// (Re-)starts the Dnssd server
     /// - if device has not yet been commissioned, then commissioning mode will show as enabled (CM=1, AC=0)
-    /// - if device has been commissioned, then commissioning mode will reflect the state of mode argument
-    void StartServer(chip::Dnssd::CommissioningMode mode = chip::Dnssd::CommissioningMode::kDisabled);
+    /// - if device has been commissioned, then commissioning mode will be disabled.
+    void StartServer();
+
+    /// (Re-)starts the Dnssd server, using the provided commissioning mode.
+    void StartServer(Dnssd::CommissioningMode mode);
 
     CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize);
 
@@ -110,6 +114,9 @@ private:
         mExtendedDiscoveryExpiration = kTimeoutCleared;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
     }
+
+    // Helper for StartServer.
+    void StartServer(Optional<Dnssd::CommissioningMode> mode);
 
     uint16_t mSecuredPort   = CHIP_PORT;
     uint16_t mUnsecuredPort = CHIP_UDC_PORT;

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -79,7 +79,7 @@ public:
     CHIP_ERROR AdvertiseOperational();
 
     /// (Re-)starts the Dnssd server
-    /// - if device has not yet been commissioned, then commissioning mode will show as enabled (CM=1, AC=0)
+    /// - if device has not yet been commissioned, then commissioning mode will show as enabled (CM=1)
     /// - if device has been commissioned, then commissioning mode will be disabled.
     void StartServer();
 


### PR DESCRIPTION
Right now it's possible for a device to both be advertising over
dns-sd with CM=1 and not be accepting PASE connections.  Which makes
the CM=1 not exactly true.

Summary of changes:

1. Change DnssdServer to clearly differentiate between "Start with
default commissioning mode behavior based on whether we have
operational credentials" and "Start with commissioning mode disabled",
instead of treating the two as synonyms.  I audited all callsites that
explicitly passed kDisabled to StartServer() instead of no args, and
they all seem to want to actually disable commissioning mode.

2. Change CommissioningWindowManager to start/stop DNS-SD
commissioning advertising in the same codepaths as BLE advertising.
This means we stop advertising with CM=1 or CM=2 when we stop
accepting PASE connections, and start doing it again when we start
accepting PASE connections again (e.g. if commissioning fails).

#### Problem
See above.

#### Change overview
See above.

#### Testing
Manually tested that a device stops advertising CM=1 while it's in the middle of being commissioned.