### PR TITLE
Add support to print long manual pairing code

### DIFF
--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -64,6 +64,15 @@ void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
     {
         ChipLogError(AppServer, "Getting manual pairing code failed!");
     }
+
+    if (GetLongManualPairingCode(manualPairingCode, aRendezvousFlags) == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "Long manual pairing code: [%s]", manualPairingCode.c_str());
+    }
+    else
+    {
+        ChipLogError(AppServer, "Getting long manual pairing code failed!");
+    }
 }
 
 void PrintOnboardingCodes(const chip::SetupPayload & payload)
@@ -211,6 +220,28 @@ CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::Rendezvo
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(AppServer, "Generating Manual Pairing Code failed: %s", chip::ErrorStr(err));
+        return err;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GetLongManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
+{
+    chip::SetupPayload payload;
+
+    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
+
+    payload.commissioningFlow = chip::CommissioningFlow::kCustom;
+    err                       = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "Generating long manual pairing code failed: %s", chip::ErrorStr(err));
         return err;
     }
 

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -26,6 +26,7 @@ CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRe
 CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetLongManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixed https://github.com/project-chip/connectedhomeip/issues/13661 Long manual pairing code.

#### Change overview
Previously, long pairing code was not showing in the log snippets, now it is available.

#### Testing
How was this tested? (at least one bullet point required)
* manually tested
* I (1160) chip[SVR]: Manual pairing code: [34970112332]
I (1160) chip[SVR]: Long Manual pairing code: [749701123309050177298]
