### PR TITLE
Update OTAProviderExample with flexible-image selection logic

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -146,6 +146,7 @@ CCMP
 CCS
 CCSTUDIO
 CCXML
+CDVersionNumber
 ced
 cfg
 CFLAGS
@@ -267,6 +268,7 @@ DBUILD
 dbus
 dcc
 DCHIP
+DCL
 DCMAKE
 DCONFIG
 debianutils
@@ -605,6 +607,7 @@ MatterLock
 matterSdkSourceBuild
 matterSourceBuildAbiFilters
 matterUTestLib
+maxApplicableSoftwareVersion
 MaxInterval
 MaxIntervalCeilingSeconds
 MaxRtrAdvInterval
@@ -640,6 +643,7 @@ microcontroller
 microcontrollers
 MicroSD
 middleware
+minApplicableSoftwareVersion
 Minicom
 MinInterval
 MinIntervalFloorSeconds
@@ -729,6 +733,7 @@ optionsOverride
 orgs
 OTA
 OTADownloader
+otaImageList
 OTAImageProcessorDriver
 OTAImageProcessorInterface
 OTAProvider
@@ -740,6 +745,7 @@ OTARequestor
 OTARequestorDriver
 OTARequestorSerialPort
 otasoftwareupdaterequestor
+otaURL
 OTBR
 otcli
 PAA
@@ -929,6 +935,7 @@ softmmu
 SoftwareDiagnostics
 SoftwareVersion
 SoftwareVersionString
+softwareVersionValid
 SPI
 spinel
 src

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -293,6 +293,7 @@ DeviceLayer
 DeviceNetworkProvisioningDelegate
 DeviceNetworkProvisioningDelegateImpl
 DevicePairingDelegate
+deviceSoftwareVersionModel
 DevKitC
 DevKitM
 df

--- a/examples/ota-provider-app/linux/BUILD.gn
+++ b/examples/ota-provider-app/linux/BUILD.gn
@@ -27,10 +27,7 @@ executable("chip-ota-provider-app") {
     "${chip_root}/third_party/jsoncpp",
   ]
 
-  cflags = [
-    "-Wconversion",
-    "-ljsoncpp",
-  ]
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/ota-provider-app/linux/BUILD.gn
+++ b/examples/ota-provider-app/linux/BUILD.gn
@@ -24,9 +24,10 @@ executable("chip-ota-provider-app") {
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib",
     "${chip_root}/src/protocols/bdx",
+    "${chip_root}/third_party/jsoncpp",
   ]
 
-  cflags = [ "-Wconversion" ]
+  cflags = [ "-Wconversion", "-ljsoncpp" ]
 
   output_dir = root_out_dir
 }

--- a/examples/ota-provider-app/linux/BUILD.gn
+++ b/examples/ota-provider-app/linux/BUILD.gn
@@ -27,7 +27,10 @@ executable("chip-ota-provider-app") {
     "${chip_root}/third_party/jsoncpp",
   ]
 
-  cflags = [ "-Wconversion", "-ljsoncpp" ]
+  cflags = [
+    "-Wconversion",
+    "-ljsoncpp",
+  ]
 
   output_dir = root_out_dir
 }

--- a/examples/ota-provider-app/linux/README.md
+++ b/examples/ota-provider-app/linux/README.md
@@ -10,13 +10,36 @@ Suggest doing the following:
 
 ## Usage
 
-`./ota-provider-app [-f/--filepath \<file\>]`
+`./ota-provider-app [-f/--filepath \<file\>] [-o/--otaImageList \<file\>]`
 
 If `--filepath` is supplied, `ota-provider-app` will automatically serve that
 file to the OTA Requestor (SoftwareVersion will be Requester version + 1).
 
