### PR TITLE
RFC: Remove the ReadClient* parameter to ReadClient::Callbacks

### DIFF
--- a/src/app/AttributeCache.cpp
+++ b/src/app/AttributeCache.cpp
@@ -66,14 +66,14 @@ CHIP_ERROR AttributeCache::UpdateCache(const ConcreteDataAttributePath & aPath, 
     return CHIP_NO_ERROR;
 }
 
-void AttributeCache::OnReportBegin(const ReadClient * apReadClient)
+void AttributeCache::OnReportBegin()
 {
     mChangedAttributeSet.clear();
     mAddedEndpoints.clear();
-    mCallback.OnReportBegin(apReadClient);
+    mCallback.OnReportBegin();
 }
 
-void AttributeCache::OnReportEnd(const ReadClient * apReadClient)
+void AttributeCache::OnReportEnd()
 {
     std::set<std::tuple<EndpointId, ClusterId>> changedClusters;
 
@@ -97,11 +97,10 @@ void AttributeCache::OnReportEnd(const ReadClient * apReadClient)
         mCallback.OnEndpointAdded(this, endpoint);
     }
 
-    mCallback.OnReportEnd(apReadClient);
+    mCallback.OnReportEnd();
 }
 
-void AttributeCache::OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath,
-                                     TLV::TLVReader * apData, const StatusIB & aStatus)
+void AttributeCache::OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus)
 {
     //
     // Since the cache itself is a ReadClient::Callback, it may be incorrectly passed in directly when registering with the
@@ -121,7 +120,7 @@ void AttributeCache::OnAttributeData(const ReadClient * apReadClient, const Conc
     //
     // Forward the call through.
     //
-    mCallback.OnAttributeData(apReadClient, aPath, apData, aStatus);
+    mCallback.OnAttributeData(aPath, apData, aStatus);
 }
 
 CHIP_ERROR AttributeCache::Get(const ConcreteAttributePath & path, TLV::TLVReader & reader)

--- a/src/app/AttributeCache.h
+++ b/src/app/AttributeCache.h
@@ -339,20 +339,18 @@ private:
     //
     // ReadClient::Callback
     //
-    void OnReportBegin(const ReadClient * apReadClient) override;
-    void OnReportEnd(const ReadClient * apReadClient) override;
-    void OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                         const StatusIB & aStatus) override;
-    void OnError(const ReadClient * apReadClient, CHIP_ERROR aError) override { return mCallback.OnError(apReadClient, aError); }
+    void OnReportBegin() override;
+    void OnReportEnd() override;
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
+    void OnError(CHIP_ERROR aError) override { return mCallback.OnError(aError); }
 
-    void OnEventData(const ReadClient * apReadClient, const EventHeader & aEventHeader, TLV::TLVReader * apData,
-                     const StatusIB * apStatus) override
+    void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) override
     {
-        return mCallback.OnEventData(apReadClient, aEventHeader, apData, apStatus);
+        return mCallback.OnEventData(aEventHeader, apData, apStatus);
     }
 
-    void OnDone(ReadClient * apReadClient) override { return mCallback.OnDone(apReadClient); }
-    void OnSubscriptionEstablished(const ReadClient * apReadClient) override { mCallback.OnSubscriptionEstablished(apReadClient); }
+    void OnDone() override { return mCallback.OnDone(); }
+    void OnSubscriptionEstablished(uint64_t aSubscriptionId) override { mCallback.OnSubscriptionEstablished(aSubscriptionId); }
 
 private:
     Callback & mCallback;

