### PR TITLE
[OTA EFR32] Add chip-shell to the EFR32 ota-requestor-app, move OTA initialization to AppTask

### DIFF
--- a/examples/ota-requestor-app/efr32/BUILD.gn
+++ b/examples/ota-requestor-app/efr32/BUILD.gn
@@ -63,6 +63,7 @@ efr32_sdk("sdk") {
     "${chip_root}/src/platform/EFR32",
     "${efr32_project_dir}/include",
     "${examples_plat_dir}",
+    "${chip_root}/src/lib",
   ]
 
   defines = [
@@ -81,6 +82,8 @@ efr32_sdk("sdk") {
 
 efr32_executable("ota_requestor_app") {
   output_name = "chip-efr32-ota-requestor-example.out"
+  include_dirs = [ "include" ]
+  defines = []
 
   sources = [
     "${examples_plat_dir}/LEDWidget.cpp",
@@ -115,10 +118,6 @@ efr32_executable("ota_requestor_app") {
       "${chip_root}/third_party/openthread/repo:libopenthread-mtd",
     ]
   }
-
-  include_dirs = [ "include" ]
-
-  defines = []
 
   if (show_qr_code) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]

--- a/examples/ota-requestor-app/efr32/args.gni
+++ b/examples/ota-requestor-app/efr32/args.gni
@@ -25,4 +25,5 @@ chip_openthread_ftd = false
 
 declare_args() {
   chip_enable_ota_requestor = true
+  chip_build_libshell = true
 }

--- a/examples/ota-requestor-app/efr32/include/AppTask.h
+++ b/examples/ota-requestor-app/efr32/include/AppTask.h
@@ -63,6 +63,8 @@ private:
 
     void DispatchEvent(AppEvent * event);
 
+    void InitOTARequestor();
+
     static void FunctionTimerEventHandler(AppEvent * aEvent);
     static void FunctionHandler(AppEvent * aEvent);
     static void LightActionEventHandler(AppEvent * aEvent);

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -545,5 +545,4 @@ void AppTask::InitOTARequestor()
     // Connect the Downloader and Image Processor objects
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     // Initialize and interconnect the Requestor and Image Processor objects -- END
-
 }

--- a/src/lib/shell/MainLoopEFR32.cpp
+++ b/src/lib/shell/MainLoopEFR32.cpp
@@ -135,7 +135,9 @@ int TokenizeLine(char * buffer, char ** tokens, int max_tokens)
         else if (IsSeparator(buffer[i]))
         {
             buffer[i] = 0;
-            if (!IsSeparator(buffer[i + 1]))
+            // Don't treat the previous character as a separator if this one is 0
+            // otherwise the trailing space will become a token
+            if (!IsSeparator(buffer[i + 1]) && buffer[i + 1] != 0)
             {
                 tokens[cursor++] = &buffer[i + 1];
             }


### PR DESCRIPTION
#### Problem
 EFR32 ota-requestor-app needs to have chip-shell enabled. Also, recent changes in `OTARequestor::Init()` require that it is called after `Server::Init()`. Also the EFR32 chip shell handles trailing spaces in a command as a separate token. 

#### Change overview
Enable chip-shell in the EFR32 ota-requestor-app, move OTA initialization to AppTask, fixed the bug in the the EFR32's version of `TokenizeLine`.

#### Testing
Verified that the application initialize successfully and shell commands can be passed to it.
