### PR TITLE
Update chip-tool commands to use subscribe instead of report

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -177,12 +177,12 @@ Command * Commands::GetGlobalCommand(CommandsVector & commands, std::string comm
 
 bool Commands::IsAttributeCommand(std::string commandName) const
 {
-    return commandName.compare("read") == 0 || commandName.compare("write") == 0 || commandName.compare("report") == 0;
+    return commandName.compare("read") == 0 || commandName.compare("write") == 0 || commandName.compare("subscribe") == 0;
 }
 
 bool Commands::IsEventCommand(std::string commandName) const
 {
-    return commandName.compare("read-event") == 0 || commandName.compare("report-event") == 0;
+    return commandName.compare("read-event") == 0 || commandName.compare("subscribe-event") == 0;
 }
 
 bool Commands::IsGlobalCommand(std::string commandName) const
@@ -216,11 +216,11 @@ void Commands::ShowCluster(std::string executable, std::string clusterName, Comm
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | Commands:                                                                           |\n");
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
-    bool readCommand        = false;
-    bool writeCommand       = false;
-    bool reportCommand      = false;
-    bool readEventCommand   = false;
-    bool reportEventCommand = false;
+    bool readCommand           = false;
+    bool writeCommand          = false;
+    bool subscribeCommand      = false;
+    bool readEventCommand      = false;
+    bool subscribeEventCommand = false;
     for (auto & command : commands)
     {
         bool shouldPrint = true;
@@ -235,17 +235,17 @@ void Commands::ShowCluster(std::string executable, std::string clusterName, Comm
             {
                 writeCommand = true;
             }
-            else if (strcmp(command->GetName(), "report") == 0 && reportCommand == false)
+            else if (strcmp(command->GetName(), "subscribe") == 0 && subscribeCommand == false)
             {
-                reportCommand = true;
+                subscribeCommand = true;
             }
             else if (strcmp(command->GetName(), "read-event") == 0 && readEventCommand == false)
             {
                 readEventCommand = true;
             }
-            else if (strcmp(command->GetName(), "report-event") == 0 && reportEventCommand == false)
+            else if (strcmp(command->GetName(), "subscribe-event") == 0 && subscribeEventCommand == false)
             {
-                reportEventCommand = true;
+                subscribeEventCommand = true;
             }
             else
             {

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -335,7 +335,7 @@ public:
 class Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
-    Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("report-event")
+    Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -462,7 +462,7 @@ private:
 class Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
-    Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("report")
+    Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("subscribe")
     {
         AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -4682,7 +4682,7 @@ public:
 class ReportAccessControlAccessControlEntryChanged : public ModelCommand
 {
 public:
-    ReportAccessControlAccessControlEntryChanged() : ModelCommand("report-event")
+    ReportAccessControlAccessControlEntryChanged() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "access-control-entry-changed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -4755,7 +4755,7 @@ public:
 class ReportAccessControlAccessControlExtensionChanged : public ModelCommand
 {
 public:
-    ReportAccessControlAccessControlExtensionChanged() : ModelCommand("report-event")
+    ReportAccessControlAccessControlExtensionChanged() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "access-control-extension-changed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -4831,7 +4831,7 @@ public:
 class ReportAccessControlAcl : public ModelCommand
 {
 public:
-    ReportAccessControlAcl() : ModelCommand("report")
+    ReportAccessControlAcl() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "acl");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -4909,7 +4909,7 @@ public:
 class ReportAccessControlExtension : public ModelCommand
 {
 public:
-    ReportAccessControlExtension() : ModelCommand("report")
+    ReportAccessControlExtension() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "extension");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -4984,7 +4984,7 @@ public:
 class ReportAccessControlAttributeList : public ModelCommand
 {
 public:
-    ReportAccessControlAttributeList() : ModelCommand("report")
+    ReportAccessControlAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5056,7 +5056,7 @@ public:
 class ReportAccessControlClusterRevision : public ModelCommand
 {
 public:
-    ReportAccessControlClusterRevision() : ModelCommand("report")
+    ReportAccessControlClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5209,7 +5209,7 @@ public:
 class ReportAccountLoginAttributeList : public ModelCommand
 {
 public:
-    ReportAccountLoginAttributeList() : ModelCommand("report")
+    ReportAccountLoginAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5281,7 +5281,7 @@ public:
 class ReportAccountLoginClusterRevision : public ModelCommand
 {
 public:
-    ReportAccountLoginClusterRevision() : ModelCommand("report")
+    ReportAccountLoginClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5441,7 +5441,7 @@ public:
 class ReportAdministratorCommissioningWindowStatus : public ModelCommand
 {
 public:
-    ReportAdministratorCommissioningWindowStatus() : ModelCommand("report")
+    ReportAdministratorCommissioningWindowStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "window-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5513,7 +5513,7 @@ public:
 class ReportAdministratorCommissioningAdminFabricIndex : public ModelCommand
 {
 public:
-    ReportAdministratorCommissioningAdminFabricIndex() : ModelCommand("report")
+    ReportAdministratorCommissioningAdminFabricIndex() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "admin-fabric-index");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5585,7 +5585,7 @@ public:
 class ReportAdministratorCommissioningAdminVendorId : public ModelCommand
 {
 public:
-    ReportAdministratorCommissioningAdminVendorId() : ModelCommand("report")
+    ReportAdministratorCommissioningAdminVendorId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "admin-vendor-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5657,7 +5657,7 @@ public:
 class ReportAdministratorCommissioningAttributeList : public ModelCommand
 {
 public:
-    ReportAdministratorCommissioningAttributeList() : ModelCommand("report")
+    ReportAdministratorCommissioningAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5729,7 +5729,7 @@ public:
 class ReportAdministratorCommissioningClusterRevision : public ModelCommand
 {
 public:
-    ReportAdministratorCommissioningClusterRevision() : ModelCommand("report")
+    ReportAdministratorCommissioningClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5821,7 +5821,7 @@ public:
 class ReportApplicationBasicVendorName : public ModelCommand
 {
 public:
-    ReportApplicationBasicVendorName() : ModelCommand("report")
+    ReportApplicationBasicVendorName() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "vendor-name");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5890,7 +5890,7 @@ public:
 class ReportApplicationBasicVendorId : public ModelCommand
 {
 public:
-    ReportApplicationBasicVendorId() : ModelCommand("report")
+    ReportApplicationBasicVendorId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "vendor-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -5959,7 +5959,7 @@ public:
 class ReportApplicationBasicApplicationName : public ModelCommand
 {
 public:
-    ReportApplicationBasicApplicationName() : ModelCommand("report")
+    ReportApplicationBasicApplicationName() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "application-name");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6031,7 +6031,7 @@ public:
 class ReportApplicationBasicProductId : public ModelCommand
 {
 public:
-    ReportApplicationBasicProductId() : ModelCommand("report")
+    ReportApplicationBasicProductId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "product-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6100,7 +6100,7 @@ public:
 class ReportApplicationBasicApplicationStatus : public ModelCommand
 {
 public:
-    ReportApplicationBasicApplicationStatus() : ModelCommand("report")
+    ReportApplicationBasicApplicationStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "application-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6172,7 +6172,7 @@ public:
 class ReportApplicationBasicApplicationVersion : public ModelCommand
 {
 public:
-    ReportApplicationBasicApplicationVersion() : ModelCommand("report")
+    ReportApplicationBasicApplicationVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "application-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6244,7 +6244,7 @@ public:
 class ReportApplicationBasicAllowedVendorList : public ModelCommand
 {
 public:
-    ReportApplicationBasicAllowedVendorList() : ModelCommand("report")
+    ReportApplicationBasicAllowedVendorList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "allowed-vendor-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6316,7 +6316,7 @@ public:
 class ReportApplicationBasicAttributeList : public ModelCommand
 {
 public:
-    ReportApplicationBasicAttributeList() : ModelCommand("report")
+    ReportApplicationBasicAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6388,7 +6388,7 @@ public:
 class ReportApplicationBasicClusterRevision : public ModelCommand
 {
 public:
-    ReportApplicationBasicClusterRevision() : ModelCommand("report")
+    ReportApplicationBasicClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6546,7 +6546,7 @@ public:
 class ReportApplicationLauncherApplicationLauncherList : public ModelCommand
 {
 public:
-    ReportApplicationLauncherApplicationLauncherList() : ModelCommand("report")
+    ReportApplicationLauncherApplicationLauncherList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "application-launcher-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6618,7 +6618,7 @@ public:
 class ReportApplicationLauncherAttributeList : public ModelCommand
 {
 public:
-    ReportApplicationLauncherAttributeList() : ModelCommand("report")
+    ReportApplicationLauncherAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6690,7 +6690,7 @@ public:
 class ReportApplicationLauncherClusterRevision : public ModelCommand
 {
 public:
-    ReportApplicationLauncherClusterRevision() : ModelCommand("report")
+    ReportApplicationLauncherClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6826,7 +6826,7 @@ public:
 class ReportAudioOutputAudioOutputList : public ModelCommand
 {
 public:
-    ReportAudioOutputAudioOutputList() : ModelCommand("report")
+    ReportAudioOutputAudioOutputList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "audio-output-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6900,7 +6900,7 @@ public:
 class ReportAudioOutputCurrentAudioOutput : public ModelCommand
 {
 public:
-    ReportAudioOutputCurrentAudioOutput() : ModelCommand("report")
+    ReportAudioOutputCurrentAudioOutput() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-audio-output");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -6969,7 +6969,7 @@ public:
 class ReportAudioOutputAttributeList : public ModelCommand
 {
 public:
-    ReportAudioOutputAttributeList() : ModelCommand("report")
+    ReportAudioOutputAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7041,7 +7041,7 @@ public:
 class ReportAudioOutputClusterRevision : public ModelCommand
 {
 public:
-    ReportAudioOutputClusterRevision() : ModelCommand("report")
+    ReportAudioOutputClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7172,7 +7172,7 @@ public:
 class ReportBarrierControlBarrierMovingState : public ModelCommand
 {
 public:
-    ReportBarrierControlBarrierMovingState() : ModelCommand("report")
+    ReportBarrierControlBarrierMovingState() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "barrier-moving-state");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7241,7 +7241,7 @@ public:
 class ReportBarrierControlBarrierSafetyStatus : public ModelCommand
 {
 public:
-    ReportBarrierControlBarrierSafetyStatus() : ModelCommand("report")
+    ReportBarrierControlBarrierSafetyStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "barrier-safety-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7310,7 +7310,7 @@ public:
 class ReportBarrierControlBarrierCapabilities : public ModelCommand
 {
 public:
-    ReportBarrierControlBarrierCapabilities() : ModelCommand("report")
+    ReportBarrierControlBarrierCapabilities() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "barrier-capabilities");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7379,7 +7379,7 @@ public:
 class ReportBarrierControlBarrierPosition : public ModelCommand
 {
 public:
-    ReportBarrierControlBarrierPosition() : ModelCommand("report")
+    ReportBarrierControlBarrierPosition() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "barrier-position");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7448,7 +7448,7 @@ public:
 class ReportBarrierControlAttributeList : public ModelCommand
 {
 public:
-    ReportBarrierControlAttributeList() : ModelCommand("report")
+    ReportBarrierControlAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7520,7 +7520,7 @@ public:
 class ReportBarrierControlClusterRevision : public ModelCommand
 {
 public:
-    ReportBarrierControlClusterRevision() : ModelCommand("report")
+    ReportBarrierControlClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7645,7 +7645,7 @@ public:
 class ReportBasicStartUp : public ModelCommand
 {
 public:
-    ReportBasicStartUp() : ModelCommand("report-event")
+    ReportBasicStartUp() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "start-up");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7716,7 +7716,7 @@ public:
 class ReportBasicShutDown : public ModelCommand
 {
 public:
-    ReportBasicShutDown() : ModelCommand("report-event")
+    ReportBasicShutDown() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "shut-down");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7786,7 +7786,7 @@ public:
 class ReportBasicLeave : public ModelCommand
 {
 public:
-    ReportBasicLeave() : ModelCommand("report-event")
+    ReportBasicLeave() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "leave");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7857,7 +7857,7 @@ public:
 class ReportBasicReachableChanged : public ModelCommand
 {
 public:
-    ReportBasicReachableChanged() : ModelCommand("report-event")
+    ReportBasicReachableChanged() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "reachable-changed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7929,7 +7929,7 @@ public:
 class ReportBasicInteractionModelVersion : public ModelCommand
 {
 public:
-    ReportBasicInteractionModelVersion() : ModelCommand("report")
+    ReportBasicInteractionModelVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "interaction-model-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -7998,7 +7998,7 @@ public:
 class ReportBasicVendorName : public ModelCommand
 {
 public:
-    ReportBasicVendorName() : ModelCommand("report")
+    ReportBasicVendorName() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "vendor-name");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8067,7 +8067,7 @@ public:
 class ReportBasicVendorID : public ModelCommand
 {
 public:
-    ReportBasicVendorID() : ModelCommand("report")
+    ReportBasicVendorID() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "vendor-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8136,7 +8136,7 @@ public:
 class ReportBasicProductName : public ModelCommand
 {
 public:
-    ReportBasicProductName() : ModelCommand("report")
+    ReportBasicProductName() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "product-name");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8205,7 +8205,7 @@ public:
 class ReportBasicProductID : public ModelCommand
 {
 public:
-    ReportBasicProductID() : ModelCommand("report")
+    ReportBasicProductID() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "product-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8300,7 +8300,7 @@ private:
 class ReportBasicNodeLabel : public ModelCommand
 {
 public:
-    ReportBasicNodeLabel() : ModelCommand("report")
+    ReportBasicNodeLabel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "node-label");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8395,7 +8395,7 @@ private:
 class ReportBasicLocation : public ModelCommand
 {
 public:
-    ReportBasicLocation() : ModelCommand("report")
+    ReportBasicLocation() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "location");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8464,7 +8464,7 @@ public:
 class ReportBasicHardwareVersion : public ModelCommand
 {
 public:
-    ReportBasicHardwareVersion() : ModelCommand("report")
+    ReportBasicHardwareVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "hardware-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8533,7 +8533,7 @@ public:
 class ReportBasicHardwareVersionString : public ModelCommand
 {
 public:
-    ReportBasicHardwareVersionString() : ModelCommand("report")
+    ReportBasicHardwareVersionString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "hardware-version-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8602,7 +8602,7 @@ public:
 class ReportBasicSoftwareVersion : public ModelCommand
 {
 public:
-    ReportBasicSoftwareVersion() : ModelCommand("report")
+    ReportBasicSoftwareVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "software-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8671,7 +8671,7 @@ public:
 class ReportBasicSoftwareVersionString : public ModelCommand
 {
 public:
-    ReportBasicSoftwareVersionString() : ModelCommand("report")
+    ReportBasicSoftwareVersionString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "software-version-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8740,7 +8740,7 @@ public:
 class ReportBasicManufacturingDate : public ModelCommand
 {
 public:
-    ReportBasicManufacturingDate() : ModelCommand("report")
+    ReportBasicManufacturingDate() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "manufacturing-date");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8809,7 +8809,7 @@ public:
 class ReportBasicPartNumber : public ModelCommand
 {
 public:
-    ReportBasicPartNumber() : ModelCommand("report")
+    ReportBasicPartNumber() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "part-number");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8878,7 +8878,7 @@ public:
 class ReportBasicProductURL : public ModelCommand
 {
 public:
-    ReportBasicProductURL() : ModelCommand("report")
+    ReportBasicProductURL() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "product-url");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -8947,7 +8947,7 @@ public:
 class ReportBasicProductLabel : public ModelCommand
 {
 public:
-    ReportBasicProductLabel() : ModelCommand("report")
+    ReportBasicProductLabel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "product-label");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9016,7 +9016,7 @@ public:
 class ReportBasicSerialNumber : public ModelCommand
 {
 public:
-    ReportBasicSerialNumber() : ModelCommand("report")
+    ReportBasicSerialNumber() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "serial-number");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9111,7 +9111,7 @@ private:
 class ReportBasicLocalConfigDisabled : public ModelCommand
 {
 public:
-    ReportBasicLocalConfigDisabled() : ModelCommand("report")
+    ReportBasicLocalConfigDisabled() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "local-config-disabled");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9180,7 +9180,7 @@ public:
 class ReportBasicReachable : public ModelCommand
 {
 public:
-    ReportBasicReachable() : ModelCommand("report")
+    ReportBasicReachable() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "reachable");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9249,7 +9249,7 @@ public:
 class ReportBasicUniqueID : public ModelCommand
 {
 public:
-    ReportBasicUniqueID() : ModelCommand("report")
+    ReportBasicUniqueID() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "unique-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9318,7 +9318,7 @@ public:
 class ReportBasicAttributeList : public ModelCommand
 {
 public:
-    ReportBasicAttributeList() : ModelCommand("report")
+    ReportBasicAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9390,7 +9390,7 @@ public:
 class ReportBasicClusterRevision : public ModelCommand
 {
 public:
-    ReportBasicClusterRevision() : ModelCommand("report")
+    ReportBasicClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9500,7 +9500,7 @@ private:
 class ReportBinaryInputBasicOutOfService : public ModelCommand
 {
 public:
-    ReportBinaryInputBasicOutOfService() : ModelCommand("report")
+    ReportBinaryInputBasicOutOfService() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "out-of-service");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9595,7 +9595,7 @@ private:
 class ReportBinaryInputBasicPresentValue : public ModelCommand
 {
 public:
-    ReportBinaryInputBasicPresentValue() : ModelCommand("report")
+    ReportBinaryInputBasicPresentValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "present-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9664,7 +9664,7 @@ public:
 class ReportBinaryInputBasicStatusFlags : public ModelCommand
 {
 public:
-    ReportBinaryInputBasicStatusFlags() : ModelCommand("report")
+    ReportBinaryInputBasicStatusFlags() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "status-flags");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9733,7 +9733,7 @@ public:
 class ReportBinaryInputBasicAttributeList : public ModelCommand
 {
 public:
-    ReportBinaryInputBasicAttributeList() : ModelCommand("report")
+    ReportBinaryInputBasicAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9805,7 +9805,7 @@ public:
 class ReportBinaryInputBasicClusterRevision : public ModelCommand
 {
 public:
-    ReportBinaryInputBasicClusterRevision() : ModelCommand("report")
+    ReportBinaryInputBasicClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -9942,7 +9942,7 @@ public:
 class ReportBindingAttributeList : public ModelCommand
 {
 public:
-    ReportBindingAttributeList() : ModelCommand("report")
+    ReportBindingAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10014,7 +10014,7 @@ public:
 class ReportBindingClusterRevision : public ModelCommand
 {
 public:
-    ReportBindingClusterRevision() : ModelCommand("report")
+    ReportBindingClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10097,7 +10097,7 @@ public:
 class ReportBooleanStateStateChange : public ModelCommand
 {
 public:
-    ReportBooleanStateStateChange() : ModelCommand("report-event")
+    ReportBooleanStateStateChange() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "state-change");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10169,7 +10169,7 @@ public:
 class ReportBooleanStateStateValue : public ModelCommand
 {
 public:
-    ReportBooleanStateStateValue() : ModelCommand("report")
+    ReportBooleanStateStateValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "state-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10238,7 +10238,7 @@ public:
 class ReportBooleanStateAttributeList : public ModelCommand
 {
 public:
-    ReportBooleanStateAttributeList() : ModelCommand("report")
+    ReportBooleanStateAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10310,7 +10310,7 @@ public:
 class ReportBooleanStateClusterRevision : public ModelCommand
 {
 public:
-    ReportBooleanStateClusterRevision() : ModelCommand("report")
+    ReportBooleanStateClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10713,7 +10713,7 @@ public:
 class ReportBridgedActionsStateChanged : public ModelCommand
 {
 public:
-    ReportBridgedActionsStateChanged() : ModelCommand("report-event")
+    ReportBridgedActionsStateChanged() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "state-changed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10784,7 +10784,7 @@ public:
 class ReportBridgedActionsActionFailed : public ModelCommand
 {
 public:
-    ReportBridgedActionsActionFailed() : ModelCommand("report-event")
+    ReportBridgedActionsActionFailed() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "action-failed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10859,7 +10859,7 @@ public:
 class ReportBridgedActionsActionList : public ModelCommand
 {
 public:
-    ReportBridgedActionsActionList() : ModelCommand("report")
+    ReportBridgedActionsActionList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "action-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -10937,7 +10937,7 @@ public:
 class ReportBridgedActionsEndpointList : public ModelCommand
 {
 public:
-    ReportBridgedActionsEndpointList() : ModelCommand("report")
+    ReportBridgedActionsEndpointList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "endpoint-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11012,7 +11012,7 @@ public:
 class ReportBridgedActionsSetupUrl : public ModelCommand
 {
 public:
-    ReportBridgedActionsSetupUrl() : ModelCommand("report")
+    ReportBridgedActionsSetupUrl() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "setup-url");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11081,7 +11081,7 @@ public:
 class ReportBridgedActionsAttributeList : public ModelCommand
 {
 public:
-    ReportBridgedActionsAttributeList() : ModelCommand("report")
+    ReportBridgedActionsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11153,7 +11153,7 @@ public:
 class ReportBridgedActionsClusterRevision : public ModelCommand
 {
 public:
-    ReportBridgedActionsClusterRevision() : ModelCommand("report")
+    ReportBridgedActionsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11234,7 +11234,7 @@ public:
 class ReportBridgedDeviceBasicAttributeList : public ModelCommand
 {
 public:
-    ReportBridgedDeviceBasicAttributeList() : ModelCommand("report")
+    ReportBridgedDeviceBasicAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11306,7 +11306,7 @@ public:
 class ReportBridgedDeviceBasicClusterRevision : public ModelCommand
 {
 public:
-    ReportBridgedDeviceBasicClusterRevision() : ModelCommand("report")
+    ReportBridgedDeviceBasicClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11466,7 +11466,7 @@ public:
 class ReportChannelChannelList : public ModelCommand
 {
 public:
-    ReportChannelChannelList() : ModelCommand("report")
+    ReportChannelChannelList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "channel-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11540,7 +11540,7 @@ public:
 class ReportChannelAttributeList : public ModelCommand
 {
 public:
-    ReportChannelAttributeList() : ModelCommand("report")
+    ReportChannelAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -11612,7 +11612,7 @@ public:
 class ReportChannelClusterRevision : public ModelCommand
 {
 public:
-    ReportChannelClusterRevision() : ModelCommand("report")
+    ReportChannelClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12306,7 +12306,7 @@ public:
 class ReportColorControlCurrentHue : public ModelCommand
 {
 public:
-    ReportColorControlCurrentHue() : ModelCommand("report")
+    ReportColorControlCurrentHue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-hue");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12375,7 +12375,7 @@ public:
 class ReportColorControlCurrentSaturation : public ModelCommand
 {
 public:
-    ReportColorControlCurrentSaturation() : ModelCommand("report")
+    ReportColorControlCurrentSaturation() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-saturation");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12444,7 +12444,7 @@ public:
 class ReportColorControlRemainingTime : public ModelCommand
 {
 public:
-    ReportColorControlRemainingTime() : ModelCommand("report")
+    ReportColorControlRemainingTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "remaining-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12513,7 +12513,7 @@ public:
 class ReportColorControlCurrentX : public ModelCommand
 {
 public:
-    ReportColorControlCurrentX() : ModelCommand("report")
+    ReportColorControlCurrentX() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12582,7 +12582,7 @@ public:
 class ReportColorControlCurrentY : public ModelCommand
 {
 public:
-    ReportColorControlCurrentY() : ModelCommand("report")
+    ReportColorControlCurrentY() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12651,7 +12651,7 @@ public:
 class ReportColorControlDriftCompensation : public ModelCommand
 {
 public:
-    ReportColorControlDriftCompensation() : ModelCommand("report")
+    ReportColorControlDriftCompensation() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "drift-compensation");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12720,7 +12720,7 @@ public:
 class ReportColorControlCompensationText : public ModelCommand
 {
 public:
-    ReportColorControlCompensationText() : ModelCommand("report")
+    ReportColorControlCompensationText() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "compensation-text");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12789,7 +12789,7 @@ public:
 class ReportColorControlColorTemperature : public ModelCommand
 {
 public:
-    ReportColorControlColorTemperature() : ModelCommand("report")
+    ReportColorControlColorTemperature() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-temperature");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12858,7 +12858,7 @@ public:
 class ReportColorControlColorMode : public ModelCommand
 {
 public:
-    ReportColorControlColorMode() : ModelCommand("report")
+    ReportColorControlColorMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -12953,7 +12953,7 @@ private:
 class ReportColorControlColorControlOptions : public ModelCommand
 {
 public:
-    ReportColorControlColorControlOptions() : ModelCommand("report")
+    ReportColorControlColorControlOptions() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-control-options");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13022,7 +13022,7 @@ public:
 class ReportColorControlNumberOfPrimaries : public ModelCommand
 {
 public:
-    ReportColorControlNumberOfPrimaries() : ModelCommand("report")
+    ReportColorControlNumberOfPrimaries() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "number-of-primaries");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13091,7 +13091,7 @@ public:
 class ReportColorControlPrimary1X : public ModelCommand
 {
 public:
-    ReportColorControlPrimary1X() : ModelCommand("report")
+    ReportColorControlPrimary1X() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary1x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13160,7 +13160,7 @@ public:
 class ReportColorControlPrimary1Y : public ModelCommand
 {
 public:
-    ReportColorControlPrimary1Y() : ModelCommand("report")
+    ReportColorControlPrimary1Y() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary1y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13229,7 +13229,7 @@ public:
 class ReportColorControlPrimary1Intensity : public ModelCommand
 {
 public:
-    ReportColorControlPrimary1Intensity() : ModelCommand("report")
+    ReportColorControlPrimary1Intensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary1intensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13298,7 +13298,7 @@ public:
 class ReportColorControlPrimary2X : public ModelCommand
 {
 public:
-    ReportColorControlPrimary2X() : ModelCommand("report")
+    ReportColorControlPrimary2X() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary2x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13367,7 +13367,7 @@ public:
 class ReportColorControlPrimary2Y : public ModelCommand
 {
 public:
-    ReportColorControlPrimary2Y() : ModelCommand("report")
+    ReportColorControlPrimary2Y() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary2y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13436,7 +13436,7 @@ public:
 class ReportColorControlPrimary2Intensity : public ModelCommand
 {
 public:
-    ReportColorControlPrimary2Intensity() : ModelCommand("report")
+    ReportColorControlPrimary2Intensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary2intensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13505,7 +13505,7 @@ public:
 class ReportColorControlPrimary3X : public ModelCommand
 {
 public:
-    ReportColorControlPrimary3X() : ModelCommand("report")
+    ReportColorControlPrimary3X() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary3x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13574,7 +13574,7 @@ public:
 class ReportColorControlPrimary3Y : public ModelCommand
 {
 public:
-    ReportColorControlPrimary3Y() : ModelCommand("report")
+    ReportColorControlPrimary3Y() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary3y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13643,7 +13643,7 @@ public:
 class ReportColorControlPrimary3Intensity : public ModelCommand
 {
 public:
-    ReportColorControlPrimary3Intensity() : ModelCommand("report")
+    ReportColorControlPrimary3Intensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary3intensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13712,7 +13712,7 @@ public:
 class ReportColorControlPrimary4X : public ModelCommand
 {
 public:
-    ReportColorControlPrimary4X() : ModelCommand("report")
+    ReportColorControlPrimary4X() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary4x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13781,7 +13781,7 @@ public:
 class ReportColorControlPrimary4Y : public ModelCommand
 {
 public:
-    ReportColorControlPrimary4Y() : ModelCommand("report")
+    ReportColorControlPrimary4Y() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary4y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13850,7 +13850,7 @@ public:
 class ReportColorControlPrimary4Intensity : public ModelCommand
 {
 public:
-    ReportColorControlPrimary4Intensity() : ModelCommand("report")
+    ReportColorControlPrimary4Intensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary4intensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13919,7 +13919,7 @@ public:
 class ReportColorControlPrimary5X : public ModelCommand
 {
 public:
-    ReportColorControlPrimary5X() : ModelCommand("report")
+    ReportColorControlPrimary5X() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary5x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -13988,7 +13988,7 @@ public:
 class ReportColorControlPrimary5Y : public ModelCommand
 {
 public:
-    ReportColorControlPrimary5Y() : ModelCommand("report")
+    ReportColorControlPrimary5Y() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary5y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14057,7 +14057,7 @@ public:
 class ReportColorControlPrimary5Intensity : public ModelCommand
 {
 public:
-    ReportColorControlPrimary5Intensity() : ModelCommand("report")
+    ReportColorControlPrimary5Intensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary5intensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14126,7 +14126,7 @@ public:
 class ReportColorControlPrimary6X : public ModelCommand
 {
 public:
-    ReportColorControlPrimary6X() : ModelCommand("report")
+    ReportColorControlPrimary6X() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary6x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14195,7 +14195,7 @@ public:
 class ReportColorControlPrimary6Y : public ModelCommand
 {
 public:
-    ReportColorControlPrimary6Y() : ModelCommand("report")
+    ReportColorControlPrimary6Y() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary6y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14264,7 +14264,7 @@ public:
 class ReportColorControlPrimary6Intensity : public ModelCommand
 {
 public:
-    ReportColorControlPrimary6Intensity() : ModelCommand("report")
+    ReportColorControlPrimary6Intensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "primary6intensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14359,7 +14359,7 @@ private:
 class ReportColorControlWhitePointX : public ModelCommand
 {
 public:
-    ReportColorControlWhitePointX() : ModelCommand("report")
+    ReportColorControlWhitePointX() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "white-point-x");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14454,7 +14454,7 @@ private:
 class ReportColorControlWhitePointY : public ModelCommand
 {
 public:
-    ReportColorControlWhitePointY() : ModelCommand("report")
+    ReportColorControlWhitePointY() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "white-point-y");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14549,7 +14549,7 @@ private:
 class ReportColorControlColorPointRX : public ModelCommand
 {
 public:
-    ReportColorControlColorPointRX() : ModelCommand("report")
+    ReportColorControlColorPointRX() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-rx");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14644,7 +14644,7 @@ private:
 class ReportColorControlColorPointRY : public ModelCommand
 {
 public:
-    ReportColorControlColorPointRY() : ModelCommand("report")
+    ReportColorControlColorPointRY() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-ry");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14739,7 +14739,7 @@ private:
 class ReportColorControlColorPointRIntensity : public ModelCommand
 {
 public:
-    ReportColorControlColorPointRIntensity() : ModelCommand("report")
+    ReportColorControlColorPointRIntensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-rintensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14834,7 +14834,7 @@ private:
 class ReportColorControlColorPointGX : public ModelCommand
 {
 public:
-    ReportColorControlColorPointGX() : ModelCommand("report")
+    ReportColorControlColorPointGX() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-gx");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -14929,7 +14929,7 @@ private:
 class ReportColorControlColorPointGY : public ModelCommand
 {
 public:
-    ReportColorControlColorPointGY() : ModelCommand("report")
+    ReportColorControlColorPointGY() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-gy");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15024,7 +15024,7 @@ private:
 class ReportColorControlColorPointGIntensity : public ModelCommand
 {
 public:
-    ReportColorControlColorPointGIntensity() : ModelCommand("report")
+    ReportColorControlColorPointGIntensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-gintensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15119,7 +15119,7 @@ private:
 class ReportColorControlColorPointBX : public ModelCommand
 {
 public:
-    ReportColorControlColorPointBX() : ModelCommand("report")
+    ReportColorControlColorPointBX() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-bx");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15214,7 +15214,7 @@ private:
 class ReportColorControlColorPointBY : public ModelCommand
 {
 public:
-    ReportColorControlColorPointBY() : ModelCommand("report")
+    ReportColorControlColorPointBY() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-by");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15309,7 +15309,7 @@ private:
 class ReportColorControlColorPointBIntensity : public ModelCommand
 {
 public:
-    ReportColorControlColorPointBIntensity() : ModelCommand("report")
+    ReportColorControlColorPointBIntensity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-point-bintensity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15378,7 +15378,7 @@ public:
 class ReportColorControlEnhancedCurrentHue : public ModelCommand
 {
 public:
-    ReportColorControlEnhancedCurrentHue() : ModelCommand("report")
+    ReportColorControlEnhancedCurrentHue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enhanced-current-hue");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15447,7 +15447,7 @@ public:
 class ReportColorControlEnhancedColorMode : public ModelCommand
 {
 public:
-    ReportColorControlEnhancedColorMode() : ModelCommand("report")
+    ReportColorControlEnhancedColorMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enhanced-color-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15516,7 +15516,7 @@ public:
 class ReportColorControlColorLoopActive : public ModelCommand
 {
 public:
-    ReportColorControlColorLoopActive() : ModelCommand("report")
+    ReportColorControlColorLoopActive() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-loop-active");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15585,7 +15585,7 @@ public:
 class ReportColorControlColorLoopDirection : public ModelCommand
 {
 public:
-    ReportColorControlColorLoopDirection() : ModelCommand("report")
+    ReportColorControlColorLoopDirection() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-loop-direction");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15654,7 +15654,7 @@ public:
 class ReportColorControlColorLoopTime : public ModelCommand
 {
 public:
-    ReportColorControlColorLoopTime() : ModelCommand("report")
+    ReportColorControlColorLoopTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-loop-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15723,7 +15723,7 @@ public:
 class ReportColorControlColorLoopStartEnhancedHue : public ModelCommand
 {
 public:
-    ReportColorControlColorLoopStartEnhancedHue() : ModelCommand("report")
+    ReportColorControlColorLoopStartEnhancedHue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-loop-start-enhanced-hue");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15795,7 +15795,7 @@ public:
 class ReportColorControlColorLoopStoredEnhancedHue : public ModelCommand
 {
 public:
-    ReportColorControlColorLoopStoredEnhancedHue() : ModelCommand("report")
+    ReportColorControlColorLoopStoredEnhancedHue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-loop-stored-enhanced-hue");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15867,7 +15867,7 @@ public:
 class ReportColorControlColorCapabilities : public ModelCommand
 {
 public:
-    ReportColorControlColorCapabilities() : ModelCommand("report")
+    ReportColorControlColorCapabilities() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-capabilities");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -15936,7 +15936,7 @@ public:
 class ReportColorControlColorTempPhysicalMin : public ModelCommand
 {
 public:
-    ReportColorControlColorTempPhysicalMin() : ModelCommand("report")
+    ReportColorControlColorTempPhysicalMin() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-temp-physical-min");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16005,7 +16005,7 @@ public:
 class ReportColorControlColorTempPhysicalMax : public ModelCommand
 {
 public:
-    ReportColorControlColorTempPhysicalMax() : ModelCommand("report")
+    ReportColorControlColorTempPhysicalMax() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "color-temp-physical-max");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16074,7 +16074,7 @@ public:
 class ReportColorControlCoupleColorTempToLevelMinMireds : public ModelCommand
 {
 public:
-    ReportColorControlCoupleColorTempToLevelMinMireds() : ModelCommand("report")
+    ReportColorControlCoupleColorTempToLevelMinMireds() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "couple-color-temp-to-level-min-mireds");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16172,7 +16172,7 @@ private:
 class ReportColorControlStartUpColorTemperatureMireds : public ModelCommand
 {
 public:
-    ReportColorControlStartUpColorTemperatureMireds() : ModelCommand("report")
+    ReportColorControlStartUpColorTemperatureMireds() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "start-up-color-temperature-mireds");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16244,7 +16244,7 @@ public:
 class ReportColorControlAttributeList : public ModelCommand
 {
 public:
-    ReportColorControlAttributeList() : ModelCommand("report")
+    ReportColorControlAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16316,7 +16316,7 @@ public:
 class ReportColorControlClusterRevision : public ModelCommand
 {
 public:
-    ReportColorControlClusterRevision() : ModelCommand("report")
+    ReportColorControlClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16453,7 +16453,7 @@ public:
 class ReportContentLauncherAcceptHeaderList : public ModelCommand
 {
 public:
-    ReportContentLauncherAcceptHeaderList() : ModelCommand("report")
+    ReportContentLauncherAcceptHeaderList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "accept-header-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16551,7 +16551,7 @@ private:
 class ReportContentLauncherSupportedStreamingProtocols : public ModelCommand
 {
 public:
-    ReportContentLauncherSupportedStreamingProtocols() : ModelCommand("report")
+    ReportContentLauncherSupportedStreamingProtocols() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "supported-streaming-protocols");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16623,7 +16623,7 @@ public:
 class ReportContentLauncherAttributeList : public ModelCommand
 {
 public:
-    ReportContentLauncherAttributeList() : ModelCommand("report")
+    ReportContentLauncherAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16695,7 +16695,7 @@ public:
 class ReportContentLauncherClusterRevision : public ModelCommand
 {
 public:
-    ReportContentLauncherClusterRevision() : ModelCommand("report")
+    ReportContentLauncherClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16782,7 +16782,7 @@ public:
 class ReportDescriptorDeviceList : public ModelCommand
 {
 public:
-    ReportDescriptorDeviceList() : ModelCommand("report")
+    ReportDescriptorDeviceList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "device-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16856,7 +16856,7 @@ public:
 class ReportDescriptorServerList : public ModelCommand
 {
 public:
-    ReportDescriptorServerList() : ModelCommand("report")
+    ReportDescriptorServerList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "server-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -16928,7 +16928,7 @@ public:
 class ReportDescriptorClientList : public ModelCommand
 {
 public:
-    ReportDescriptorClientList() : ModelCommand("report")
+    ReportDescriptorClientList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "client-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17000,7 +17000,7 @@ public:
 class ReportDescriptorPartsList : public ModelCommand
 {
 public:
-    ReportDescriptorPartsList() : ModelCommand("report")
+    ReportDescriptorPartsList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "parts-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17072,7 +17072,7 @@ public:
 class ReportDescriptorAttributeList : public ModelCommand
 {
 public:
-    ReportDescriptorAttributeList() : ModelCommand("report")
+    ReportDescriptorAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17144,7 +17144,7 @@ public:
 class ReportDescriptorClusterRevision : public ModelCommand
 {
 public:
-    ReportDescriptorClusterRevision() : ModelCommand("report")
+    ReportDescriptorClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17253,7 +17253,7 @@ public:
 class ReportDiagnosticLogsAttributeList : public ModelCommand
 {
 public:
-    ReportDiagnosticLogsAttributeList() : ModelCommand("report")
+    ReportDiagnosticLogsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17574,7 +17574,7 @@ public:
 class ReportDoorLockDoorLockAlarm : public ModelCommand
 {
 public:
-    ReportDoorLockDoorLockAlarm() : ModelCommand("report-event")
+    ReportDoorLockDoorLockAlarm() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "door-lock-alarm");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17645,7 +17645,7 @@ public:
 class ReportDoorLockDoorStateChange : public ModelCommand
 {
 public:
-    ReportDoorLockDoorStateChange() : ModelCommand("report-event")
+    ReportDoorLockDoorStateChange() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "door-state-change");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17716,7 +17716,7 @@ public:
 class ReportDoorLockLockOperation : public ModelCommand
 {
 public:
-    ReportDoorLockLockOperation() : ModelCommand("report-event")
+    ReportDoorLockLockOperation() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "lock-operation");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17787,7 +17787,7 @@ public:
 class ReportDoorLockLockOperationError : public ModelCommand
 {
 public:
-    ReportDoorLockLockOperationError() : ModelCommand("report-event")
+    ReportDoorLockLockOperationError() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "lock-operation-error");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17858,7 +17858,7 @@ public:
 class ReportDoorLockLockUserChange : public ModelCommand
 {
 public:
-    ReportDoorLockLockUserChange() : ModelCommand("report-event")
+    ReportDoorLockLockUserChange() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "lock-user-change");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -17931,7 +17931,7 @@ public:
 class ReportDoorLockLockState : public ModelCommand
 {
 public:
-    ReportDoorLockLockState() : ModelCommand("report")
+    ReportDoorLockLockState() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "lock-state");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18004,7 +18004,7 @@ public:
 class ReportDoorLockLockType : public ModelCommand
 {
 public:
-    ReportDoorLockLockType() : ModelCommand("report")
+    ReportDoorLockLockType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "lock-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18076,7 +18076,7 @@ public:
 class ReportDoorLockActuatorEnabled : public ModelCommand
 {
 public:
-    ReportDoorLockActuatorEnabled() : ModelCommand("report")
+    ReportDoorLockActuatorEnabled() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "actuator-enabled");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18146,7 +18146,7 @@ public:
 class ReportDoorLockDoorState : public ModelCommand
 {
 public:
-    ReportDoorLockDoorState() : ModelCommand("report")
+    ReportDoorLockDoorState() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "door-state");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18219,7 +18219,7 @@ public:
 class ReportDoorLockNumberOfTotalUsersSupported : public ModelCommand
 {
 public:
-    ReportDoorLockNumberOfTotalUsersSupported() : ModelCommand("report")
+    ReportDoorLockNumberOfTotalUsersSupported() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "number-of-total-users-supported");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18288,7 +18288,7 @@ public:
 class ReportDoorLockNumberOfPINUsersSupported : public ModelCommand
 {
 public:
-    ReportDoorLockNumberOfPINUsersSupported() : ModelCommand("report")
+    ReportDoorLockNumberOfPINUsersSupported() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "number-of-pinusers-supported");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18357,7 +18357,7 @@ public:
 class ReportDoorLockMaxPINCodeLength : public ModelCommand
 {
 public:
-    ReportDoorLockMaxPINCodeLength() : ModelCommand("report")
+    ReportDoorLockMaxPINCodeLength() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-pincode-length");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18426,7 +18426,7 @@ public:
 class ReportDoorLockMinPINCodeLength : public ModelCommand
 {
 public:
-    ReportDoorLockMinPINCodeLength() : ModelCommand("report")
+    ReportDoorLockMinPINCodeLength() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-pincode-length");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18521,7 +18521,7 @@ private:
 class ReportDoorLockLanguage : public ModelCommand
 {
 public:
-    ReportDoorLockLanguage() : ModelCommand("report")
+    ReportDoorLockLanguage() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "language");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18616,7 +18616,7 @@ private:
 class ReportDoorLockAutoRelockTime : public ModelCommand
 {
 public:
-    ReportDoorLockAutoRelockTime() : ModelCommand("report")
+    ReportDoorLockAutoRelockTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "auto-relock-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18711,7 +18711,7 @@ private:
 class ReportDoorLockSoundVolume : public ModelCommand
 {
 public:
-    ReportDoorLockSoundVolume() : ModelCommand("report")
+    ReportDoorLockSoundVolume() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "sound-volume");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18806,7 +18806,7 @@ private:
 class ReportDoorLockOperatingMode : public ModelCommand
 {
 public:
-    ReportDoorLockOperatingMode() : ModelCommand("report")
+    ReportDoorLockOperatingMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "operating-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18878,7 +18878,7 @@ public:
 class ReportDoorLockSupportedOperatingModes : public ModelCommand
 {
 public:
-    ReportDoorLockSupportedOperatingModes() : ModelCommand("report")
+    ReportDoorLockSupportedOperatingModes() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "supported-operating-modes");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -18973,7 +18973,7 @@ private:
 class ReportDoorLockEnableOneTouchLocking : public ModelCommand
 {
 public:
-    ReportDoorLockEnableOneTouchLocking() : ModelCommand("report")
+    ReportDoorLockEnableOneTouchLocking() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enable-one-touch-locking");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19068,7 +19068,7 @@ private:
 class ReportDoorLockEnablePrivacyModeButton : public ModelCommand
 {
 public:
-    ReportDoorLockEnablePrivacyModeButton() : ModelCommand("report")
+    ReportDoorLockEnablePrivacyModeButton() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enable-privacy-mode-button");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19163,7 +19163,7 @@ private:
 class ReportDoorLockWrongCodeEntryLimit : public ModelCommand
 {
 public:
-    ReportDoorLockWrongCodeEntryLimit() : ModelCommand("report")
+    ReportDoorLockWrongCodeEntryLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "wrong-code-entry-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19232,7 +19232,7 @@ public:
 class ReportDoorLockAttributeList : public ModelCommand
 {
 public:
-    ReportDoorLockAttributeList() : ModelCommand("report")
+    ReportDoorLockAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19304,7 +19304,7 @@ public:
 class ReportDoorLockClusterRevision : public ModelCommand
 {
 public:
-    ReportDoorLockClusterRevision() : ModelCommand("report")
+    ReportDoorLockClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19396,7 +19396,7 @@ public:
 class ReportElectricalMeasurementMeasurementType : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementMeasurementType() : ModelCommand("report")
+    ReportElectricalMeasurementMeasurementType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "measurement-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19468,7 +19468,7 @@ public:
 class ReportElectricalMeasurementTotalActivePower : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementTotalActivePower() : ModelCommand("report")
+    ReportElectricalMeasurementTotalActivePower() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "total-active-power");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19540,7 +19540,7 @@ public:
 class ReportElectricalMeasurementRmsVoltage : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementRmsVoltage() : ModelCommand("report")
+    ReportElectricalMeasurementRmsVoltage() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rms-voltage");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19609,7 +19609,7 @@ public:
 class ReportElectricalMeasurementRmsVoltageMin : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementRmsVoltageMin() : ModelCommand("report")
+    ReportElectricalMeasurementRmsVoltageMin() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rms-voltage-min");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19678,7 +19678,7 @@ public:
 class ReportElectricalMeasurementRmsVoltageMax : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementRmsVoltageMax() : ModelCommand("report")
+    ReportElectricalMeasurementRmsVoltageMax() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rms-voltage-max");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19747,7 +19747,7 @@ public:
 class ReportElectricalMeasurementRmsCurrent : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementRmsCurrent() : ModelCommand("report")
+    ReportElectricalMeasurementRmsCurrent() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rms-current");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19816,7 +19816,7 @@ public:
 class ReportElectricalMeasurementRmsCurrentMin : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementRmsCurrentMin() : ModelCommand("report")
+    ReportElectricalMeasurementRmsCurrentMin() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rms-current-min");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19885,7 +19885,7 @@ public:
 class ReportElectricalMeasurementRmsCurrentMax : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementRmsCurrentMax() : ModelCommand("report")
+    ReportElectricalMeasurementRmsCurrentMax() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rms-current-max");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -19954,7 +19954,7 @@ public:
 class ReportElectricalMeasurementActivePower : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementActivePower() : ModelCommand("report")
+    ReportElectricalMeasurementActivePower() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-power");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20023,7 +20023,7 @@ public:
 class ReportElectricalMeasurementActivePowerMin : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementActivePowerMin() : ModelCommand("report")
+    ReportElectricalMeasurementActivePowerMin() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-power-min");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20092,7 +20092,7 @@ public:
 class ReportElectricalMeasurementActivePowerMax : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementActivePowerMax() : ModelCommand("report")
+    ReportElectricalMeasurementActivePowerMax() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-power-max");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20161,7 +20161,7 @@ public:
 class ReportElectricalMeasurementAttributeList : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementAttributeList() : ModelCommand("report")
+    ReportElectricalMeasurementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20233,7 +20233,7 @@ public:
 class ReportElectricalMeasurementClusterRevision : public ModelCommand
 {
 public:
-    ReportElectricalMeasurementClusterRevision() : ModelCommand("report")
+    ReportElectricalMeasurementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20348,7 +20348,7 @@ public:
 class ReportEthernetNetworkDiagnosticsPHYRate : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsPHYRate() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsPHYRate() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "phyrate");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20417,7 +20417,7 @@ public:
 class ReportEthernetNetworkDiagnosticsFullDuplex : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsFullDuplex() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsFullDuplex() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "full-duplex");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20486,7 +20486,7 @@ public:
 class ReportEthernetNetworkDiagnosticsPacketRxCount : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsPacketRxCount() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsPacketRxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "packet-rx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20558,7 +20558,7 @@ public:
 class ReportEthernetNetworkDiagnosticsPacketTxCount : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsPacketTxCount() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsPacketTxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "packet-tx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20630,7 +20630,7 @@ public:
 class ReportEthernetNetworkDiagnosticsTxErrCount : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsTxErrCount() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsTxErrCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-err-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20702,7 +20702,7 @@ public:
 class ReportEthernetNetworkDiagnosticsCollisionCount : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsCollisionCount() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsCollisionCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "collision-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20774,7 +20774,7 @@ public:
 class ReportEthernetNetworkDiagnosticsOverrunCount : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsOverrunCount() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsOverrunCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "overrun-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20846,7 +20846,7 @@ public:
 class ReportEthernetNetworkDiagnosticsCarrierDetect : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsCarrierDetect() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsCarrierDetect() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "carrier-detect");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20915,7 +20915,7 @@ public:
 class ReportEthernetNetworkDiagnosticsTimeSinceReset : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsTimeSinceReset() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsTimeSinceReset() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "time-since-reset");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -20987,7 +20987,7 @@ public:
 class ReportEthernetNetworkDiagnosticsAttributeList : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsAttributeList() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21059,7 +21059,7 @@ public:
 class ReportEthernetNetworkDiagnosticsFeatureMap : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsFeatureMap() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21131,7 +21131,7 @@ public:
 class ReportEthernetNetworkDiagnosticsClusterRevision : public ModelCommand
 {
 public:
-    ReportEthernetNetworkDiagnosticsClusterRevision() : ModelCommand("report")
+    ReportEthernetNetworkDiagnosticsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21218,7 +21218,7 @@ public:
 class ReportFixedLabelLabelList : public ModelCommand
 {
 public:
-    ReportFixedLabelLabelList() : ModelCommand("report")
+    ReportFixedLabelLabelList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "label-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21292,7 +21292,7 @@ public:
 class ReportFixedLabelAttributeList : public ModelCommand
 {
 public:
-    ReportFixedLabelAttributeList() : ModelCommand("report")
+    ReportFixedLabelAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21364,7 +21364,7 @@ public:
 class ReportFixedLabelClusterRevision : public ModelCommand
 {
 public:
-    ReportFixedLabelClusterRevision() : ModelCommand("report")
+    ReportFixedLabelClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21449,7 +21449,7 @@ public:
 class ReportFlowMeasurementMeasuredValue : public ModelCommand
 {
 public:
-    ReportFlowMeasurementMeasuredValue() : ModelCommand("report")
+    ReportFlowMeasurementMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21518,7 +21518,7 @@ public:
 class ReportFlowMeasurementMinMeasuredValue : public ModelCommand
 {
 public:
-    ReportFlowMeasurementMinMeasuredValue() : ModelCommand("report")
+    ReportFlowMeasurementMinMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21587,7 +21587,7 @@ public:
 class ReportFlowMeasurementMaxMeasuredValue : public ModelCommand
 {
 public:
-    ReportFlowMeasurementMaxMeasuredValue() : ModelCommand("report")
+    ReportFlowMeasurementMaxMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21656,7 +21656,7 @@ public:
 class ReportFlowMeasurementTolerance : public ModelCommand
 {
 public:
-    ReportFlowMeasurementTolerance() : ModelCommand("report")
+    ReportFlowMeasurementTolerance() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tolerance");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21725,7 +21725,7 @@ public:
 class ReportFlowMeasurementAttributeList : public ModelCommand
 {
 public:
-    ReportFlowMeasurementAttributeList() : ModelCommand("report")
+    ReportFlowMeasurementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21797,7 +21797,7 @@ public:
 class ReportFlowMeasurementClusterRevision : public ModelCommand
 {
 public:
-    ReportFlowMeasurementClusterRevision() : ModelCommand("report")
+    ReportFlowMeasurementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -21985,7 +21985,7 @@ private:
 class ReportGeneralCommissioningBreadcrumb : public ModelCommand
 {
 public:
-    ReportGeneralCommissioningBreadcrumb() : ModelCommand("report")
+    ReportGeneralCommissioningBreadcrumb() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "breadcrumb");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22057,7 +22057,7 @@ public:
 class ReportGeneralCommissioningBasicCommissioningInfoList : public ModelCommand
 {
 public:
-    ReportGeneralCommissioningBasicCommissioningInfoList() : ModelCommand("report")
+    ReportGeneralCommissioningBasicCommissioningInfoList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "basic-commissioning-info-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22133,7 +22133,7 @@ public:
 class ReportGeneralCommissioningRegulatoryConfig : public ModelCommand
 {
 public:
-    ReportGeneralCommissioningRegulatoryConfig() : ModelCommand("report")
+    ReportGeneralCommissioningRegulatoryConfig() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "regulatory-config");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22202,7 +22202,7 @@ public:
 class ReportGeneralCommissioningLocationCapability : public ModelCommand
 {
 public:
-    ReportGeneralCommissioningLocationCapability() : ModelCommand("report")
+    ReportGeneralCommissioningLocationCapability() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "location-capability");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22274,7 +22274,7 @@ public:
 class ReportGeneralCommissioningAttributeList : public ModelCommand
 {
 public:
-    ReportGeneralCommissioningAttributeList() : ModelCommand("report")
+    ReportGeneralCommissioningAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22346,7 +22346,7 @@ public:
 class ReportGeneralCommissioningClusterRevision : public ModelCommand
 {
 public:
-    ReportGeneralCommissioningClusterRevision() : ModelCommand("report")
+    ReportGeneralCommissioningClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22440,7 +22440,7 @@ public:
 class ReportGeneralDiagnosticsHardwareFaultChange : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsHardwareFaultChange() : ModelCommand("report-event")
+    ReportGeneralDiagnosticsHardwareFaultChange() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "hardware-fault-change");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22513,7 +22513,7 @@ public:
 class ReportGeneralDiagnosticsRadioFaultChange : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsRadioFaultChange() : ModelCommand("report-event")
+    ReportGeneralDiagnosticsRadioFaultChange() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "radio-fault-change");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22586,7 +22586,7 @@ public:
 class ReportGeneralDiagnosticsNetworkFaultChange : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsNetworkFaultChange() : ModelCommand("report-event")
+    ReportGeneralDiagnosticsNetworkFaultChange() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "network-fault-change");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22658,7 +22658,7 @@ public:
 class ReportGeneralDiagnosticsBootReason : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsBootReason() : ModelCommand("report-event")
+    ReportGeneralDiagnosticsBootReason() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "boot-reason");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22733,7 +22733,7 @@ public:
 class ReportGeneralDiagnosticsNetworkInterfaces : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsNetworkInterfaces() : ModelCommand("report")
+    ReportGeneralDiagnosticsNetworkInterfaces() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "network-interfaces");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22807,7 +22807,7 @@ public:
 class ReportGeneralDiagnosticsRebootCount : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsRebootCount() : ModelCommand("report")
+    ReportGeneralDiagnosticsRebootCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "reboot-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22876,7 +22876,7 @@ public:
 class ReportGeneralDiagnosticsUpTime : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsUpTime() : ModelCommand("report")
+    ReportGeneralDiagnosticsUpTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "up-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -22945,7 +22945,7 @@ public:
 class ReportGeneralDiagnosticsTotalOperationalHours : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsTotalOperationalHours() : ModelCommand("report")
+    ReportGeneralDiagnosticsTotalOperationalHours() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "total-operational-hours");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23017,7 +23017,7 @@ public:
 class ReportGeneralDiagnosticsBootReasons : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsBootReasons() : ModelCommand("report")
+    ReportGeneralDiagnosticsBootReasons() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "boot-reasons");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23086,7 +23086,7 @@ public:
 class ReportGeneralDiagnosticsActiveHardwareFaults : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsActiveHardwareFaults() : ModelCommand("report")
+    ReportGeneralDiagnosticsActiveHardwareFaults() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-hardware-faults");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23158,7 +23158,7 @@ public:
 class ReportGeneralDiagnosticsActiveRadioFaults : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsActiveRadioFaults() : ModelCommand("report")
+    ReportGeneralDiagnosticsActiveRadioFaults() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-radio-faults");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23230,7 +23230,7 @@ public:
 class ReportGeneralDiagnosticsActiveNetworkFaults : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsActiveNetworkFaults() : ModelCommand("report")
+    ReportGeneralDiagnosticsActiveNetworkFaults() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-network-faults");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23302,7 +23302,7 @@ public:
 class ReportGeneralDiagnosticsAttributeList : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsAttributeList() : ModelCommand("report")
+    ReportGeneralDiagnosticsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23374,7 +23374,7 @@ public:
 class ReportGeneralDiagnosticsClusterRevision : public ModelCommand
 {
 public:
-    ReportGeneralDiagnosticsClusterRevision() : ModelCommand("report")
+    ReportGeneralDiagnosticsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23562,7 +23562,7 @@ public:
 class ReportGroupKeyManagementGroupKeyMap : public ModelCommand
 {
 public:
-    ReportGroupKeyManagementGroupKeyMap() : ModelCommand("report")
+    ReportGroupKeyManagementGroupKeyMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "group-key-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23640,7 +23640,7 @@ public:
 class ReportGroupKeyManagementGroupTable : public ModelCommand
 {
 public:
-    ReportGroupKeyManagementGroupTable() : ModelCommand("report")
+    ReportGroupKeyManagementGroupTable() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "group-table");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23715,7 +23715,7 @@ public:
 class ReportGroupKeyManagementMaxGroupsPerFabric : public ModelCommand
 {
 public:
-    ReportGroupKeyManagementMaxGroupsPerFabric() : ModelCommand("report")
+    ReportGroupKeyManagementMaxGroupsPerFabric() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-groups-per-fabric");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23787,7 +23787,7 @@ public:
 class ReportGroupKeyManagementMaxGroupKeysPerFabric : public ModelCommand
 {
 public:
-    ReportGroupKeyManagementMaxGroupKeysPerFabric() : ModelCommand("report")
+    ReportGroupKeyManagementMaxGroupKeysPerFabric() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-group-keys-per-fabric");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23859,7 +23859,7 @@ public:
 class ReportGroupKeyManagementAttributeList : public ModelCommand
 {
 public:
-    ReportGroupKeyManagementAttributeList() : ModelCommand("report")
+    ReportGroupKeyManagementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -23931,7 +23931,7 @@ public:
 class ReportGroupKeyManagementClusterRevision : public ModelCommand
 {
 public:
-    ReportGroupKeyManagementClusterRevision() : ModelCommand("report")
+    ReportGroupKeyManagementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24161,7 +24161,7 @@ public:
 class ReportGroupsNameSupport : public ModelCommand
 {
 public:
-    ReportGroupsNameSupport() : ModelCommand("report")
+    ReportGroupsNameSupport() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "name-support");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24230,7 +24230,7 @@ public:
 class ReportGroupsAttributeList : public ModelCommand
 {
 public:
-    ReportGroupsAttributeList() : ModelCommand("report")
+    ReportGroupsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24302,7 +24302,7 @@ public:
 class ReportGroupsClusterRevision : public ModelCommand
 {
 public:
-    ReportGroupsClusterRevision() : ModelCommand("report")
+    ReportGroupsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24485,7 +24485,7 @@ private:
 class ReportIdentifyIdentifyTime : public ModelCommand
 {
 public:
-    ReportIdentifyIdentifyTime() : ModelCommand("report")
+    ReportIdentifyIdentifyTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "identify-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24554,7 +24554,7 @@ public:
 class ReportIdentifyIdentifyType : public ModelCommand
 {
 public:
-    ReportIdentifyIdentifyType() : ModelCommand("report")
+    ReportIdentifyIdentifyType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "identify-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24623,7 +24623,7 @@ public:
 class ReportIdentifyAttributeList : public ModelCommand
 {
 public:
-    ReportIdentifyAttributeList() : ModelCommand("report")
+    ReportIdentifyAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24695,7 +24695,7 @@ public:
 class ReportIdentifyClusterRevision : public ModelCommand
 {
 public:
-    ReportIdentifyClusterRevision() : ModelCommand("report")
+    ReportIdentifyClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24781,7 +24781,7 @@ public:
 class ReportIlluminanceMeasurementMeasuredValue : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementMeasuredValue() : ModelCommand("report")
+    ReportIlluminanceMeasurementMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24853,7 +24853,7 @@ public:
 class ReportIlluminanceMeasurementMinMeasuredValue : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementMinMeasuredValue() : ModelCommand("report")
+    ReportIlluminanceMeasurementMinMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24925,7 +24925,7 @@ public:
 class ReportIlluminanceMeasurementMaxMeasuredValue : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementMaxMeasuredValue() : ModelCommand("report")
+    ReportIlluminanceMeasurementMaxMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -24997,7 +24997,7 @@ public:
 class ReportIlluminanceMeasurementTolerance : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementTolerance() : ModelCommand("report")
+    ReportIlluminanceMeasurementTolerance() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tolerance");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25066,7 +25066,7 @@ public:
 class ReportIlluminanceMeasurementLightSensorType : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementLightSensorType() : ModelCommand("report")
+    ReportIlluminanceMeasurementLightSensorType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "light-sensor-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25138,7 +25138,7 @@ public:
 class ReportIlluminanceMeasurementAttributeList : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementAttributeList() : ModelCommand("report")
+    ReportIlluminanceMeasurementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25210,7 +25210,7 @@ public:
 class ReportIlluminanceMeasurementClusterRevision : public ModelCommand
 {
 public:
-    ReportIlluminanceMeasurementClusterRevision() : ModelCommand("report")
+    ReportIlluminanceMeasurementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25320,7 +25320,7 @@ public:
 class ReportKeypadInputAttributeList : public ModelCommand
 {
 public:
-    ReportKeypadInputAttributeList() : ModelCommand("report")
+    ReportKeypadInputAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25392,7 +25392,7 @@ public:
 class ReportKeypadInputClusterRevision : public ModelCommand
 {
 public:
-    ReportKeypadInputClusterRevision() : ModelCommand("report")
+    ReportKeypadInputClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25703,7 +25703,7 @@ public:
 class ReportLevelControlCurrentLevel : public ModelCommand
 {
 public:
-    ReportLevelControlCurrentLevel() : ModelCommand("report")
+    ReportLevelControlCurrentLevel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-level");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25772,7 +25772,7 @@ public:
 class ReportLevelControlRemainingTime : public ModelCommand
 {
 public:
-    ReportLevelControlRemainingTime() : ModelCommand("report")
+    ReportLevelControlRemainingTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "remaining-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25841,7 +25841,7 @@ public:
 class ReportLevelControlMinLevel : public ModelCommand
 {
 public:
-    ReportLevelControlMinLevel() : ModelCommand("report")
+    ReportLevelControlMinLevel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-level");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25910,7 +25910,7 @@ public:
 class ReportLevelControlMaxLevel : public ModelCommand
 {
 public:
-    ReportLevelControlMaxLevel() : ModelCommand("report")
+    ReportLevelControlMaxLevel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-level");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -25979,7 +25979,7 @@ public:
 class ReportLevelControlCurrentFrequency : public ModelCommand
 {
 public:
-    ReportLevelControlCurrentFrequency() : ModelCommand("report")
+    ReportLevelControlCurrentFrequency() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-frequency");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26048,7 +26048,7 @@ public:
 class ReportLevelControlMinFrequency : public ModelCommand
 {
 public:
-    ReportLevelControlMinFrequency() : ModelCommand("report")
+    ReportLevelControlMinFrequency() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-frequency");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26117,7 +26117,7 @@ public:
 class ReportLevelControlMaxFrequency : public ModelCommand
 {
 public:
-    ReportLevelControlMaxFrequency() : ModelCommand("report")
+    ReportLevelControlMaxFrequency() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-frequency");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26212,7 +26212,7 @@ private:
 class ReportLevelControlOptions : public ModelCommand
 {
 public:
-    ReportLevelControlOptions() : ModelCommand("report")
+    ReportLevelControlOptions() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "options");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26307,7 +26307,7 @@ private:
 class ReportLevelControlOnOffTransitionTime : public ModelCommand
 {
 public:
-    ReportLevelControlOnOffTransitionTime() : ModelCommand("report")
+    ReportLevelControlOnOffTransitionTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "on-off-transition-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26402,7 +26402,7 @@ private:
 class ReportLevelControlOnLevel : public ModelCommand
 {
 public:
-    ReportLevelControlOnLevel() : ModelCommand("report")
+    ReportLevelControlOnLevel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "on-level");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26500,7 +26500,7 @@ private:
 class ReportLevelControlOnTransitionTime : public ModelCommand
 {
 public:
-    ReportLevelControlOnTransitionTime() : ModelCommand("report")
+    ReportLevelControlOnTransitionTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "on-transition-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26598,7 +26598,7 @@ private:
 class ReportLevelControlOffTransitionTime : public ModelCommand
 {
 public:
-    ReportLevelControlOffTransitionTime() : ModelCommand("report")
+    ReportLevelControlOffTransitionTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "off-transition-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26696,7 +26696,7 @@ private:
 class ReportLevelControlDefaultMoveRate : public ModelCommand
 {
 public:
-    ReportLevelControlDefaultMoveRate() : ModelCommand("report")
+    ReportLevelControlDefaultMoveRate() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "default-move-rate");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26794,7 +26794,7 @@ private:
 class ReportLevelControlStartUpCurrentLevel : public ModelCommand
 {
 public:
-    ReportLevelControlStartUpCurrentLevel() : ModelCommand("report")
+    ReportLevelControlStartUpCurrentLevel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "start-up-current-level");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26866,7 +26866,7 @@ public:
 class ReportLevelControlAttributeList : public ModelCommand
 {
 public:
-    ReportLevelControlAttributeList() : ModelCommand("report")
+    ReportLevelControlAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -26938,7 +26938,7 @@ public:
 class ReportLevelControlFeatureMap : public ModelCommand
 {
 public:
-    ReportLevelControlFeatureMap() : ModelCommand("report")
+    ReportLevelControlFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27007,7 +27007,7 @@ public:
 class ReportLevelControlClusterRevision : public ModelCommand
 {
 public:
-    ReportLevelControlClusterRevision() : ModelCommand("report")
+    ReportLevelControlClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27115,7 +27115,7 @@ private:
 class ReportLocalizationConfigurationActiveLocale : public ModelCommand
 {
 public:
-    ReportLocalizationConfigurationActiveLocale() : ModelCommand("report")
+    ReportLocalizationConfigurationActiveLocale() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-locale");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27187,7 +27187,7 @@ public:
 class ReportLocalizationConfigurationSupportedLocales : public ModelCommand
 {
 public:
-    ReportLocalizationConfigurationSupportedLocales() : ModelCommand("report")
+    ReportLocalizationConfigurationSupportedLocales() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "supported-locales");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27259,7 +27259,7 @@ public:
 class ReportLocalizationConfigurationClusterRevision : public ModelCommand
 {
 public:
-    ReportLocalizationConfigurationClusterRevision() : ModelCommand("report")
+    ReportLocalizationConfigurationClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27364,7 +27364,7 @@ public:
 class ReportLowPowerAttributeList : public ModelCommand
 {
 public:
-    ReportLowPowerAttributeList() : ModelCommand("report")
+    ReportLowPowerAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27436,7 +27436,7 @@ public:
 class ReportLowPowerClusterRevision : public ModelCommand
 {
 public:
-    ReportLowPowerClusterRevision() : ModelCommand("report")
+    ReportLowPowerClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27614,7 +27614,7 @@ public:
 class ReportMediaInputMediaInputList : public ModelCommand
 {
 public:
-    ReportMediaInputMediaInputList() : ModelCommand("report")
+    ReportMediaInputMediaInputList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "media-input-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27688,7 +27688,7 @@ public:
 class ReportMediaInputCurrentMediaInput : public ModelCommand
 {
 public:
-    ReportMediaInputCurrentMediaInput() : ModelCommand("report")
+    ReportMediaInputCurrentMediaInput() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-media-input");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27757,7 +27757,7 @@ public:
 class ReportMediaInputAttributeList : public ModelCommand
 {
 public:
-    ReportMediaInputAttributeList() : ModelCommand("report")
+    ReportMediaInputAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -27829,7 +27829,7 @@ public:
 class ReportMediaInputClusterRevision : public ModelCommand
 {
 public:
-    ReportMediaInputClusterRevision() : ModelCommand("report")
+    ReportMediaInputClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28159,7 +28159,7 @@ public:
 class ReportMediaPlaybackPlaybackState : public ModelCommand
 {
 public:
-    ReportMediaPlaybackPlaybackState() : ModelCommand("report")
+    ReportMediaPlaybackPlaybackState() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "playback-state");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28231,7 +28231,7 @@ public:
 class ReportMediaPlaybackStartTime : public ModelCommand
 {
 public:
-    ReportMediaPlaybackStartTime() : ModelCommand("report")
+    ReportMediaPlaybackStartTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "start-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28300,7 +28300,7 @@ public:
 class ReportMediaPlaybackDuration : public ModelCommand
 {
 public:
-    ReportMediaPlaybackDuration() : ModelCommand("report")
+    ReportMediaPlaybackDuration() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "duration");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28369,7 +28369,7 @@ public:
 class ReportMediaPlaybackPlaybackSpeed : public ModelCommand
 {
 public:
-    ReportMediaPlaybackPlaybackSpeed() : ModelCommand("report")
+    ReportMediaPlaybackPlaybackSpeed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "playback-speed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28438,7 +28438,7 @@ public:
 class ReportMediaPlaybackSeekRangeEnd : public ModelCommand
 {
 public:
-    ReportMediaPlaybackSeekRangeEnd() : ModelCommand("report")
+    ReportMediaPlaybackSeekRangeEnd() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "seek-range-end");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28507,7 +28507,7 @@ public:
 class ReportMediaPlaybackSeekRangeStart : public ModelCommand
 {
 public:
-    ReportMediaPlaybackSeekRangeStart() : ModelCommand("report")
+    ReportMediaPlaybackSeekRangeStart() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "seek-range-start");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28576,7 +28576,7 @@ public:
 class ReportMediaPlaybackAttributeList : public ModelCommand
 {
 public:
-    ReportMediaPlaybackAttributeList() : ModelCommand("report")
+    ReportMediaPlaybackAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28648,7 +28648,7 @@ public:
 class ReportMediaPlaybackClusterRevision : public ModelCommand
 {
 public:
-    ReportMediaPlaybackClusterRevision() : ModelCommand("report")
+    ReportMediaPlaybackClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28759,7 +28759,7 @@ public:
 class ReportModeSelectCurrentMode : public ModelCommand
 {
 public:
-    ReportModeSelectCurrentMode() : ModelCommand("report")
+    ReportModeSelectCurrentMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28831,7 +28831,7 @@ public:
 class ReportModeSelectSupportedModes : public ModelCommand
 {
 public:
-    ReportModeSelectSupportedModes() : ModelCommand("report")
+    ReportModeSelectSupportedModes() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "supported-modes");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -28932,7 +28932,7 @@ private:
 class ReportModeSelectOnMode : public ModelCommand
 {
 public:
-    ReportModeSelectOnMode() : ModelCommand("report")
+    ReportModeSelectOnMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "on-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29001,7 +29001,7 @@ public:
 class ReportModeSelectStartUpMode : public ModelCommand
 {
 public:
-    ReportModeSelectStartUpMode() : ModelCommand("report")
+    ReportModeSelectStartUpMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "start-up-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29070,7 +29070,7 @@ public:
 class ReportModeSelectDescription : public ModelCommand
 {
 public:
-    ReportModeSelectDescription() : ModelCommand("report")
+    ReportModeSelectDescription() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "description");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29139,7 +29139,7 @@ public:
 class ReportModeSelectAttributeList : public ModelCommand
 {
 public:
-    ReportModeSelectAttributeList() : ModelCommand("report")
+    ReportModeSelectAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29211,7 +29211,7 @@ public:
 class ReportModeSelectClusterRevision : public ModelCommand
 {
 public:
-    ReportModeSelectClusterRevision() : ModelCommand("report")
+    ReportModeSelectClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29458,7 +29458,7 @@ public:
 class ReportNetworkCommissioningMaxNetworks : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningMaxNetworks() : ModelCommand("report")
+    ReportNetworkCommissioningMaxNetworks() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-networks");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29530,7 +29530,7 @@ public:
 class ReportNetworkCommissioningNetworks : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningNetworks() : ModelCommand("report")
+    ReportNetworkCommissioningNetworks() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "networks");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29605,7 +29605,7 @@ public:
 class ReportNetworkCommissioningScanMaxTimeSeconds : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningScanMaxTimeSeconds() : ModelCommand("report")
+    ReportNetworkCommissioningScanMaxTimeSeconds() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "scan-max-time-seconds");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29677,7 +29677,7 @@ public:
 class ReportNetworkCommissioningConnectMaxTimeSeconds : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningConnectMaxTimeSeconds() : ModelCommand("report")
+    ReportNetworkCommissioningConnectMaxTimeSeconds() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "connect-max-time-seconds");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29775,7 +29775,7 @@ private:
 class ReportNetworkCommissioningInterfaceEnabled : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningInterfaceEnabled() : ModelCommand("report")
+    ReportNetworkCommissioningInterfaceEnabled() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "interface-enabled");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29844,7 +29844,7 @@ public:
 class ReportNetworkCommissioningLastNetworkingStatus : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningLastNetworkingStatus() : ModelCommand("report")
+    ReportNetworkCommissioningLastNetworkingStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "last-networking-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29916,7 +29916,7 @@ public:
 class ReportNetworkCommissioningLastNetworkID : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningLastNetworkID() : ModelCommand("report")
+    ReportNetworkCommissioningLastNetworkID() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "last-network-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -29988,7 +29988,7 @@ public:
 class ReportNetworkCommissioningLastConnectErrorValue : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningLastConnectErrorValue() : ModelCommand("report")
+    ReportNetworkCommissioningLastConnectErrorValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "last-connect-error-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30060,7 +30060,7 @@ public:
 class ReportNetworkCommissioningFeatureMap : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningFeatureMap() : ModelCommand("report")
+    ReportNetworkCommissioningFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30129,7 +30129,7 @@ public:
 class ReportNetworkCommissioningClusterRevision : public ModelCommand
 {
 public:
-    ReportNetworkCommissioningClusterRevision() : ModelCommand("report")
+    ReportNetworkCommissioningClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30294,7 +30294,7 @@ public:
 class ReportOtaSoftwareUpdateProviderAttributeList : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateProviderAttributeList() : ModelCommand("report")
+    ReportOtaSoftwareUpdateProviderAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30366,7 +30366,7 @@ public:
 class ReportOtaSoftwareUpdateProviderClusterRevision : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateProviderClusterRevision() : ModelCommand("report")
+    ReportOtaSoftwareUpdateProviderClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30489,7 +30489,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorStateTransition : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorStateTransition() : ModelCommand("report-event")
+    ReportOtaSoftwareUpdateRequestorStateTransition() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "state-transition");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30562,7 +30562,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorVersionApplied : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorVersionApplied() : ModelCommand("report-event")
+    ReportOtaSoftwareUpdateRequestorVersionApplied() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "version-applied");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30635,7 +30635,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorDownloadError : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorDownloadError() : ModelCommand("report-event")
+    ReportOtaSoftwareUpdateRequestorDownloadError() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "download-error");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30711,7 +30711,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorDefaultOtaProviders : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorDefaultOtaProviders() : ModelCommand("report")
+    ReportOtaSoftwareUpdateRequestorDefaultOtaProviders() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "default-ota-providers");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30787,7 +30787,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorUpdatePossible : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorUpdatePossible() : ModelCommand("report")
+    ReportOtaSoftwareUpdateRequestorUpdatePossible() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "update-possible");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30859,7 +30859,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorUpdateState : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorUpdateState() : ModelCommand("report")
+    ReportOtaSoftwareUpdateRequestorUpdateState() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "update-state");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -30931,7 +30931,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorUpdateStateProgress : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorUpdateStateProgress() : ModelCommand("report")
+    ReportOtaSoftwareUpdateRequestorUpdateStateProgress() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "update-state-progress");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31004,7 +31004,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorAttributeList : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorAttributeList() : ModelCommand("report")
+    ReportOtaSoftwareUpdateRequestorAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31076,7 +31076,7 @@ public:
 class ReportOtaSoftwareUpdateRequestorClusterRevision : public ModelCommand
 {
 public:
-    ReportOtaSoftwareUpdateRequestorClusterRevision() : ModelCommand("report")
+    ReportOtaSoftwareUpdateRequestorClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31163,7 +31163,7 @@ public:
 class ReportOccupancySensingOccupancy : public ModelCommand
 {
 public:
-    ReportOccupancySensingOccupancy() : ModelCommand("report")
+    ReportOccupancySensingOccupancy() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "occupancy");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31232,7 +31232,7 @@ public:
 class ReportOccupancySensingOccupancySensorType : public ModelCommand
 {
 public:
-    ReportOccupancySensingOccupancySensorType() : ModelCommand("report")
+    ReportOccupancySensingOccupancySensorType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "occupancy-sensor-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31301,7 +31301,7 @@ public:
 class ReportOccupancySensingOccupancySensorTypeBitmap : public ModelCommand
 {
 public:
-    ReportOccupancySensingOccupancySensorTypeBitmap() : ModelCommand("report")
+    ReportOccupancySensingOccupancySensorTypeBitmap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "occupancy-sensor-type-bitmap");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31373,7 +31373,7 @@ public:
 class ReportOccupancySensingAttributeList : public ModelCommand
 {
 public:
-    ReportOccupancySensingAttributeList() : ModelCommand("report")
+    ReportOccupancySensingAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31445,7 +31445,7 @@ public:
 class ReportOccupancySensingClusterRevision : public ModelCommand
 {
 public:
-    ReportOccupancySensingClusterRevision() : ModelCommand("report")
+    ReportOccupancySensingClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31672,7 +31672,7 @@ public:
 class ReportOnOffOnOff : public ModelCommand
 {
 public:
-    ReportOnOffOnOff() : ModelCommand("report")
+    ReportOnOffOnOff() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "on-off");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31741,7 +31741,7 @@ public:
 class ReportOnOffGlobalSceneControl : public ModelCommand
 {
 public:
-    ReportOnOffGlobalSceneControl() : ModelCommand("report")
+    ReportOnOffGlobalSceneControl() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "global-scene-control");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31836,7 +31836,7 @@ private:
 class ReportOnOffOnTime : public ModelCommand
 {
 public:
-    ReportOnOffOnTime() : ModelCommand("report")
+    ReportOnOffOnTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "on-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -31931,7 +31931,7 @@ private:
 class ReportOnOffOffWaitTime : public ModelCommand
 {
 public:
-    ReportOnOffOffWaitTime() : ModelCommand("report")
+    ReportOnOffOffWaitTime() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "off-wait-time");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32026,7 +32026,7 @@ private:
 class ReportOnOffStartUpOnOff : public ModelCommand
 {
 public:
-    ReportOnOffStartUpOnOff() : ModelCommand("report")
+    ReportOnOffStartUpOnOff() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "start-up-on-off");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32095,7 +32095,7 @@ public:
 class ReportOnOffAttributeList : public ModelCommand
 {
 public:
-    ReportOnOffAttributeList() : ModelCommand("report")
+    ReportOnOffAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32167,7 +32167,7 @@ public:
 class ReportOnOffFeatureMap : public ModelCommand
 {
 public:
-    ReportOnOffFeatureMap() : ModelCommand("report")
+    ReportOnOffFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32236,7 +32236,7 @@ public:
 class ReportOnOffClusterRevision : public ModelCommand
 {
 public:
-    ReportOnOffClusterRevision() : ModelCommand("report")
+    ReportOnOffClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32319,7 +32319,7 @@ public:
 class ReportOnOffSwitchConfigurationSwitchType : public ModelCommand
 {
 public:
-    ReportOnOffSwitchConfigurationSwitchType() : ModelCommand("report")
+    ReportOnOffSwitchConfigurationSwitchType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "switch-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32414,7 +32414,7 @@ private:
 class ReportOnOffSwitchConfigurationSwitchActions : public ModelCommand
 {
 public:
-    ReportOnOffSwitchConfigurationSwitchActions() : ModelCommand("report")
+    ReportOnOffSwitchConfigurationSwitchActions() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "switch-actions");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32486,7 +32486,7 @@ public:
 class ReportOnOffSwitchConfigurationAttributeList : public ModelCommand
 {
 public:
-    ReportOnOffSwitchConfigurationAttributeList() : ModelCommand("report")
+    ReportOnOffSwitchConfigurationAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32558,7 +32558,7 @@ public:
 class ReportOnOffSwitchConfigurationClusterRevision : public ModelCommand
 {
 public:
-    ReportOnOffSwitchConfigurationClusterRevision() : ModelCommand("report")
+    ReportOnOffSwitchConfigurationClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32881,7 +32881,7 @@ public:
 class ReportOperationalCredentialsNOCs : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsNOCs() : ModelCommand("report")
+    ReportOperationalCredentialsNOCs() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nocs");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -32959,7 +32959,7 @@ public:
 class ReportOperationalCredentialsFabricsList : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsFabricsList() : ModelCommand("report")
+    ReportOperationalCredentialsFabricsList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "fabrics-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33033,7 +33033,7 @@ public:
 class ReportOperationalCredentialsSupportedFabrics : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsSupportedFabrics() : ModelCommand("report")
+    ReportOperationalCredentialsSupportedFabrics() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "supported-fabrics");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33105,7 +33105,7 @@ public:
 class ReportOperationalCredentialsCommissionedFabrics : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsCommissionedFabrics() : ModelCommand("report")
+    ReportOperationalCredentialsCommissionedFabrics() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "commissioned-fabrics");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33177,7 +33177,7 @@ public:
 class ReportOperationalCredentialsTrustedRootCertificates : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsTrustedRootCertificates() : ModelCommand("report")
+    ReportOperationalCredentialsTrustedRootCertificates() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "trusted-root-certificates");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33250,7 +33250,7 @@ public:
 class ReportOperationalCredentialsCurrentFabricIndex : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsCurrentFabricIndex() : ModelCommand("report")
+    ReportOperationalCredentialsCurrentFabricIndex() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-fabric-index");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33322,7 +33322,7 @@ public:
 class ReportOperationalCredentialsAttributeList : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsAttributeList() : ModelCommand("report")
+    ReportOperationalCredentialsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33394,7 +33394,7 @@ public:
 class ReportOperationalCredentialsClusterRevision : public ModelCommand
 {
 public:
-    ReportOperationalCredentialsClusterRevision() : ModelCommand("report")
+    ReportOperationalCredentialsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33488,7 +33488,7 @@ public:
 class ReportPowerSourceStatus : public ModelCommand
 {
 public:
-    ReportPowerSourceStatus() : ModelCommand("report")
+    ReportPowerSourceStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33557,7 +33557,7 @@ public:
 class ReportPowerSourceOrder : public ModelCommand
 {
 public:
-    ReportPowerSourceOrder() : ModelCommand("report")
+    ReportPowerSourceOrder() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "order");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33626,7 +33626,7 @@ public:
 class ReportPowerSourceDescription : public ModelCommand
 {
 public:
-    ReportPowerSourceDescription() : ModelCommand("report")
+    ReportPowerSourceDescription() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "description");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33695,7 +33695,7 @@ public:
 class ReportPowerSourceBatteryVoltage : public ModelCommand
 {
 public:
-    ReportPowerSourceBatteryVoltage() : ModelCommand("report")
+    ReportPowerSourceBatteryVoltage() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "battery-voltage");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33764,7 +33764,7 @@ public:
 class ReportPowerSourceBatteryPercentRemaining : public ModelCommand
 {
 public:
-    ReportPowerSourceBatteryPercentRemaining() : ModelCommand("report")
+    ReportPowerSourceBatteryPercentRemaining() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "battery-percent-remaining");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33833,7 +33833,7 @@ public:
 class ReportPowerSourceBatteryTimeRemaining : public ModelCommand
 {
 public:
-    ReportPowerSourceBatteryTimeRemaining() : ModelCommand("report")
+    ReportPowerSourceBatteryTimeRemaining() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "battery-time-remaining");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33902,7 +33902,7 @@ public:
 class ReportPowerSourceBatteryChargeLevel : public ModelCommand
 {
 public:
-    ReportPowerSourceBatteryChargeLevel() : ModelCommand("report")
+    ReportPowerSourceBatteryChargeLevel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "battery-charge-level");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -33971,7 +33971,7 @@ public:
 class ReportPowerSourceActiveBatteryFaults : public ModelCommand
 {
 public:
-    ReportPowerSourceActiveBatteryFaults() : ModelCommand("report")
+    ReportPowerSourceActiveBatteryFaults() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-battery-faults");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34043,7 +34043,7 @@ public:
 class ReportPowerSourceBatteryChargeState : public ModelCommand
 {
 public:
-    ReportPowerSourceBatteryChargeState() : ModelCommand("report")
+    ReportPowerSourceBatteryChargeState() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "battery-charge-state");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34112,7 +34112,7 @@ public:
 class ReportPowerSourceAttributeList : public ModelCommand
 {
 public:
-    ReportPowerSourceAttributeList() : ModelCommand("report")
+    ReportPowerSourceAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34184,7 +34184,7 @@ public:
 class ReportPowerSourceFeatureMap : public ModelCommand
 {
 public:
-    ReportPowerSourceFeatureMap() : ModelCommand("report")
+    ReportPowerSourceFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34253,7 +34253,7 @@ public:
 class ReportPowerSourceClusterRevision : public ModelCommand
 {
 public:
-    ReportPowerSourceClusterRevision() : ModelCommand("report")
+    ReportPowerSourceClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34335,7 +34335,7 @@ public:
 class ReportPowerSourceConfigurationSources : public ModelCommand
 {
 public:
-    ReportPowerSourceConfigurationSources() : ModelCommand("report")
+    ReportPowerSourceConfigurationSources() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "sources");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34407,7 +34407,7 @@ public:
 class ReportPowerSourceConfigurationAttributeList : public ModelCommand
 {
 public:
-    ReportPowerSourceConfigurationAttributeList() : ModelCommand("report")
+    ReportPowerSourceConfigurationAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34479,7 +34479,7 @@ public:
 class ReportPowerSourceConfigurationClusterRevision : public ModelCommand
 {
 public:
-    ReportPowerSourceConfigurationClusterRevision() : ModelCommand("report")
+    ReportPowerSourceConfigurationClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34566,7 +34566,7 @@ public:
 class ReportPressureMeasurementMeasuredValue : public ModelCommand
 {
 public:
-    ReportPressureMeasurementMeasuredValue() : ModelCommand("report")
+    ReportPressureMeasurementMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34635,7 +34635,7 @@ public:
 class ReportPressureMeasurementMinMeasuredValue : public ModelCommand
 {
 public:
-    ReportPressureMeasurementMinMeasuredValue() : ModelCommand("report")
+    ReportPressureMeasurementMinMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34704,7 +34704,7 @@ public:
 class ReportPressureMeasurementMaxMeasuredValue : public ModelCommand
 {
 public:
-    ReportPressureMeasurementMaxMeasuredValue() : ModelCommand("report")
+    ReportPressureMeasurementMaxMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34773,7 +34773,7 @@ public:
 class ReportPressureMeasurementAttributeList : public ModelCommand
 {
 public:
-    ReportPressureMeasurementAttributeList() : ModelCommand("report")
+    ReportPressureMeasurementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34845,7 +34845,7 @@ public:
 class ReportPressureMeasurementClusterRevision : public ModelCommand
 {
 public:
-    ReportPressureMeasurementClusterRevision() : ModelCommand("report")
+    ReportPressureMeasurementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -34969,7 +34969,7 @@ public:
 class ReportPumpConfigurationAndControlSupplyVoltageLow : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlSupplyVoltageLow() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlSupplyVoltageLow() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "supply-voltage-low");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35042,7 +35042,7 @@ public:
 class ReportPumpConfigurationAndControlSupplyVoltageHigh : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlSupplyVoltageHigh() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlSupplyVoltageHigh() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "supply-voltage-high");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35115,7 +35115,7 @@ public:
 class ReportPumpConfigurationAndControlPowerMissingPhase : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlPowerMissingPhase() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlPowerMissingPhase() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "power-missing-phase");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35188,7 +35188,7 @@ public:
 class ReportPumpConfigurationAndControlSystemPressureLow : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlSystemPressureLow() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlSystemPressureLow() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "system-pressure-low");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35261,7 +35261,7 @@ public:
 class ReportPumpConfigurationAndControlSystemPressureHigh : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlSystemPressureHigh() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlSystemPressureHigh() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "system-pressure-high");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35334,7 +35334,7 @@ public:
 class ReportPumpConfigurationAndControlDryRunning : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlDryRunning() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlDryRunning() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "dry-running");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35407,7 +35407,7 @@ public:
 class ReportPumpConfigurationAndControlMotorTemperatureHigh : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMotorTemperatureHigh() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlMotorTemperatureHigh() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "motor-temperature-high");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35482,7 +35482,7 @@ public:
 class ReportPumpConfigurationAndControlPumpMotorFatalFailure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlPumpMotorFatalFailure() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlPumpMotorFatalFailure() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "pump-motor-fatal-failure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35558,7 +35558,7 @@ public:
 class ReportPumpConfigurationAndControlElectronicTemperatureHigh : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlElectronicTemperatureHigh() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlElectronicTemperatureHigh() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "electronic-temperature-high");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35633,7 +35633,7 @@ public:
 class ReportPumpConfigurationAndControlPumpBlocked : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlPumpBlocked() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlPumpBlocked() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "pump-blocked");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35706,7 +35706,7 @@ public:
 class ReportPumpConfigurationAndControlSensorFailure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlSensorFailure() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlSensorFailure() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "sensor-failure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35781,7 +35781,7 @@ public:
 class ReportPumpConfigurationAndControlElectronicNonFatalFailure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlElectronicNonFatalFailure() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlElectronicNonFatalFailure() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "electronic-non-fatal-failure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35857,7 +35857,7 @@ public:
 class ReportPumpConfigurationAndControlElectronicFatalFailure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlElectronicFatalFailure() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlElectronicFatalFailure() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "electronic-fatal-failure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -35931,7 +35931,7 @@ public:
 class ReportPumpConfigurationAndControlGeneralFault : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlGeneralFault() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlGeneralFault() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "general-fault");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36004,7 +36004,7 @@ public:
 class ReportPumpConfigurationAndControlLeakage : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlLeakage() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlLeakage() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "leakage");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36077,7 +36077,7 @@ public:
 class ReportPumpConfigurationAndControlAirDetection : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlAirDetection() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlAirDetection() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "air-detection");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36150,7 +36150,7 @@ public:
 class ReportPumpConfigurationAndControlTurbineOperation : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlTurbineOperation() : ModelCommand("report-event")
+    ReportPumpConfigurationAndControlTurbineOperation() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "turbine-operation");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36223,7 +36223,7 @@ public:
 class ReportPumpConfigurationAndControlMaxPressure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxPressure() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxPressure() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-pressure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36295,7 +36295,7 @@ public:
 class ReportPumpConfigurationAndControlMaxSpeed : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxSpeed() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxSpeed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-speed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36364,7 +36364,7 @@ public:
 class ReportPumpConfigurationAndControlMaxFlow : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxFlow() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxFlow() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-flow");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36433,7 +36433,7 @@ public:
 class ReportPumpConfigurationAndControlMinConstPressure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMinConstPressure() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMinConstPressure() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-const-pressure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36505,7 +36505,7 @@ public:
 class ReportPumpConfigurationAndControlMaxConstPressure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxConstPressure() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxConstPressure() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-const-pressure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36577,7 +36577,7 @@ public:
 class ReportPumpConfigurationAndControlMinCompPressure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMinCompPressure() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMinCompPressure() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-comp-pressure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36649,7 +36649,7 @@ public:
 class ReportPumpConfigurationAndControlMaxCompPressure : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxCompPressure() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxCompPressure() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-comp-pressure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36721,7 +36721,7 @@ public:
 class ReportPumpConfigurationAndControlMinConstSpeed : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMinConstSpeed() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMinConstSpeed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-const-speed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36793,7 +36793,7 @@ public:
 class ReportPumpConfigurationAndControlMaxConstSpeed : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxConstSpeed() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxConstSpeed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-const-speed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36865,7 +36865,7 @@ public:
 class ReportPumpConfigurationAndControlMinConstFlow : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMinConstFlow() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMinConstFlow() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-const-flow");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -36937,7 +36937,7 @@ public:
 class ReportPumpConfigurationAndControlMaxConstFlow : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxConstFlow() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxConstFlow() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-const-flow");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37009,7 +37009,7 @@ public:
 class ReportPumpConfigurationAndControlMinConstTemp : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMinConstTemp() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMinConstTemp() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-const-temp");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37081,7 +37081,7 @@ public:
 class ReportPumpConfigurationAndControlMaxConstTemp : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlMaxConstTemp() : ModelCommand("report")
+    ReportPumpConfigurationAndControlMaxConstTemp() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-const-temp");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37153,7 +37153,7 @@ public:
 class ReportPumpConfigurationAndControlPumpStatus : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlPumpStatus() : ModelCommand("report")
+    ReportPumpConfigurationAndControlPumpStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "pump-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37226,7 +37226,7 @@ public:
 class ReportPumpConfigurationAndControlEffectiveOperationMode : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlEffectiveOperationMode() : ModelCommand("report")
+    ReportPumpConfigurationAndControlEffectiveOperationMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "effective-operation-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37299,7 +37299,7 @@ public:
 class ReportPumpConfigurationAndControlEffectiveControlMode : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlEffectiveControlMode() : ModelCommand("report")
+    ReportPumpConfigurationAndControlEffectiveControlMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "effective-control-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37372,7 +37372,7 @@ public:
 class ReportPumpConfigurationAndControlCapacity : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlCapacity() : ModelCommand("report")
+    ReportPumpConfigurationAndControlCapacity() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "capacity");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37441,7 +37441,7 @@ public:
 class ReportPumpConfigurationAndControlSpeed : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlSpeed() : ModelCommand("report")
+    ReportPumpConfigurationAndControlSpeed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "speed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37536,7 +37536,7 @@ private:
 class ReportPumpConfigurationAndControlLifetimeRunningHours : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlLifetimeRunningHours() : ModelCommand("report")
+    ReportPumpConfigurationAndControlLifetimeRunningHours() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "lifetime-running-hours");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37609,7 +37609,7 @@ public:
 class ReportPumpConfigurationAndControlPower : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlPower() : ModelCommand("report")
+    ReportPumpConfigurationAndControlPower() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "power");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37706,7 +37706,7 @@ private:
 class ReportPumpConfigurationAndControlLifetimeEnergyConsumed : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlLifetimeEnergyConsumed() : ModelCommand("report")
+    ReportPumpConfigurationAndControlLifetimeEnergyConsumed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "lifetime-energy-consumed");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37805,7 +37805,7 @@ private:
 class ReportPumpConfigurationAndControlOperationMode : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlOperationMode() : ModelCommand("report")
+    ReportPumpConfigurationAndControlOperationMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "operation-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37903,7 +37903,7 @@ private:
 class ReportPumpConfigurationAndControlControlMode : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlControlMode() : ModelCommand("report")
+    ReportPumpConfigurationAndControlControlMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "control-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -37975,7 +37975,7 @@ public:
 class ReportPumpConfigurationAndControlAlarmMask : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlAlarmMask() : ModelCommand("report")
+    ReportPumpConfigurationAndControlAlarmMask() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "alarm-mask");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38047,7 +38047,7 @@ public:
 class ReportPumpConfigurationAndControlAttributeList : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlAttributeList() : ModelCommand("report")
+    ReportPumpConfigurationAndControlAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38119,7 +38119,7 @@ public:
 class ReportPumpConfigurationAndControlFeatureMap : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlFeatureMap() : ModelCommand("report")
+    ReportPumpConfigurationAndControlFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38191,7 +38191,7 @@ public:
 class ReportPumpConfigurationAndControlClusterRevision : public ModelCommand
 {
 public:
-    ReportPumpConfigurationAndControlClusterRevision() : ModelCommand("report")
+    ReportPumpConfigurationAndControlClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38279,7 +38279,7 @@ public:
 class ReportRelativeHumidityMeasurementMeasuredValue : public ModelCommand
 {
 public:
-    ReportRelativeHumidityMeasurementMeasuredValue() : ModelCommand("report")
+    ReportRelativeHumidityMeasurementMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38351,7 +38351,7 @@ public:
 class ReportRelativeHumidityMeasurementMinMeasuredValue : public ModelCommand
 {
 public:
-    ReportRelativeHumidityMeasurementMinMeasuredValue() : ModelCommand("report")
+    ReportRelativeHumidityMeasurementMinMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38423,7 +38423,7 @@ public:
 class ReportRelativeHumidityMeasurementMaxMeasuredValue : public ModelCommand
 {
 public:
-    ReportRelativeHumidityMeasurementMaxMeasuredValue() : ModelCommand("report")
+    ReportRelativeHumidityMeasurementMaxMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38495,7 +38495,7 @@ public:
 class ReportRelativeHumidityMeasurementTolerance : public ModelCommand
 {
 public:
-    ReportRelativeHumidityMeasurementTolerance() : ModelCommand("report")
+    ReportRelativeHumidityMeasurementTolerance() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tolerance");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38567,7 +38567,7 @@ public:
 class ReportRelativeHumidityMeasurementAttributeList : public ModelCommand
 {
 public:
-    ReportRelativeHumidityMeasurementAttributeList() : ModelCommand("report")
+    ReportRelativeHumidityMeasurementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38639,7 +38639,7 @@ public:
 class ReportRelativeHumidityMeasurementClusterRevision : public ModelCommand
 {
 public:
-    ReportRelativeHumidityMeasurementClusterRevision() : ModelCommand("report")
+    ReportRelativeHumidityMeasurementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38912,7 +38912,7 @@ public:
 class ReportScenesSceneCount : public ModelCommand
 {
 public:
-    ReportScenesSceneCount() : ModelCommand("report")
+    ReportScenesSceneCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "scene-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -38981,7 +38981,7 @@ public:
 class ReportScenesCurrentScene : public ModelCommand
 {
 public:
-    ReportScenesCurrentScene() : ModelCommand("report")
+    ReportScenesCurrentScene() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-scene");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39050,7 +39050,7 @@ public:
 class ReportScenesCurrentGroup : public ModelCommand
 {
 public:
-    ReportScenesCurrentGroup() : ModelCommand("report")
+    ReportScenesCurrentGroup() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-group");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39119,7 +39119,7 @@ public:
 class ReportScenesSceneValid : public ModelCommand
 {
 public:
-    ReportScenesSceneValid() : ModelCommand("report")
+    ReportScenesSceneValid() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "scene-valid");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39188,7 +39188,7 @@ public:
 class ReportScenesNameSupport : public ModelCommand
 {
 public:
-    ReportScenesNameSupport() : ModelCommand("report")
+    ReportScenesNameSupport() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "name-support");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39257,7 +39257,7 @@ public:
 class ReportScenesAttributeList : public ModelCommand
 {
 public:
-    ReportScenesAttributeList() : ModelCommand("report")
+    ReportScenesAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39329,7 +39329,7 @@ public:
 class ReportScenesClusterRevision : public ModelCommand
 {
 public:
-    ReportScenesClusterRevision() : ModelCommand("report")
+    ReportScenesClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39438,7 +39438,7 @@ public:
 class ReportSoftwareDiagnosticsSoftwareFault : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsSoftwareFault() : ModelCommand("report-event")
+    ReportSoftwareDiagnosticsSoftwareFault() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "software-fault");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39513,7 +39513,7 @@ public:
 class ReportSoftwareDiagnosticsThreadMetrics : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsThreadMetrics() : ModelCommand("report")
+    ReportSoftwareDiagnosticsThreadMetrics() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "thread-metrics");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39588,7 +39588,7 @@ public:
 class ReportSoftwareDiagnosticsCurrentHeapFree : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsCurrentHeapFree() : ModelCommand("report")
+    ReportSoftwareDiagnosticsCurrentHeapFree() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-heap-free");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39657,7 +39657,7 @@ public:
 class ReportSoftwareDiagnosticsCurrentHeapUsed : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsCurrentHeapUsed() : ModelCommand("report")
+    ReportSoftwareDiagnosticsCurrentHeapUsed() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-heap-used");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39726,7 +39726,7 @@ public:
 class ReportSoftwareDiagnosticsCurrentHeapHighWatermark : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsCurrentHeapHighWatermark() : ModelCommand("report")
+    ReportSoftwareDiagnosticsCurrentHeapHighWatermark() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-heap-high-watermark");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39798,7 +39798,7 @@ public:
 class ReportSoftwareDiagnosticsAttributeList : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsAttributeList() : ModelCommand("report")
+    ReportSoftwareDiagnosticsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39870,7 +39870,7 @@ public:
 class ReportSoftwareDiagnosticsFeatureMap : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsFeatureMap() : ModelCommand("report")
+    ReportSoftwareDiagnosticsFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -39939,7 +39939,7 @@ public:
 class ReportSoftwareDiagnosticsClusterRevision : public ModelCommand
 {
 public:
-    ReportSoftwareDiagnosticsClusterRevision() : ModelCommand("report")
+    ReportSoftwareDiagnosticsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40031,7 +40031,7 @@ public:
 class ReportSwitchSwitchLatched : public ModelCommand
 {
 public:
-    ReportSwitchSwitchLatched() : ModelCommand("report-event")
+    ReportSwitchSwitchLatched() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "switch-latched");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40102,7 +40102,7 @@ public:
 class ReportSwitchInitialPress : public ModelCommand
 {
 public:
-    ReportSwitchInitialPress() : ModelCommand("report-event")
+    ReportSwitchInitialPress() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "initial-press");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40173,7 +40173,7 @@ public:
 class ReportSwitchLongPress : public ModelCommand
 {
 public:
-    ReportSwitchLongPress() : ModelCommand("report-event")
+    ReportSwitchLongPress() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "long-press");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40244,7 +40244,7 @@ public:
 class ReportSwitchShortRelease : public ModelCommand
 {
 public:
-    ReportSwitchShortRelease() : ModelCommand("report-event")
+    ReportSwitchShortRelease() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "short-release");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40315,7 +40315,7 @@ public:
 class ReportSwitchLongRelease : public ModelCommand
 {
 public:
-    ReportSwitchLongRelease() : ModelCommand("report-event")
+    ReportSwitchLongRelease() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "long-release");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40386,7 +40386,7 @@ public:
 class ReportSwitchMultiPressOngoing : public ModelCommand
 {
 public:
-    ReportSwitchMultiPressOngoing() : ModelCommand("report-event")
+    ReportSwitchMultiPressOngoing() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "multi-press-ongoing");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40457,7 +40457,7 @@ public:
 class ReportSwitchMultiPressComplete : public ModelCommand
 {
 public:
-    ReportSwitchMultiPressComplete() : ModelCommand("report-event")
+    ReportSwitchMultiPressComplete() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "multi-press-complete");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40529,7 +40529,7 @@ public:
 class ReportSwitchNumberOfPositions : public ModelCommand
 {
 public:
-    ReportSwitchNumberOfPositions() : ModelCommand("report")
+    ReportSwitchNumberOfPositions() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "number-of-positions");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40598,7 +40598,7 @@ public:
 class ReportSwitchCurrentPosition : public ModelCommand
 {
 public:
-    ReportSwitchCurrentPosition() : ModelCommand("report")
+    ReportSwitchCurrentPosition() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40667,7 +40667,7 @@ public:
 class ReportSwitchMultiPressMax : public ModelCommand
 {
 public:
-    ReportSwitchMultiPressMax() : ModelCommand("report")
+    ReportSwitchMultiPressMax() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "multi-press-max");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40736,7 +40736,7 @@ public:
 class ReportSwitchAttributeList : public ModelCommand
 {
 public:
-    ReportSwitchAttributeList() : ModelCommand("report")
+    ReportSwitchAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40808,7 +40808,7 @@ public:
 class ReportSwitchFeatureMap : public ModelCommand
 {
 public:
-    ReportSwitchFeatureMap() : ModelCommand("report")
+    ReportSwitchFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40877,7 +40877,7 @@ public:
 class ReportSwitchClusterRevision : public ModelCommand
 {
 public:
-    ReportSwitchClusterRevision() : ModelCommand("report")
+    ReportSwitchClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -40988,7 +40988,7 @@ public:
 class ReportTargetNavigatorTargetNavigatorList : public ModelCommand
 {
 public:
-    ReportTargetNavigatorTargetNavigatorList() : ModelCommand("report")
+    ReportTargetNavigatorTargetNavigatorList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "target-navigator-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41062,7 +41062,7 @@ public:
 class ReportTargetNavigatorCurrentNavigatorTarget : public ModelCommand
 {
 public:
-    ReportTargetNavigatorCurrentNavigatorTarget() : ModelCommand("report")
+    ReportTargetNavigatorCurrentNavigatorTarget() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-navigator-target");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41134,7 +41134,7 @@ public:
 class ReportTargetNavigatorAttributeList : public ModelCommand
 {
 public:
-    ReportTargetNavigatorAttributeList() : ModelCommand("report")
+    ReportTargetNavigatorAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41206,7 +41206,7 @@ public:
 class ReportTargetNavigatorClusterRevision : public ModelCommand
 {
 public:
-    ReportTargetNavigatorClusterRevision() : ModelCommand("report")
+    ReportTargetNavigatorClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41291,7 +41291,7 @@ public:
 class ReportTemperatureMeasurementMeasuredValue : public ModelCommand
 {
 public:
-    ReportTemperatureMeasurementMeasuredValue() : ModelCommand("report")
+    ReportTemperatureMeasurementMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41360,7 +41360,7 @@ public:
 class ReportTemperatureMeasurementMinMeasuredValue : public ModelCommand
 {
 public:
-    ReportTemperatureMeasurementMinMeasuredValue() : ModelCommand("report")
+    ReportTemperatureMeasurementMinMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41432,7 +41432,7 @@ public:
 class ReportTemperatureMeasurementMaxMeasuredValue : public ModelCommand
 {
 public:
-    ReportTemperatureMeasurementMaxMeasuredValue() : ModelCommand("report")
+    ReportTemperatureMeasurementMaxMeasuredValue() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-measured-value");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41504,7 +41504,7 @@ public:
 class ReportTemperatureMeasurementTolerance : public ModelCommand
 {
 public:
-    ReportTemperatureMeasurementTolerance() : ModelCommand("report")
+    ReportTemperatureMeasurementTolerance() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tolerance");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41573,7 +41573,7 @@ public:
 class ReportTemperatureMeasurementAttributeList : public ModelCommand
 {
 public:
-    ReportTemperatureMeasurementAttributeList() : ModelCommand("report")
+    ReportTemperatureMeasurementAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -41645,7 +41645,7 @@ public:
 class ReportTemperatureMeasurementClusterRevision : public ModelCommand
 {
 public:
-    ReportTemperatureMeasurementClusterRevision() : ModelCommand("report")
+    ReportTemperatureMeasurementClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42242,7 +42242,7 @@ public:
 class ReportTestClusterTestEvent : public ModelCommand
 {
 public:
-    ReportTestClusterTestEvent() : ModelCommand("report-event")
+    ReportTestClusterTestEvent() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "test-event");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42340,7 +42340,7 @@ private:
 class ReportTestClusterBoolean : public ModelCommand
 {
 public:
-    ReportTestClusterBoolean() : ModelCommand("report")
+    ReportTestClusterBoolean() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "boolean");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42435,7 +42435,7 @@ private:
 class ReportTestClusterBitmap8 : public ModelCommand
 {
 public:
-    ReportTestClusterBitmap8() : ModelCommand("report")
+    ReportTestClusterBitmap8() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "bitmap8");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42530,7 +42530,7 @@ private:
 class ReportTestClusterBitmap16 : public ModelCommand
 {
 public:
-    ReportTestClusterBitmap16() : ModelCommand("report")
+    ReportTestClusterBitmap16() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "bitmap16");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42625,7 +42625,7 @@ private:
 class ReportTestClusterBitmap32 : public ModelCommand
 {
 public:
-    ReportTestClusterBitmap32() : ModelCommand("report")
+    ReportTestClusterBitmap32() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "bitmap32");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42720,7 +42720,7 @@ private:
 class ReportTestClusterBitmap64 : public ModelCommand
 {
 public:
-    ReportTestClusterBitmap64() : ModelCommand("report")
+    ReportTestClusterBitmap64() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "bitmap64");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42815,7 +42815,7 @@ private:
 class ReportTestClusterInt8u : public ModelCommand
 {
 public:
-    ReportTestClusterInt8u() : ModelCommand("report")
+    ReportTestClusterInt8u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int8u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -42910,7 +42910,7 @@ private:
 class ReportTestClusterInt16u : public ModelCommand
 {
 public:
-    ReportTestClusterInt16u() : ModelCommand("report")
+    ReportTestClusterInt16u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int16u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43005,7 +43005,7 @@ private:
 class ReportTestClusterInt24u : public ModelCommand
 {
 public:
-    ReportTestClusterInt24u() : ModelCommand("report")
+    ReportTestClusterInt24u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int24u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43100,7 +43100,7 @@ private:
 class ReportTestClusterInt32u : public ModelCommand
 {
 public:
-    ReportTestClusterInt32u() : ModelCommand("report")
+    ReportTestClusterInt32u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int32u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43195,7 +43195,7 @@ private:
 class ReportTestClusterInt40u : public ModelCommand
 {
 public:
-    ReportTestClusterInt40u() : ModelCommand("report")
+    ReportTestClusterInt40u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int40u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43290,7 +43290,7 @@ private:
 class ReportTestClusterInt48u : public ModelCommand
 {
 public:
-    ReportTestClusterInt48u() : ModelCommand("report")
+    ReportTestClusterInt48u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int48u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43385,7 +43385,7 @@ private:
 class ReportTestClusterInt56u : public ModelCommand
 {
 public:
-    ReportTestClusterInt56u() : ModelCommand("report")
+    ReportTestClusterInt56u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int56u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43480,7 +43480,7 @@ private:
 class ReportTestClusterInt64u : public ModelCommand
 {
 public:
-    ReportTestClusterInt64u() : ModelCommand("report")
+    ReportTestClusterInt64u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int64u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43575,7 +43575,7 @@ private:
 class ReportTestClusterInt8s : public ModelCommand
 {
 public:
-    ReportTestClusterInt8s() : ModelCommand("report")
+    ReportTestClusterInt8s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int8s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43670,7 +43670,7 @@ private:
 class ReportTestClusterInt16s : public ModelCommand
 {
 public:
-    ReportTestClusterInt16s() : ModelCommand("report")
+    ReportTestClusterInt16s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int16s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43765,7 +43765,7 @@ private:
 class ReportTestClusterInt24s : public ModelCommand
 {
 public:
-    ReportTestClusterInt24s() : ModelCommand("report")
+    ReportTestClusterInt24s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int24s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43860,7 +43860,7 @@ private:
 class ReportTestClusterInt32s : public ModelCommand
 {
 public:
-    ReportTestClusterInt32s() : ModelCommand("report")
+    ReportTestClusterInt32s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int32s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -43955,7 +43955,7 @@ private:
 class ReportTestClusterInt40s : public ModelCommand
 {
 public:
-    ReportTestClusterInt40s() : ModelCommand("report")
+    ReportTestClusterInt40s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int40s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44050,7 +44050,7 @@ private:
 class ReportTestClusterInt48s : public ModelCommand
 {
 public:
-    ReportTestClusterInt48s() : ModelCommand("report")
+    ReportTestClusterInt48s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int48s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44145,7 +44145,7 @@ private:
 class ReportTestClusterInt56s : public ModelCommand
 {
 public:
-    ReportTestClusterInt56s() : ModelCommand("report")
+    ReportTestClusterInt56s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int56s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44240,7 +44240,7 @@ private:
 class ReportTestClusterInt64s : public ModelCommand
 {
 public:
-    ReportTestClusterInt64s() : ModelCommand("report")
+    ReportTestClusterInt64s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "int64s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44335,7 +44335,7 @@ private:
 class ReportTestClusterEnum8 : public ModelCommand
 {
 public:
-    ReportTestClusterEnum8() : ModelCommand("report")
+    ReportTestClusterEnum8() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enum8");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44430,7 +44430,7 @@ private:
 class ReportTestClusterEnum16 : public ModelCommand
 {
 public:
-    ReportTestClusterEnum16() : ModelCommand("report")
+    ReportTestClusterEnum16() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enum16");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44525,7 +44525,7 @@ private:
 class ReportTestClusterFloatSingle : public ModelCommand
 {
 public:
-    ReportTestClusterFloatSingle() : ModelCommand("report")
+    ReportTestClusterFloatSingle() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "float-single");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44620,7 +44620,7 @@ private:
 class ReportTestClusterFloatDouble : public ModelCommand
 {
 public:
-    ReportTestClusterFloatDouble() : ModelCommand("report")
+    ReportTestClusterFloatDouble() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "float-double");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44715,7 +44715,7 @@ private:
 class ReportTestClusterOctetString : public ModelCommand
 {
 public:
-    ReportTestClusterOctetString() : ModelCommand("report")
+    ReportTestClusterOctetString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "octet-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44784,7 +44784,7 @@ public:
 class ReportTestClusterListInt8u : public ModelCommand
 {
 public:
-    ReportTestClusterListInt8u() : ModelCommand("report")
+    ReportTestClusterListInt8u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "list-int8u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44856,7 +44856,7 @@ public:
 class ReportTestClusterListOctetString : public ModelCommand
 {
 public:
-    ReportTestClusterListOctetString() : ModelCommand("report")
+    ReportTestClusterListOctetString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "list-octet-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -44931,7 +44931,7 @@ public:
 class ReportTestClusterListStructOctetString : public ModelCommand
 {
 public:
-    ReportTestClusterListStructOctetString() : ModelCommand("report")
+    ReportTestClusterListStructOctetString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "list-struct-octet-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45032,7 +45032,7 @@ private:
 class ReportTestClusterLongOctetString : public ModelCommand
 {
 public:
-    ReportTestClusterLongOctetString() : ModelCommand("report")
+    ReportTestClusterLongOctetString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "long-octet-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45127,7 +45127,7 @@ private:
 class ReportTestClusterCharString : public ModelCommand
 {
 public:
-    ReportTestClusterCharString() : ModelCommand("report")
+    ReportTestClusterCharString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "char-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45222,7 +45222,7 @@ private:
 class ReportTestClusterLongCharString : public ModelCommand
 {
 public:
-    ReportTestClusterLongCharString() : ModelCommand("report")
+    ReportTestClusterLongCharString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "long-char-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45317,7 +45317,7 @@ private:
 class ReportTestClusterEpochUs : public ModelCommand
 {
 public:
-    ReportTestClusterEpochUs() : ModelCommand("report")
+    ReportTestClusterEpochUs() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "epoch-us");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45412,7 +45412,7 @@ private:
 class ReportTestClusterEpochS : public ModelCommand
 {
 public:
-    ReportTestClusterEpochS() : ModelCommand("report")
+    ReportTestClusterEpochS() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "epoch-s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45507,7 +45507,7 @@ private:
 class ReportTestClusterVendorId : public ModelCommand
 {
 public:
-    ReportTestClusterVendorId() : ModelCommand("report")
+    ReportTestClusterVendorId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "vendor-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45579,7 +45579,7 @@ public:
 class ReportTestClusterListNullablesAndOptionalsStruct : public ModelCommand
 {
 public:
-    ReportTestClusterListNullablesAndOptionalsStruct() : ModelCommand("report")
+    ReportTestClusterListNullablesAndOptionalsStruct() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "list-nullables-and-optionals-struct");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45679,7 +45679,7 @@ private:
 class ReportTestClusterEnumAttr : public ModelCommand
 {
 public:
-    ReportTestClusterEnumAttr() : ModelCommand("report")
+    ReportTestClusterEnumAttr() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "enum-attr");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45777,7 +45777,7 @@ private:
 class ReportTestClusterRangeRestrictedInt8u : public ModelCommand
 {
 public:
-    ReportTestClusterRangeRestrictedInt8u() : ModelCommand("report")
+    ReportTestClusterRangeRestrictedInt8u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "range-restricted-int8u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45872,7 +45872,7 @@ private:
 class ReportTestClusterRangeRestrictedInt8s : public ModelCommand
 {
 public:
-    ReportTestClusterRangeRestrictedInt8s() : ModelCommand("report")
+    ReportTestClusterRangeRestrictedInt8s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "range-restricted-int8s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -45967,7 +45967,7 @@ private:
 class ReportTestClusterRangeRestrictedInt16u : public ModelCommand
 {
 public:
-    ReportTestClusterRangeRestrictedInt16u() : ModelCommand("report")
+    ReportTestClusterRangeRestrictedInt16u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "range-restricted-int16u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46062,7 +46062,7 @@ private:
 class ReportTestClusterRangeRestrictedInt16s : public ModelCommand
 {
 public:
-    ReportTestClusterRangeRestrictedInt16s() : ModelCommand("report")
+    ReportTestClusterRangeRestrictedInt16s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "range-restricted-int16s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46131,7 +46131,7 @@ public:
 class ReportTestClusterListLongOctetString : public ModelCommand
 {
 public:
-    ReportTestClusterListLongOctetString() : ModelCommand("report")
+    ReportTestClusterListLongOctetString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "list-long-octet-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46229,7 +46229,7 @@ private:
 class ReportTestClusterTimedWriteBoolean : public ModelCommand
 {
 public:
-    ReportTestClusterTimedWriteBoolean() : ModelCommand("report")
+    ReportTestClusterTimedWriteBoolean() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "timed-write-boolean");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46324,7 +46324,7 @@ private:
 class ReportTestClusterUnsupported : public ModelCommand
 {
 public:
-    ReportTestClusterUnsupported() : ModelCommand("report")
+    ReportTestClusterUnsupported() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "unsupported");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46419,7 +46419,7 @@ private:
 class ReportTestClusterNullableBoolean : public ModelCommand
 {
 public:
-    ReportTestClusterNullableBoolean() : ModelCommand("report")
+    ReportTestClusterNullableBoolean() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-boolean");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46517,7 +46517,7 @@ private:
 class ReportTestClusterNullableBitmap8 : public ModelCommand
 {
 public:
-    ReportTestClusterNullableBitmap8() : ModelCommand("report")
+    ReportTestClusterNullableBitmap8() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-bitmap8");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46615,7 +46615,7 @@ private:
 class ReportTestClusterNullableBitmap16 : public ModelCommand
 {
 public:
-    ReportTestClusterNullableBitmap16() : ModelCommand("report")
+    ReportTestClusterNullableBitmap16() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-bitmap16");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46713,7 +46713,7 @@ private:
 class ReportTestClusterNullableBitmap32 : public ModelCommand
 {
 public:
-    ReportTestClusterNullableBitmap32() : ModelCommand("report")
+    ReportTestClusterNullableBitmap32() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-bitmap32");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46811,7 +46811,7 @@ private:
 class ReportTestClusterNullableBitmap64 : public ModelCommand
 {
 public:
-    ReportTestClusterNullableBitmap64() : ModelCommand("report")
+    ReportTestClusterNullableBitmap64() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-bitmap64");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -46909,7 +46909,7 @@ private:
 class ReportTestClusterNullableInt8u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt8u() : ModelCommand("report")
+    ReportTestClusterNullableInt8u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int8u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47007,7 +47007,7 @@ private:
 class ReportTestClusterNullableInt16u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt16u() : ModelCommand("report")
+    ReportTestClusterNullableInt16u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int16u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47105,7 +47105,7 @@ private:
 class ReportTestClusterNullableInt24u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt24u() : ModelCommand("report")
+    ReportTestClusterNullableInt24u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int24u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47203,7 +47203,7 @@ private:
 class ReportTestClusterNullableInt32u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt32u() : ModelCommand("report")
+    ReportTestClusterNullableInt32u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int32u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47301,7 +47301,7 @@ private:
 class ReportTestClusterNullableInt40u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt40u() : ModelCommand("report")
+    ReportTestClusterNullableInt40u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int40u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47399,7 +47399,7 @@ private:
 class ReportTestClusterNullableInt48u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt48u() : ModelCommand("report")
+    ReportTestClusterNullableInt48u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int48u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47497,7 +47497,7 @@ private:
 class ReportTestClusterNullableInt56u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt56u() : ModelCommand("report")
+    ReportTestClusterNullableInt56u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int56u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47595,7 +47595,7 @@ private:
 class ReportTestClusterNullableInt64u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt64u() : ModelCommand("report")
+    ReportTestClusterNullableInt64u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int64u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47693,7 +47693,7 @@ private:
 class ReportTestClusterNullableInt8s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt8s() : ModelCommand("report")
+    ReportTestClusterNullableInt8s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int8s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47791,7 +47791,7 @@ private:
 class ReportTestClusterNullableInt16s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt16s() : ModelCommand("report")
+    ReportTestClusterNullableInt16s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int16s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47889,7 +47889,7 @@ private:
 class ReportTestClusterNullableInt24s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt24s() : ModelCommand("report")
+    ReportTestClusterNullableInt24s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int24s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -47987,7 +47987,7 @@ private:
 class ReportTestClusterNullableInt32s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt32s() : ModelCommand("report")
+    ReportTestClusterNullableInt32s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int32s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48085,7 +48085,7 @@ private:
 class ReportTestClusterNullableInt40s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt40s() : ModelCommand("report")
+    ReportTestClusterNullableInt40s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int40s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48183,7 +48183,7 @@ private:
 class ReportTestClusterNullableInt48s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt48s() : ModelCommand("report")
+    ReportTestClusterNullableInt48s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int48s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48281,7 +48281,7 @@ private:
 class ReportTestClusterNullableInt56s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt56s() : ModelCommand("report")
+    ReportTestClusterNullableInt56s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int56s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48379,7 +48379,7 @@ private:
 class ReportTestClusterNullableInt64s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableInt64s() : ModelCommand("report")
+    ReportTestClusterNullableInt64s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-int64s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48477,7 +48477,7 @@ private:
 class ReportTestClusterNullableEnum8 : public ModelCommand
 {
 public:
-    ReportTestClusterNullableEnum8() : ModelCommand("report")
+    ReportTestClusterNullableEnum8() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-enum8");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48575,7 +48575,7 @@ private:
 class ReportTestClusterNullableEnum16 : public ModelCommand
 {
 public:
-    ReportTestClusterNullableEnum16() : ModelCommand("report")
+    ReportTestClusterNullableEnum16() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-enum16");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48673,7 +48673,7 @@ private:
 class ReportTestClusterNullableFloatSingle : public ModelCommand
 {
 public:
-    ReportTestClusterNullableFloatSingle() : ModelCommand("report")
+    ReportTestClusterNullableFloatSingle() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-float-single");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48771,7 +48771,7 @@ private:
 class ReportTestClusterNullableFloatDouble : public ModelCommand
 {
 public:
-    ReportTestClusterNullableFloatDouble() : ModelCommand("report")
+    ReportTestClusterNullableFloatDouble() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-float-double");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48869,7 +48869,7 @@ private:
 class ReportTestClusterNullableOctetString : public ModelCommand
 {
 public:
-    ReportTestClusterNullableOctetString() : ModelCommand("report")
+    ReportTestClusterNullableOctetString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-octet-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -48967,7 +48967,7 @@ private:
 class ReportTestClusterNullableCharString : public ModelCommand
 {
 public:
-    ReportTestClusterNullableCharString() : ModelCommand("report")
+    ReportTestClusterNullableCharString() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-char-string");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49066,7 +49066,7 @@ private:
 class ReportTestClusterNullableEnumAttr : public ModelCommand
 {
 public:
-    ReportTestClusterNullableEnumAttr() : ModelCommand("report")
+    ReportTestClusterNullableEnumAttr() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-enum-attr");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49165,7 +49165,7 @@ private:
 class ReportTestClusterNullableRangeRestrictedInt8u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableRangeRestrictedInt8u() : ModelCommand("report")
+    ReportTestClusterNullableRangeRestrictedInt8u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-range-restricted-int8u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49263,7 +49263,7 @@ private:
 class ReportTestClusterNullableRangeRestrictedInt8s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableRangeRestrictedInt8s() : ModelCommand("report")
+    ReportTestClusterNullableRangeRestrictedInt8s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-range-restricted-int8s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49361,7 +49361,7 @@ private:
 class ReportTestClusterNullableRangeRestrictedInt16u : public ModelCommand
 {
 public:
-    ReportTestClusterNullableRangeRestrictedInt16u() : ModelCommand("report")
+    ReportTestClusterNullableRangeRestrictedInt16u() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-range-restricted-int16u");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49459,7 +49459,7 @@ private:
 class ReportTestClusterNullableRangeRestrictedInt16s : public ModelCommand
 {
 public:
-    ReportTestClusterNullableRangeRestrictedInt16s() : ModelCommand("report")
+    ReportTestClusterNullableRangeRestrictedInt16s() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "nullable-range-restricted-int16s");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49531,7 +49531,7 @@ public:
 class ReportTestClusterAttributeList : public ModelCommand
 {
 public:
-    ReportTestClusterAttributeList() : ModelCommand("report")
+    ReportTestClusterAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49603,7 +49603,7 @@ public:
 class ReportTestClusterClusterRevision : public ModelCommand
 {
 public:
-    ReportTestClusterClusterRevision() : ModelCommand("report")
+    ReportTestClusterClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49831,7 +49831,7 @@ public:
 class ReportThermostatLocalTemperature : public ModelCommand
 {
 public:
-    ReportThermostatLocalTemperature() : ModelCommand("report")
+    ReportThermostatLocalTemperature() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "local-temperature");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49900,7 +49900,7 @@ public:
 class ReportThermostatAbsMinHeatSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatAbsMinHeatSetpointLimit() : ModelCommand("report")
+    ReportThermostatAbsMinHeatSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "abs-min-heat-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -49969,7 +49969,7 @@ public:
 class ReportThermostatAbsMaxHeatSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatAbsMaxHeatSetpointLimit() : ModelCommand("report")
+    ReportThermostatAbsMaxHeatSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "abs-max-heat-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50038,7 +50038,7 @@ public:
 class ReportThermostatAbsMinCoolSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatAbsMinCoolSetpointLimit() : ModelCommand("report")
+    ReportThermostatAbsMinCoolSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "abs-min-cool-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50107,7 +50107,7 @@ public:
 class ReportThermostatAbsMaxCoolSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatAbsMaxCoolSetpointLimit() : ModelCommand("report")
+    ReportThermostatAbsMaxCoolSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "abs-max-cool-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50202,7 +50202,7 @@ private:
 class ReportThermostatOccupiedCoolingSetpoint : public ModelCommand
 {
 public:
-    ReportThermostatOccupiedCoolingSetpoint() : ModelCommand("report")
+    ReportThermostatOccupiedCoolingSetpoint() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "occupied-cooling-setpoint");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50297,7 +50297,7 @@ private:
 class ReportThermostatOccupiedHeatingSetpoint : public ModelCommand
 {
 public:
-    ReportThermostatOccupiedHeatingSetpoint() : ModelCommand("report")
+    ReportThermostatOccupiedHeatingSetpoint() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "occupied-heating-setpoint");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50392,7 +50392,7 @@ private:
 class ReportThermostatMinHeatSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatMinHeatSetpointLimit() : ModelCommand("report")
+    ReportThermostatMinHeatSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-heat-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50487,7 +50487,7 @@ private:
 class ReportThermostatMaxHeatSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatMaxHeatSetpointLimit() : ModelCommand("report")
+    ReportThermostatMaxHeatSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-heat-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50582,7 +50582,7 @@ private:
 class ReportThermostatMinCoolSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatMinCoolSetpointLimit() : ModelCommand("report")
+    ReportThermostatMinCoolSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-cool-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50677,7 +50677,7 @@ private:
 class ReportThermostatMaxCoolSetpointLimit : public ModelCommand
 {
 public:
-    ReportThermostatMaxCoolSetpointLimit() : ModelCommand("report")
+    ReportThermostatMaxCoolSetpointLimit() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "max-cool-setpoint-limit");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50772,7 +50772,7 @@ private:
 class ReportThermostatMinSetpointDeadBand : public ModelCommand
 {
 public:
-    ReportThermostatMinSetpointDeadBand() : ModelCommand("report")
+    ReportThermostatMinSetpointDeadBand() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "min-setpoint-dead-band");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50867,7 +50867,7 @@ private:
 class ReportThermostatControlSequenceOfOperation : public ModelCommand
 {
 public:
-    ReportThermostatControlSequenceOfOperation() : ModelCommand("report")
+    ReportThermostatControlSequenceOfOperation() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "control-sequence-of-operation");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -50962,7 +50962,7 @@ private:
 class ReportThermostatSystemMode : public ModelCommand
 {
 public:
-    ReportThermostatSystemMode() : ModelCommand("report")
+    ReportThermostatSystemMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "system-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51031,7 +51031,7 @@ public:
 class ReportThermostatStartOfWeek : public ModelCommand
 {
 public:
-    ReportThermostatStartOfWeek() : ModelCommand("report")
+    ReportThermostatStartOfWeek() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "start-of-week");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51100,7 +51100,7 @@ public:
 class ReportThermostatNumberOfWeeklyTransitions : public ModelCommand
 {
 public:
-    ReportThermostatNumberOfWeeklyTransitions() : ModelCommand("report")
+    ReportThermostatNumberOfWeeklyTransitions() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "number-of-weekly-transitions");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51169,7 +51169,7 @@ public:
 class ReportThermostatNumberOfDailyTransitions : public ModelCommand
 {
 public:
-    ReportThermostatNumberOfDailyTransitions() : ModelCommand("report")
+    ReportThermostatNumberOfDailyTransitions() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "number-of-daily-transitions");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51238,7 +51238,7 @@ public:
 class ReportThermostatAttributeList : public ModelCommand
 {
 public:
-    ReportThermostatAttributeList() : ModelCommand("report")
+    ReportThermostatAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51310,7 +51310,7 @@ public:
 class ReportThermostatFeatureMap : public ModelCommand
 {
 public:
-    ReportThermostatFeatureMap() : ModelCommand("report")
+    ReportThermostatFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51379,7 +51379,7 @@ public:
 class ReportThermostatClusterRevision : public ModelCommand
 {
 public:
-    ReportThermostatClusterRevision() : ModelCommand("report")
+    ReportThermostatClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51491,7 +51491,7 @@ private:
 class ReportThermostatUserInterfaceConfigurationTemperatureDisplayMode : public ModelCommand
 {
 public:
-    ReportThermostatUserInterfaceConfigurationTemperatureDisplayMode() : ModelCommand("report")
+    ReportThermostatUserInterfaceConfigurationTemperatureDisplayMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "temperature-display-mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51592,7 +51592,7 @@ private:
 class ReportThermostatUserInterfaceConfigurationKeypadLockout : public ModelCommand
 {
 public:
-    ReportThermostatUserInterfaceConfigurationKeypadLockout() : ModelCommand("report")
+    ReportThermostatUserInterfaceConfigurationKeypadLockout() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "keypad-lockout");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51694,7 +51694,7 @@ private:
 class ReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibility : public ModelCommand
 {
 public:
-    ReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibility() : ModelCommand("report")
+    ReportThermostatUserInterfaceConfigurationScheduleProgrammingVisibility() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "schedule-programming-visibility");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51768,7 +51768,7 @@ public:
 class ReportThermostatUserInterfaceConfigurationAttributeList : public ModelCommand
 {
 public:
-    ReportThermostatUserInterfaceConfigurationAttributeList() : ModelCommand("report")
+    ReportThermostatUserInterfaceConfigurationAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -51842,7 +51842,7 @@ public:
 class ReportThermostatUserInterfaceConfigurationClusterRevision : public ModelCommand
 {
 public:
-    ReportThermostatUserInterfaceConfigurationClusterRevision() : ModelCommand("report")
+    ReportThermostatUserInterfaceConfigurationClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52014,7 +52014,7 @@ public:
 class ReportThreadNetworkDiagnosticsConnectionStatus : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsConnectionStatus() : ModelCommand("report-event")
+    ReportThreadNetworkDiagnosticsConnectionStatus() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "connection-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52087,7 +52087,7 @@ public:
 class ReportThreadNetworkDiagnosticsChannel : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsChannel() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsChannel() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "channel");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52156,7 +52156,7 @@ public:
 class ReportThreadNetworkDiagnosticsRoutingRole : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRoutingRole() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRoutingRole() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "routing-role");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52225,7 +52225,7 @@ public:
 class ReportThreadNetworkDiagnosticsNetworkName : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsNetworkName() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsNetworkName() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "network-name");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52297,7 +52297,7 @@ public:
 class ReportThreadNetworkDiagnosticsPanId : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsPanId() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsPanId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "pan-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52366,7 +52366,7 @@ public:
 class ReportThreadNetworkDiagnosticsExtendedPanId : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsExtendedPanId() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsExtendedPanId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "extended-pan-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52438,7 +52438,7 @@ public:
 class ReportThreadNetworkDiagnosticsMeshLocalPrefix : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsMeshLocalPrefix() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsMeshLocalPrefix() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "mesh-local-prefix");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52510,7 +52510,7 @@ public:
 class ReportThreadNetworkDiagnosticsOverrunCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsOverrunCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsOverrunCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "overrun-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52585,7 +52585,7 @@ public:
 class ReportThreadNetworkDiagnosticsNeighborTableList : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsNeighborTableList() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsNeighborTableList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "neighbor-table-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52661,7 +52661,7 @@ public:
 class ReportThreadNetworkDiagnosticsRouteTableList : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRouteTableList() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRouteTableList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "route-table-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52735,7 +52735,7 @@ public:
 class ReportThreadNetworkDiagnosticsPartitionId : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsPartitionId() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsPartitionId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "partition-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52804,7 +52804,7 @@ public:
 class ReportThreadNetworkDiagnosticsWeighting : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsWeighting() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsWeighting() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "weighting");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52873,7 +52873,7 @@ public:
 class ReportThreadNetworkDiagnosticsDataVersion : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsDataVersion() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsDataVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "data-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -52942,7 +52942,7 @@ public:
 class ReportThreadNetworkDiagnosticsStableDataVersion : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsStableDataVersion() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsStableDataVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "stable-data-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53014,7 +53014,7 @@ public:
 class ReportThreadNetworkDiagnosticsLeaderRouterId : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsLeaderRouterId() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsLeaderRouterId() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "leader-router-id");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53086,7 +53086,7 @@ public:
 class ReportThreadNetworkDiagnosticsDetachedRoleCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsDetachedRoleCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsDetachedRoleCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "detached-role-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53158,7 +53158,7 @@ public:
 class ReportThreadNetworkDiagnosticsChildRoleCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsChildRoleCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsChildRoleCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "child-role-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53230,7 +53230,7 @@ public:
 class ReportThreadNetworkDiagnosticsRouterRoleCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRouterRoleCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRouterRoleCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "router-role-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53302,7 +53302,7 @@ public:
 class ReportThreadNetworkDiagnosticsLeaderRoleCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsLeaderRoleCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsLeaderRoleCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "leader-role-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53374,7 +53374,7 @@ public:
 class ReportThreadNetworkDiagnosticsAttachAttemptCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsAttachAttemptCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsAttachAttemptCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attach-attempt-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53446,7 +53446,7 @@ public:
 class ReportThreadNetworkDiagnosticsPartitionIdChangeCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsPartitionIdChangeCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsPartitionIdChangeCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "partition-id-change-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53520,7 +53520,7 @@ public:
 class ReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "better-partition-attach-attempt-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53593,7 +53593,7 @@ public:
 class ReportThreadNetworkDiagnosticsParentChangeCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsParentChangeCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsParentChangeCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "parent-change-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53665,7 +53665,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxTotalCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxTotalCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxTotalCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-total-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53737,7 +53737,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxUnicastCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxUnicastCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxUnicastCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-unicast-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53809,7 +53809,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxBroadcastCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxBroadcastCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxBroadcastCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-broadcast-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53881,7 +53881,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxAckRequestedCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxAckRequestedCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxAckRequestedCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-ack-requested-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -53953,7 +53953,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxAckedCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxAckedCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxAckedCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-acked-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54025,7 +54025,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxNoAckRequestedCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxNoAckRequestedCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxNoAckRequestedCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-no-ack-requested-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54098,7 +54098,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxDataCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxDataCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxDataCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-data-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54167,7 +54167,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxDataPollCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxDataPollCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxDataPollCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-data-poll-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54239,7 +54239,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxBeaconCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxBeaconCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxBeaconCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-beacon-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54311,7 +54311,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxBeaconRequestCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxBeaconRequestCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxBeaconRequestCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-beacon-request-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54384,7 +54384,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxOtherCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxOtherCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxOtherCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-other-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54456,7 +54456,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxRetryCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxRetryCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxRetryCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-retry-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54529,7 +54529,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-direct-max-retry-expiry-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54603,7 +54603,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-indirect-max-retry-expiry-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54676,7 +54676,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxErrCcaCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxErrCcaCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxErrCcaCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-err-cca-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54748,7 +54748,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxErrAbortCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxErrAbortCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxErrAbortCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-err-abort-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54820,7 +54820,7 @@ public:
 class ReportThreadNetworkDiagnosticsTxErrBusyChannelCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsTxErrBusyChannelCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsTxErrBusyChannelCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "tx-err-busy-channel-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54893,7 +54893,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxTotalCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxTotalCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxTotalCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-total-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -54965,7 +54965,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxUnicastCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxUnicastCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxUnicastCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-unicast-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55037,7 +55037,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxBroadcastCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxBroadcastCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxBroadcastCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-broadcast-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55109,7 +55109,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxDataCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxDataCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxDataCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-data-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55178,7 +55178,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxDataPollCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxDataPollCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxDataPollCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-data-poll-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55250,7 +55250,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxBeaconCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxBeaconCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxBeaconCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-beacon-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55322,7 +55322,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxBeaconRequestCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxBeaconRequestCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxBeaconRequestCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-beacon-request-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55395,7 +55395,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxOtherCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxOtherCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxOtherCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-other-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55467,7 +55467,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxAddressFilteredCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxAddressFilteredCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxAddressFilteredCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-address-filtered-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55540,7 +55540,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxDestAddrFilteredCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxDestAddrFilteredCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxDestAddrFilteredCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-dest-addr-filtered-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55613,7 +55613,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxDuplicatedCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxDuplicatedCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxDuplicatedCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-duplicated-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55685,7 +55685,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxErrNoFrameCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxErrNoFrameCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxErrNoFrameCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-err-no-frame-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55758,7 +55758,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxErrUnknownNeighborCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxErrUnknownNeighborCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxErrUnknownNeighborCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-err-unknown-neighbor-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55831,7 +55831,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-err-invalid-src-addr-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55904,7 +55904,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxErrSecCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxErrSecCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxErrSecCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-err-sec-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -55976,7 +55976,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxErrFcsCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxErrFcsCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxErrFcsCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-err-fcs-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56048,7 +56048,7 @@ public:
 class ReportThreadNetworkDiagnosticsRxErrOtherCount : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsRxErrOtherCount() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsRxErrOtherCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rx-err-other-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56120,7 +56120,7 @@ public:
 class ReportThreadNetworkDiagnosticsActiveTimestamp : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsActiveTimestamp() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsActiveTimestamp() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-timestamp");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56192,7 +56192,7 @@ public:
 class ReportThreadNetworkDiagnosticsPendingTimestamp : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsPendingTimestamp() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsPendingTimestamp() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "pending-timestamp");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56264,7 +56264,7 @@ public:
 class ReportThreadNetworkDiagnosticsDelay : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsDelay() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsDelay() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "delay");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56336,7 +56336,7 @@ public:
 class ReportThreadNetworkDiagnosticsSecurityPolicy : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsSecurityPolicy() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsSecurityPolicy() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "security-policy");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56410,7 +56410,7 @@ public:
 class ReportThreadNetworkDiagnosticsChannelMask : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsChannelMask() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsChannelMask() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "channel-mask");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56486,7 +56486,7 @@ public:
 class ReportThreadNetworkDiagnosticsOperationalDatasetComponents : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsOperationalDatasetComponents() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsOperationalDatasetComponents() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "operational-dataset-components");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56564,7 +56564,7 @@ public:
 class ReportThreadNetworkDiagnosticsActiveNetworkFaultsList : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsActiveNetworkFaultsList() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsActiveNetworkFaultsList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-network-faults-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56639,7 +56639,7 @@ public:
 class ReportThreadNetworkDiagnosticsAttributeList : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsAttributeList() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56711,7 +56711,7 @@ public:
 class ReportThreadNetworkDiagnosticsFeatureMap : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsFeatureMap() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56780,7 +56780,7 @@ public:
 class ReportThreadNetworkDiagnosticsClusterRevision : public ModelCommand
 {
 public:
-    ReportThreadNetworkDiagnosticsClusterRevision() : ModelCommand("report")
+    ReportThreadNetworkDiagnosticsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56892,7 +56892,7 @@ private:
 class ReportTimeFormatLocalizationHourFormat : public ModelCommand
 {
 public:
-    ReportTimeFormatLocalizationHourFormat() : ModelCommand("report")
+    ReportTimeFormatLocalizationHourFormat() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "hour-format");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -56990,7 +56990,7 @@ private:
 class ReportTimeFormatLocalizationActiveCalendarType : public ModelCommand
 {
 public:
-    ReportTimeFormatLocalizationActiveCalendarType() : ModelCommand("report")
+    ReportTimeFormatLocalizationActiveCalendarType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "active-calendar-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57064,7 +57064,7 @@ public:
 class ReportTimeFormatLocalizationSupportedCalendarTypes : public ModelCommand
 {
 public:
-    ReportTimeFormatLocalizationSupportedCalendarTypes() : ModelCommand("report")
+    ReportTimeFormatLocalizationSupportedCalendarTypes() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "supported-calendar-types");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57139,7 +57139,7 @@ public:
 class ReportTimeFormatLocalizationClusterRevision : public ModelCommand
 {
 public:
-    ReportTimeFormatLocalizationClusterRevision() : ModelCommand("report")
+    ReportTimeFormatLocalizationClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57225,7 +57225,7 @@ public:
 class ReportUserLabelLabelList : public ModelCommand
 {
 public:
-    ReportUserLabelLabelList() : ModelCommand("report")
+    ReportUserLabelLabelList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "label-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57299,7 +57299,7 @@ public:
 class ReportUserLabelClusterRevision : public ModelCommand
 {
 public:
-    ReportUserLabelClusterRevision() : ModelCommand("report")
+    ReportUserLabelClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57381,7 +57381,7 @@ public:
 class ReportWakeOnLanWakeOnLanMacAddress : public ModelCommand
 {
 public:
-    ReportWakeOnLanWakeOnLanMacAddress() : ModelCommand("report")
+    ReportWakeOnLanWakeOnLanMacAddress() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "wake-on-lan-mac-address");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57450,7 +57450,7 @@ public:
 class ReportWakeOnLanAttributeList : public ModelCommand
 {
 public:
-    ReportWakeOnLanAttributeList() : ModelCommand("report")
+    ReportWakeOnLanAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57522,7 +57522,7 @@ public:
 class ReportWakeOnLanClusterRevision : public ModelCommand
 {
 public:
-    ReportWakeOnLanClusterRevision() : ModelCommand("report")
+    ReportWakeOnLanClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57642,7 +57642,7 @@ public:
 class ReportWiFiNetworkDiagnosticsDisconnection : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsDisconnection() : ModelCommand("report-event")
+    ReportWiFiNetworkDiagnosticsDisconnection() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "disconnection");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57715,7 +57715,7 @@ public:
 class ReportWiFiNetworkDiagnosticsAssociationFailure : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsAssociationFailure() : ModelCommand("report-event")
+    ReportWiFiNetworkDiagnosticsAssociationFailure() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "association-failure");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57788,7 +57788,7 @@ public:
 class ReportWiFiNetworkDiagnosticsConnectionStatus : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsConnectionStatus() : ModelCommand("report-event")
+    ReportWiFiNetworkDiagnosticsConnectionStatus() : ModelCommand("subscribe-event")
     {
         AddArgument("event-name", "connection-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57861,7 +57861,7 @@ public:
 class ReportWiFiNetworkDiagnosticsBssid : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsBssid() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsBssid() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "bssid");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57930,7 +57930,7 @@ public:
 class ReportWiFiNetworkDiagnosticsSecurityType : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsSecurityType() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsSecurityType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "security-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -57999,7 +57999,7 @@ public:
 class ReportWiFiNetworkDiagnosticsWiFiVersion : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsWiFiVersion() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsWiFiVersion() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "wi-fi-version");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58068,7 +58068,7 @@ public:
 class ReportWiFiNetworkDiagnosticsChannelNumber : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsChannelNumber() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsChannelNumber() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "channel-number");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58137,7 +58137,7 @@ public:
 class ReportWiFiNetworkDiagnosticsRssi : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsRssi() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsRssi() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "rssi");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58206,7 +58206,7 @@ public:
 class ReportWiFiNetworkDiagnosticsBeaconLostCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsBeaconLostCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsBeaconLostCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "beacon-lost-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58278,7 +58278,7 @@ public:
 class ReportWiFiNetworkDiagnosticsBeaconRxCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsBeaconRxCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsBeaconRxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "beacon-rx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58347,7 +58347,7 @@ public:
 class ReportWiFiNetworkDiagnosticsPacketMulticastRxCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsPacketMulticastRxCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsPacketMulticastRxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "packet-multicast-rx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58420,7 +58420,7 @@ public:
 class ReportWiFiNetworkDiagnosticsPacketMulticastTxCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsPacketMulticastTxCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsPacketMulticastTxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "packet-multicast-tx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58493,7 +58493,7 @@ public:
 class ReportWiFiNetworkDiagnosticsPacketUnicastRxCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsPacketUnicastRxCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsPacketUnicastRxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "packet-unicast-rx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58565,7 +58565,7 @@ public:
 class ReportWiFiNetworkDiagnosticsPacketUnicastTxCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsPacketUnicastTxCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsPacketUnicastTxCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "packet-unicast-tx-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58637,7 +58637,7 @@ public:
 class ReportWiFiNetworkDiagnosticsCurrentMaxRate : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsCurrentMaxRate() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsCurrentMaxRate() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-max-rate");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58709,7 +58709,7 @@ public:
 class ReportWiFiNetworkDiagnosticsOverrunCount : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsOverrunCount() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsOverrunCount() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "overrun-count");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58778,7 +58778,7 @@ public:
 class ReportWiFiNetworkDiagnosticsAttributeList : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsAttributeList() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58850,7 +58850,7 @@ public:
 class ReportWiFiNetworkDiagnosticsFeatureMap : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsFeatureMap() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -58919,7 +58919,7 @@ public:
 class ReportWiFiNetworkDiagnosticsClusterRevision : public ModelCommand
 {
 public:
-    ReportWiFiNetworkDiagnosticsClusterRevision() : ModelCommand("report")
+    ReportWiFiNetworkDiagnosticsClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59187,7 +59187,7 @@ public:
 class ReportWindowCoveringType : public ModelCommand
 {
 public:
-    ReportWindowCoveringType() : ModelCommand("report")
+    ReportWindowCoveringType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59256,7 +59256,7 @@ public:
 class ReportWindowCoveringCurrentPositionLift : public ModelCommand
 {
 public:
-    ReportWindowCoveringCurrentPositionLift() : ModelCommand("report")
+    ReportWindowCoveringCurrentPositionLift() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position-lift");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59328,7 +59328,7 @@ public:
 class ReportWindowCoveringCurrentPositionTilt : public ModelCommand
 {
 public:
-    ReportWindowCoveringCurrentPositionTilt() : ModelCommand("report")
+    ReportWindowCoveringCurrentPositionTilt() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position-tilt");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59400,7 +59400,7 @@ public:
 class ReportWindowCoveringConfigStatus : public ModelCommand
 {
 public:
-    ReportWindowCoveringConfigStatus() : ModelCommand("report")
+    ReportWindowCoveringConfigStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "config-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59469,7 +59469,7 @@ public:
 class ReportWindowCoveringCurrentPositionLiftPercentage : public ModelCommand
 {
 public:
-    ReportWindowCoveringCurrentPositionLiftPercentage() : ModelCommand("report")
+    ReportWindowCoveringCurrentPositionLiftPercentage() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position-lift-percentage");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59541,7 +59541,7 @@ public:
 class ReportWindowCoveringCurrentPositionTiltPercentage : public ModelCommand
 {
 public:
-    ReportWindowCoveringCurrentPositionTiltPercentage() : ModelCommand("report")
+    ReportWindowCoveringCurrentPositionTiltPercentage() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position-tilt-percentage");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59613,7 +59613,7 @@ public:
 class ReportWindowCoveringOperationalStatus : public ModelCommand
 {
 public:
-    ReportWindowCoveringOperationalStatus() : ModelCommand("report")
+    ReportWindowCoveringOperationalStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "operational-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59682,7 +59682,7 @@ public:
 class ReportWindowCoveringTargetPositionLiftPercent100ths : public ModelCommand
 {
 public:
-    ReportWindowCoveringTargetPositionLiftPercent100ths() : ModelCommand("report")
+    ReportWindowCoveringTargetPositionLiftPercent100ths() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "target-position-lift-percent100ths");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59755,7 +59755,7 @@ public:
 class ReportWindowCoveringTargetPositionTiltPercent100ths : public ModelCommand
 {
 public:
-    ReportWindowCoveringTargetPositionTiltPercent100ths() : ModelCommand("report")
+    ReportWindowCoveringTargetPositionTiltPercent100ths() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "target-position-tilt-percent100ths");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59828,7 +59828,7 @@ public:
 class ReportWindowCoveringEndProductType : public ModelCommand
 {
 public:
-    ReportWindowCoveringEndProductType() : ModelCommand("report")
+    ReportWindowCoveringEndProductType() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "end-product-type");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59897,7 +59897,7 @@ public:
 class ReportWindowCoveringCurrentPositionLiftPercent100ths : public ModelCommand
 {
 public:
-    ReportWindowCoveringCurrentPositionLiftPercent100ths() : ModelCommand("report")
+    ReportWindowCoveringCurrentPositionLiftPercent100ths() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position-lift-percent100ths");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -59970,7 +59970,7 @@ public:
 class ReportWindowCoveringCurrentPositionTiltPercent100ths : public ModelCommand
 {
 public:
-    ReportWindowCoveringCurrentPositionTiltPercent100ths() : ModelCommand("report")
+    ReportWindowCoveringCurrentPositionTiltPercent100ths() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "current-position-tilt-percent100ths");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60043,7 +60043,7 @@ public:
 class ReportWindowCoveringInstalledOpenLimitLift : public ModelCommand
 {
 public:
-    ReportWindowCoveringInstalledOpenLimitLift() : ModelCommand("report")
+    ReportWindowCoveringInstalledOpenLimitLift() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "installed-open-limit-lift");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60115,7 +60115,7 @@ public:
 class ReportWindowCoveringInstalledClosedLimitLift : public ModelCommand
 {
 public:
-    ReportWindowCoveringInstalledClosedLimitLift() : ModelCommand("report")
+    ReportWindowCoveringInstalledClosedLimitLift() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "installed-closed-limit-lift");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60187,7 +60187,7 @@ public:
 class ReportWindowCoveringInstalledOpenLimitTilt : public ModelCommand
 {
 public:
-    ReportWindowCoveringInstalledOpenLimitTilt() : ModelCommand("report")
+    ReportWindowCoveringInstalledOpenLimitTilt() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "installed-open-limit-tilt");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60259,7 +60259,7 @@ public:
 class ReportWindowCoveringInstalledClosedLimitTilt : public ModelCommand
 {
 public:
-    ReportWindowCoveringInstalledClosedLimitTilt() : ModelCommand("report")
+    ReportWindowCoveringInstalledClosedLimitTilt() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "installed-closed-limit-tilt");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60357,7 +60357,7 @@ private:
 class ReportWindowCoveringMode : public ModelCommand
 {
 public:
-    ReportWindowCoveringMode() : ModelCommand("report")
+    ReportWindowCoveringMode() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "mode");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60426,7 +60426,7 @@ public:
 class ReportWindowCoveringSafetyStatus : public ModelCommand
 {
 public:
-    ReportWindowCoveringSafetyStatus() : ModelCommand("report")
+    ReportWindowCoveringSafetyStatus() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "safety-status");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60495,7 +60495,7 @@ public:
 class ReportWindowCoveringAttributeList : public ModelCommand
 {
 public:
-    ReportWindowCoveringAttributeList() : ModelCommand("report")
+    ReportWindowCoveringAttributeList() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "attribute-list");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60567,7 +60567,7 @@ public:
 class ReportWindowCoveringFeatureMap : public ModelCommand
 {
 public:
-    ReportWindowCoveringFeatureMap() : ModelCommand("report")
+    ReportWindowCoveringFeatureMap() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "feature-map");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -60636,7 +60636,7 @@ public:
 class ReportWindowCoveringClusterRevision : public ModelCommand
 {
 public:
-    ReportWindowCoveringClusterRevision() : ModelCommand("report")
+    ReportWindowCoveringClusterRevision() : ModelCommand("subscribe")
     {
         AddArgument("attr-name", "cluster-revision");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);


### PR DESCRIPTION
#### Problem
Currently, `examples/chip-tool` uses `report` command to subscribe to attributes and `report-event` command to subscribe to events. The names are quite confusing as it is the subscribe interaction that is initiated and it will be the other end that reports the data (attribute/event)

#### Change overview
- Change the below commands:
`report -> subscribe`
`report-event -> subscribe-event`
- Update generated code

#### Testing
- Tested manual compilation of chip-tool
- Verified that the changes are reflected in the help command:
```
$ ./out/debug/chip-tool switch
[1643113920.446514][379270:379270] CHIP:TOO: Missing command name
Usage:
  ./out/debug/chip-tool switch command_name [param1 param2 ...]

  +-------------------------------------------------------------------------------------+
  | Commands:                                                                           |
  +-------------------------------------------------------------------------------------+
  | * read                                                                              |
  | * subscribe                                                                         |
  | * read-event                                                                        |
  | * subscribe-event                                                                   |
  +-------------------------------------------------------------------------------------+
```
- Verified using the actual subscribe, subscribe-event commands on all-clusters-app