--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -29,20 +29,20 @@
 namespace chip {
 namespace app {
 
-void BufferedReadCallback::OnReportBegin(const ReadClient * apReadClient)
+void BufferedReadCallback::OnReportBegin()
 {
-    mCallback.OnReportBegin(apReadClient);
+    mCallback.OnReportBegin();
 }
 
-void BufferedReadCallback::OnReportEnd(const ReadClient * apReadClient)
+void BufferedReadCallback::OnReportEnd()
 {
-    CHIP_ERROR err = DispatchBufferedData(apReadClient, mBufferedPath, StatusIB(), true);
+    CHIP_ERROR err = DispatchBufferedData(mBufferedPath, StatusIB(), true);
     if (err != CHIP_NO_ERROR)
     {
-        mCallback.OnError(apReadClient, err);
+        mCallback.OnError(err);
     }
 
-    mCallback.OnReportEnd(apReadClient);
+    mCallback.OnReportEnd();
 }
 
 CHIP_ERROR BufferedReadCallback::GenerateListTLV(TLV::ScopedBufferTLVReader & aReader)
@@ -168,8 +168,8 @@ CHIP_ERROR BufferedReadCallback::BufferData(const ConcreteDataAttributePath & aP
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BufferedReadCallback::DispatchBufferedData(const ReadClient * apReadClient, const ConcreteAttributePath & aPath,
-                                                      const StatusIB & aStatusIB, bool aEndOfReport)
+CHIP_ERROR BufferedReadCallback::DispatchBufferedData(const ConcreteAttributePath & aPath, const StatusIB & aStatusIB,
+                                                      bool aEndOfReport)
 {
     if (aPath == mBufferedPath)
     {
@@ -215,7 +215,7 @@ CHIP_ERROR BufferedReadCallback::DispatchBufferedData(const ReadClient * apReadC
     //
     ReturnErrorOnFailure(reader.Next());
 
-    mCallback.OnAttributeData(apReadClient, mBufferedPath, &reader, statusIB);
+    mCallback.OnAttributeData(mBufferedPath, &reader, statusIB);
 
     //
     // Clear out our buffered contents to free up allocated buffers, and reset the buffered path.
@@ -226,15 +226,15 @@ CHIP_ERROR BufferedReadCallback::DispatchBufferedData(const ReadClient * apReadC
     return CHIP_NO_ERROR;
 }
 
-void BufferedReadCallback::OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath,
-                                           TLV::TLVReader * apData, const StatusIB & aStatus)
+void BufferedReadCallback::OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
+                                           const StatusIB & aStatus)
 {
     CHIP_ERROR err;
 
     //
     // First, let's dispatch to our registered callback any buffered up list data from previous calls.
     //
-    err = DispatchBufferedData(apReadClient, aPath, aStatus);
+    err = DispatchBufferedData(aPath, aStatus);
     SuccessOrExit(err);
 
     //
@@ -247,7 +247,7 @@ void BufferedReadCallback::OnAttributeData(const ReadClient * apReadClient, cons
     }
     else
     {
-        mCallback.OnAttributeData(apReadClient, aPath, apData, aStatus);
+        mCallback.OnAttributeData(aPath, apData, aStatus);
     }
 
     //
@@ -258,7 +258,7 @@ void BufferedReadCallback::OnAttributeData(const ReadClient * apReadClient, cons
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        mCallback.OnError(apReadClient, err);
+        mCallback.OnError(err);
     }
 }
 

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -56,8 +56,7 @@ private:
      *  2. The path provided in aPath is similar to what is buffered but we've hit the end of the report.
      *
      */
-    CHIP_ERROR DispatchBufferedData(const ReadClient * apReadClient, const ConcreteAttributePath & aPath, const StatusIB & aStatus,
-                                    bool aEndOfReport = false);
+    CHIP_ERROR DispatchBufferedData(const ConcreteAttributePath & aPath, const StatusIB & aStatus, bool aEndOfReport = false);
 
     /*
      * Buffer up list data as they arrive.
@@ -68,19 +67,17 @@ private:
     //
     // ReadClient::Callback
     //
-    void OnReportBegin(const ReadClient * apReadClient) override;
-    void OnReportEnd(const ReadClient * apReadClient) override;
-    void OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                         const StatusIB & aStatus) override;
-    void OnError(const ReadClient * apReadClient, CHIP_ERROR aError) override { return mCallback.OnError(apReadClient, aError); }
-    void OnEventData(const ReadClient * apReadClient, const EventHeader & aEventHeader, TLV::TLVReader * apData,
-                     const StatusIB * apStatus) override
+    void OnReportBegin() override;
+    void OnReportEnd() override;
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
+    void OnError(CHIP_ERROR aError) override { return mCallback.OnError(aError); }
+    void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) override
     {
-        return mCallback.OnEventData(apReadClient, aEventHeader, apData, apStatus);
+        return mCallback.OnEventData(aEventHeader, apData, apStatus);
     }
 
-    void OnDone(ReadClient * apReadClient) override { return mCallback.OnDone(apReadClient); }
-    void OnSubscriptionEstablished(const ReadClient * apReadClient) override { mCallback.OnSubscriptionEstablished(apReadClient); }
+    void OnDone() override { return mCallback.OnDone(); }
+    void OnSubscriptionEstablished(uint64_t aSubscriptionId) override { mCallback.OnSubscriptionEstablished(aSubscriptionId); }
 
 private:
     /*

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -84,10 +84,10 @@ void ReadClient::Close(CHIP_ERROR aError)
 
     if (aError != CHIP_NO_ERROR)
     {
-        mpCallback.OnError(this, aError);
+        mpCallback.OnError(aError);
     }
 
-    mpCallback.OnDone(this);
+    mpCallback.OnDone();
 }
 
 const char * ReadClient::GetStateStr() const
@@ -404,7 +404,7 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
 
         if (mIsInitialReport)
         {
-            mpCallback.OnReportBegin(this);
+            mpCallback.OnReportBegin();
             mIsInitialReport = false;
         }
 
@@ -413,7 +413,7 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
 
         if (!mPendingMoreChunks)
         {
-            mpCallback.OnReportEnd(this);
+            mpCallback.OnReportEnd();
             mIsInitialReport = true;
         }
     }
@@ -510,7 +510,7 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
             ReturnErrorOnFailure(ProcessAttributePath(path, attributePath));
             ReturnErrorOnFailure(status.GetErrorStatus(&errorStatus));
             ReturnErrorOnFailure(errorStatus.DecodeStatusIB(statusIB));
-            mpCallback.OnAttributeData(this, attributePath, nullptr, statusIB);
+            mpCallback.OnAttributeData(attributePath, nullptr, statusIB);
         }
         else if (CHIP_END_OF_TLV == err)
         {
@@ -526,7 +526,7 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
                 attributePath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
             }
 
-            mpCallback.OnAttributeData(this, attributePath, &dataReader, statusIB);
+            mpCallback.OnAttributeData(attributePath, &dataReader, statusIB);
         }
     }
 
@@ -559,7 +559,7 @@ CHIP_ERROR ReadClient::ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsRea
         mEventMin       = header.mEventNumber + 1;
         ReturnErrorOnFailure(data.GetData(&dataReader));
 
-        mpCallback.OnEventData(this, header, &dataReader, nullptr);
+        mpCallback.OnEventData(header, &dataReader, nullptr);
     }
 
     if (CHIP_END_OF_TLV == err)
@@ -635,7 +635,7 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
     ReturnLogErrorOnFailure(subscribeResponse.GetMinIntervalFloorSeconds(&mMinIntervalFloorSeconds));
     ReturnLogErrorOnFailure(subscribeResponse.GetMaxIntervalCeilingSeconds(&mMaxIntervalCeilingSeconds));
 
-    mpCallback.OnSubscriptionEstablished(this);
+    mpCallback.OnSubscriptionEstablished(subscriptionId);
 
     MoveToState(ClientState::SubscriptionActive);
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -72,7 +72,7 @@ public:
          * receives an OnDone call to destroy the object.
          *
          */
-        virtual void OnReportBegin(const ReadClient * apReadClient) {}
+        virtual void OnReportBegin() {}
 
         /**
          * Used to signal the completion of processing of the last attribute report in a given exchange.
@@ -81,7 +81,7 @@ public:
          * receives an OnDone call to destroy the object.
          *
          */
-        virtual void OnReportEnd(const ReadClient * apReadClient) {}
+        virtual void OnReportEnd() {}
 
         /**
          * Used to deliver event data received through the Read and Subscribe interactions
@@ -91,15 +91,12 @@ public:
          * This object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param[in] apReadClient: The read client object that initiated the read or subscribe transaction.
          * @param[in] aEventHeader: The event header in report response.
          * @param[in] apData: A TLVReader positioned right on the payload of the event.
          * @param[in] apStatus: Event-specific status, containing an InteractionModel::Status code as well as an optional
          *                     cluster-specific status code.
          */
-        virtual void OnEventData(const ReadClient * apReadClient, const EventHeader & aEventHeader, TLV::TLVReader * apData,
-                                 const StatusIB * apStatus)
-        {}
+        virtual void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) {}
 
         /**
          * Used to deliver attribute data received through the Read and Subscribe interactions.
@@ -112,15 +109,12 @@ public:
          * This object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param[in] apReadClient The read client object that initiated the read or subscribe transaction.
          * @param[in] aPath        The attribute path field in report response.
          * @param[in] apData       The attribute data of the given path, will be a nullptr if status is not Success.
          * @param[in] aStatus      Attribute-specific status, containing an InteractionModel::Status code as well as an
          *                         optional cluster-specific status code.
          */
-        virtual void OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath,
-                                     TLV::TLVReader * apData, const StatusIB & aStatus)
-        {}
+        virtual void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) {}
 
         /**
          * OnSubscriptionEstablished will be called when a subscription is established for the given subscription transaction.
@@ -128,9 +122,9 @@ public:
          * This object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param[in] apReadClient The read client object that initiated the read transaction.
+         * @param[in] aSubscriptionId The identifier of the subscription that was established.
          */
-        virtual void OnSubscriptionEstablished(const ReadClient * apReadClient) {}
+        virtual void OnSubscriptionEstablished(uint64_t aSubscriptionId) {}
 
         /**
          * OnError will be called when an error occurs *after* a successful call to SendRequest(). The following
@@ -146,10 +140,9 @@ public:
          * This object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param[in] apReadClient The read client object that initiated the attribute read transaction.
          * @param[in] aError       A system error code that conveys the overall error code.
          */
-        virtual void OnError(const ReadClient * apReadClient, CHIP_ERROR aError) {}
+        virtual void OnError(CHIP_ERROR aError) {}
 
         /**
          * OnDone will be called when ReadClient has finished all work and is safe to destroy and free the
@@ -161,9 +154,8 @@ public:
          *      - Only be called after a successful call to SendRequest has been
          *        made, when the read completes or the subscription is shut down.
          *
-         * @param[in] apReadClient The read client object of the terminated read or subscribe interaction.
          */
-        virtual void OnDone(ReadClient * apReadClient) = 0;
+        virtual void OnDone() = 0;
     };
 
     enum class InteractionType : uint8_t

