### PR TITLE
Fix the value of EMBER_BROADCAST_ENDPOINT.

### DIFF
--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -1555,12 +1555,6 @@ typedef struct
     uint32_t timeStamp;
 } EmberAfJoiningDevice;
 
-#define EMBER_AF_INVALID_CLUSTER_ID 0xFFFF
-
-#define EMBER_AF_INVALID_ENDPOINT 0xFF
-
-#define EMBER_AF_INVALID_PAN_ID 0xFFFF
-
 /**
  * @brief Permit join times
  */

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1725,7 +1725,7 @@ typedef struct
 /**
  * @brief The broadcast endpoint, as defined in the ZigBee spec.
  */
-#define EMBER_BROADCAST_ENDPOINT 0xFF
+#define EMBER_BROADCAST_ENDPOINT (chip::kInvalidEndpointId)
 
 /**
  * @brief Useful to reference a single bit of a byte.


### PR DESCRIPTION
0xFF is a valid endpoint id in Matter.

Also removes some unused "Invalid *" ids, which weren't the right
numerical values anyway.

#### Problem
Valid endpoint id used to represent a sentinel value.

#### Change overview
Use the the "invalid endpoint" value.

#### Testing
No behavior changes except if someone defines an endpoint numbered 255...