### PR TITLE
Fix the cluster association for the NetworkCommissioningFeature enum.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
@@ -143,6 +143,7 @@ limitations under the License.
         </command>
     </cluster>
     <bitmap name="NetworkCommissioningFeature" type="BITMAP32">
+        <cluster code="0x0031"/>
         <field name="WiFiNetworkInterface" mask="0x1"/>
         <field name="ThreadNetworkInterface" mask="0x2"/>
         <field name="EthernetNetworkInterface" mask="0x4"/>

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -10096,6 +10096,14 @@ enum class WiFiBand : uint8_t
     k60g  = 0x04,
 };
 
+// Bitmap for NetworkCommissioningFeature
+enum class NetworkCommissioningFeature : uint32_t
+{
+    kWiFiNetworkInterface     = 0x1,
+    kThreadNetworkInterface   = 0x2,
+    kEthernetNetworkInterface = 0x4,
+};
+
 namespace Structs {
 namespace NetworkInfo {
 enum class Fields


### PR DESCRIPTION
Without that, the enum is not being code-generated.

#### Problem
Enum not being codegenned.

#### Change overview
Codegen it.

#### Testing
Looked at the generated code.