--- a/src/app/tests/TestAttributeCache.cpp
+++ b/src/app/tests/TestAttributeCache.cpp
@@ -127,7 +127,7 @@ void DataSeriesGenerator::Generate()
     ReadClient::Callback * callback = mReadCallback;
     StatusIB status;
 
-    callback->OnReportBegin(nullptr);
+    callback->OnReportBegin();
 
     uint8_t index = 0;
     for (auto & instruction : mInstructionList)
@@ -198,19 +198,19 @@ void DataSeriesGenerator::Generate()
             writer.Finalize(&handle);
             reader.Init(std::move(handle));
             NL_TEST_ASSERT(gSuite, reader.Next() == CHIP_NO_ERROR);
-            callback->OnAttributeData(nullptr, path, &reader, status);
+            callback->OnAttributeData(path, &reader, status);
         }
         else
         {
             ChipLogProgress(DataManagement, "\t -- Generating Status");
             status.mStatus = Protocols::InteractionModel::Status::Failure;
-            callback->OnAttributeData(nullptr, path, nullptr, status);
+            callback->OnAttributeData(path, nullptr, status);
         }
 
         index++;
     }
 
-    callback->OnReportEnd(nullptr);
+    callback->OnReportEnd();
 }
 
 class CacheValidator : public AttributeCache::Callback
