### PR TITLE
Use FabricIndex instead of CompressedFabricId inside PeerId

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -35,7 +35,7 @@ public:
         ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(chip::DeviceLayer::UDPEndPointManager()));
         chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
-        return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
+        return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerInfo(remoteId, fabricId),
                                                                chip::Inet::IPAddressType::kAny,
                                                                chip::Dnssd::Resolver::CacheBypass::On);
     }
@@ -44,7 +44,7 @@ public:
     {
         char addrBuffer[chip::Transport::PeerAddress::kMaxToStringSize];
 
-        ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Port: %" PRIu16, nodeData.mPeerId.GetNodeId(), nodeData.mPort);
+        ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Port: %" PRIu16, nodeData.mPeerInfo.GetNodeId(), nodeData.mPort);
         ChipLogProgress(chipTool, "    Hostname: %s", nodeData.mHostName);
         for (size_t i = 0; i < nodeData.mNumIPs; ++i)
         {
@@ -66,7 +66,7 @@ public:
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 
-    void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override
+    void OnNodeIdResolutionFailed(const chip::PeerInfo & peerInfo, CHIP_ERROR error) override
     {
         ChipLogProgress(chipTool, "NodeId Resolution: failed!");
         SetCommandExitStatus(CHIP_ERROR_INTERNAL);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -82,6 +82,10 @@ public:
     CHIP_ERROR FindOrEstablishSession(PeerId peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                       Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
+    // DEPRECATED, for backward competibility, the one takes a PeerId should be used instead.
+    [[deprecated]] CHIP_ERROR FindOrEstablishSession(PeerInfo peerInfo, Callback::Callback<OnDeviceConnected> * onConnection,
+                                      Callback::Callback<OnDeviceConnectionFailure> * onFailure);
+
     OperationalDeviceProxy * FindExistingSession(PeerId peerId);
 
     void ReleaseSession(PeerId peerId);
@@ -105,9 +109,12 @@ public:
      */
     CHIP_ERROR GetPeerAddress(PeerId peerId, Transport::PeerAddress & addr);
 
+    // DEPRECATED, for backward competibility, the one takes a PeerId should be used instead.
+    [[deprecated]] CHIP_ERROR GetPeerAddress(PeerInfo peerInfo, Transport::PeerAddress & addr);
+
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData) override;
-    void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override;
+    void OnNodeIdResolutionFailed(const PeerInfo & peerInfo, CHIP_ERROR error) override;
     void OnNodeDiscoveryComplete(const Dnssd::DiscoveredNodeData & nodeData) override {}
 
 private:

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -56,7 +56,8 @@ CHIP_ERROR OperationalDeviceProxy::Connect(Callback::Callback<OnDeviceConnected>
 
     case State::NeedsAddress:
         VerifyOrReturnError(resolver != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        err = resolver->ResolveNodeId(mPeerId, chip::Inet::IPAddressType::kAny);
+        VerifyOrReturnError(mFabricInfo->GetFabricIndex() == mPeerId.GetFabricIndex(), CHIP_ERROR_INVALID_ARGUMENT);
+        err = resolver->ResolveNodeId(PeerInfo(mPeerId.GetNodeId(), mFabricInfo->GetCachedCompressidFabricId()), chip::Inet::IPAddressType::kAny);
         EnqueueConnectionCallbacks(onConnection, onFailure);
         break;
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -87,7 +87,7 @@ public:
         mSystemLayer = params.exchangeMgr->GetSessionManager()->SystemLayer();
         mInitParams  = params;
         mPeerId      = peerId;
-        mFabricInfo  = params.fabricTable->FindFabricWithCompressedId(peerId.GetCompressedFabricId());
+        mFabricInfo  = params.fabricTable->FindFabricWithIndex(peerId.GetFabricIndex());
 
         mState = State::NeedsAddress;
     }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -259,7 +259,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
             chip::DeviceLayer::ConfigurationMgr().GetPrimaryMACAddress(mac);
 
             const auto advertiseParameters = chip::Dnssd::OperationalAdvertisingParameters()
-                                                 .SetPeerId(fabricInfo.GetPeerId())
+                                                 .SetPeerInfo(PeerInfo(fabricInfo.GetPeerId().GetNodeId(), fabricInfo.GetCachedCompressidFabricId()))
                                                  .SetMac(mac)
                                                  .SetPort(GetSecuredPort())
                                                  .SetMRPConfig(gDefaultMRPConfig)
@@ -269,8 +269,8 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
             auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
             ChipLogProgress(Discovery, "Advertise operational node " ChipLogFormatX64 "-" ChipLogFormatX64,
-                            ChipLogValueX64(advertiseParameters.GetPeerId().GetCompressedFabricId()),
-                            ChipLogValueX64(advertiseParameters.GetPeerId().GetNodeId()));
+                            ChipLogValueX64(advertiseParameters.GetPeerInfo().GetCompressedFabricId()),
+                            ChipLogValueX64(advertiseParameters.GetPeerInfo().GetNodeId()));
             // Should we keep trying to advertise the other operational
             // identities on failure?
             ReturnErrorOnFailure(mdnsAdvertiser.Advertise(advertiseParameters));

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -55,7 +55,7 @@ public:
         ChipLogError(Controller, "Unsupported operation CommissionableNodeController::OnNodeIdResolved");
     }
 
-    void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override
+    void OnNodeIdResolutionFailed(const chip::PeerInfo & peerInfo, CHIP_ERROR error) override
     {
         ChipLogError(Controller, "Unsupported operation CommissionableNodeController::OnNodeIdResolutionFailed");
     }

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -204,6 +204,9 @@ public:
      */
     virtual CHIP_ERROR Shutdown();
 
+    // DEPRECATED, for backward competibility, the one takes a PeerId should be used instead.
+    [[deprecated]] CHIP_ERROR GetPeerAddressAndPort(PeerInfo peerInfo, Inet::IPAddress & addr, uint16_t & port);
+
     CHIP_ERROR GetPeerAddressAndPort(PeerId peerId, Inet::IPAddress & addr, uint16_t & port);
 
     /**
@@ -319,7 +322,7 @@ public:
     /**
      * @brief Get the Compressed Fabric ID assigned to the device.
      */
-    uint64_t GetCompressedFabricId() const { return mLocalId.GetCompressedFabricId(); }
+    uint64_t GetCompressedFabricId() const { return mFabricInfo->GetCachedCompressidFabricId(); }
 
     /**
      * @brief Get the raw Fabric ID assigned to the device.
@@ -383,7 +386,7 @@ protected:
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override;
-    void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override;
+    void OnNodeIdResolutionFailed(const chip::PeerInfo & peerInfo, CHIP_ERROR error) override;
     DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mCommissionableNodes); }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
@@ -602,7 +605,7 @@ public:
     int GetMaxCommissionableNodesSupported() { return kMaxCommissionableNodes; }
 
     void OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override;
-    void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override;
+    void OnNodeIdResolutionFailed(const chip::PeerInfo & peerInfo, CHIP_ERROR error) override;
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     /**

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -265,10 +265,7 @@ ChipError::StorageType pychip_DeviceController_GetAddressAndPort(chip::Controlle
                                                                  uint16_t * outPort)
 {
     Inet::IPAddress address;
-    ReturnErrorOnFailure(
-        devCtrl
-            ->GetPeerAddressAndPort(PeerId().SetCompressedFabricId(devCtrl->GetCompressedFabricId()).SetNodeId(nodeId), address,
-                                    *outPort)
+    ReturnErrorOnFailure(devCtrl->GetPeerAddressAndPort(PeerInfo(nodeId, devCtrl->GetCompressedFabricId()), address, *outPort)
             .AsInteger());
     VerifyOrReturnError(address.ToString(outAddress, maxAddressLen), CHIP_ERROR_BUFFER_TOO_SMALL.AsInteger());
 

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -44,12 +44,12 @@ public:
 
             // TODO: For now, just provide addr 0, but this should really provide all and
             // allow the caller to choose.
-            mSuccessCallback(                                                            //
-                nodeData.mPeerId.GetCompressedFabricId(),                                //
-                nodeData.mPeerId.GetNodeId(),                                            //
-                nodeData.mInterfaceId.GetPlatformInterface(),                            //
-                nodeData.mAddress[0].ToString(ipAddressBuffer, sizeof(ipAddressBuffer)), //
-                nodeData.mPort                                                           //
+            mSuccessCallback(
+                nodeData.mPeerInfo.GetCompressedFabricId(),
+                nodeData.mPeerInfo.GetNodeId(),
+                nodeData.mInterfaceId.GetPlatformInterface(),
+                nodeData.mAddress[0].ToString(ipAddressBuffer, sizeof(ipAddressBuffer)),
+                nodeData.mPort
             );
         }
         else
@@ -58,11 +58,11 @@ public:
         }
     }
 
-    void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override
+    void OnNodeIdResolutionFailed(const PeerInfo & peerInfo, CHIP_ERROR error) override
     {
         if (mFailureCallback != nullptr)
         {
-            mFailureCallback(peerId.GetCompressedFabricId(), peerId.GetNodeId(), error.AsInteger());
+            mFailureCallback(peerInfo.GetCompressedFabricId(), peerInfo.GetNodeId(), error.AsInteger());
         }
         else
         {
@@ -99,8 +99,7 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
         ReturnOnFailure(result);
         Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
 
-        result = Resolver::Instance().ResolveNodeId(chip::PeerId().SetCompressedFabricId(fabricId).SetNodeId(nodeId),
-                                                    chip::Inet::IPAddressType::kAny);
+        result = Resolver::Instance().ResolveNodeId(chip::PeerInfo(nodeId, fabricId), chip::Inet::IPAddressType::kAny);
     });
 
     return result.AsInteger();

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -34,7 +34,7 @@ public:
     CHIP_ERROR Init(chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> * udpEndPointManager) override { return InitStatus; }
     void Shutdown() override {}
     void SetResolverDelegate(ResolverDelegate *) override {}
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass) override
+    CHIP_ERROR ResolveNodeId(const PeerInfo & peerInfo, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass) override
     {
         return ResolveNodeIdStatus;
     }

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -55,22 +55,20 @@ void TestGetCompressedFabricID(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, fabricInfo.SetRootCert(ByteSpan(sTestRootCert)) == CHIP_NO_ERROR);
 
-    PeerId compressedId;
-    NL_TEST_ASSERT(inSuite, fabricInfo.GetCompressedId(1234, 4321, &compressedId) == CHIP_NO_ERROR);
+    CompressedFabricId compressedId;
+    NL_TEST_ASSERT(inSuite, fabricInfo.GetCompressedId(1234, 4321, compressedId) == CHIP_NO_ERROR);
 
     // We are compairing with hard coded values here (which are generated manually when the test was written)
     // This is to ensure that the same value is generated on big endian and little endian platforms.
     // If in this test any input to GetCompressedId() is changed, this value must be recomputed.
-    NL_TEST_ASSERT(inSuite, compressedId.GetCompressedFabricId() == 0x090F17C67be7b663);
-    NL_TEST_ASSERT(inSuite, compressedId.GetNodeId() == 4321);
+    NL_TEST_ASSERT(inSuite, compressedId == 0x090F17C67be7b663);
 
-    NL_TEST_ASSERT(inSuite, fabricInfo.GetCompressedId(0xabcd, 0xdeed, &compressedId) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, fabricInfo.GetCompressedId(0xabcd, 0xdeed, compressedId) == CHIP_NO_ERROR);
 
     // We are compairing with hard coded values here (which are generated manually when the test was written)
     // This is to ensure that the same value is generated on big endian and little endian platforms
     // If in this test any input to GetCompressedId() is changed, this value must be recomputed.
-    NL_TEST_ASSERT(inSuite, compressedId.GetCompressedFabricId() == 0xf3fecbcec485d5d7);
-    NL_TEST_ASSERT(inSuite, compressedId.GetNodeId() == 0xdeed);
+    NL_TEST_ASSERT(inSuite, compressedId == 0xf3fecbcec485d5d7);
 }
 
 // Test Suite

--- a/src/lib/core/DataModelTypes.h
+++ b/src/lib/core/DataModelTypes.h
@@ -42,6 +42,7 @@ typedef uint32_t FieldId;
 typedef uint16_t ListIndex;
 typedef uint32_t TransactionId;
 typedef uint16_t KeysetId;
+using CompressedFabricId = uint64_t;
 
 constexpr FabricIndex kUndefinedFabricIndex = 0;
 constexpr EndpointId kInvalidEndpointId     = 0xFFFF;

--- a/src/lib/core/PeerId.h
+++ b/src/lib/core/PeerId.h
@@ -17,51 +17,54 @@
 
 #pragma once
 
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/NodeId.h>
 
 namespace chip {
 
-using CompressedFabricId = uint64_t;
 using FabricId           = uint64_t;
-
-constexpr CompressedFabricId kUndefinedCompressedFabricId = 0ULL;
 
 constexpr FabricId kUndefinedFabricId = 0ULL;
 constexpr uint16_t kUndefinedVendorId = 0U;
 
-/// A peer is identified by a node id within a compressed fabric ID
+/// A peer is identified by a node id within a fabric.
 class PeerId
 {
 public:
-    PeerId() {}
+    PeerId() : mNodeId(kUndefinedNodeId), mFabricIndex(kUndefinedFabricIndex) {}
+    PeerId(NodeId nodeId, FabricIndex fabricIndex) : mNodeId(nodeId), mFabricIndex(fabricIndex) {}
+
+    PeerId(const PeerId &) = default;
+    PeerId(PeerId &&) = default;
+    PeerId & operator=(const PeerId &) = default;
+    PeerId & operator=(PeerId &&) = default;
 
     NodeId GetNodeId() const { return mNodeId; }
-    PeerId & SetNodeId(NodeId id)
-    {
-        mNodeId = id;
-        return *this;
+    FabricIndex GetFabricIndex() const { return mFabricIndex; }
+
+    bool operator==(const PeerId & other) const {
+        if (mFabricIndex == kUndefinedFabricIndex)
+        {
+            if (mNodeId == kUndefinedNodeId || other.mNodeId == kUndefinedNodeId)
+            {
+                return false; // (kUndefinedFabricIndex, kUndefinedNodeId) are not equal to each other.
+            }
+            else
+            {
+                return mNodeId == other.mNodeId;
+            }
+        }
+        else
+        {
+            return (mNodeId == other.mNodeId) && (mFabricIndex == other.mFabricIndex);
+        }
     }
 
-    CompressedFabricId GetCompressedFabricId() const { return mCompressedFabricId; }
-    PeerId & SetCompressedFabricId(CompressedFabricId id)
-    {
-        mCompressedFabricId = id;
-        return *this;
-    }
-
-    bool operator==(const PeerId & other) const
-    {
-        return (mNodeId == other.mNodeId) && (mCompressedFabricId == other.mCompressedFabricId);
-    }
-    bool operator!=(const PeerId & other) const
-    {
-        return (mNodeId != other.mNodeId) || (mCompressedFabricId != other.mCompressedFabricId);
-    }
+    bool operator!=(const PeerId & other) const { return !(*this == other); }
 
 private:
-    NodeId mNodeId = kUndefinedNodeId;
-
-    CompressedFabricId mCompressedFabricId = kUndefinedCompressedFabricId;
+    NodeId mNodeId;
+    FabricIndex mFabricIndex;
 };
 
 } // namespace chip

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -114,17 +114,17 @@ public:
     static constexpr size_t kTxtTotalKeySize   = kCommonTxtTotalKeySize;
     static constexpr size_t kTxtTotalValueSize = kCommonTxtTotalValueSize;
 
-    OperationalAdvertisingParameters & SetPeerId(const PeerId & peerId)
+    OperationalAdvertisingParameters & SetPeerInfo(const PeerInfo & peerInfo)
     {
-        mPeerId = peerId;
+        mPeerInfo = peerInfo;
         return *this;
     }
-    PeerId GetPeerId() const { return mPeerId; }
+    PeerInfo GetPeerInfo() const { return mPeerInfo; }
 
-    CompressedFabricId GetCompressedFabricId() const { return mPeerId.GetCompressedFabricId(); }
+    CompressedFabricId GetCompressedFabricId() const { return mPeerInfo.GetCompressedFabricId(); }
 
 private:
-    PeerId mPeerId;
+    PeerInfo mPeerInfo;
 };
 
 class CommissionAdvertisingParameters : public BaseAdvertisingParams<CommissionAdvertisingParameters>

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -340,7 +340,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
     char nameBuffer[Operational::kInstanceNameMaxLength + 1] = "";
 
     /// need to set server name
-    ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), params.GetPeerId()));
+    ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), params.GetPeerInfo()));
 
     QNamePart nameCheckParts[]  = { nameBuffer, kOperationalServiceName, kOperationalProtocol, kLocalDomain };
     FullQName nameCheck         = FullQName(nameCheckParts);
@@ -412,7 +412,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
         }
     }
     MakeServiceSubtype(nameBuffer, sizeof(nameBuffer),
-                       DiscoveryFilter(DiscoveryFilterType::kCompressedFabricId, params.GetPeerId().GetCompressedFabricId()));
+                       DiscoveryFilter(DiscoveryFilterType::kCompressedFabricId, params.GetPeerInfo().GetCompressedFabricId()));
     FullQName compressedFabricIdSubtype = operationalAllocator->AllocateQName(
         nameBuffer, kSubtypeServiceNamePart, kOperationalServiceName, kOperationalProtocol, kLocalDomain);
     ReturnErrorCodeIf(compressedFabricIdSubtype.nameCount == 0, CHIP_ERROR_NO_MEMORY);

--- a/src/lib/dnssd/BUILD.gn
+++ b/src/lib/dnssd/BUILD.gn
@@ -25,6 +25,7 @@ static_library("dnssd") {
     ":platform_header",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/dnssd:dnsbase",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging:messaging_mrp_config",
   ]
@@ -61,4 +62,18 @@ static_library("dnssd") {
   } else {
     assert(false, "Unknown Dnssd advertiser implementation.")
   }
+}
+
+static_library("dnsbase") {
+  public_deps = [
+    ":platform_header",
+    "${chip_root}/src/credentials",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+
+  sources = [
+    "PeerInfo.cpp",
+    "PeerInfo.h",
+  ]
 }

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -50,7 +50,7 @@ public:
 
     // Members that implement Resolver interface.
     void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverProxy.SetResolverDelegate(delegate); }
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass) override;
+    CHIP_ERROR ResolveNodeId(const PeerInfo & peerInfo, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
@@ -75,7 +75,7 @@ private:
                               size_t subTypeSize, const CommissionAdvertisingParameters & params);
     CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
                               size_t subTypeSize, uint16_t port, const chip::ByteSpan & mac, DnssdServiceProtocol procotol,
-                              PeerId peerId);
+                              PeerInfo peerInfo);
 
     OperationalAdvertisingParameters mOperationalNodeAdvertisingParams;
     CommissionAdvertisingParameters mCommissionableNodeAdvertisingParams;

--- a/src/lib/dnssd/PeerInfo.cpp
+++ b/src/lib/dnssd/PeerInfo.cpp
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/dnssd/PeerInfo.h>
+
+namespace chip {
+
+CHIP_ERROR PeerInfo::FromPeerId(PeerInfo & result, const PeerId peerId, FabricTable * fabricTable)
+{
+    FabricInfo * fabricInfo = fabricTable->FindFabricWithIndex(peerId.GetFabricIndex());
+    VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    result = PeerInfo(peerId.GetNodeId(), fabricInfo->GetCachedCompressidFabricId());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PeerInfo::ToPeerId(PeerId & result, const PeerInfo peerInfo, FabricTable * fabricTable)
+{
+    FabricInfo * fabricInfo = fabricTable->FindFabricWithCompressedId(peerInfo.GetCompressedFabricId());
+    if (fabricInfo == nullptr) return CHIP_ERROR_INVALID_ARGUMENT;
+    result = PeerId(peerInfo.GetNodeId(), fabricInfo->GetFabricIndex());
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip
+

--- a/src/lib/dnssd/PeerInfo.h
+++ b/src/lib/dnssd/PeerInfo.h
@@ -1,0 +1,66 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <credentials/FabricTable.h>
+#include <lib/core/NodeId.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/PeerId.h>
+
+namespace chip {
+
+/// A peer is identified by a node id within a compressed fabric ID
+class PeerInfo
+{
+public:
+    PeerInfo() : mNodeId(kUndefinedNodeId), mCompressedFabricId(kUndefinedCompressedFabricId) {}
+    PeerInfo(NodeId nodeId, CompressedFabricId compressedFabricId) : mNodeId(nodeId), mCompressedFabricId(compressedFabricId) {}
+
+    NodeId GetNodeId() const { return mNodeId; }
+    CompressedFabricId GetCompressedFabricId() const { return mCompressedFabricId; }
+
+    PeerInfo & SetNodeId(NodeId id)
+    {
+        mNodeId = id;
+        return *this;
+    }
+
+    PeerInfo & SetCompressedFabricId(CompressedFabricId id)
+    {
+        mCompressedFabricId = id;
+        return *this;
+    }
+
+    bool operator==(const PeerInfo & that) const
+    {
+        return (mNodeId == that.mNodeId) && (mCompressedFabricId == that.mCompressedFabricId);
+    }
+    bool operator!=(const PeerInfo & that) const
+    {
+        return !(*this == that);
+    }
+
+    static CHIP_ERROR FromPeerId(PeerInfo & result, const PeerId peerId, FabricTable * fabricTable);
+    static CHIP_ERROR ToPeerId(PeerId & result, const PeerInfo peerInfo, FabricTable * fabricTable);
+
+private:
+    NodeId mNodeId;
+    CompressedFabricId mCompressedFabricId;
+};
+
+} // namespace chip
+

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -20,14 +20,14 @@
 #include <cstdint>
 #include <limits>
 
-#include "lib/support/logging/CHIPLogging.h"
+#include <lib/support/logging/CHIPLogging.h>
 #include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
-#include <lib/core/PeerId.h>
 #include <lib/dnssd/Constants.h>
+#include <lib/dnssd/PeerInfo.h>
 #include <lib/support/BytesToHex.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
 
@@ -45,7 +45,7 @@ struct ResolvedNodeData
 
         // Would be nice to log the interface id, but sorting out how to do so
         // across our differnet InterfaceId implementations is a pain.
-        ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+        ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64, ChipLogValueX64(mPeerInfo.GetNodeId()));
         for (size_t i = 0; i < mNumIPs; ++i)
         {
             mAddress[i].ToString(addrBuffer);
@@ -75,7 +75,7 @@ struct ResolvedNodeData
         return false;
     }
 
-    PeerId mPeerId;
+    PeerInfo mPeerInfo;
     size_t mNumIPs = 0;
     Inet::InterfaceId mInterfaceId;
     Inet::IPAddress mAddress[kMaxIPAddresses];
@@ -261,7 +261,7 @@ public:
     virtual void OnNodeIdResolved(const ResolvedNodeData & nodeData) = 0;
 
     /// Called when a CHIP node ID resolution has failed
-    virtual void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) = 0;
+    virtual void OnNodeIdResolutionFailed(const PeerInfo & peerInfo, CHIP_ERROR error) = 0;
 
     // Called when a CHIP Node acting as Commissioner or in commissioning mode is found
     virtual void OnNodeDiscoveryComplete(const DiscoveredNodeData & nodeData) = 0;
@@ -310,7 +310,7 @@ public:
      * the result of the operation is passed to the delegate's `OnNodeIdResolved` or
      * `OnNodeIdResolutionFailed` method, respectively.
      */
-    virtual CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type,
+    virtual CHIP_ERROR ResolveNodeId(const PeerInfo & peerInfo, Inet::IPAddressType type,
                                      Resolver::CacheBypass dnssdCacheBypass = CacheBypass::Off) = 0;
 
     /**

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -37,11 +37,11 @@ public:
         }
     }
 
-    void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override
+    void OnNodeIdResolutionFailed(const PeerInfo & peerInfo, CHIP_ERROR error) override
     {
         if (mDelegate != nullptr)
         {
-            mDelegate->OnNodeIdResolutionFailed(peerId, error);
+            mDelegate->OnNodeIdResolutionFailed(peerInfo, error);
         }
     }
 
@@ -85,7 +85,7 @@ public:
         mDelegate = nullptr;
     }
 
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type,
+    CHIP_ERROR ResolveNodeId(const PeerInfo & peerInfo, Inet::IPAddressType type,
                              Resolver::CacheBypass dnssdCacheBypass = CacheBypass::Off) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;

--- a/src/lib/dnssd/ServiceNaming.h
+++ b/src/lib/dnssd/ServiceNaming.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/PeerId.h>
 #include <lib/dnssd/Constants.h>
+#include <lib/dnssd/PeerInfo.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/Span.h>
 
@@ -49,13 +49,13 @@ constexpr size_t kMaxOperationalServiceNameSize =
     Operational::kInstanceNameMaxLength + 1 + sizeof(kOperationalServiceName) + sizeof(kOperationalProtocol) + sizeof(kLocalDomain);
 
 /// builds the MDNS advertising name for a given fabric + nodeid pair
-CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peerId);
+CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerInfo & peerInfo);
 
 /// Inverse of MakeInstanceName.  Will return errors on non-spec-compliant ids,
 /// _except_ for allowing lowercase hex, not just the spec-defined uppercase
 /// hex.  The part of "name" up to the first '.' (or end of string, whichever
 /// comes first) is parsed as a FABRICID-NODEID.
-CHIP_ERROR ExtractIdFromInstanceName(const char * name, PeerId * peerId);
+CHIP_ERROR ExtractIdFromInstanceName(const char * name, PeerInfo * peerInfo);
 
 /// Generates the host name that a CHIP device is to use for a given unique
 /// identifier (MAC address or EUI64)

--- a/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.cpp
@@ -28,75 +28,72 @@ namespace Minimal {
 
 constexpr chip::System::Clock::Timeout ActiveResolveAttempts::kMaxRetryDelay;
 
-void ActiveResolveAttempts::Reset()
-
+ActiveResolveAttempts::RetryEntry * ActiveResolveAttempts::FindEntry(const chip::PeerInfo & peerInfo)
 {
-    for (auto & item : mRetryQueue)
-    {
-        item.peerId.SetNodeId(kUndefinedNodeId);
-    }
-}
-
-void ActiveResolveAttempts::Complete(const PeerId & peerId)
-{
-    for (auto & item : mRetryQueue)
-    {
-        if (item.peerId == peerId)
+    RetryEntry * result = nullptr;
+    mRetryQueue.ForEachActiveObject([&] (RetryEntry * item) {
+        if (item->peerInfo == peerInfo)
         {
-            item.peerId.SetNodeId(kUndefinedNodeId);
-            return;
+            result = item;
+            return Loop::Break;
         }
-    }
-
-    // This may happen during boot time adverisements: nodes come online
-    // and advertise their IP without any explicit queries for them
-    ChipLogProgress(Discovery, "Discovered node without a pending query");
+        return Loop::Continue;
+    });
+    return result;
 }
 
-void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
+void ActiveResolveAttempts::Complete(const PeerInfo & peerInfo)
 {
-    // Strategy when picking the peer id to use:
-    //   1 if a matching peer id is already found, use that one
+    RetryEntry * match = FindEntry(peerInfo);
+    if (match != nullptr)
+    {
+        mRetryQueue.ReleaseObject(match);
+    }
+    else
+    {
+        ChipLogProgress(Discovery, "Discovered node without a pending query");
+    }
+}
+
+void ActiveResolveAttempts::MarkPending(const PeerInfo & peerInfo)
+{
+    // Strategy when picking the peer to use:
+    //   1 if a matching peer is already found, use that one
     //   2 if an 'unused' entry is found, use that
     //   3 otherwise expire the one with the largest nextRetryDelay
     //     or if equal nextRetryDelay, pick the one with the oldest
     //     queryDueTime
 
-    RetryEntry * entryToUse = &mRetryQueue[0];
-
-    for (size_t i = 1; i < kRetryQueueSize; i++)
+    // Rule 1: peer id match always matches
+    RetryEntry * entryToUse = FindEntry(peerInfo);
+    if (entryToUse != nullptr)
     {
-        if (entryToUse->peerId == peerId)
+        MarkPending(entryToUse);
+        return;
+    }
+
+    // Rule 2: select unused entries
+    if (mRetryQueue.Allocated() < kRetryQueueSize)
+    {
+        entryToUse = mRetryQueue.CreateObject(peerInfo);
+        if (entryToUse != nullptr)
         {
-            break; // best match possible
+            MarkPending(entryToUse);
+            return;
         }
+    }
 
-        RetryEntry * entry = mRetryQueue + i;
-
-        // Rule 1: peer id match always matches
-        if (entry->peerId == peerId)
+    // Rule 3: both choices are used (have a defined node id):
+    //    - try to find the one with the largest next delay (oldest request)
+    //    - on same delay, use queryDueTime to determine the oldest request
+    //      (the one with the smallest  due time was issued the longest time
+    //       ago)
+    mRetryQueue.ForEachActiveObject([&] (RetryEntry * entry) {
+        if (entryToUse == nullptr)
         {
             entryToUse = entry;
-            continue;
         }
-
-        // Rule 2: select unused entries
-        if ((entryToUse->peerId.GetNodeId() != kUndefinedNodeId) && (entry->peerId.GetNodeId() == kUndefinedNodeId))
-        {
-            entryToUse = entry;
-            continue;
-        }
-        else if (entryToUse->peerId.GetNodeId() == kUndefinedNodeId)
-        {
-            continue;
-        }
-
-        // Rule 3: both choices are used (have a defined node id):
-        //    - try to find the one with the largest next delay (oldest request)
-        //    - on same delay, use queryDueTime to determine the oldest request
-        //      (the one with the smallest  due time was issued the longest time
-        //       ago)
-        if (entry->nextRetryDelay > entryToUse->nextRetryDelay)
+        else if (entry->nextRetryDelay > entryToUse->nextRetryDelay)
         {
             entryToUse = entry;
         }
@@ -104,10 +101,16 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
         {
             entryToUse = entry;
         }
-    }
 
-    if ((entryToUse->peerId.GetNodeId() != kUndefinedNodeId) && (entryToUse->peerId != peerId))
+        return Loop::Continue;
+    });
+
+    if (entryToUse != nullptr)
     {
+        mRetryQueue.ReleaseObject(entryToUse);
+        entryToUse = mRetryQueue.CreateObject(peerInfo);
+        VerifyOrDie(entryToUse != nullptr);
+
         // TODO: node was evicted here, if/when resolution failures are
         // supported this could be a place for error callbacks
         //
@@ -116,9 +119,13 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
         // still be received for this peer id (query was already sent on the
         // network)
         ChipLogError(Discovery, "Re-using pending resolve entry before reply was received.");
+        MarkPending(entryToUse);
+        return;
     }
+}
 
-    entryToUse->peerId         = peerId;
+void ActiveResolveAttempts::MarkPending(RetryEntry * entryToUse)
+{
     entryToUse->queryDueTime   = mClock->GetMonotonicTimestamp();
     entryToUse->nextRetryDelay = System::Clock::Seconds16(1);
 }
@@ -129,59 +136,61 @@ Optional<System::Clock::Timeout> ActiveResolveAttempts::GetTimeUntilNextExpected
 
     chip::System::Clock::Timestamp now = mClock->GetMonotonicTimestamp();
 
-    for (auto & entry : mRetryQueue)
-    {
-        if (entry.peerId.GetNodeId() == kUndefinedNodeId)
-        {
-            continue;
-        }
-
-        if (now >= entry.queryDueTime)
+    mRetryQueue.ForEachActiveObject([&] (const RetryEntry * entry) {
+        if (now >= entry->queryDueTime)
         {
             // found an entry that needs processing right now
-            return Optional<System::Clock::Timeout>::Value(0);
+            minDelay = Optional<System::Clock::Timeout>::Value(0);
+            return Loop::Break;
         }
 
-        System::Clock::Timeout entryDelay = entry.queryDueTime - now;
+        System::Clock::Timeout entryDelay = entry->queryDueTime - now;
         if (!minDelay.HasValue() || (minDelay.Value() > entryDelay))
         {
             minDelay.SetValue(entryDelay);
         }
-    }
+
+        return Loop::Continue;
+    });
 
     return minDelay;
 }
 
-Optional<PeerId> ActiveResolveAttempts::NextScheduledPeer()
+Optional<PeerInfo> ActiveResolveAttempts::NextScheduledPeer()
 {
     chip::System::Clock::Timestamp now = mClock->GetMonotonicTimestamp();
 
-    for (auto & entry : mRetryQueue)
-    {
-        if (entry.peerId.GetNodeId() == kUndefinedNodeId)
+    RetryEntry * result = nullptr;
+    mRetryQueue.ForEachActiveObject([&] (RetryEntry * entry) {
+        if (entry->queryDueTime > now)
         {
-            continue; // not a pending item
+            return Loop::Continue; // not yet due
         }
 
-        if (entry.queryDueTime > now)
-        {
-            continue; // not yet due
-        }
-
-        if (entry.nextRetryDelay > kMaxRetryDelay)
+        if (entry->nextRetryDelay > kMaxRetryDelay)
         {
             ChipLogError(Discovery, "Timeout waiting for mDNS resolution.");
-            entry.peerId.SetNodeId(kUndefinedNodeId);
-            continue;
+            mRetryQueue.ReleaseObject(entry);
+            return Loop::Continue;
         }
 
-        entry.queryDueTime = now + entry.nextRetryDelay;
-        entry.nextRetryDelay *= 2;
+        if (result == nullptr || entry->queryDueTime < result->queryDueTime)
+        {
+            result = entry;
+        }
+        return Loop::Continue;
+    });
 
-        return Optional<PeerId>::Value(entry.peerId);
+    if (result != nullptr)
+    {
+        result->queryDueTime = now + result->nextRetryDelay;
+        result->nextRetryDelay *= 2;
+        return Optional<PeerInfo>::Value(result->peerInfo);
     }
-
-    return Optional<PeerId>::Missing();
+    else
+    {
+        return Optional<PeerInfo>::Missing();
+    }
 }
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/BUILD.gn
@@ -60,6 +60,7 @@ static_library("minimal_mdns") {
   public_deps = [
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/dnssd:dnsbase",
     "${chip_root}/src/lib/dnssd/minimal_mdns/core",
     "${chip_root}/src/lib/dnssd/minimal_mdns/responders",
     "${chip_root}/src/platform",

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -53,12 +53,12 @@ const FullQName kHostnameName       = FullQName(kHostnameParts);
 // Operational records and queries.
 const QNamePart kMatterOperationalQueryParts[3] = { "_matter", "_tcp", "local" };
 const FullQName kMatterOperationalQueryName     = FullQName(kMatterOperationalQueryParts);
-const PeerId kPeerId1                           = PeerId().SetCompressedFabricId(0xBEEFBEEFF00DF00D).SetNodeId(0x1111222233334444);
-const PeerId kPeerId2                           = PeerId().SetCompressedFabricId(0x5555666677778888).SetNodeId(0x1212343456567878);
-const PeerId kPeerId3                           = PeerId().SetCompressedFabricId(0x3333333333333333).SetNodeId(0x3333333333333333);
-const PeerId kPeerId4                           = PeerId().SetCompressedFabricId(0x4444444444444444).SetNodeId(0x4444444444444444);
-const PeerId kPeerId5                           = PeerId().SetCompressedFabricId(0x5555555555555555).SetNodeId(0x5555555555555555);
-const PeerId kPeerId6                           = PeerId().SetCompressedFabricId(0x6666666666666666).SetNodeId(0x6666666666666666);
+const PeerInfo kPeerInfo1                           = PeerInfo(0x1111222233334444, 0xBEEFBEEFF00DF00D);
+const PeerInfo kPeerInfo2                           = PeerInfo(0x1212343456567878, 0x5555666677778888);
+const PeerInfo kPeerInfo3                           = PeerInfo(0x3333333333333333, 0x3333333333333333);
+const PeerInfo kPeerInfo4                           = PeerInfo(0x4444444444444444, 0x4444444444444444);
+const PeerInfo kPeerInfo5                           = PeerInfo(0x5555555555555555, 0x5555555555555555);
+const PeerInfo kPeerInfo6                           = PeerInfo(0x6666666666666666, 0x6666666666666666);
 const QNamePart kInstanceNameParts1[]           = { "BEEFBEEFF00DF00D-1111222233334444", "_matter", "_tcp", "local" };
 const FullQName kInstanceName1                  = FullQName(kInstanceNameParts1);
 const QNamePart kInstanceNameParts2[]           = { "5555666677778888-1212343456567878", "_matter", "_tcp", "local" };
@@ -73,22 +73,22 @@ PtrResourceRecord ptrServiceSubCompressedId1    = PtrResourceRecord(kDnsSdQueryN
 PtrResourceRecord ptrServiceSubCompressedId2    = PtrResourceRecord(kDnsSdQueryName, kCompressedIdSubName2);
 
 OperationalAdvertisingParameters operationalParams1 = OperationalAdvertisingParameters()
-                                                          .SetPeerId(kPeerId1)
+                                                          .SetPeerInfo(kPeerInfo1)
                                                           .SetMac(ByteSpan(kMac))
                                                           .SetPort(CHIP_PORT)
                                                           .EnableIpV4(true)
                                                           .SetTcpSupported(chip::Optional<bool>(false))
                                                           .SetMRPConfig(ReliableMessageProtocolConfig(32_ms32, 33_ms32));
 OperationalAdvertisingParameters operationalParams2 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId2).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters().SetPeerInfo(kPeerInfo2).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams3 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId3).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters().SetPeerInfo(kPeerInfo3).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams4 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId4).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters().SetPeerInfo(kPeerInfo4).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams5 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId5).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters().SetPeerInfo(kPeerInfo5).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams6 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId6).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters().SetPeerInfo(kPeerInfo6).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 const QNamePart txtOperational1Parts[]  = { "CRI=32", "CRA=33", "T=0" };
 PtrResourceRecord ptrOperationalService = PtrResourceRecord(kDnsSdQueryName, kMatterOperationalQueryName);
 PtrResourceRecord ptrOperational1       = PtrResourceRecord(kMatterOperationalQueryName, kInstanceName1);

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -16,8 +16,8 @@
  *    limitations under the License.
  */
 
-#include <lib/core/PeerId.h>
 #include <lib/dnssd/Discovery_ImplPlatform.h>
+#include <lib/dnssd/PeerInfo.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -36,10 +36,10 @@ using namespace chip::Dnssd;
 const uint8_t kMac[kMaxMacSize] = { 1, 2, 3, 4, 5, 6, 7, 8 };
 const char host[]               = "0102030405060708";
 
-const PeerId kPeerId1 = PeerId().SetCompressedFabricId(0xBEEFBEEFF00DF00D).SetNodeId(0x1111222233334444);
-const PeerId kPeerId2 = PeerId().SetCompressedFabricId(0x5555666677778888).SetNodeId(0x1212343456567878);
+const PeerInfo kPeerInfo1 = PeerInfo(0x1111222233334444, 0xBEEFBEEFF00DF00D);
+const PeerInfo kPeerInfo2 = PeerInfo(0x1212343456567878, 0x5555666677778888);
 OperationalAdvertisingParameters operationalParams1 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId1).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters().SetPeerInfo(kPeerInfo1).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 test::ExpectedCall operationalCall1 = test::ExpectedCall()
                                           .SetProtocol(DnssdServiceProtocol::kDnssdProtocolTcp)
                                           .SetServiceName("_matter")
@@ -47,7 +47,7 @@ test::ExpectedCall operationalCall1 = test::ExpectedCall()
                                           .SetHostName(host)
                                           .AddSubtype("_IBEEFBEEFF00DF00D");
 OperationalAdvertisingParameters operationalParams2 = OperationalAdvertisingParameters()
-                                                          .SetPeerId(kPeerId2)
+                                                          .SetPeerInfo(kPeerInfo2)
                                                           .SetMac(ByteSpan(kMac))
                                                           .SetPort(CHIP_PORT)
                                                           .EnableIpV4(true)

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -380,7 +380,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
 
 bool NodeDataIsEmpty(const ResolvedNodeData & nodeData)
 {
-    return nodeData.mPeerId == PeerId{} && nodeData.mNumIPs == 0 && nodeData.mPort == 0 &&
+    return nodeData.mPeerInfo == PeerInfo{} && nodeData.mNumIPs == 0 && nodeData.mPort == 0 &&
         !nodeData.mMrpRetryIntervalIdle.HasValue() && !nodeData.mMrpRetryIntervalActive.HasValue() && !nodeData.mSupportsTcp;
 }
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -44,7 +44,7 @@ public:
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData) override
     {
         streamer_printf(streamer_get(), "DNS resolve for " ChipLogFormatX64 "-" ChipLogFormatX64 " succeeded:\r\n",
-                        ChipLogValueX64(nodeData.mPeerId.GetCompressedFabricId()), ChipLogValueX64(nodeData.mPeerId.GetNodeId()));
+                        ChipLogValueX64(nodeData.mPeerInfo.GetCompressedFabricId()), ChipLogValueX64(nodeData.mPeerInfo.GetNodeId()));
         streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.mHostName);
         for (size_t i = 0; i < nodeData.mNumIPs; ++i)
         {
@@ -65,7 +65,7 @@ public:
         streamer_printf(streamer_get(), "   Supports TCP: %s\r\n", nodeData.mSupportsTcp ? "yes" : "no");
     }
 