-If no `--filepath` is supplied, `ota-provider-app` will respond to `QueryImage`
-with `NotAvailable` status.
+If `--otaImageList` is supplied, `ota-provider-app` will parse the CSV file and
+extract all required data. Then the most recent software version will be
+selected and sent to the OTA Requestor.
+
+The `ota-provider-app`'s Basic CSV parser expects a precise format - Device
+Software Version Model Schema (lines beginning with # are ignored).
+
+vendorId,productId,softwareVersion,softwareVersionString,CDVersionNumber,
+softwareVersionValid,minApplicableSoftwareVersion,maxApplicableSoftwareVersion,otaURL
+
+Here's an example of the otaImageList file contents:
+
+#vendorId,productId,softwareVersion,softwareVersionString,CDVersionNumber,softwareVersionValid,minApplicableSoftwareVersion,maxApplicableSoftwareVersion,otaURL
+1,1,10,Version_1,18,true,0,100,/tmp/ota.txt
+1,1,20,Version_2,14,true,0,100,/tmp/ota.txt
+1,1,30,Version_3,49,true,0,100,/tmp/ota.txt
+1,1,40,Version_4,10,true,0,100,/tmp/ota.txt
+1,1,50,Version_5,23,true,0,100,/tmp/ota.txt
+
+TODO: Replace with a JSON file for simpler parsing. The idea is that the
+contents of the response from the DCL server will be populated into this file
+appropriately.
+
+If neither `--filepath` nor `--otaImageList` are supplied, `ota-provider-app`
+will respond to `QueryImage` with `NotAvailable` status.
 
 ## Current Features/Limitations
 

--- a/examples/ota-provider-app/linux/README.md
+++ b/examples/ota-provider-app/linux/README.md
@@ -15,28 +15,73 @@ Suggest doing the following:
 If `--filepath` is supplied, `ota-provider-app` will automatically serve that
 file to the OTA Requestor (SoftwareVersion will be Requester version + 1).
 
-If `--otaImageList` is supplied, `ota-provider-app` will parse the CSV file and
-extract all required data. Then the most recent software version will be
-selected and sent to the OTA Requestor.
+If `--otaImageList` is supplied, `ota-provider-app` will parse the JSON file and
+extract all required data. Then the most recent, valid software version will be
+selected and the corresponding ota-file will be sent to the OTA Requestor.
 
-The `ota-provider-app`'s Basic CSV parser expects a precise format - Device
-Software Version Model Schema (lines beginning with # are ignored).
-
-vendorId,productId,softwareVersion,softwareVersionString,CDVersionNumber,
-softwareVersionValid,minApplicableSoftwareVersion,maxApplicableSoftwareVersion,otaURL
 
 Here's an example of the otaImageList file contents:
 
-#vendorId,productId,softwareVersion,softwareVersionString,CDVersionNumber,softwareVersionValid,minApplicableSoftwareVersion,maxApplicableSoftwareVersion,otaURL
-1,1,10,Version_1,18,true,0,100,/tmp/ota.txt
-1,1,20,Version_2,14,true,0,100,/tmp/ota.txt
-1,1,30,Version_3,49,true,0,100,/tmp/ota.txt
-1,1,40,Version_4,10,true,0,100,/tmp/ota.txt
-1,1,50,Version_5,23,true,0,100,/tmp/ota.txt
-
-TODO: Replace with a JSON file for simpler parsing. The idea is that the
-contents of the response from the DCL server will be populated into this file
-appropriately.
+{
+    "foo": 1, // ignored by parser
+    "deviceSoftwareVersionModel": [
+        {
+            "vendorId": 1,
+            "productId": 1,
+            "softwareVersion": 10,
+            "softwareVersionString": "1.0.0",
+            "CDVersionNumber": 18,
+            "softwareVersionValid": true,
+            "minApplicableSoftwareVersion": 0,
+            "maxApplicableSoftwareVersion": 100,
+            "otaURL": "/tmp/ota.txt"
+        },
+        {
+            "vendorId": 1,
+            "productId": 1,
+            "softwareVersion": 20,
+            "softwareVersionString": "1.0.1",
+            "CDVersionNumber": 18,
+            "softwareVersionValid": false,
+            "minApplicableSoftwareVersion": 0,
+            "maxApplicableSoftwareVersion": 100,
+            "otaURL": "/tmp/ota.txt"
+        },
+        {
+            "vendorId": 1,
+            "productId": 1,
+            "softwareVersion": 30,
+            "softwareVersionString": "1.0.2",
+            "CDVersionNumber": 18,
+            "softwareVersionValid": true,
+            "minApplicableSoftwareVersion": 0,
+            "maxApplicableSoftwareVersion": 100,
+            "otaURL": "/tmp/ota.txt"
+        },
+        {
+            "vendorId": 1,
+            "productId": 1,
+            "softwareVersion": 40,
+            "softwareVersionString": "1.1.0",
+            "CDVersionNumber": 18,
+            "softwareVersionValid": true,
+            "minApplicableSoftwareVersion": 0,
+            "maxApplicableSoftwareVersion": 100,
+            "otaURL": "/tmp/ota.txt"
+        },
+        {
+            "vendorId": 1,
+            "productId": 1,
+            "softwareVersion": 50,
+            "softwareVersionString": "1.1.1",
+            "CDVersionNumber": 18,
+            "softwareVersionValid": false,
+            "minApplicableSoftwareVersion": 0,
+            "maxApplicableSoftwareVersion": 100,
+            "otaURL": "/tmp/ota.txt"
+        }
+    ]
+}
 
 If neither `--filepath` nor `--otaImageList` are supplied, `ota-provider-app`
 will respond to `QueryImage` with `NotAvailable` status.

--- a/examples/ota-provider-app/linux/README.md
+++ b/examples/ota-provider-app/linux/README.md
@@ -23,21 +23,21 @@ Here's an example of the otaImageList file contents:
 
 { "foo": 1, // ignored by parser "deviceSoftwareVersionModel": [ { "vendorId":
 1, "productId": 1, "softwareVersion": 10, "softwareVersionString": "1.0.0",
-"CDVersionNumber": 18, "softwareVersionValid": true,
+"cDVersionNumber": 18, "softwareVersionValid": true,
 "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
 "otaURL": "/tmp/ota.txt" }, { "vendorId": 1, "productId": 1, "softwareVersion":
-20, "softwareVersionString": "1.0.1", "CDVersionNumber": 18,
+20, "softwareVersionString": "1.0.1", "cDVersionNumber": 18,
 "softwareVersionValid": false, "minApplicableSoftwareVersion": 0,
 "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }, { "vendorId":
 1, "productId": 1, "softwareVersion": 30, "softwareVersionString": "1.0.2",
-"CDVersionNumber": 18, "softwareVersionValid": true,
+"cDVersionNumber": 18, "softwareVersionValid": true,
 "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
 "otaURL": "/tmp/ota.txt" }, { "vendorId": 1, "productId": 1, "softwareVersion":
-40, "softwareVersionString": "1.1.0", "CDVersionNumber": 18,
+40, "softwareVersionString": "1.1.0", "cDVersionNumber": 18,
 "softwareVersionValid": true, "minApplicableSoftwareVersion": 0,
 "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }, { "vendorId":
 1, "productId": 1, "softwareVersion": 50, "softwareVersionString": "1.1.1",
-"CDVersionNumber": 18, "softwareVersionValid": false,
+"cDVersionNumber": 18, "softwareVersionValid": false,
 "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
 "otaURL": "/tmp/ota.txt" } ] }
 