@@ -221,7 +221,7 @@ public:
     Clusters::TestCluster::Attributes::TypeInfo::DecodableType clusterValue;
 
 private:
-    void OnDone(ReadClient * apReadClient) override {}
+    void OnDone() override {}
     void DecodeAttribute(const AttributeInstruction & instruction, const ConcreteAttributePath & path, AttributeCache * cache)
     {
         CHIP_ERROR err;
@@ -417,7 +417,7 @@ private:
         mExpectedEndpoints.erase(iter);
     }
 
-    void OnReportEnd(const ReadClient * apReadClient) override
+    void OnReportEnd() override
     {
         NL_TEST_ASSERT(gSuite, mExpectedAttributes.size() == 0);
         NL_TEST_ASSERT(gSuite, mExpectedClusters.size() == 0);

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -78,25 +78,24 @@ public:
     // BufferedReadCallback::Callback
     //
 
-    void OnReportBegin(const ReadClient * apReadClient) override;
-    void OnReportEnd(const ReadClient * apReadClient) override;
-    void OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                         const StatusIB & aStatus) override;
-    void OnDone(ReadClient * apClient) override {}
+    void OnReportBegin() override;
+    void OnReportEnd() override;
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
+    void OnDone() override {}
 
     std::vector<ValidationInstruction> mInstructionList;
     uint32_t mCurrentInstruction = 0;
 };
 
-void DataSeriesValidator::OnReportBegin(const ReadClient * apReadClient)
+void DataSeriesValidator::OnReportBegin()
 {
     mCurrentInstruction = 0;
 }
 
-void DataSeriesValidator::OnReportEnd(const ReadClient * apReadClient) {}
+void DataSeriesValidator::OnReportEnd() {}
 
-void DataSeriesValidator::OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath,
-                                          TLV::TLVReader * apData, const StatusIB & aStatus)
+void DataSeriesValidator::OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
+                                          const StatusIB & aStatus)
 {
     uint32_t expectedListLength;
 
@@ -303,7 +302,7 @@ void DataSeriesGenerator::Generate()
     StatusIB status;
     bool hasData;
 
-    callback->OnReportBegin(nullptr);
+    callback->OnReportBegin();
 
     uint8_t index = 0;
     for (auto & instruction : mInstructionList)
@@ -402,7 +401,7 @@ void DataSeriesGenerator::Generate()
             path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
             status.mStatus    = Protocols::InteractionModel::Status::Failure;
             hasData           = false;
-            callback->OnAttributeData(nullptr, path, &reader, status);
+            callback->OnAttributeData(path, &reader, status);
             break;
         }
 
