### PR TITLE
[OTA] Use ConfigurationManager as the source of truth for Basic cluster attributes

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -94,7 +94,7 @@ public:
             response.product_id = CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID;
         }
 
-        uint16_t software_version;
+        uint32_t software_version;
         if (DeviceLayer::ConfigurationMgr().GetSoftwareVersion(software_version) == CHIP_NO_ERROR)
         {
             response.software_version = software_version;

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -248,7 +248,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version String: 0x%02x", status));
     }
 
-    uint16_t softwareVersion;
+    uint32_t softwareVersion;
     if (ConfigurationMgr().GetSoftwareVersion(softwareVersion) == CHIP_NO_ERROR)
     {
         status = Attributes::SoftwareVersion::Set(endpoint, softwareVersion);

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -86,7 +86,7 @@ public:
         mBdxDownloader      = downloader;
 
         uint32_t version;
-        VerifyOrDie(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(version) == CHIP_NO_ERROR);
+        ReturnOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(version));
         mCurrentVersion = version;
 
         OtaRequestorServerSetUpdateState(mCurrentUpdateState);

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -86,7 +86,7 @@ public:
         mBdxDownloader      = downloader;
 
         uint32_t version;
-        VerifyOrDie(app::Clusters::Basic::Attributes::SoftwareVersion::Get(kRootEndpointId, &version) == EMBER_ZCL_STATUS_SUCCESS);
+        VerifyOrDie(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(version) == CHIP_NO_ERROR);
         mCurrentVersion = version;
 
         OtaRequestorServerSetUpdateState(mCurrentUpdateState);

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -93,7 +93,7 @@ public:
     virtual CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf)                                    = 0;
     virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) = 0;
     virtual CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize)                         = 0;
-    virtual CHIP_ERROR GetSoftwareVersion(uint16_t & softwareVer)                                   = 0;
+    virtual CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer)                                   = 0;
     virtual CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode)                                     = 0;
     virtual CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator)                         = 0;
     // Lifetime counter is monotonic counter that is incremented only in the case of a factory reset

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -61,7 +61,7 @@ public:
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVer) override;
     CHIP_ERROR StoreHardwareVersion(uint16_t hardwareVer) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetSoftwareVersion(uint16_t & softwareVer) override;
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override;
     CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
@@ -157,7 +157,7 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductId(uin
 }
 
 template <class ConfigClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSoftwareVersion(uint16_t & softwareVer)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSoftwareVersion(uint32_t & softwareVer)
 {
     softwareVer = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION);
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -395,7 +395,7 @@ void PlatformManagerImpl::HandleDeviceRebooted(intptr_t arg)
     // The StartUp event SHALL be emitted by a Node after completing a boot or reboot process
     if (platformManagerDelegate != nullptr)
     {
-        uint16_t softwareVersion;
+        uint32_t softwareVersion;
 
         ReturnOnFailure(ConfigurationMgr().GetSoftwareVersion(softwareVersion));
         platformManagerDelegate->OnStartUp(softwareVersion);

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -195,7 +195,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetProductName(char * buf, size_t bufSize)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint16_t & softwareVer)
+CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint32_t & softwareVer)
 {
     CHIP_ERROR err;
     uint32_t u32SoftwareVer = 0;

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -44,7 +44,7 @@ public:
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetSoftwareVersion(uint16_t & softwareVer) override;
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     CHIP_ERROR GetNodeLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR StoreNodeLabel(const char * buf, size_t bufSize) override;
     CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -43,7 +43,7 @@ private:
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreHardwareVersion(uint16_t hardwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetSoftwareVersion(uint16_t & softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
#### Problem
OTA is setting the Basic cluster attribute upon `NotifyUpdateApplied` being called. This value should only be updated by the platform when it is running the new image. OTA (common SDK code) should be a consumer of this value to determine the current software version that is running. It should never modify it.

#### Change overview
- Remove any calls to update Basic cluster SoftwareVersion attribute
- Use the ConfigurationManager as the source of truth to read Basic cluster attributes (Basic cluster uses ConfigurationManager as the source of truth as well)

#### Testing
Manual testing of Linux provider/requestor case
