### PR TITLE
Implement the Access control event support

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -32,7 +32,7 @@ if(${IDF_TARGET} STREQUAL "esp32")
 endif()
 
 project(chip-all-clusters-app)
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-Wno-maybe-uninitialized;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 # For the C3, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat

--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -32,7 +32,7 @@ if(${IDF_TARGET} STREQUAL "esp32")
 endif()
 
 project(chip-all-clusters-app)
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-Wno-maybe-uninitialized;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 # For the C3, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -333,7 +333,7 @@ public:
     /**
      * The accessing subject descriptor for this write interaction.
      */
-    Access::SubjectDescriptor & GetSubjectDescriptor() { return mSubjectDescriptor; }
+    const Access::SubjectDescriptor & GetSubjectDescriptor() const { return mSubjectDescriptor; }
 
 private:
     TLV::TLVReader & mReader;

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -338,7 +338,7 @@ public:
 private:
     TLV::TLVReader & mReader;
     bool mTriedDecode = false;
-    Access::SubjectDescriptor mSubjectDescriptor;
+    const Access::SubjectDescriptor mSubjectDescriptor;
 };
 
 class AttributeAccessInterface

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <access/AccessControl.h>
 #include <app/ClusterInfo.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/MessageDef/AttributeReportIBs.h>
