### PR TITLE
Update ble-wifi pairing documentation

### DIFF
--- a/docs/guides/mbedos_commissioning.md
+++ b/docs/guides/mbedos_commissioning.md
@@ -168,12 +168,12 @@ In order to send commands to a device, it must be paired with the client and
 connected to the network.
 
 To run the commissioning process via BLE, run the built executable and pass it
-the network ssid and password, fabric id, discriminator and pairing code of the
-remote device.
+the network ssid and password, discriminator and pairing code of the remote
+device.
 
 Example:
 
-    $ chip-tool pairing ble-wifi network_ssid network_password 0 20202021 3840
+    $ chip-tool pairing ble-wifi network_ssid network_password 20202021 3840
 
 ## Sending ZCL commands
 

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -67,7 +67,7 @@ remote device, as well as the network credentials to use.
 The command below uses the default values hard-coded into the debug versions of
 the ESP32 all-clusters-app to commission it onto a Wi-Fi network:
 
-    $ chip-tool pairing ble-wifi ${NODE_ID_TO_ASSIGN} ${SSID} ${PASSWORD} 0 20202021 3840
+    $ chip-tool pairing ble-wifi ${NODE_ID_TO_ASSIGN} ${SSID} ${PASSWORD} 20202021 3840
 
 where:
 
@@ -76,16 +76,14 @@ where:
 -   \${SSID} is the Wi-Fi SSID either as a string, or in the form hex:XXXXXXXX
     where the bytes of the SSID are encoded as two-digit hex numbers.
 -   \${PASSWORD} is the Wi-Fi password, again either as a string or as hex data
--   The 0 is the fabric id, until more complete support for multiple fabrics is
-    implemented in our commissioning process.
 
 For example:
 
-    $ chip-tool pairing ble-wifi 0x11 xyz secret 0 20202021 3840
+    $ chip-tool pairing ble-wifi 0x11 xyz secret 20202021 3840
 
 or equivalently:
 
-    $ chip-tool pairing ble-wifi 17 hex:787980 hex:736563726574 0 20202021 3840
+    $ chip-tool pairing ble-wifi 17 hex:787980 hex:736563726574 20202021 3840
 
 #### Pair a device over IP
 


### PR DESCRIPTION
#### Problem
chip-tool no longer wants a fabric id specified for ble-wifi pairing.

#### Change overview
Remove fabric id from documentation.

#### Testing
How was this tested? (at least one bullet point required)
* None
