### PR TITLE
[Darwin] Retrieve data stored into ~/Documents/chip.store

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -19,6 +19,8 @@ import time
 from datetime import datetime
 import typing
 import threading
+from pathlib import Path
+import platform
 
 from enum import Enum, auto
 from dataclasses import dataclass
@@ -99,12 +101,26 @@ class TestDefinition:
                     "Unknown test target - don't know which application to run")
 
             tool_cmd = paths.chip_tool
-            if os.path.exists('/tmp/chip_tool_config.ini'):
-                os.unlink('/tmp/chip_tool_config.ini')
+
+            files_to_unlink = [
+                '/tmp/chip_tool_config.ini',
+                '/tmp/chip_tool_config.alpha.ini',
+                '/tmp/chip_tool_config.beta.ini',
+                '/tmp/chip_tool_config.gamma.ini',
+            ]
+
+            for f in files_to_unlink:
+                if os.path.exists(f):
+                    os.unlink(f)
 
             # Remove server all_clusters_app or tv_app storage, so it will be commissionable again
-            if os.path.exists('/tmp/chip_kvs'):
-                os.unlink('/tmp/chip_kvs')
+            if platform.system() == 'Linux':
+                if os.path.exists('/tmp/chip_kvs'):
+                    os.unlink('/tmp/chip_kvs')
+
+            if platform.system() == "Darwin":
+                if os.path.exists(str(Path.home()) + '/Documents/chip.store'):
+                    os.unlink(str(Path.home()) + '/Documents/chip.store')
 
             discriminator = str(randrange(1, 4096))
             logging.debug(
@@ -139,3 +155,4 @@ class TestDefinition:
         finally:
             if app_process:
                 app_process.kill()
+                app_process.wait(3)

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -109,9 +109,12 @@ namespace DeviceLayer {
                 return model;
             }
 
-            KeyValueItem * FindItemForKey(NSString * key, NSError ** error)
+            KeyValueItem * FindItemForKey(NSString * key, NSError ** error, BOOL returnsData)
             {
                 NSFetchRequest * request = [[NSFetchRequest alloc] initWithEntityName:@"KeyValue"];
+                if (returnsData) {
+                    [request setReturnsObjectsAsFaults:NO];
+                }
                 request.predicate = [NSPredicate predicateWithFormat:@"key = %@", key];
 
                 NSArray * result = [gContext executeFetchRequest:request error:error];
@@ -124,6 +127,8 @@ namespace DeviceLayer {
                 }
                 return (KeyValueItem *) [result objectAtIndex:0];
             }
+
+            KeyValueItem * FindItemForKey(NSString * key, NSError ** error) { return FindItemForKey(key, error, false); }
 
         }
 
@@ -196,7 +201,7 @@ namespace DeviceLayer {
             ReturnErrorCodeIf(key == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
             ReturnErrorCodeIf(offset != 0, CHIP_ERROR_INVALID_ARGUMENT);
 
-            KeyValueItem * item = FindItemForKey([[NSString alloc] initWithUTF8String:key], nil);
+            KeyValueItem * item = FindItemForKey([[NSString alloc] initWithUTF8String:key], nil, true);
             if (!item) {
                 return CHIP_ERROR_KEY_NOT_FOUND;
             }


### PR DESCRIPTION
#### Problem

Values saved into local database are not retrieved properly, and so while the correct informations are stored, they are not read and reused after reboot.

#### Change overview
 * Get the data to be extracted from the local database directly
 * Update the test suites to makes sure the accessory is commissioned again

#### Testing
 I have updated the test suite to make sure the device is commissioned again, otherwise the test suite just hangs.