@@ -311,8 +312,8 @@ private:
 class AttributeValueDecoder
 {
 public:
-    AttributeValueDecoder(TLV::TLVReader & aReader, FabricIndex aAccessingFabricIndex) :
-        mReader(aReader), mAccessingFabricIndex(aAccessingFabricIndex)
+    AttributeValueDecoder(TLV::TLVReader & aReader, const Access::SubjectDescriptor & aSubjectDescriptor) :
+        mReader(aReader), mSubjectDescriptor(aSubjectDescriptor)
     {}
 
     template <typename T>
@@ -327,12 +328,17 @@ public:
     /**
      * The accessing fabric index for this write interaction.
      */
-    FabricIndex AccessingFabricIndex() const { return mAccessingFabricIndex; }
+    FabricIndex AccessingFabricIndex() const { return mSubjectDescriptor.fabricIndex; }
+
+    /**
+     * The accessing subject descriptor for this write interaction.
+     */
+    Access::SubjectDescriptor & GetSubjectDescriptor() { return mSubjectDescriptor; }
 
 private:
     TLV::TLVReader & mReader;
     bool mTriedDecode = false;
-    const FabricIndex mAccessingFabricIndex;
+    Access::SubjectDescriptor mSubjectDescriptor;
 };
 
 class AttributeAccessInterface

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <access/AccessControl.h>
+#include <access/SubjectDescriptor.h>
 #include <app/ClusterInfo.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/MessageDef/AttributeReportIBs.h>

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -836,7 +836,7 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
 
     if (auto * attrOverride = findAttributeAccessOverride(aClusterInfo.mEndpointId, aClusterInfo.mClusterId))
     {
-        AttributeValueDecoder valueDecoder(aReader, apWriteHandler->GetAccessingFabricIndex());
+        AttributeValueDecoder valueDecoder(aReader, aSubjectDescriptor);
         ReturnErrorOnFailure(attrOverride->Write(aPath, valueDecoder));
 
         if (valueDecoder.TriedDecode())

--- a/src/lib/core/NodeId.h
+++ b/src/lib/core/NodeId.h
@@ -45,8 +45,9 @@ constexpr NodeId kPlaceholderNodeId   = 0xFFFF'FFFE'FFFF'FFFFULL;
 constexpr NodeId kMinCASEAuthTag = 0xFFFF'FFFD'0000'0000ULL;
 constexpr NodeId kMaxCASEAuthTag = 0xFFFF'FFFD'FFFF'FFFFULL;
 
-constexpr NodeId kMinPAKEKeyId = 0xFFFF'FFFB'0000'0000ULL;
-constexpr NodeId kMaxPAKEKeyId = 0xFFFF'FFFB'FFFF'FFFFULL;
+constexpr NodeId kMinPAKEKeyId  = 0xFFFF'FFFB'0000'0000ULL;
+constexpr NodeId kMaxPAKEKeyId  = 0xFFFF'FFFB'FFFF'FFFFULL;
+constexpr NodeId kMaskPAKEKeyId = 0x0000'0000'0000'FFFFULL;
 
 // There are more reserved ranges here, not assigned to anything yet, going down
 // all the way to 0xFFFF'FFF0'0000'0000ULL
@@ -81,6 +82,11 @@ constexpr NodeId NodeIdFromGroupId(GroupId aGroupId)
 constexpr NodeId NodeIdFromPAKEKeyId(uint16_t aPAKEKeyId)
 {
     return kMinPAKEKeyId | aPAKEKeyId;
+}
+
+constexpr uint16_t PAKEKeyIdFromNodeId(NodeId aNodeId)
+{
+    return aNodeId & kMaskPAKEKeyId;
 }
 
 } // namespace chip

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -68,10 +68,13 @@ public:
     {
         if (mHasValue)
         {
+            // The -Wmaybe-uninitialized warning gets confused about the fact
+            // that other.mValue is always initialized if other.mHasValue is
+            // true, so suppress it for our access to other.mValue.
 #pragma GCC diagnostic push
 #if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
+#endif // !defined(__clang__)
             new (&mValue.mData) T(other.mValue.mData);
 #pragma GCC diagnostic pop
         }

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -68,7 +68,12 @@ public:
     {
         if (mHasValue)
         {
+#pragma GCC diagnostic push
+#if !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
             new (&mValue.mData) T(other.mValue.mData);
+#pragma GCC diagnostic pop
         }
     }
 


### PR DESCRIPTION
#### Problem
* Access Control Cluster needs to generate events when ACLs are managed
* Fixes #10255

#### Change overview
Implement the Access Control event support

#### Testing
How was this tested? (at least one bullet point required)
* Read ACL with async command in repl: 
await devCtrl.ReadAttribute(1, [ (0, Clusters.AccessControl.Attributes.Acl ) ] ) This will return some metadata (status etc.) and a list (which will be empty in your case).

* Make a local variable acl containing an entry:
acl = [ Clusters.AccessControl.Structs.AccessControlEntry(   fabricIndex = 1,   privilege = Clusters.AccessControl.Enums.Privilege.kAdminister,   authMode = Clusters.AccessControl.Enums.AuthMode.kCase,   subjects = [ 12344321 ] ) ]

* Write that local variable to the ACL attribute: 
await devCtrl.WriteAttribute(1, [ (0, Clusters.AccessControl.Attributes.Acl( acl ) ) ] ) Again this will return metata (status etc.)

Confirm ACL event is logged from the server side log:

```
[1643051038.764038][353595:353595] CHIP:EM: Received message of type 0x6 with protocolId (0, 1) and MessageCounter:7625419 on exchange 63326r
[1643051038.764058][353595:353595] CHIP:EM: Handling via exchange: 63326r, Delegate: 0x55ea1ba5bb60
[1643051038.764071][353595:353595] CHIP:IM: Received Write request
[1643051038.764079][353595:353595] CHIP:DMG: IM WH moving to [Initialized]
[1643051038.764093][353595:353595] CHIP:DMG: WriteRequestMessage =
[1643051038.764099][353595:353595] CHIP:DMG: {
[1643051038.764105][353595:353595] CHIP:DMG: 	timedRequest = false, 
[1643051038.764110][353595:353595] CHIP:DMG: 	AttributeDataIBs =
[1643051038.764119][353595:353595] CHIP:DMG: 	[
[1643051038.764124][353595:353595] CHIP:DMG: 		AttributeDataIB =
[1643051038.764130][353595:353595] CHIP:DMG: 		{
[1643051038.764136][353595:353595] CHIP:DMG: 			DataVersion = 0x0,
[1643051038.764142][353595:353595] CHIP:DMG: 			AttributePathIB =
[1643051038.764147][353595:353595] CHIP:DMG: 			{
[1643051038.764153][353595:353595] CHIP:DMG: 				Endpoint = 0x0,
[1643051038.764160][353595:353595] CHIP:DMG: 				Cluster = 0x1f,
[1643051038.764165][353595:353595] CHIP:DMG: 				Attribute = 0x0000_0000,
[1643051038.764171][353595:353595] CHIP:DMG: 			}
[1643051038.764177][353595:353595] CHIP:DMG: 				
[1643051038.764182][353595:353595] CHIP:DMG: 				Data = [
[1643051038.764188][353595:353595] CHIP:DMG: 					
[1643051038.764194][353595:353595] CHIP:DMG: 					{
[1643051038.764201][353595:353595] CHIP:DMG: 						0x0 = 1, 
[1643051038.764209][353595:353595] CHIP:DMG: 						0x1 = 5, 
[1643051038.764216][353595:353595] CHIP:DMG: 						0x2 = 2, 
[1643051038.764223][353595:353595] CHIP:DMG: 						0x3 = [
[1643051038.764230][353595:353595] CHIP:DMG: 							12344321, 
[1643051038.764238][353595:353595] CHIP:DMG: 						],
[1643051038.764246][353595:353595] CHIP:DMG: 						0x4 = NULL
[1643051038.764254][353595:353595] CHIP:DMG: 					},
[1643051038.764262][353595:353595] CHIP:DMG: 				],
[1643051038.764268][353595:353595] CHIP:DMG: 		},
[1643051038.764278][353595:353595] CHIP:DMG: 		
[1643051038.764282][353595:353595] CHIP:DMG: 	],
[1643051038.764292][353595:353595] CHIP:DMG: 	
[1643051038.764298][353595:353595] CHIP:DMG: 	isFabricFiltered = false, 
[1643051038.764303][353595:353595] CHIP:DMG: },
[1643051038.764371][353595:353595] CHIP:EVL: LogEvent event number: 0x0000000000000001 priority: 1, endpoint id:  0x0 cluster id: 0x0000_001F event id: 0x0 Sys timestamp: 0x00000000164EA325
[1643051038.764388][353595:353595] CHIP:DMG: IM WH moving to [AddStatus]
```
