### PR TITLE
Add MatchesFabricIndex method to codec

### DIFF
--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -271,6 +271,16 @@ struct AccessControlEntryCodec
         return CHIP_NO_ERROR;
     }
 
+    bool MatchesFabricIndex(FabricIndex fabricIndex) const
+    {
+        FabricIndex entryFabricIndex;
+        if (entry.GetFabricIndex(entryFabricIndex) == CHIP_NO_ERROR)
+        {
+            return fabricIndex == entryFabricIndex;
+        }
+        return false;
+    }
+
     AccessControl::Entry entry;
 };
 


### PR DESCRIPTION
#### Problem
ACL not fabric filtered when read

#### Change overview
Add MatchesFabricIndex method to AccessControlEntryCodec

This is necessary for fabric filtered read to work, if using that
codec for encoding.

This is a quick fix, it may be preferable to move encoding to a
higher level to use more of the generated types, but that will
require more refactoring.

#### Testing
- Built and ran all-clusters-app with REPL on Linux
- Commissioned two fabrics and wrote ACL entries
- Verified each REPL could not read the other fabric's ACL entries