--- a/examples/ota-provider-app/linux/README.md
+++ b/examples/ota-provider-app/linux/README.md
@@ -19,69 +19,27 @@ If `--otaImageList` is supplied, `ota-provider-app` will parse the JSON file and
 extract all required data. Then the most recent, valid software version will be
 selected and the corresponding ota-file will be sent to the OTA Requestor.
 
-
 Here's an example of the otaImageList file contents:
 
-{
-    "foo": 1, // ignored by parser
-    "deviceSoftwareVersionModel": [
-        {
-            "vendorId": 1,
-            "productId": 1,
-            "softwareVersion": 10,
-            "softwareVersionString": "1.0.0",
-            "CDVersionNumber": 18,
-            "softwareVersionValid": true,
-            "minApplicableSoftwareVersion": 0,
-            "maxApplicableSoftwareVersion": 100,
-            "otaURL": "/tmp/ota.txt"
-        },
-        {
-            "vendorId": 1,
-            "productId": 1,
-            "softwareVersion": 20,
-            "softwareVersionString": "1.0.1",
-            "CDVersionNumber": 18,
-            "softwareVersionValid": false,
-            "minApplicableSoftwareVersion": 0,
-            "maxApplicableSoftwareVersion": 100,
-            "otaURL": "/tmp/ota.txt"
-        },
-        {
-            "vendorId": 1,
-            "productId": 1,
-            "softwareVersion": 30,
-            "softwareVersionString": "1.0.2",
-            "CDVersionNumber": 18,
-            "softwareVersionValid": true,
-            "minApplicableSoftwareVersion": 0,
-            "maxApplicableSoftwareVersion": 100,
-            "otaURL": "/tmp/ota.txt"
-        },
-        {
-            "vendorId": 1,
-            "productId": 1,
-            "softwareVersion": 40,
-            "softwareVersionString": "1.1.0",
-            "CDVersionNumber": 18,
-            "softwareVersionValid": true,
-            "minApplicableSoftwareVersion": 0,
-            "maxApplicableSoftwareVersion": 100,
-            "otaURL": "/tmp/ota.txt"
-        },
-        {
-            "vendorId": 1,
-            "productId": 1,
-            "softwareVersion": 50,
-            "softwareVersionString": "1.1.1",
-            "CDVersionNumber": 18,
-            "softwareVersionValid": false,
-            "minApplicableSoftwareVersion": 0,
-            "maxApplicableSoftwareVersion": 100,
-            "otaURL": "/tmp/ota.txt"
-        }
-    ]
-}
+{ "foo": 1, // ignored by parser "deviceSoftwareVersionModel": [ { "vendorId":
+1, "productId": 1, "softwareVersion": 10, "softwareVersionString": "1.0.0",
+"CDVersionNumber": 18, "softwareVersionValid": true,
+"minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
+"otaURL": "/tmp/ota.txt" }, { "vendorId": 1, "productId": 1, "softwareVersion":
+20, "softwareVersionString": "1.0.1", "CDVersionNumber": 18,
+"softwareVersionValid": false, "minApplicableSoftwareVersion": 0,
+"maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }, { "vendorId":
+1, "productId": 1, "softwareVersion": 30, "softwareVersionString": "1.0.2",
+"CDVersionNumber": 18, "softwareVersionValid": true,
+"minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
+"otaURL": "/tmp/ota.txt" }, { "vendorId": 1, "productId": 1, "softwareVersion":
+40, "softwareVersionString": "1.1.0", "CDVersionNumber": 18,
+"softwareVersionValid": true, "minApplicableSoftwareVersion": 0,
+"maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }, { "vendorId":
+1, "productId": 1, "softwareVersion": 50, "softwareVersionString": "1.1.1",
+"CDVersionNumber": 18, "softwareVersionValid": false,
+"minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
+"otaURL": "/tmp/ota.txt" } ] }
 
 If neither `--filepath` nor `--otaImageList` are supplied, `ota-provider-app`
 will respond to `QueryImage` with `NotAvailable` status.

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -35,6 +35,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
 
 using chip::BitFlags;
