### PR TITLE
esp32: erase fabric information during factoryreset

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -286,6 +286,14 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 #elif CHIP_DEVICE_CONFIG_ENABLE_THREAD
     ThreadStackMgr().ErasePersistentInfo();
 #endif
+
+    // Erase all key-values including fabric info.
+    err = PersistedStorage::KeyValueStoreMgrImpl().EraseAll();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Clear Key-Value Storage failed");
+    }
+
     // Restart the system.
     ChipLogProgress(DeviceLayer, "System restarting");
     esp_restart();

--- a/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
@@ -87,6 +87,17 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR KeyValueStoreManagerImpl::EraseAll(void)
+{
+    Internal::ScopedNvsHandle handle;
+
+    ReturnErrorOnFailure(handle.Open(kNamespace, NVS_READWRITE));
+    ReturnMappedErrorOnFailure(nvs_erase_all(handle));
+    ReturnMappedErrorOnFailure(nvs_commit(handle));
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace PersistedStorage
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/KeyValueStoreManagerImpl.h
+++ b/src/platform/ESP32/KeyValueStoreManagerImpl.h
@@ -42,6 +42,8 @@ public:
 
     CHIP_ERROR _Put(const char * key, const void * value, size_t value_size);
 
+    CHIP_ERROR EraseAll(void);
+
 private:
     const char * kNamespace = "CHIP_KVS";
 


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/13720

The fabric info was not erased during factoryreset in ESP platform. After https://github.com/project-chip/connectedhomeip/pull/13181, the device only checks the fabric info and considers itself already commissioned even after factoryreset.

#### Change overview
Erase fabric information during factoryreset

#### Testing
Verified on m5stack.
