### PR TITLE
Remedy race condition in advertising switch

### DIFF
--- a/src/platform/qpg/BLEManagerImpl.cpp
+++ b/src/platform/qpg/BLEManagerImpl.cpp
@@ -930,8 +930,8 @@ void BLEManagerImpl::BleAdvTimeoutHandler(TimerHandle_t xTimer)
     {
         /* Stop advertising and defer restart for when stop confirmation is received from the stack */
         ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertissment");
-        sInstance.StopAdvertising();
         sInstance.mFlags.Set(Flags::kRestartAdvertising);
+        sInstance.StopAdvertising();
     }
     else if (BLEMgrImpl().mFlags.Has(Flags::kAdvertising))
     {


### PR DESCRIPTION
#### Problem
* Device fails to switch to slow advertising after 30s

#### Change overview
Race condition removed by code reorder

#### Testing
* Internal advertising tests
* Manual pairing after 30s with chip-tool