@@ -50,29 +51,115 @@ using chip::Messaging::ExchangeManager;
 constexpr chip::EndpointId kOtaProviderEndpoint = 0;
 
 constexpr uint16_t kOptionFilepath             = 'f';
+constexpr uint16_t kOptionOtaImageList         = 'o';
 constexpr uint16_t kOptionQueryImageBehavior   = 'q';
 constexpr uint16_t kOptionDelayedActionTimeSec = 'd';
 
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
-OTAProviderExample::QueryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
-uint32_t gDelayedActionTimeSec                                 = 0;
-const char * gOtaFilepath                                      = nullptr;
+static OTAProviderExample::QueryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
+static uint32_t gDelayedActionTimeSec                                 = 0;
+static const char * gOtaFilepath                                      = nullptr;
+static const char * gOtaImageListFilepath                             = nullptr;
+
+// Basic CSV parser that expects a precise format - Device Software Version Model Schema.
+// vendorId,productId,softwareVersion,softwareVersionString,CDVersionNumber,softwareVersionValid,minApplicableSoftwareVersion,maxApplicableSoftwareVersion,otaURL
+// Example of file contents:
+// 1,1,10,Version_1,18,true,0,100,/tmp/ota1.txt
+// 1,1,20,Version_2,45,false,4,123,/tmp/ota2.txt
+// TODO: Replace with a JSON file for simpler parsing. The idea is that the contents of the
+// response from the DCL server will be populated into this file appropriately.
+static bool parse_csv_file_and_populate_candidates(const char * filepath,
+                                                   std::vector<OTAProviderExample::DeviceSoftwareVersionModel> & candidates)
+{
+    std::ifstream fpStream(filepath);
+    std::string line;
+    while (std::getline(fpStream, line))
+    {
+        OTAProviderExample::DeviceSoftwareVersionModel candidate;
+        if (line.find("#") == 0)
+            continue; // Ignore lines starting with #
+        std::istringstream s(line);
+        std::string field;
+        uint8_t pos = 0;
+        while (getline(s, field, ','))
+        {
+            switch (pos)
+            {
+            case 0:
+                candidate.vendorId = static_cast<uint16_t>(std::stoul(field));
+                break;
+            case 1:
+                candidate.productId = static_cast<uint16_t>(std::stoul(field));
+                break;
+            case 2:
+                candidate.softwareVersion = static_cast<uint32_t>(std::stoul(field));
+                break;
+            case 3:
+                strncpy(candidate.softwareVersionString, field.c_str(), OTAProviderExample::SW_VER_STR_MAX_LEN);
+                break;
+            case 4:
+                candidate.CDVersionNumber = static_cast<uint16_t>(std::stoul(field));
+                break;
+            case 5:
+                candidate.softwareVersionValid = (strcmp(field.c_str(), "true") == 0) ? true : false;
+                break;
+            case 6:
+                candidate.minApplicableSoftwareVersion = static_cast<uint32_t>(std::stoul(field));
+                break;
+            case 7:
+                candidate.maxApplicableSoftwareVersion = static_cast<uint32_t>(std::stoul(field));
+                break;
+            case 8:
+                strncpy(candidate.otaURL, field.c_str(), OTAProviderExample::OTA_URL_MAX_LEN);
+                break;
+            }
+            pos++;
+        }
+        candidates.push_back(candidate);
+    }
+    return true;
+}
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
     bool retval = true;
