### PR TITLE
[Ameba] Update dockerfile for rotating_id support

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x \
     && cd ${AMEBA_DIR} \
     && git clone --progress -b cmake_build https://github.com/pankore/ambd_sdk_with_chip_non_NDA.git \
     && cd ambd_sdk_with_chip_non_NDA \
-    && git reset --hard 0eafdc7 \
+    && git reset --hard 4dc12dc \
     && git submodule update --depth 1 --init --progress \
     && cd project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/toolchain \
     && cat asdk/asdk-10.3.0-linux-newlib-build-3638-x86_64.tar.bz2.part* > asdk/asdk-10.3.0-linux-newlib-build-3638-x86_64.tar.bz2 \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.49 Version bump reason: [Ameba] Revise 'otar' to 'ota_requestor'
+0.5.50 Version bump reason: [Ameba] Support Rotating ID for BLE beaconing


### PR DESCRIPTION
#### Problem
* Support Rotating ID for BLE beaconing
* Fix auto-build error in 0.5.49

#### Change overview
* Add C3 characteristic for Rotating ID
* Revise build script to fix the auto-build error in 0.5.49

#### Testing
Tested docker build