-    void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override {}
+    void OnNodeIdResolutionFailed(const PeerInfo & peerInfo, CHIP_ERROR error) override {}
 
     void OnNodeDiscoveryComplete(const Dnssd::DiscoveredNodeData & nodeData) override
     {
@@ -122,11 +122,8 @@ CHIP_ERROR ResolveHandler(int argc, char ** argv)
 
     streamer_printf(streamer_get(), "Resolving ...\r\n");
 
-    PeerId peerId;
-    peerId.SetCompressedFabricId(strtoull(argv[0], NULL, 10));
-    peerId.SetNodeId(strtoull(argv[1], NULL, 10));
-
-    return sResolverProxy.ResolveNodeId(peerId, Inet::IPAddressType::kAny, Dnssd::Resolver::CacheBypass::On);
+    PeerInfo peerInfo(strtoull(argv[1], NULL, 10), strtoull(argv[0], NULL, 10));
+    return sResolverProxy.ResolveNodeId(peerInfo, Inet::IPAddressType::kAny, Dnssd::Resolver::CacheBypass::On);
 }
 
 bool ParseSubType(int argc, char ** argv, Dnssd::DiscoveryFilter & filter)

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1264,12 +1264,13 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const ByteSpan & respon
 
     ReturnErrorOnFailure(SetEffectiveTime());
 
-    PeerId peerId;
+    NodeId nodeId;
+    CompressedFabricId compressedFabricId;
     FabricId rawFabricId;
     ReturnErrorOnFailure(
-        mFabricInfo->VerifyCredentials(responderNOC, responderICAC, mValidContext, peerId, rawFabricId, responderID));
+        mFabricInfo->VerifyCredentials(responderNOC, responderICAC, mValidContext, nodeId, compressedFabricId, rawFabricId, responderID));
 
-    SetPeerNodeId(peerId.GetNodeId());
+    SetPeerNodeId(nodeId);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
`PeerId` is tuple of `<NodeId, CompressedFabricId>`, but `CompressedFabricId` is only being used in mDNS, on the other hand `FabricIndex` is used more widely.

#### Change overview
* Change `PeerId` into tuple of `<NodeId, FabricIndex>`
* For mDNS, add another class `PeerInfo`, which holds `<NodeId, CompressedFabricId>` as same as `PeerId` as before. mDNS will focus on `PeerInfo`
* Use `ObjectPool` for `DnssdCache::mLookupTable` and `ActiveResolveAttempts::mRetryQueue`

#### Testing
Verified by unit-tests.