@@ -413,7 +412,7 @@ void DataSeriesGenerator::Generate()
             path.mListOp      = ConcreteDataAttributePath::ListOperation::ReplaceAll;
             status.mStatus    = Protocols::InteractionModel::Status::Failure;
             hasData           = false;
-            callback->OnAttributeData(nullptr, path, &reader, status);
+            callback->OnAttributeData(path, &reader, status);
             break;
         }
 
@@ -431,7 +430,7 @@ void DataSeriesGenerator::Generate()
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
                 NL_TEST_ASSERT(gSuite, reader.Next() == CHIP_NO_ERROR);
-                callback->OnAttributeData(nullptr, path, &reader, status);
+                callback->OnAttributeData(path, &reader, status);
             }
 
             ChipLogProgress(DataManagement, "\t -- Generating C0..C512");
@@ -454,7 +453,7 @@ void DataSeriesGenerator::Generate()
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
                 NL_TEST_ASSERT(gSuite, reader.Next() == CHIP_NO_ERROR);
-                callback->OnAttributeData(nullptr, path, &reader, status);
+                callback->OnAttributeData(path, &reader, status);
             }
 
             break;
@@ -474,7 +473,7 @@ void DataSeriesGenerator::Generate()
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
                 NL_TEST_ASSERT(gSuite, reader.Next() == CHIP_NO_ERROR);
-                callback->OnAttributeData(nullptr, path, &reader, status);
+                callback->OnAttributeData(path, &reader, status);
             }
 
             ChipLogProgress(DataManagement, "\t -- Generating D0..D512");
@@ -493,7 +492,7 @@ void DataSeriesGenerator::Generate()
                 writer.Finalize(&handle);
                 reader.Init(std::move(handle));
                 NL_TEST_ASSERT(gSuite, reader.Next() == CHIP_NO_ERROR);
-                callback->OnAttributeData(nullptr, path, &reader, status);
+                callback->OnAttributeData(path, &reader, status);
             }
 
             break;
@@ -508,13 +507,13 @@ void DataSeriesGenerator::Generate()
             writer.Finalize(&handle);
             reader.Init(std::move(handle));
             NL_TEST_ASSERT(gSuite, reader.Next() == CHIP_NO_ERROR);
-            callback->OnAttributeData(nullptr, path, &reader, status);
+            callback->OnAttributeData(path, &reader, status);
         }
 
         index++;
     }
 
