### PR TITLE
[EFR32] Enable SED build option

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -888,7 +888,6 @@ SDK's
 SDKs
 SDKTARGETSYSROOT
 sdl
-sed
 SED
 SEGGER
 semver

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -418,6 +418,7 @@ FreeRTOSConfig
 fsl
 fstab
 fsync
+ftd
 fullclean
 gbl
 gcloud
@@ -887,6 +888,8 @@ SDK's
 SDKs
 SDKTARGETSYSROOT
 sdl
+sed
+SED
 SEGGER
 semver
 sendto

--- a/examples/lighting-app/efr32/.gn
+++ b/examples/lighting-app/efr32/.gn
@@ -23,6 +23,6 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "freertos"
-
+  chip_openthread_ftd = true
   import("//args.gni")
 }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -47,7 +47,7 @@ declare_args() {
 
   # Enable Sleepy end device
   sleepy_device = false
-  
+
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false
   use_rs911x = false

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -46,7 +46,7 @@ declare_args() {
   enable_heap_monitoring = false
 
   # Enable Sleepy end device
-  sleepy_device = false
+  enable_sleepy_device = false
 
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -45,6 +45,9 @@ declare_args() {
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 
+  # Enable Sleepy end device
+  sleepy_device = false
+  
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false
   use_rs911x = false

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -105,7 +105,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=efr32_board="BRD4161A" sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=efr32_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RCP
 

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -85,7 +85,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
 
-OR use GN/Ninja directly
+    OR use GN/Ninja directly
 
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
@@ -99,7 +99,19 @@ OR use GN/Ninja directly
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ rm -rf out/
 
-*   Build the example with pigweed RCP use GN/Ninja Directly
+*   Build the example as Sleepy End Device (SED)
+
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32/ ./out/lighting-app_SED BRD4161A --sed
+
+    or use gn as previously mentioned but adding the following arguments:
+
+          $ gn gen out/debug '--args=efr32_board="BRD4161A" sleepy_device=true chip_openthread_ftd=false'
+
+*   Build the example with pigweed RCP
+
+          $ ./scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/lighting_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+
+    or use GN/Ninja Directly
 
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
@@ -109,6 +121,11 @@ OR use GN/Ninja directly
           $ ninja -C out/debug
 
     [Running Pigweed RPC console](#running-pigweed-rpc-console)
+
+For more build options, help is provided when running the build script without
+arguments
+
+         ./scripts/examples/gn_efr32_example.sh
 
 <a name="flashing"></a>
 

--- a/examples/lighting-app/efr32/args.gni
+++ b/examples/lighting-app/efr32/args.gni
@@ -21,5 +21,4 @@ efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
-chip_openthread_ftd = true
 chip_system_config_use_open_thread_udp = true

--- a/examples/lighting-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/lighting-app/efr32/include/FreeRTOSConfig.h
@@ -127,13 +127,12 @@ extern "C" {
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
 #else
 #define configUSE_TICKLESS_IDLE 0
-#endif //SL_CATALOG_POWER_MANAGER_PRESENT
+#endif // SL_CATALOG_POWER_MANAGER_PRESENT
 
 #define configTICK_RATE_HZ (1000)
 /* Definition used by Keil to replace default system clock source. */

--- a/examples/lighting-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/lighting-app/efr32/include/FreeRTOSConfig.h
@@ -127,34 +127,15 @@ extern "C" {
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-/* Set configCREATE_LOW_POWER_DEMO as follows:
- *
- * 0: Build the full test and demo application.
- * 1: Build the simple blinky tickless low power demo, generating the tick
- *    interrupt from the RTCC.  EM2 will be entered.  The LXFO clock is used.
- *  See the comments at the top of main.c, main_full.c and main_low_power.c for
- *  more information.
- */
-
-#define configCREATE_LOW_POWER_DEMO (0)
-
-/* Some configuration is dependent on the demo being built. */
-#if (configCREATE_LOW_POWER_DEMO == 0)
-
-/* Tickless mode is not used. */
-
-/* Some of the standard demo test tasks assume a tick rate of 1KHz, even
-though that is faster than would normally be warranted by a real
-application. */
-#define configTICK_RATE_HZ (1000)
 
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
 #else
 #define configUSE_TICKLESS_IDLE 0
-#endif
+#endif //SL_CATALOG_POWER_MANAGER_PRESENT
 
+#define configTICK_RATE_HZ (1000)
 /* Definition used by Keil to replace default system clock source. */
 #define configOVERRIDE_DEFAULT_TICK_CONFIGURATION 1
 
@@ -163,30 +144,6 @@ application. */
 #define configCHECK_FOR_STACK_OVERFLOW (2)
 #define configUSE_MALLOC_FAILED_HOOK (1)
 #define configUSE_IDLE_HOOK (1)
-
-#define configENERGY_MODE (sleepEM1)
-
-#else
-
-/* Tickless idle mode, generating RTOS tick interrupts from the RTC, fed
-by the LXFO clock. */
-
-/* The slow clock used to generate the tick interrupt in the low power demo
-runs at 32768/8=4096Hz.  Ensure the tick rate is a multiple of the clock. */
-#define configTICK_RATE_HZ (128)
-
-/* The low power demo uses the tickless idle feature. */
-#define configUSE_TICKLESS_IDLE (1)
-#define configOVERRIDE_DEFAULT_TICK_CONFIGURATION (1)
-
-/* Hook function related definitions. */
-#define configUSE_TICK_HOOK (0)
-#define configCHECK_FOR_STACK_OVERFLOW (0)
-#define configUSE_MALLOC_FAILED_HOOK (0)
-#define configUSE_IDLE_HOOK (1)
-
-#define configENERGY_MODE (sleepEM3)
-#endif
 
 /* Main functions*/
 /* Run time stats gathering related definitions. */

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -150,7 +150,14 @@ int main(void)
         appError(ret);
     }
 
+#if CHIP_DEVICE_CONFIG_THREAD_FTD
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
+#else // CHIP_DEVICE_CONFIG_THREAD_FTD
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+#endif // CHIP_DEVICE_CONFIG_THREAD_FTD
     if (ret != CHIP_NO_ERROR)
     {
         EFR32_LOG("ConnectivityMgr().SetThreadDeviceType() failed");

--- a/examples/lock-app/efr32/.gn
+++ b/examples/lock-app/efr32/.gn
@@ -23,6 +23,6 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "freertos"
-
+  chip_openthread_ftd = true
   import("//args.gni")
 }

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -43,7 +43,7 @@ declare_args() {
 
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
-  
+
   # Enable Sleepy end device
   sleepy_device = false
 

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -43,6 +43,9 @@ declare_args() {
 
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
+  
+  # Enable Sleepy end device
+  sleepy_device = false
 
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -45,7 +45,7 @@ declare_args() {
   enable_heap_monitoring = false
 
   # Enable Sleepy end device
-  sleepy_device = false
+  enable_sleepy_device = false
 
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -98,7 +98,6 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip/examples/lock-app/efr32
           $ rm -rf out/
 
-
 *   Build the example as Sleepy End Device (SED)
 
           $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32/ ./out/lighting-app_SED BRD4161A --sed

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -104,7 +104,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=efr32_board="BRD4161A" sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=efr32_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RCP
 

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -84,7 +84,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
 
-OR use GN/Ninja directly
+    OR use GN/Ninja directly
 
           $ cd ~/connectedhomeip/examples/lock-app/efr32
           $ git submodule update --init
@@ -97,6 +97,35 @@ OR use GN/Ninja directly
 
           $ cd ~/connectedhomeip/examples/lock-app/efr32
           $ rm -rf out/
+
+
+*   Build the example as Sleepy End Device (SED)
+
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32/ ./out/lighting-app_SED BRD4161A --sed
+
+    or use gn as previously mentioned but adding the following arguments:
+
+          $ gn gen out/debug '--args=efr32_board="BRD4161A" sleepy_device=true chip_openthread_ftd=false'
+
+*   Build the example with pigweed RCP
+
+          $ ./scripts/examples/gn_efr32_example.sh examples/lock-app/efr32/ out/lock_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+
+    or use GN/Ninja Directly
+
+          $ cd ~/connectedhomeip/examples/lock-app/efr32
+          $ git submodule update --init
+          $ source third_party/connectedhomeip/scripts/activate.sh
+          $ export EFR32_BOARD=BRD4161A
+          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+          $ ninja -C out/debug
+
+    [Running Pigweed RPC console](#running-pigweed-rpc-console)
+
+For more build options, help is provided when running the build script without
+arguments
+
+         ./scripts/examples/gn_efr32_example.sh
 
 <a name="flashing"></a>
 

--- a/examples/lock-app/efr32/args.gni
+++ b/examples/lock-app/efr32/args.gni
@@ -19,6 +19,5 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_openthread = true
-chip_openthread_ftd = true
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/lock-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/lock-app/efr32/include/FreeRTOSConfig.h
@@ -127,13 +127,12 @@ extern "C" {
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
 #else
 #define configUSE_TICKLESS_IDLE 0
-#endif //SL_CATALOG_POWER_MANAGER_PRESENT
+#endif // SL_CATALOG_POWER_MANAGER_PRESENT
 
 #define configTICK_RATE_HZ (1000)
 /* Definition used by Keil to replace default system clock source. */

--- a/examples/lock-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/lock-app/efr32/include/FreeRTOSConfig.h
@@ -127,34 +127,15 @@ extern "C" {
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-/* Set configCREATE_LOW_POWER_DEMO as follows:
- *
- * 0: Build the full test and demo application.
- * 1: Build the simple blinky tickless low power demo, generating the tick
- *    interrupt from the RTCC.  EM2 will be entered.  The LXFO clock is used.
- *  See the comments at the top of main.c, main_full.c and main_low_power.c for
- *  more information.
- */
-
-#define configCREATE_LOW_POWER_DEMO (0)
-
-/* Some configuration is dependent on the demo being built. */
-#if (configCREATE_LOW_POWER_DEMO == 0)
-
-/* Tickless mode is not used. */
-
-/* Some of the standard demo test tasks assume a tick rate of 1KHz, even
-though that is faster than would normally be warranted by a real
-application. */
-#define configTICK_RATE_HZ (1000)
 
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
 #else
 #define configUSE_TICKLESS_IDLE 0
-#endif
+#endif //SL_CATALOG_POWER_MANAGER_PRESENT
 
+#define configTICK_RATE_HZ (1000)
 /* Definition used by Keil to replace default system clock source. */
 #define configOVERRIDE_DEFAULT_TICK_CONFIGURATION 1
 
@@ -163,30 +144,6 @@ application. */
 #define configCHECK_FOR_STACK_OVERFLOW (2)
 #define configUSE_MALLOC_FAILED_HOOK (1)
 #define configUSE_IDLE_HOOK (1)
-
-#define configENERGY_MODE (sleepEM1)
-
-#else
-
-/* Tickless idle mode, generating RTOS tick interrupts from the RTC, fed
-by the LXFO clock. */
-
-/* The slow clock used to generate the tick interrupt in the low power demo
-runs at 32768/8=4096Hz.  Ensure the tick rate is a multiple of the clock. */
-#define configTICK_RATE_HZ (128)
-
-/* The low power demo uses the tickless idle feature. */
-#define configUSE_TICKLESS_IDLE (1)
-#define configOVERRIDE_DEFAULT_TICK_CONFIGURATION (1)
-
-/* Hook function related definitions. */
-#define configUSE_TICK_HOOK (0)
-#define configCHECK_FOR_STACK_OVERFLOW (0)
-#define configUSE_MALLOC_FAILED_HOOK (0)
-#define configUSE_IDLE_HOOK (1)
-
-#define configENERGY_MODE (sleepEM3)
-#endif
 
 /* Main functions*/
 /* Run time stats gathering related definitions. */

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -146,7 +146,14 @@ int main(void)
         appError(ret);
     }
 
+#if CHIP_DEVICE_CONFIG_THREAD_FTD
     ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
+#else // CHIP_DEVICE_CONFIG_THREAD_FTD
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+#endif // CHIP_DEVICE_CONFIG_THREAD_FTD
     if (ret != CHIP_NO_ERROR)
     {
         EFR32_LOG("ConnectivityMgr().SetThreadDeviceType() failed");

--- a/examples/platform/efr32/uart.cpp
+++ b/examples/platform/efr32/uart.cpp
@@ -32,6 +32,10 @@ extern "C" {
 #include <stddef.h>
 #include <string.h>
 
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif
+
 #if !defined(MIN)
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
 #endif
@@ -245,12 +249,23 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
         return UART_CONSOLE_ERR;
     }
 
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+    sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
+#endif
+
     // Use of ForceTransmit here. Transmit with DMA was causing errors with PW_RPC
     // TODO Use DMA and find/fix what causes the issue with PW
     if (UARTDRV_ForceTransmit(sl_uartdrv_usart_vcom_handle, (uint8_t *) Buf, BufLength) == ECODE_EMDRV_UARTDRV_OK)
     {
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+        sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
+#endif
         return BufLength;
     }
+
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+    sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
+#endif
 
     return UART_CONSOLE_ERR;
 }

--- a/examples/window-app/efr32/.gn
+++ b/examples/window-app/efr32/.gn
@@ -23,6 +23,6 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "freertos"
-
+  chip_openthread_ftd = true
   import("//args.gni")
 }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -38,6 +38,9 @@ declare_args() {
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 
+  # Enable Sleepy end device
+  sleepy_device = false
+  
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false
   use_rs911x = false

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -40,7 +40,7 @@ declare_args() {
 
   # Enable Sleepy end device
   sleepy_device = false
-  
+
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false
   use_rs911x = false

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -39,7 +39,7 @@ declare_args() {
   enable_heap_monitoring = false
 
   # Enable Sleepy end device
-  sleepy_device = false
+  enable_sleepy_device = false
 
   # Wifi related stuff - they are overriden by gn -args="use_wf200=true"
   use_wf200 = false

--- a/examples/window-app/efr32/README.md
+++ b/examples/window-app/efr32/README.md
@@ -109,7 +109,7 @@ Silicon Labs platform.
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=efr32_board="BRD4161A" sleepy_device=true chip_openthread_ftd=false'
+          $ gn gen out/debug '--args=efr32_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
 
 *   Build the example with pigweed RCP
 

--- a/examples/window-app/efr32/README.md
+++ b/examples/window-app/efr32/README.md
@@ -89,7 +89,7 @@ Silicon Labs platform.
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
 
-OR use GN/Ninja directly
+    OR use GN/Ninja directly
 
           $ cd ~/connectedhomeip/examples/window-app/efr32
           $ git submodule update --init
@@ -103,7 +103,19 @@ OR use GN/Ninja directly
           $ cd ~/connectedhomeip/examples/window-app/efr32
           $ rm -rf out/
 
-*   Build the example with pigweed RCP use GN/Ninja Directly
+*   Build the example as Sleepy End Device (SED)
+
+          $ ./scripts/examples/gn_efr32_example.sh ./examples/window-app/efr32/ ./out/window-app_SED BRD4161A --sed
+
+    or use gn as previously mentioned but adding the following arguments:
+
+          $ gn gen out/debug '--args=efr32_board="BRD4161A" sleepy_device=true chip_openthread_ftd=false'
+
+*   Build the example with pigweed RCP
+
+          $ ./scripts/examples/gn_efr32_example.sh examples/window-app/efr32/ out/window_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
+
+    or use GN/Ninja Directly
 
           $ cd ~/connectedhomeip/examples/window-app/efr32
           $ git submodule update --init
@@ -113,6 +125,11 @@ OR use GN/Ninja directly
           $ ninja -C out/debug
 
     [Running Pigweed RPC console](#running-pigweed-rpc-console)
+
+For more build options, help is provided when running the build script without
+arguments
+
+         ./scripts/examples/gn_efr32_example.sh
 
 <a name="flashing"></a>
 

--- a/examples/window-app/efr32/args.gni
+++ b/examples/window-app/efr32/args.gni
@@ -21,4 +21,3 @@ efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
-chip_openthread_ftd = true

--- a/examples/window-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/window-app/efr32/include/FreeRTOSConfig.h
@@ -127,13 +127,12 @@ extern "C" {
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
 #else
 #define configUSE_TICKLESS_IDLE 0
-#endif //SL_CATALOG_POWER_MANAGER_PRESENT
+#endif // SL_CATALOG_POWER_MANAGER_PRESENT
 
 #define configTICK_RATE_HZ (1000)
 /* Definition used by Keil to replace default system clock source. */

--- a/examples/window-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/window-app/efr32/include/FreeRTOSConfig.h
@@ -127,34 +127,15 @@ extern "C" {
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-/* Set configCREATE_LOW_POWER_DEMO as follows:
- *
- * 0: Build the full test and demo application.
- * 1: Build the simple blinky tickless low power demo, generating the tick
- *    interrupt from the RTCC.  EM2 will be entered.  The LXFO clock is used.
- *  See the comments at the top of main.c, main_full.c and main_low_power.c for
- *  more information.
- */
-
-#define configCREATE_LOW_POWER_DEMO (0)
-
-/* Some configuration is dependent on the demo being built. */
-#if (configCREATE_LOW_POWER_DEMO == 0)
-
-/* Tickless mode is not used. */
-
-/* Some of the standard demo test tasks assume a tick rate of 1KHz, even
-though that is faster than would normally be warranted by a real
-application. */
-#define configTICK_RATE_HZ (1000)
 
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
 #else
 #define configUSE_TICKLESS_IDLE 0
-#endif
+#endif //SL_CATALOG_POWER_MANAGER_PRESENT
 
+#define configTICK_RATE_HZ (1000)
 /* Definition used by Keil to replace default system clock source. */
 #define configOVERRIDE_DEFAULT_TICK_CONFIGURATION 1
 
@@ -163,30 +144,6 @@ application. */
 #define configCHECK_FOR_STACK_OVERFLOW (2)
 #define configUSE_MALLOC_FAILED_HOOK (1)
 #define configUSE_IDLE_HOOK (1)
-
-#define configENERGY_MODE (sleepEM1)
-
-#else
-
-/* Tickless idle mode, generating RTOS tick interrupts from the RTC, fed
-by the LXFO clock. */
-
-/* The slow clock used to generate the tick interrupt in the low power demo
-runs at 32768/8=4096Hz.  Ensure the tick rate is a multiple of the clock. */
-#define configTICK_RATE_HZ (128)
-
-/* The low power demo uses the tickless idle feature. */
-#define configUSE_TICKLESS_IDLE (1)
-#define configOVERRIDE_DEFAULT_TICK_CONFIGURATION (1)
-
-/* Hook function related definitions. */
-#define configUSE_TICK_HOOK (0)
-#define configCHECK_FOR_STACK_OVERFLOW (0)
-#define configUSE_MALLOC_FAILED_HOOK (0)
-#define configUSE_IDLE_HOOK (1)
-
-#define configENERGY_MODE (sleepEM3)
-#endif
 
 /* Main functions*/
 /* Run time stats gathering related definitions. */

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -382,7 +382,10 @@ void WindowAppImpl::UpdateLCD()
     }
     else
     {
-        LCDWriteQRCode((uint8_t *) mQRCode.c_str());
+        if (GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
+        {
+            LCDWriteQRCode((uint8_t *) mQRCode.c_str());
+        }
     }
 #endif
 }

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -131,7 +131,14 @@ int main(void)
         appError(err);
     }
 
+#if CHIP_DEVICE_CONFIG_THREAD_FTD
     err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
+#else // CHIP_DEVICE_CONFIG_THREAD_FTD
+#if CHIP_DEVICE_CONFIG_ENABLE_SED
+    err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+    err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+#endif // CHIP_DEVICE_CONFIG_THREAD_FTD
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("ConnectivityMgr().SetThreadDeviceType() failed");

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -23,79 +23,133 @@ source "$(dirname "$0")/../../scripts/activate.sh"
 
 set -x
 env
-USE_WF200=0
-USE_RS911X=0
-USE_WIFI=0
+USE_WIFI=false
 
-ROOT=$1
-arg2=$2
-shift
-shift
-while [ $# -gt 0 ]; do
-    case $1 in
-        --wifi)
-            if [ -z "$2" ]; then
-                echo "--efr requires BRDxxxx"
-                exit 1
-            fi
-            if [ X"$2" = "Xrs911x" ]; then
-                WIFI_ARGS="use_rs911x=true"
-            elif [ "$2" = wf200 ]; then
-                WIFI_ARGS="use_wf200=true"
-            else
-                echo "Wifi usage: --wifi rs911x|wf200"
-                exit 1
-            fi
-            shift
-            shift
+USAGE="./scripts/examples/gn_efr32_example.sh <AppRootFolder> <outputFolder> <efr32_board_name> [<Build options>]"
 
-            ;;
-        --efr)
-            if [ -z "$2" ]; then
-                echo "--efr requires BRDxxxx"
-                exit 1
-            fi
-            EFR32_BOARD=$2
-            shift
-            shift
-            ;;
+if [ "$#" == "0" ]; then
+    echo "Build script for EFR32 Matter apps
+    Format:
+    $USAGE
 
-        --gnargs)
-            echo "-gnargs - Not yet implemented"
-            exit 1
-            GNARGS=$2
-            shift
-            shift
-            ;;
+    <AppRootFolder>
+        Root Location of the app e.g: examples/lighting-app/efr32/
 
-        *)
-            EFR32_BOARD=$1
-            shift
-            if [ X"$1" != "X" ]; then
-                GNARGS=$1
-                shift
-            fi
-            ;;
-    esac
-done
+    <outputFolder>
+        Desired location for the output files
 
-if [ X"$EFR32_BOARD" = "X" ]; then
-    echo "EFR32_BOARD not defined"
-    exit 1
-fi
-BUILD_DIR=$arg2/$EFR32_BOARD
-echo BUILD_DIR="$BUILD_DIR"
-if [ "X$WIFI_ARGS" != "X" ]; then
-    gn gen --check --fail-on-unused-args --root="$ROOT" --dotfile="$ROOT"/build_for_wifi_gnfile.gn --args="efr32_board=\"$EFR32_BOARD\" $WIFI_ARGS" "$BUILD_DIR"
+    <efr32_board_name>
+        Identifier of the board for which this app is built
+        Currently Supported :
+            BRD4161A
+            BRD4163A
+            BRD4164A
+            BRD4166A
+            BRD4170A
+            BRD4186A
+            BRD4187A
+            BRD4304A
+
+    <Build options> - optional noteworthy build options for EFR32
+        chip_build_libshell
+            Enable libshell support. (Default false)
+        chip_logging
+            Current value (Default true)
+        chip_openthread_ftd
+            Use openthread Full Thread Device, else, use Minimal Thread Device. (Default true)
+        efr32_sdk_root
+            Location for an alternate or modified efr32 SDK
+        enable_heap_monitoring
+            Monitor & log memory usage at runtime. (Default false)
+        setupDiscriminator
+            Discriminatoor value used for BLE connexion. (Default 3840)
+        setupPinCode
+            PIN code for PASE session establishment. (Default 73141520)
+        sleepy_device
+            Enable Sleepy end device. (Default false)
+            Must also set chip_openthread_ftd=false
+        use_rs911x
+            Build wifi example with extension board rs911x. (Default false)
+        use_wf200
+            Build wifi example with extension board wf200. (Default false)
+        'import("//with_pw_rpc.gni")'
+            Use to build the example with pigweed RPC
+
+        Presets
+        --sed
+            enable sleepy end device and set thread mtd
+        --wifi <wf200 | rs911x>
+            build wifi example variant for given exansion board
+    "
+elif [ "$#" -lt "2" ]; then
+    echo "Invalid number of arguments
+    Format:
+    $USAGE"
 else
-    # thread build
-    #
-    if [ -z "$GNARGS" ]; then
-        gn gen --check --fail-on-unused-args --root="$ROOT" --args="efr32_board=\"$EFR32_BOARD\"" "$BUILD_DIR"
-    else
-        gn gen --check --fail-on-unused-args --root="$ROOT" --args="efr32_board=\"$EFR32_BOARD\" $GNARGS" "$BUILD_DIR"
+    ROOT=$1
+    OUTDIR=$2
+
+    if [ "$#" -gt "2" ]; then
+        EFR32_BOARD=$3
+        shift
     fi
+
+    shift
+    shift
+    while [ $# -gt 0 ]; do
+        case $1 in
+            --wifi)
+                if [ -z "$2" ]; then
+                    echo "--wifi requires rs911x or wf200"
+                    exit 1
+                fi
+                if [ "$2" = "rs911x" ]; then
+                    optArgs+="use_rs911x=true"
+                elif [ "$2" = "wf200" ]; then
+                    optArgs+="use_wf200=true"
+                else
+                    echo "Wifi usage: --wifi rs911x|wf200"
+                    exit 1
+                fi
+                USE_WIFI=true
+                shift
+                shift
+                ;;
+            --sed)
+                optArgs+="sleepy_device=true chip_openthread_ftd=false "
+                shift
+                ;;
+            *)
+                if [ "$1" =~ *"use_rs911x=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
+                    USE_WIFI=true
+                fi
+
+                optArgs+=$1" "
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$EFR32_BOARD" ]; then
+        echo "EFR32_BOARD not defined"
+        exit 1
+    fi
+
+    BUILD_DIR=$OUTDIR/$EFR32_BOARD
+    echo BUILD_DIR="$BUILD_DIR"
+    if [ "$USE_WIFI" == true ]; then
+        gn gen --check --fail-on-unused-args --root="$ROOT" --dotfile="$ROOT"/build_for_wifi_gnfile.gn --args="efr32_board=\"$EFR32_BOARD\" $optArgs" "$BUILD_DIR"
+    else
+        # thread build
+        #
+        if [ -z "$optArgs" ]; then
+            gn gen --check --fail-on-unused-args --root="$ROOT" --args="efr32_board=\"$EFR32_BOARD\"" "$BUILD_DIR"
+        else
+            gn gen --check --fail-on-unused-args --root="$ROOT" --args="efr32_board=\"$EFR32_BOARD\" $optArgs" "$BUILD_DIR"
+        fi
+    fi
+    ninja -v -C "$BUILD_DIR"/
+    #print stats
+    arm-none-eabi-size -A "$BUILD_DIR"/*.out
+
 fi
-ninja -v -C "$BUILD_DIR"/
-#print stats
-arm-none-eabi-size -A "$BUILD_DIR"/*.out

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -65,7 +65,7 @@ if [ "$#" == "0" ]; then
             Discriminatoor value used for BLE connexion. (Default 3840)
         setupPinCode
             PIN code for PASE session establishment. (Default 73141520)
-        sleepy_device
+        enable_sleepy_device
             Enable Sleepy end device. (Default false)
             Must also set chip_openthread_ftd=false
         use_rs911x
@@ -116,7 +116,7 @@ else
                 shift
                 ;;
             --sed)
-                optArgs+="sleepy_device=true chip_openthread_ftd=false "
+                optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
                 shift
                 ;;
             *)

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -91,7 +91,7 @@ void ExchangeContext::UpdateSEDPollingMode()
     Transport::Session::SessionType sessType = sessionHandle->GetSessionType();
 
     // During PASE session, which happen on BLE, the session is kUnauthenticated
-    // So AsSecureSession() ends up faulting the sytem
+    // So AsSecureSession() ends up faulting the system
     if (sessType != Transport::Session::SessionType::kUnauthenticated)
     {
         if (sessionHandle->AsSecureSession()->GetPeerAddress().GetTransportType() != Transport::Type::kBle)

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -87,15 +87,23 @@ void ExchangeContext::SetResponseTimeout(Timeout timeout)
 #if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
 void ExchangeContext::UpdateSEDPollingMode()
 {
-    if (GetSessionHandle()->AsSecureSession()->GetPeerAddress().GetTransportType() != Transport::Type::kBle)
+    SessionHandle sessionHandle              = GetSessionHandle();
+    Transport::Session::SessionType sessType = sessionHandle->GetSessionType();
+
+    // During PASE session, which happen on BLE, the session is kUnauthenticated
+    // So AsSecureSession() ends up faulting the sytem
+    if (sessType != Transport::Session::SessionType::kUnauthenticated)
     {
-        if (!IsResponseExpected() && !IsSendExpected() && (mExchangeMgr->GetNumActiveExchanges() == 1))
+        if (sessionHandle->AsSecureSession()->GetPeerAddress().GetTransportType() != Transport::Type::kBle)
         {
-            chip::DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(false);
-        }
-        else
-        {
-            chip::DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(true);
+            if (!IsResponseExpected() && !IsSendExpected() && (mExchangeMgr->GetNumActiveExchanges() == 1))
+            {
+                chip::DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(false);
+            }
+            else
+            {
+                chip::DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(true);
+            }
         }
     }
 }

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -152,6 +152,18 @@ template("efr32_sdk") {
 
     defines += board_defines
 
+    if (defined(invoker.sleepy_device))
+    {
+      if (invoker.sleepy_device) {
+        print("INVOKER SLEEPY")
+        defines += [
+          "CHIP_DEVICE_CONFIG_ENABLE_SED=1",
+          "SL_CATALOG_POWER_MANAGER_PRESENT",
+          "SL_CATALOG_SLEEPTIMER_PRESENT",
+          ]
+      }
+    } 
+
     if (chip_build_libshell) {
       defines += [
         "ENABLE_CHIP_SHELL",

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -152,17 +152,15 @@ template("efr32_sdk") {
 
     defines += board_defines
 
-    if (defined(invoker.sleepy_device))
-    {
+    if (defined(invoker.sleepy_device)) {
       if (invoker.sleepy_device) {
-        print("INVOKER SLEEPY")
         defines += [
           "CHIP_DEVICE_CONFIG_ENABLE_SED=1",
           "SL_CATALOG_POWER_MANAGER_PRESENT",
           "SL_CATALOG_SLEEPTIMER_PRESENT",
-          ]
+        ]
       }
-    } 
+    }
 
     if (chip_build_libshell) {
       defines += [
@@ -438,6 +436,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/croutine.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/event_groups.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/list.c",
+      "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/queue.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/stream_buffer.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/tasks.c",

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -436,12 +436,19 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/croutine.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/event_groups.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/list.c",
-      "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/queue.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/stream_buffer.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/tasks.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/timers.c",
     ]
+
+    if (defined(invoker.sleepy_device)) {
+      if (invoker.sleepy_device) {
+        sources += [
+          "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c",
+        ]
+      }
+    }
 
     if (defined(enable_fem)) {
       sources += [

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -444,9 +444,7 @@ template("efr32_sdk") {
 
     if (defined(invoker.sleepy_device)) {
       if (invoker.sleepy_device) {
-        sources += [
-          "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c",
-        ]
+        sources += [ "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c" ]
       }
     }
 

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -152,8 +152,8 @@ template("efr32_sdk") {
 
     defines += board_defines
 
-    if (defined(invoker.sleepy_device)) {
-      if (invoker.sleepy_device) {
+    if (defined(invoker.enable_sleepy_device)) {
+      if (invoker.enable_sleepy_device) {
         defines += [
           "CHIP_DEVICE_CONFIG_ENABLE_SED=1",
           "SL_CATALOG_POWER_MANAGER_PRESENT",
@@ -442,8 +442,8 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/timers.c",
     ]
 
-    if (defined(invoker.sleepy_device)) {
-      if (invoker.sleepy_device) {
+    if (defined(invoker.enable_sleepy_device)) {
+      if (invoker.enable_sleepy_device) {
         sources += [ "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/SiliconLabs/tick_power_manager.c" ]
       }
     }


### PR DESCRIPTION
#### Problem
EFR32 examples do not support Sleepy end device

#### Change overview
- Add power manager and enable for efr32 device to handle the available sleep modes 
- Add the support for Matter Sleep End Device in efr32 examples
- Re-work efr32 build script to simplify building the examples with different configurations

#### Testing
- Build Light and lock examples as SED.
- Commission the device using chip-tool and send a few commands over a few minutes
