### PR TITLE
Add Platform::SharedPtr, similar to Platform::UniquePtr

### DIFF
--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -179,6 +179,15 @@ inline UniquePtr<T> MakeUnique(Args &&... args)
     return UniquePtr<T>(New<T>(std::forward<Args>(args)...));
 }
 
+template <typename T>
+using SharedPtr = std::shared_ptr<T>;
+
+template <typename T, typename... Args>
+inline SharedPtr<T> MakeShared(Args &&... args)
+{
+    return SharedPtr<T>(New<T>(std::forward<Args>(args)...), Deleter<T>());
+}
+
 // See MemoryDebugCheckPointer().
 extern bool MemoryInternalCheckPointer(const void * p, size_t min_size);
 


### PR DESCRIPTION
#### Problem

A Platform::SharedPtr using the platform allocator, and similar to the existing Platform::UniquePtr, would be useful.

#### Change overview

This adds the Platform::SharedPtr wrapper for std::shared_ptr, using the chip platform allocator.

#### Testing

New unit tests for the Platform::SharedPtr have been added.  Tests pass.