-    callback->OnReportEnd(nullptr);
+    callback->OnReportEnd();
 }
 
 void RunAndValidateSequence(std::vector<ValidationInstruction> instructionList)

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -136,15 +136,15 @@ void GenerateEvents(nlTestSuite * apSuite, void * apContext, bool aIsUrgent = fa
 class MockInteractionModelApp : public chip::app::ReadClient::Callback
 {
 public:
-    void OnEventData(const chip::app::ReadClient * apReadClient, const chip::app::EventHeader & aEventHeader,
-                     chip::TLV::TLVReader * apData, const chip::app::StatusIB * apStatus) override
+    void OnEventData(const chip::app::EventHeader & aEventHeader, chip::TLV::TLVReader * apData,
+                     const chip::app::StatusIB * apStatus) override
     {
         ++mNumDataElementIndex;
         mGotEventResponse = true;
     }
 
-    void OnAttributeData(const chip::app::ReadClient * apReadClient, const chip::app::ConcreteDataAttributePath & aPath,
-                         chip::TLV::TLVReader * apData, const chip::app::StatusIB & status) override
+    void OnAttributeData(const chip::app::ConcreteDataAttributePath & aPath, chip::TLV::TLVReader * apData,
+                         const chip::app::StatusIB & status) override
     {
         if (status.mStatus == chip::Protocols::InteractionModel::Status::Success)
         {
@@ -153,9 +153,9 @@ public:
         }
     }
 
-    void OnError(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override { mReadError = true; }
+    void OnError(CHIP_ERROR aError) override { mReadError = true; }
 
-    void OnDone(chip::app::ReadClient * apReadClient) override {}
+    void OnDone() override {}
 
     int mNumDataElementIndex               = 0;
     bool mGotEventResponse                 = false;

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -52,10 +52,7 @@ CHIP_ERROR ReportAttribute(Messaging::ExchangeManager * exchangeMgr, EndpointId 
     readParams.mpAttributePathParamsList    = &attributePath;
     readParams.mAttributePathParamsListSize = 1;
 
-    auto onDone = [](app::ReadClient * apReadClient, TypedReadAttributeCallback<DecodableAttributeType> * callback) {
-        chip::Platform::Delete(apReadClient);
-        chip::Platform::Delete(callback);
-    };
+    auto onDone = [](TypedReadAttributeCallback<DecodableAttributeType> * callback) { chip::Platform::Delete(callback); };
 
     auto callback = chip::Platform::MakeUnique<TypedReadAttributeCallback<DecodableAttributeType>>(
         clusterId, attributeId, readParams.mOnReportCb, readParams.mOnErrorCb, onDone, readParams.mOnSubscriptionEstablishedCb);
@@ -71,8 +68,8 @@ CHIP_ERROR ReportAttribute(Messaging::ExchangeManager * exchangeMgr, EndpointId 
     // of the read operation to permit us to free up the callback object. So, release ownership of the callback
     // object now to prevent it from being reclaimed at the end of this scoped block.
     //
+    callback->AdoptReadClient(std::move(readClient));
     callback.release();
-    readClient.release();
 
     return err;
 }
@@ -188,10 +185,7 @@ CHIP_ERROR ReportEvent(Messaging::ExchangeManager * apExchangeMgr, EndpointId en
     readParams.mpEventPathParamsList    = &eventPath;
     readParams.mEventPathParamsListSize = 1;
 
-    auto onDone = [](app::ReadClient * apReadClient, TypedReadEventCallback<DecodableEventType> * callback) {
-        chip::Platform::Delete(apReadClient);
-        chip::Platform::Delete(callback);
-    };
+    auto onDone = [](TypedReadEventCallback<DecodableEventType> * callback) { chip::Platform::Delete(callback); };
 
     auto callback = chip::Platform::MakeUnique<TypedReadEventCallback<DecodableEventType>>(
         readParams.mOnReportCb, readParams.mOnErrorCb, onDone, readParams.mOnSubscriptionEstablishedCb);
@@ -206,7 +200,7 @@ CHIP_ERROR ReportEvent(Messaging::ExchangeManager * apExchangeMgr, EndpointId en
     // of the read operation to permit us to free up the callback object. So, release ownership of the callback
     // object now to prevent it from being reclaimed at the end of this scoped block.
     //
-    callback.release();
+    callback->AdoptReadClient(std::move(readClient));
     readClient.release();
 
     return err;

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -78,8 +78,7 @@ public:
 
     app::BufferedReadCallback * GetBufferedReadCallback() { return &mBufferedReadCallback; }
 
-    void OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                         const StatusIB & aStatus) override
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override
     {
         //
         // We shouldn't be getting list item operations in the provided path since that should be handled by the buffered read
@@ -101,7 +100,7 @@ public:
             CHIP_ERROR err = writer.CopyElement(TLV::AnonymousTag(), *apData);
             if (err != CHIP_NO_ERROR)
             {
-                this->OnError(apReadClient, err);
+                this->OnError(err);
                 return;
             }
             size = writer.GetLengthWritten();
@@ -111,13 +110,12 @@ public:
                                      to_underlying(aStatus.mStatus), buffer.get(), size);
     }
 
-    void OnSubscriptionEstablished(const ReadClient * apReadClient) override
+    void OnSubscriptionEstablished(uint64_t aSubscriptionId) override
     {
-        gOnSubscriptionEstablishedCallback(mAppContext, apReadClient->GetSubscriptionId().ValueOr(0));
+        gOnSubscriptionEstablishedCallback(mAppContext, aSubscriptionId);
     }
 
-    void OnEventData(const ReadClient * apReadClient, const EventHeader & aEventHeader, TLV::TLVReader * apData,
-                     const StatusIB * apStatus) override
+    void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) override
     {
         uint8_t buffer[CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE];
         uint32_t size  = 0;
@@ -134,7 +132,7 @@ public:
             err = writer.CopyElement(TLV::AnonymousTag(), *apData);
             if (err != CHIP_NO_ERROR)
             {
-                this->OnError(apReadClient, err);
+                this->OnError(err);
                 return;
             }
             size = writer.GetLengthWritten();
@@ -142,7 +140,7 @@ public:
         else
         {
             err = CHIP_ERROR_INCORRECT_STATE;
-            this->OnError(apReadClient, err);
+            this->OnError(err);
         }
 
         gOnReadEventDataCallback(mAppContext, aEventHeader.mPath.mEndpointId, aEventHeader.mPath.mClusterId,
@@ -150,26 +148,27 @@ public:
                                  aEventHeader.mTimestamp.mValue, to_underlying(aEventHeader.mTimestamp.mType), buffer, size);
     }
 
-    void OnError(const ReadClient * apReadClient, CHIP_ERROR aError) override
-    {
-        gOnReadErrorCallback(mAppContext, aError.AsInteger());
-    }
+    void OnError(CHIP_ERROR aError) override { gOnReadErrorCallback(mAppContext, aError.AsInteger()); }
 
-    void OnReportBegin(const ReadClient * apReadClient) override { gOnReportBeginCallback(mAppContext); }
+    void OnReportBegin() override { gOnReportBeginCallback(mAppContext); }
 
-    void OnReportEnd(const ReadClient * apReadClient) override { gOnReportEndCallback(mAppContext); }
+    void OnReportEnd() override { gOnReportEndCallback(mAppContext); }
 
-    void OnDone(ReadClient * apReadClient) override
+    void OnDone() override
     {
         gOnReadDoneCallback(mAppContext);
 
-        delete apReadClient;
         delete this;
     };
 
+    void AdoptReadClient(std::unique_ptr<ReadClient> apReadClient) { mReadClient = std::move(apReadClient); }
+
 private:
     BufferedReadCallback mBufferedReadCallback;
+
     PyObject * mAppContext;
+
+    std::unique_ptr<ReadClient> mReadClient;
 };
 
 extern "C" {
@@ -375,8 +374,9 @@ chip::ChipError::StorageType pychip_ReadClient_ReadAttributes(void * appContext,
     *pReadClient = readClient.get();
     *pCallback   = callback.get();
 
+    callback->AdoptReadClient(std::move(readClient));
+
     callback.release();
-    readClient.release();
 
 exit:
     va_end(args);

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -96,20 +96,20 @@ class TestReadCallback : public app::ReadClient::Callback
 {
 public:
     TestReadCallback() : mBufferedCallback(*this) {}
-    void OnAttributeData(const app::ReadClient * apReadClient, const app::ConcreteDataAttributePath & aPath,
-                         TLV::TLVReader * apData, const app::StatusIB & aStatus) override;
+    void OnAttributeData(const app::ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
+                         const app::StatusIB & aStatus) override;
 
-    void OnDone(app::ReadClient * apReadClient) override;
+    void OnDone() override;
 
-    void OnReportEnd(const app::ReadClient * apReadClient) override { mOnReportEnd = true; }
+    void OnReportEnd() override { mOnReportEnd = true; }
 
     uint32_t mAttributeCount = 0;
     bool mOnReportEnd        = false;
     app::BufferedReadCallback mBufferedCallback;
 };
 
-void TestReadCallback::OnAttributeData(const app::ReadClient * apReadClient, const app::ConcreteDataAttributePath & aPath,
-                                       TLV::TLVReader * apData, const app::StatusIB & aStatus)
+void TestReadCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
+                                       const app::StatusIB & aStatus)
 {
     if (aPath.mAttributeId != kTestListAttribute)
     {
@@ -134,7 +134,7 @@ void TestReadCallback::OnAttributeData(const app::ReadClient * apReadClient, con
     mAttributeCount++;
 }
 
-void TestReadCallback::OnDone(app::ReadClient * apReadClient) {}
+void TestReadCallback::OnDone() {}
 
 class TestAttrAccess : public app::AttributeAccessInterface
 {

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -89,21 +89,20 @@ public:
     BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
 
     // We need to exist to get a ReadClient, so can't take this as a constructor argument.
-    void SetReadClient(ReadClient * aReadClient) { mReadClient = aReadClient; }
+    void AdoptReadClient(std::unique_ptr<ReadClient> aReadClient) { mReadClient = std::move(aReadClient); }
 
 private:
-    void OnReportBegin(const ReadClient * apReadClient) override;
+    void OnReportBegin() override;
 
-    void OnReportEnd(const ReadClient * apReadClient) override;
+    void OnReportEnd() override;
 
-    void OnAttributeData(const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-        const StatusIB & aStatus) override;
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
 
-    void OnError(const ReadClient * apReadClient, CHIP_ERROR aError) override;
+    void OnError(CHIP_ERROR aError) override;
 
-    void OnDone(ReadClient * apReadClient) override;
+    void OnDone() override;
 
-    void OnSubscriptionEstablished(const ReadClient * apReadClient) override;
+    void OnSubscriptionEstablished(uint64_t aSubscriptionId) override;
 
     void ReportError(CHIP_ERROR err);
     void ReportError(EmberAfStatus status);
@@ -130,7 +129,7 @@ private:
     // 2) We ensure that we delete ourselves and the passed in ReadClient only from OnDone or a queued-up
     //    error callback, but not both, by tracking whether we have a queued-up
     //    deletion.
-    ReadClient * mReadClient = nullptr;
+    std::unique_ptr<ReadClient> mReadClient;
     bool mHaveQueuedDeletion = false;
 };
 
@@ -156,8 +155,8 @@ private:
     params.mpAttributePathParamsList = &attributePath;
     params.mAttributePathParamsListSize = 1;
 
-    auto callback = new SubscriptionCallback(queue, reportHandler, subscriptionEstablishedHandler);
-    ReadClient * readClient = new ReadClient(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+    auto callback = std::make_unique<SubscriptionCallback>(queue, reportHandler, subscriptionEstablishedHandler);
+    auto readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
         callback->GetBufferedCallback(), ReadClient::InteractionType::Subscribe);
 
     CHIP_ERROR err = readClient->SendRequest(params);
@@ -166,14 +165,13 @@ private:
             reportHandler(nil, [CHIPError errorForCHIPErrorCode:err]);
         });
 
-        delete readClient;
-        delete callback;
         return;
     }
 
     // Callback and ReadClient will be deleted when OnDone is called or an error is
     // encountered.
-    callback->SetReadClient(readClient);
+    callback->AdoptReadClient(std::move(readClient));
+    callback.release();
 }
 @end
 
@@ -201,9 +199,9 @@ private:
 @end
 
 namespace {
-void SubscriptionCallback::OnReportBegin(const ReadClient * apReadClient) { mReports = [NSMutableArray new]; }
+void SubscriptionCallback::OnReportBegin() { mReports = [NSMutableArray new]; }
 
-void SubscriptionCallback::OnReportEnd(const ReadClient * apReadClient)
+void SubscriptionCallback::OnReportEnd()
 {
     __block NSArray * reports = mReports;
     mReports = nil;
@@ -216,7 +214,7 @@ void SubscriptionCallback::OnReportEnd(const ReadClient * apReadClient)
 }
 
 void SubscriptionCallback::OnAttributeData(
-    const ReadClient * apReadClient, const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus)
+    const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus)
 {
     if (aPath.IsListItemOperation()) {
         ReportError(CHIP_ERROR_INCORRECT_STATE);
@@ -254,21 +252,17 @@ void SubscriptionCallback::OnAttributeData(
     [mReports addObject:[[CHIPAttributeReport alloc] initWithPath:aPath value:value]];
 }
 
-void SubscriptionCallback::OnError(const ReadClient * apReadClient, CHIP_ERROR aError)
-{
-    ReportError([CHIPError errorForCHIPErrorCode:aError]);
-}
+void SubscriptionCallback::OnError(CHIP_ERROR aError) { ReportError([CHIPError errorForCHIPErrorCode:aError]); }
 
-void SubscriptionCallback::OnDone(ReadClient * apReadClient)
+void SubscriptionCallback::OnDone()
 {
     if (!mHaveQueuedDeletion) {
         delete this;
-        delete apReadClient;
         return; // Make sure we touch nothing else.
     }
 }
 
-void SubscriptionCallback::OnSubscriptionEstablished(const ReadClient * apReadClient)
+void SubscriptionCallback::OnSubscriptionEstablished(uint64_t aSubscriptionId)
 {
     if (mSubscriptionEstablishedHandler) {
         dispatch_async(mQueue, mSubscriptionEstablishedHandler);
@@ -299,7 +293,6 @@ void SubscriptionCallback::ReportError(NSError * _Nullable err)
     dispatch_async(mQueue, ^{
         callback(nil, err);
 
-        delete mReadClient;
         delete myself;
     });
 


### PR DESCRIPTION
#### Problem

Currently each ReadClient callback takes as a parameter a pointer to the
ReadClient itself. This is not very useful and introduces undesirable
coupling: It prevents creating another class (say, MockReadClient or
NextGenReadClient) that is compatible with existing callbacks
without the same concrete implementation class.

This is showing up very concretely in tests that are passing "nullptr"
since their test double cannot be passed through the callback.

#### Change overview

Remove the ReadClient pointer from each callback. There are few
uses of this, and none are crucial, as the creator of the read client
already has as pointer to it.

The only nontrivial use of of this is freeing read clients in OnDone,
which is quite subtle and problematic because shutting down
with pending IM callbacks will leak the client. In any case, we
can preserve the semantics by simply adopting the client
into the callback.

#### Testing

Unit tests.
