### PR TITLE
Fix Compile Error depend Glib version

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -44,6 +44,11 @@
 #include <signal.h>
 #include <unistd.h>
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
+#endif
+
 using namespace ::chip::app::Clusters;
 
 namespace chip {


### PR DESCRIPTION
#### Problem
* Fix Compile Error depend glib version.
* Some of arm compiler happend to compile error because don't support gettid() function.

#### Change overview
- gettid() code is depend on glib version, It should be fixed.


#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
-> It is compile test by Arm compiler