### PR TITLE
[Chip-Cert] Avoid Serialized packet loss (chip-cert genCert - Chip_Base64)

### DIFF
--- a/src/tools/chip-cert/KeyUtils.cpp
+++ b/src/tools/chip-cert/KeyUtils.cpp
@@ -244,11 +244,11 @@ bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt)
     FILE * file               = nullptr;
     uint8_t * keyToWrite      = nullptr;
     uint32_t keyToWriteLen    = 0;
-    uint32_t chipKeyLen       = kP256_PublicKey_Length + kP256_PrivateKey_Length;
+    P256SerializedKeypair serializedKeypair;
+    uint32_t chipKeyLen       = sizeof(serializedKeypair);
     uint32_t chipKeyBase64Len = BASE64_ENCODED_LEN(chipKeyLen);
     std::unique_ptr<uint8_t[]> chipKey(new uint8_t[chipKeyLen]);
     std::unique_ptr<uint8_t[]> chipKeyBase64(new uint8_t[chipKeyBase64Len]);
-    P256SerializedKeypair serializedKeypair;
 
     VerifyOrExit(key != nullptr, res = false);
 
@@ -282,7 +282,7 @@ bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt)
 
         if (keyFmt == kKeyFormat_Chip_Base64)
         {
-            res = Base64Encode(serializedKeypair, static_cast<uint32_t>(serializedKeypair.Length()), chipKeyBase64.get(),
+            res = Base64Encode(serializedKeypair, static_cast<uint32_t>(sizeof(serializedKeypair)), chipKeyBase64.get(),
                                chipKeyBase64Len, chipKeyBase64Len);
             VerifyTrueOrExit(res);
 

--- a/src/tools/chip-cert/KeyUtils.cpp
+++ b/src/tools/chip-cert/KeyUtils.cpp
@@ -240,10 +240,10 @@ exit:
 
 bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt)
 {
-    bool res                  = true;
-    FILE * file               = nullptr;
-    uint8_t * keyToWrite      = nullptr;
-    uint32_t keyToWriteLen    = 0;
+    bool res               = true;
+    FILE * file            = nullptr;
+    uint8_t * keyToWrite   = nullptr;
+    uint32_t keyToWriteLen = 0;
     P256SerializedKeypair serializedKeypair;
     uint32_t chipKeyLen       = sizeof(serializedKeypair);
     uint32_t chipKeyBase64Len = BASE64_ENCODED_LEN(chipKeyLen);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* When generate rootCA using chip-cert tool, Keypair is lost in chip_base64 mode.
  (Linux platform can't deserialize this result.)

#### Change overview
Change serializedKeyPair length.
In other Platforms, It is implemented like this:
https://github.com/project-chip/connectedhomeip/blob/master/src/controller/ExampleOperationalCredentialsIssuer.cpp#L52

#### Testing
How was this tested? (at least one bullet point required)
* Generate Key Pair (rootCA, NOC)
* Check to parse deserialize