+    static bool kOptionFilepathSelected;
+    static bool kOptionOtaImageListSelected;
 
     switch (aIdentifier)
     {
     case kOptionFilepath:
+        kOptionFilepathSelected = true;
         if (0 != access(aValue, R_OK))
         {
             PrintArgError("%s: not permitted to read %s\n", aProgram, aValue);
             retval = false;
         }
+        else if (kOptionOtaImageListSelected)
+        {
+            PrintArgError("%s: Cannot have both OptionOtaImageList and kOptionOtaFilepath \n", aProgram);
+            retval = false;
+        }
         else
         {
             gOtaFilepath = aValue;
+        }
+        break;
+    case kOptionOtaImageList:
+        kOptionOtaImageListSelected = true;
+        if (0 != access(aValue, R_OK))
+        {
+            PrintArgError("%s: not permitted to read %s\n", aProgram, aValue);
+            retval = false;
+        }
+        else if (kOptionFilepathSelected)
+        {
+            PrintArgError("%s: Cannot have both OptionOtaImageList and kOptionOtaFilepath \n", aProgram);
+            retval = false;
+        }
+        else
+        {
+            gOtaImageListFilepath = aValue;
         }
         break;
     case kOptionQueryImageBehavior:
@@ -113,6 +200,7 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
 
 OptionDef cmdLineOptionsDef[] = {
     { "filepath", chip::ArgParser::kArgumentRequired, kOptionFilepath },
+    { "otaImageList", chip::ArgParser::kArgumentRequired, kOptionOtaImageList },
     { "QueryImageBehavior", chip::ArgParser::kArgumentRequired, kOptionQueryImageBehavior },
     { "DelayedActionTimeSec", chip::ArgParser::kArgumentRequired, kOptionDelayedActionTimeSec },
     {},
@@ -121,6 +209,8 @@ OptionDef cmdLineOptionsDef[] = {
 OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS",
                              "  -f/--filepath <file>\n"
                              "        Path to a file containing an OTA image.\n"
+                             "  -o/--otaImageList <file>\n"
+                             "        Path to a file containing a list of OTA images.\n"
                              "  -q/--QueryImageBehavior <UpdateAvailable | Busy | UpdateNotAvailable>\n"
                              "        Status value in the Query Image Response\n"
                              "  -d/--DelayedActionTimeSec <time>\n"
@@ -178,6 +268,16 @@ int main(int argc, char * argv[])
 
     otaProvider.SetQueryImageBehavior(gQueryImageBehavior);
     otaProvider.SetDelayedActionTimeSec(gDelayedActionTimeSec);
+
+    ChipLogDetail(SoftwareUpdate, "using ImageList file: %s", gOtaImageListFilepath ? gOtaImageListFilepath : "(none)");
+
+    if (gOtaImageListFilepath != nullptr)
+    {
+        // Parse CSV file and load the ota candidates
+        std::vector<OTAProviderExample::DeviceSoftwareVersionModel> candidates;
+        parse_csv_file_and_populate_candidates(gOtaImageListFilepath, candidates);
+        otaProvider.SetOTACandidates(candidates);
+    }
 
     chip::app::Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, &otaProvider);
 

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -63,7 +63,7 @@ static const char * gOtaImageListFilepath                             = nullptr;
 
 // Parses the JSON filepath and extracts DeviceSoftwareVersionModel parameters
 static bool ParseJsonFileAndPopulateCandidates(const char * filepath,
-                                                    std::vector<OTAProviderExample::DeviceSoftwareVersionModel> & candidates)
+                                               std::vector<OTAProviderExample::DeviceSoftwareVersionModel> & candidates)
 {
     bool ret = false;
     Json::Value root;
@@ -101,10 +101,9 @@ static bool ParseJsonFileAndPopulateCandidates(const char * filepath,
             candidate.softwareVersion = static_cast<uint32_t>(iter.get("softwareVersion", 10).asUInt64());
             strncpy(candidate.softwareVersionString, iter.get("softwareVersionString", "1.0.0").asCString(),
                     OTAProviderExample::SW_VER_STR_MAX_LEN);
-            candidate.cDVersionNumber      = static_cast<uint16_t>(iter.get("cDVersionNumber", 0).asUInt());
-            candidate.softwareVersionValid = iter.get("softwareVersionValid", true).asBool() ? true : false;
-            candidate.minApplicableSoftwareVersion =
-                static_cast<uint32_t>(iter.get("minApplicableSoftwareVersion", 0).asUInt64());
+            candidate.cDVersionNumber              = static_cast<uint16_t>(iter.get("cDVersionNumber", 0).asUInt());
+            candidate.softwareVersionValid         = iter.get("softwareVersionValid", true).asBool() ? true : false;
+            candidate.minApplicableSoftwareVersion = static_cast<uint32_t>(iter.get("minApplicableSoftwareVersion", 0).asUInt64());
             candidate.maxApplicableSoftwareVersion =
                 static_cast<uint32_t>(iter.get("maxApplicableSoftwareVersion", 1000).asUInt64());
             strncpy(candidate.otaURL, iter.get("otaURL", "https://test.com").asCString(), OTAProviderExample::OTA_URL_MAX_LEN);

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -119,7 +119,7 @@ bool OTAProviderExample::SelectOTACandidate(const uint16_t requestorVendorID, co
     {
         // VendorID and ProductID will be the primary key when querying
         // the DCL servers. If not we can add the vendor/product ID checks here.
-        if (requestorSoftwareVersion < candidate.softwareVersion &&
+        if (candidate.softwareVersionValid && requestorSoftwareVersion < candidate.softwareVersion &&
             requestorSoftwareVersion >= candidate.minApplicableSoftwareVersion &&
             requestorSoftwareVersion <= candidate.maxApplicableSoftwareVersion)
         {

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -18,6 +18,7 @@
 
 #include <ota-provider-common/OTAProviderExample.h>
 
+#include <algorithm>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
 #include <app/server/Server.h>
@@ -77,6 +78,7 @@ OTAProviderExample::OTAProviderExample()
     memset(mOTAFilePath, 0, kFilepathBufLen);
     mQueryImageBehavior   = kRespondWithNotAvailable;
     mDelayedActionTimeSec = 0;
+    mCandidates.clear();
 }
 
 void OTAProviderExample::SetOTAFilePath(const char * path)
@@ -91,26 +93,87 @@ void OTAProviderExample::SetOTAFilePath(const char * path)
     }
 }
 
+void OTAProviderExample::SetOTACandidates(std::vector<OTAProviderExample::DeviceSoftwareVersionModel> candidates)
+{
+    mCandidates = std::move(candidates);
+}
+
+void OTAProviderExample::SetOTACandidates(OTAProviderExample::DeviceSoftwareVersionModel entry)
+{
+    mCandidates.push_back(entry);
+}
+
+static bool compareSoftwareVersions(const OTAProviderExample::DeviceSoftwareVersionModel & a,
+                                    const OTAProviderExample::DeviceSoftwareVersionModel & b)
+{
+    return (a.softwareVersion < b.softwareVersion);
+}
+
+bool OTAProviderExample::SelectOTACandidate(const uint16_t requestorVendorID, const uint16_t requestorProductID,
+                                            const uint32_t requestorSoftwareVersion,
+                                            OTAProviderExample::DeviceSoftwareVersionModel & finalCandidate)
+{
+    bool candidateFound = false;
+    std::sort(mCandidates.begin(), mCandidates.end(), compareSoftwareVersions);
+    for (auto candidate : mCandidates)
+    {
+        // VendorID and ProductID will be the primary key when querying
+        // the DCL servers. If not we can add the vendor/product ID checks here.
+        if (requestorSoftwareVersion < candidate.softwareVersion &&
+            requestorSoftwareVersion >= candidate.minApplicableSoftwareVersion &&
+            requestorSoftwareVersion <= candidate.maxApplicableSoftwareVersion)
+        {
+            candidateFound = true;
+            finalCandidate = candidate;
+        }
+    }
+    return candidateFound;
+}
+
 EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * commandObj,
                                                    const chip::app::ConcreteCommandPath & commandPath,
                                                    const QueryImage::DecodableType & commandData)
 {
     // TODO: add confiuration for returning BUSY status
 
-    OTAQueryStatus queryStatus  = OTAQueryStatus::kNotAvailable;
-    uint32_t newSoftwareVersion = commandData.softwareVersion + 1; // This implementation will always indicate that an update is
-                                                                   // available (if the user provides a file).
-    constexpr char kExampleSoftwareString[] = "Example-Image-V0.1";
-    bool userConsentNeeded                  = false;
-    uint8_t updateToken[kUpdateTokenLen]    = { 0 };
-    char strBuf[kUpdateTokenStrLen]         = { 0 };
-    char uriBuf[kUriMaxLen]                 = { 0 };
+    OTAQueryStatus queryStatus = OTAQueryStatus::kNotAvailable;
+    OTAProviderExample::DeviceSoftwareVersionModel candidate;
+    bool otaAvailable                     = false;
+    uint32_t newSoftwareVersion           = 0;
+    const char * newSoftwareVersionString = nullptr;
+    const char * otaFilePath              = nullptr;
+    bool userConsentNeeded                = false;
+    uint8_t updateToken[kUpdateTokenLen]  = { 0 };
+    char strBuf[kUpdateTokenStrLen]       = { 0 };
+    char uriBuf[kUriMaxLen]               = { 0 };
+
+    // This use-case is a subset of the ota-candidates-file option.
+    // Can be removed once all other platforms (ESP, etc.)
+    // start using the ota-candidates-file method.
+    if (strlen(mOTAFilePath)) // If OTA file is directly provided
+    {
+        otaAvailable       = true;
+        newSoftwareVersion = commandData.softwareVersion + 1; // This implementation will always indicate that an update is
+                                                              // available (if the user provides a file).
+        newSoftwareVersionString = "Example-Image-V0.1";
+        otaFilePath              = mOTAFilePath;
+    }
+    else if (!mCandidates.empty()) // If list of OTA candidates is supplied instead
+    {
+        otaAvailable = SelectOTACandidate(commandData.vendorId, commandData.productId, commandData.softwareVersion, candidate);
+        if (otaAvailable)
+        {
+            newSoftwareVersion       = candidate.softwareVersion;
+            newSoftwareVersionString = candidate.softwareVersionString;
+            otaFilePath              = candidate.otaURL;
+        }
+    }
 
     GenerateUpdateToken(updateToken, kUpdateTokenLen);
     GetUpdateTokenString(ByteSpan(updateToken), strBuf, kUpdateTokenStrLen);
     ChipLogDetail(SoftwareUpdate, "generated updateToken: %s", strBuf);
 
-    if (strlen(mOTAFilePath))
+    if (otaAvailable)
     {
         // TODO: This uses the current node as the provider to supply the OTA image. This can be configurable such that the provider
         // supplying the response is not the provider supplying the OTA image.
@@ -128,12 +191,12 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     switch (mQueryImageBehavior)
     {
     case kRespondWithUpdateAvailable: {
-        if (strlen(mOTAFilePath) != 0)
+        if (otaAvailable)
         {
             queryStatus = OTAQueryStatus::kUpdateAvailable;
 
             // Initialize the transfer session in prepartion for a BDX transfer
-            mBdxOtaSender.SetFilepath(mOTAFilePath);
+            mBdxOtaSender.SetFilepath(otaFilePath);
             BitFlags<TransferControlFlags> bdxFlags;
             bdxFlags.Set(TransferControlFlags::kReceiverDrive);
             CHIP_ERROR err = mBdxOtaSender.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender,
@@ -166,14 +229,16 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     QueryImageResponse::Type response;
     response.status = queryStatus;
     response.delayedActionTime.Emplace(mDelayedActionTimeSec);
-    response.imageURI.Emplace(chip::CharSpan::fromCharString(uriBuf));
-    response.softwareVersion.Emplace(newSoftwareVersion);
-    response.softwareVersionString.Emplace(chip::CharSpan::fromCharString(kExampleSoftwareString));
-    response.updateToken.Emplace(chip::ByteSpan(updateToken));
-    response.userConsentNeeded.Emplace(userConsentNeeded);
-    // Could also just not send metadataForRequestor at all.
-    response.metadataForRequestor.Emplace(chip::ByteSpan());
-
+    if (queryStatus == OTAQueryStatus::kUpdateAvailable)
+    {
+        response.imageURI.Emplace(chip::CharSpan::fromCharString(uriBuf));
+        response.softwareVersion.Emplace(newSoftwareVersion);
+        response.softwareVersionString.Emplace(chip::CharSpan::fromCharString(newSoftwareVersionString));
+        response.updateToken.Emplace(chip::ByteSpan(updateToken));
+        response.userConsentNeeded.Emplace(userConsentNeeded);
+        // Could also just not send metadataForRequestor at all.
+        response.metadataForRequestor.Emplace(chip::ByteSpan());
+    }
     VerifyOrReturnError(commandObj->AddResponseData(commandPath, response) == CHIP_NO_ERROR, EMBER_ZCL_STATUS_FAILURE);
     return EMBER_ZCL_STATUS_SUCCESS;
 }

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -98,12 +98,7 @@ void OTAProviderExample::SetOTACandidates(std::vector<OTAProviderExample::Device
     mCandidates = std::move(candidates);
 }
 
-void OTAProviderExample::SetOTACandidates(OTAProviderExample::DeviceSoftwareVersionModel entry)
-{
-    mCandidates.push_back(entry);
-}
-
-static bool compareSoftwareVersions(const OTAProviderExample::DeviceSoftwareVersionModel & a,
+static bool CompareSoftwareVersions(const OTAProviderExample::DeviceSoftwareVersionModel & a,
                                     const OTAProviderExample::DeviceSoftwareVersionModel & b)
 {
     return (a.softwareVersion < b.softwareVersion);
@@ -114,7 +109,7 @@ bool OTAProviderExample::SelectOTACandidate(const uint16_t requestorVendorID, co
                                             OTAProviderExample::DeviceSoftwareVersionModel & finalCandidate)
 {
     bool candidateFound = false;
-    std::sort(mCandidates.begin(), mCandidates.end(), compareSoftwareVersions);
+    std::sort(mCandidates.begin(), mCandidates.end(), CompareSoftwareVersions);
     for (auto candidate : mCandidates)
     {
         // VendorID and ProductID will be the primary key when querying

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -21,6 +21,7 @@
 #include <app/CommandHandler.h>
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
 #include <ota-provider-common/BdxOtaSender.h>
+#include <vector>
 
 /**
  * A reference implementation for an OTA Provider. Includes a method for providing a path to a local OTA file to serve.
@@ -50,13 +51,33 @@ public:
         kRespondWithBusy,
         kRespondWithNotAvailable
     };
+    static constexpr uint16_t SW_VER_STR_MAX_LEN = 32;
+    static constexpr uint16_t OTA_URL_MAX_LEN    = 512;
+    typedef struct DeviceSoftwareVersionModel
+    {
+        uint16_t vendorId;
+        uint16_t productId;
+        uint32_t softwareVersion;
+        char softwareVersionString[SW_VER_STR_MAX_LEN];
+        uint16_t CDVersionNumber;
+        bool softwareVersionValid;
+        uint32_t minApplicableSoftwareVersion;
+        uint32_t maxApplicableSoftwareVersion;
+        char otaURL[OTA_URL_MAX_LEN];
+    } DeviceSoftwareVersionModel;
+    void SetOTACandidates(OTAProviderExample::DeviceSoftwareVersionModel entry);
+    void SetOTACandidates(std::vector<OTAProviderExample::DeviceSoftwareVersionModel> candidates);
     void SetQueryImageBehavior(QueryImageBehaviorType behavior) { mQueryImageBehavior = behavior; }
     void SetDelayedActionTimeSec(uint32_t time) { mDelayedActionTimeSec = time; }
 
 private:
     BdxOtaSender mBdxOtaSender;
+    std::vector<DeviceSoftwareVersionModel> mCandidates;
     static constexpr size_t kFilepathBufLen = 256;
     char mOTAFilePath[kFilepathBufLen]; // null-terminated
     QueryImageBehaviorType mQueryImageBehavior;
     uint32_t mDelayedActionTimeSec;
+    bool SelectOTACandidate(const uint16_t requestorVendorID, const uint16_t requestorProductID,
+                            const uint32_t requestorSoftwareVersion,
+                            OTAProviderExample::DeviceSoftwareVersionModel & finalCandidate);
 };

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -55,17 +55,16 @@ public:
     static constexpr uint16_t OTA_URL_MAX_LEN    = 512;
     typedef struct DeviceSoftwareVersionModel
     {
-        uint16_t vendorId;
+        chip::VendorId vendorId;
         uint16_t productId;
         uint32_t softwareVersion;
         char softwareVersionString[SW_VER_STR_MAX_LEN];
-        uint16_t CDVersionNumber;
+        uint16_t cDVersionNumber;
         bool softwareVersionValid;
         uint32_t minApplicableSoftwareVersion;
         uint32_t maxApplicableSoftwareVersion;
         char otaURL[OTA_URL_MAX_LEN];
     } DeviceSoftwareVersionModel;
-    void SetOTACandidates(OTAProviderExample::DeviceSoftwareVersionModel entry);
     void SetOTACandidates(std::vector<OTAProviderExample::DeviceSoftwareVersionModel> candidates);
     void SetQueryImageBehavior(QueryImageBehaviorType behavior) { mQueryImageBehavior = behavior; }
     void SetDelayedActionTimeSec(uint32_t time) { mDelayedActionTimeSec = time; }


### PR DESCRIPTION
#### Problem (Issue #13652)
The OTA provider reference application currently provides only one image for OTA-download. This should be augmented with the ability for the OTA-provider to lookup a list of available ota-images and make a selection based on the QueryImage request parameters.

#### Change overview

Section 11.20.3.3, “Availability of Software Images"
Section 11.20.3.3.2, “Conceptual algorithm for matching OTA Software Images applicable to a query"

The OTA-Provider will implement a solution based on the above sections of the spec.

The OTA provider will be provided with a list of software images following the DeviceSoftwareVersionModel Schema. This will be in the form of a simple CSV/JSON file (this can be replaced with a DCL server connection in the future).
The OTA provider will process the QueryImage parameters (VendorID, ProductID, and SoftwareVersion)and make a decision which OTA image is best suited from the available list (Section 11.20.3.3.2).
The selected OTA file will be sent to the OTA-requestor over the BDX protocol. If no relevant image is found, a "NotAvailable" status will be sent as a response to the QueryImage request.

#### Testing
- Ran the OTAProvider/Requestor apps on a local Linux machine.
- Ensured no memory leaks using valgrind.
