### PR TITLE
Add storage to the example ACL implementation

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -33,6 +33,8 @@
 #include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <access/examples/ExampleAccessControlDelegate.h>
+
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ScopedBuffer.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
@@ -64,6 +66,27 @@ using namespace chip::DeviceLayer;
 using namespace chip::Inet;
 using namespace chip::Transport;
 
+class GeneralStorageDelegate : public PersistentStorageDelegate
+{
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    {
+        ChipLogProgress(NotSpecified, "Retrieved value from general storage.");
+        return PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
+    }
+
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    {
+        ChipLogProgress(NotSpecified, "Stored value in general storage");
+        return PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
+    }
+
+    CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+    {
+        ChipLogProgress(NotSpecified, "Delete value in general storage");
+        return PersistedStorage::KeyValueStoreMgr().Delete(key);
+    }
+};
+
 #if defined(ENABLE_CHIP_SHELL)
 using chip::Shell::Engine;
 #endif
@@ -88,6 +111,8 @@ void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg
         ChipLogProgress(DeviceLayer, "Receive kCHIPoBLEConnectionEstablished");
     }
 }
+
+GeneralStorageDelegate gAclStorageDelegate;
 } // namespace
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -135,6 +160,8 @@ int ChipLinuxAppInit(int argc, char ** argv)
     ConfigurationMgr().LogDeviceConfig();
 
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
+
+    Access::Examples::SetAccessControlDelegateStorage(&gAclStorageDelegate);
 
 #if defined(PW_RPC_ENABLED)
     chip::rpc::Init();

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -201,10 +201,8 @@ public:
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
     {
-        // mCluster
         ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         ReturnErrorOnFailure(reader.Get(mCluster));
-        // mFabricIndex
         ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         return reader.Get(mDeviceType);
     }
@@ -570,20 +568,15 @@ public:
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
-        // mInUse
         ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagInUse)));
         ReturnErrorOnFailure(reader.Get(mInUse));
-        // mFabricIndex
         ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagFabricIndex)));
         ReturnErrorOnFailure(reader.Get(mFabricIndex));
-        // mAuthMode
         ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagAuthMode)));
         ReturnErrorOnFailure(reader.Get(mAuthMode));
-        // mPrivilege
         ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagPrivilege)));
         ReturnErrorOnFailure(reader.Get(mPrivilege));
 
-        // mSubjects
         chip::TLV::TLVType innerContainer;
         ReturnErrorOnFailure(reader.Next(chip::TLV::TLVType::kTLVType_Array, chip::TLV::ContextTag(kTagSubjects)));
         ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
@@ -1266,13 +1259,11 @@ private:
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
-        // Version
         ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagVersion)));
         uint32_t version;
         ReturnErrorOnFailure(reader.Get(version));
         VerifyOrReturnError(version == kExampleAclStorageVersion, CHIP_ERROR_VERSION_MISMATCH);
 
-        // Entries
         for (size_t i = 0; i < EntryStorage::kNumberOfFabrics * EntryStorage::kEntriesPerFabric; ++i)
         {
             ReturnErrorOnFailure(EntryStorage::acl[i].Deserialize(mStorageDelegate, key.AccessControlEntry(i)));

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -518,7 +518,7 @@ public:
     static constexpr uint8_t kTagSubjects    = 5;
     static constexpr uint8_t kTagTargets     = 6;
     // This value was chosen to be large enough to contain the data, but has not been fine-tuned.
-    static const size_t kStorageBufferSize   = 192;
+    static const size_t kStorageBufferSize = 192;
 
     CHIP_ERROR Serialize(chip::PersistentStorageDelegate * storage, const char * key)
     {
@@ -1240,8 +1240,8 @@ private:
     // The version of the storage data format. Increment this key when the format of the data model changes.
     static const uint32_t kExampleAclStorageVersion = 1;
     // This value was chosen to be large enough to contain the data, but has not been fine-tuned.
-    static const size_t kStorageBufferSize          = 32;
-    static constexpr uint8_t kTagVersion            = 1;
+    static const size_t kStorageBufferSize = 32;
+    static constexpr uint8_t kTagVersion   = 1;
 
     CHIP_ERROR LoadFromFlash()
     {

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -517,6 +517,7 @@ public:
     static constexpr uint8_t kTagPrivilege   = 4;
     static constexpr uint8_t kTagSubjects    = 5;
     static constexpr uint8_t kTagTargets     = 6;
+    // This value was chosen to be large enough to contain the data, but has not been fine-tuned.
     static const size_t kStorageBufferSize   = 192;
 
     CHIP_ERROR Serialize(chip::PersistentStorageDelegate * storage, const char * key)
@@ -1238,6 +1239,7 @@ private:
 
     // The version of the storage data format. Increment this key when the format of the data model changes.
     static const uint32_t kExampleAclStorageVersion = 1;
+    // This value was chosen to be large enough to contain the data, but has not been fine-tuned.
     static const size_t kStorageBufferSize          = 32;
     static constexpr uint8_t kTagVersion            = 1;
 

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -128,31 +128,15 @@ public:
     }
 
 public:
-    static constexpr uint8_t kTagNode = 1;
-
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
     {
-        chip::TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
-
-        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagNode), mNode));
-
-        return writer.EndContainer(container);
+        return writer.Put(chip::TLV::AnonymousTag(), mNode);
     }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
     {
         ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
-        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
-
-        chip::TLV::TLVType container;
-        ReturnErrorOnFailure(reader.EnterContainer(container));
-
-        // mNode
-        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagNode)));
-        ReturnErrorOnFailure(reader.Get(mNode));
-
-        return reader.ExitContainer(container);
+        return reader.Get(mNode);
     }
 
 private:
@@ -211,36 +195,20 @@ public:
     }
 
 public:
-    static constexpr uint8_t kTagCluster    = 1;
-    static constexpr uint8_t kTagDeviceType = 2;
-
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
     {
-        chip::TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
-
-        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagCluster), mCluster));
-        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagDeviceType), mDeviceType));
-
-        return writer.EndContainer(container);
+        ReturnErrorOnFailure(writer.Put(chip::TLV::AnonymousTag(), mCluster));
+        return writer.Put(chip::TLV::AnonymousTag(), mDeviceType);
     }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
     {
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
-        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
-
-        chip::TLV::TLVType container;
-        ReturnErrorOnFailure(reader.EnterContainer(container));
-
         // mCluster
-        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagCluster)));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         ReturnErrorOnFailure(reader.Get(mCluster));
         // mFabricIndex
-        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagDeviceType)));
-        ReturnErrorOnFailure(reader.Get(mDeviceType));
-
-        return reader.ExitContainer(container);
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
+        return reader.Get(mDeviceType);
     }
 
 private:
@@ -559,7 +527,7 @@ public:
     {
         uint8_t buffer[kStorageBufferSize] = { 0 };
         chip::TLV::TLVWriter writer;
-        writer.Init(buffer, sizeof(buffer));
+        writer.Init(buffer);
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
 
@@ -597,8 +565,7 @@ public:
         chip::TLV::TLVReader reader;
         reader.Init(buffer, bufferSize);
 
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
-        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(reader.Next(chip::TLV::TLVType::kTLVType_Structure, chip::TLV::AnonymousTag()));
 
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
@@ -618,8 +585,7 @@ public:
 
         // mSubjects
         chip::TLV::TLVType innerContainer;
-        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagSubjects)));
-        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Array, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(reader.Next(chip::TLV::TLVType::kTLVType_Array, chip::TLV::ContextTag(kTagSubjects)));
         ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
         for (size_t i = 0; i < kMaxSubjects; ++i)
         {
@@ -628,8 +594,7 @@ public:
         ReturnErrorOnFailure(reader.ExitContainer(innerContainer));
 
         // mTargets
-        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagTargets)));
-        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Array, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(reader.Next(chip::TLV::TLVType::kTLVType_Array, chip::TLV::ContextTag(kTagTargets)));
         ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
         for (size_t i = 0; i < kMaxTargets; ++i)
         {
@@ -1275,8 +1240,7 @@ private:
         chip::TLV::TLVReader reader;
         reader.Init(buffer, size);
 
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
-        VerifyOrReturnError(reader.GetType() == chip::TLV::kTLVType_Structure, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(reader.Next(chip::TLV::kTLVType_Structure, chip::TLV::AnonymousTag()));
 
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
@@ -1301,7 +1265,7 @@ private:
 
         uint8_t buffer[kStorageBufferSize] = { 0 };
         chip::TLV::TLVWriter writer;
-        writer.Init(buffer, sizeof(buffer));
+        writer.Init(buffer);
         chip::DefaultStorageKeyAllocator key;
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -129,10 +129,7 @@ public:
     }
 
 public:
-    CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
-    {
-        return writer.Put(chip::TLV::AnonymousTag(), mNode);
-    }
+    CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer) { return writer.Put(chip::TLV::AnonymousTag(), mNode); }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
     {
@@ -538,14 +535,16 @@ public:
         ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagPrivilege), mPrivilege));
 
         chip::TLV::TLVType internalContainer;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::ContextTag(kTagSubjects), chip::TLV::TLVType::kTLVType_Array, internalContainer));
+        ReturnErrorOnFailure(
+            writer.StartContainer(chip::TLV::ContextTag(kTagSubjects), chip::TLV::TLVType::kTLVType_Array, internalContainer));
         for (size_t i = 0; i < kMaxSubjects; ++i)
         {
             ReturnErrorOnFailure(mSubjects[i].Serialize(writer));
         }
         ReturnErrorOnFailure(writer.EndContainer(internalContainer));
 
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::ContextTag(kTagTargets), chip::TLV::TLVType::kTLVType_Array, internalContainer));
+        ReturnErrorOnFailure(
+            writer.StartContainer(chip::TLV::ContextTag(kTagTargets), chip::TLV::TLVType::kTLVType_Array, internalContainer));
         for (size_t i = 0; i < kMaxTargets; ++i)
         {
             ReturnErrorOnFailure(mTargets[i].Serialize(writer));

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -128,28 +128,28 @@ public:
     }
 
 public:
-    static const chip::TLV::Tag kTagNode = chip::TLV::ContextTag(1);
+    static constexpr uint8_t kTagNode = 1;
 
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
     {
         chip::TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagNode, mNode));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagNode), mNode));
 
         return writer.EndContainer(container);
     }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
     {
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
 
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // mNode
-        ReturnErrorOnFailure(reader.Next(kTagNode));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagNode)));
         ReturnErrorOnFailure(reader.Get(mNode));
 
         return reader.ExitContainer(container);
@@ -211,33 +211,33 @@ public:
     }
 
 public:
-    static const chip::TLV::Tag kTagCluster    = chip::TLV::ContextTag(1);
-    static const chip::TLV::Tag kTagDeviceType = chip::TLV::ContextTag(2);
+    static constexpr uint8_t kTagCluster    = 1;
+    static constexpr uint8_t kTagDeviceType = 2;
 
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
     {
         chip::TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagCluster, mCluster));
-        ReturnErrorOnFailure(writer.Put(kTagDeviceType, mDeviceType));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagCluster), mCluster));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagDeviceType), mDeviceType));
 
         return writer.EndContainer(container);
     }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
     {
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
 
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // mCluster
-        ReturnErrorOnFailure(reader.Next(kTagCluster));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagCluster)));
         ReturnErrorOnFailure(reader.Get(mCluster));
         // mFabricIndex
-        ReturnErrorOnFailure(reader.Next(kTagDeviceType));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagDeviceType)));
         ReturnErrorOnFailure(reader.Get(mDeviceType));
 
         return reader.ExitContainer(container);
@@ -547,13 +547,13 @@ public:
     }
 
 public:
-    static const chip::TLV::Tag kTagInUse       = chip::TLV::ContextTag(1);
-    static const chip::TLV::Tag kTagFabricIndex = chip::TLV::ContextTag(2);
-    static const chip::TLV::Tag kTagAuthMode    = chip::TLV::ContextTag(3);
-    static const chip::TLV::Tag kTagPrivilege   = chip::TLV::ContextTag(4);
-    static const chip::TLV::Tag kTagSubjects    = chip::TLV::ContextTag(5);
-    static const chip::TLV::Tag kTagTargets     = chip::TLV::ContextTag(6);
-    static const size_t kStorageBufferSize      = 192;
+    static constexpr uint8_t kTagInUse       = 1;
+    static constexpr uint8_t kTagFabricIndex = 2;
+    static constexpr uint8_t kTagAuthMode    = 3;
+    static constexpr uint8_t kTagPrivilege   = 4;
+    static constexpr uint8_t kTagSubjects    = 5;
+    static constexpr uint8_t kTagTargets     = 6;
+    static const size_t kStorageBufferSize   = 192;
 
     CHIP_ERROR Serialize(chip::PersistentStorageDelegate * storage, const char * key)
     {
@@ -561,22 +561,22 @@ public:
         chip::TLV::TLVWriter writer;
         writer.Init(buffer, sizeof(buffer));
         chip::TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
 
-        ReturnErrorOnFailure(writer.Put(kTagInUse, mInUse));
-        ReturnErrorOnFailure(writer.Put(kTagFabricIndex, mFabricIndex));
-        ReturnErrorOnFailure(writer.Put(kTagAuthMode, mAuthMode));
-        ReturnErrorOnFailure(writer.Put(kTagPrivilege, mPrivilege));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagInUse), mInUse));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagFabricIndex), mFabricIndex));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagAuthMode), mAuthMode));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagPrivilege), mPrivilege));
 
         chip::TLV::TLVType internalContainer;
-        ReturnErrorOnFailure(writer.StartContainer(kTagSubjects, chip::TLV::TLVType::kTLVType_Array, internalContainer));
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::ContextTag(kTagSubjects), chip::TLV::TLVType::kTLVType_Array, internalContainer));
         for (size_t i = 0; i < kMaxSubjects; ++i)
         {
             ReturnErrorOnFailure(mSubjects[i].Serialize(writer));
         }
         ReturnErrorOnFailure(writer.EndContainer(internalContainer));
 
-        ReturnErrorOnFailure(writer.StartContainer(kTagTargets, chip::TLV::TLVType::kTLVType_Array, internalContainer));
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::ContextTag(kTagTargets), chip::TLV::TLVType::kTLVType_Array, internalContainer));
         for (size_t i = 0; i < kMaxTargets; ++i)
         {
             ReturnErrorOnFailure(mTargets[i].Serialize(writer));
@@ -597,28 +597,28 @@ public:
         chip::TLV::TLVReader reader;
         reader.Init(buffer, bufferSize);
 
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
 
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // mInUse
-        ReturnErrorOnFailure(reader.Next(kTagInUse));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagInUse)));
         ReturnErrorOnFailure(reader.Get(mInUse));
         // mFabricIndex
-        ReturnErrorOnFailure(reader.Next(kTagFabricIndex));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagFabricIndex)));
         ReturnErrorOnFailure(reader.Get(mFabricIndex));
         // mAuthMode
-        ReturnErrorOnFailure(reader.Next(kTagAuthMode));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagAuthMode)));
         ReturnErrorOnFailure(reader.Get(mAuthMode));
         // mPrivilege
-        ReturnErrorOnFailure(reader.Next(kTagPrivilege));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagPrivilege)));
         ReturnErrorOnFailure(reader.Get(mPrivilege));
 
         // mSubjects
         chip::TLV::TLVType innerContainer;
-        ReturnErrorOnFailure(reader.Next(kTagSubjects));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagSubjects)));
         VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Array, CHIP_ERROR_INTERNAL);
         ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
         for (size_t i = 0; i < kMaxSubjects; ++i)
@@ -628,7 +628,7 @@ public:
         ReturnErrorOnFailure(reader.ExitContainer(innerContainer));
 
         // mTargets
-        ReturnErrorOnFailure(reader.Next(kTagTargets));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagTargets)));
         VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Array, CHIP_ERROR_INTERNAL);
         ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
         for (size_t i = 0; i < kMaxTargets; ++i)
@@ -1261,7 +1261,7 @@ private:
     // The version of the storage data format. Increment this key when the format of the data model changes.
     static const uint32_t kExampleAclStorageVersion = 1;
     static const size_t kStorageBufferSize          = 32;
-    static const chip::TLV::Tag kTagVersion         = chip::TLV::ContextTag(1);
+    static constexpr uint8_t kTagVersion            = 1;
 
     CHIP_ERROR LoadFromFlash()
     {
@@ -1275,14 +1275,14 @@ private:
         chip::TLV::TLVReader reader;
         reader.Init(buffer, size);
 
-        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag()));
         VerifyOrReturnError(reader.GetType() == chip::TLV::kTLVType_Structure, CHIP_ERROR_INTERNAL);
 
         chip::TLV::TLVType container;
         ReturnErrorOnFailure(reader.EnterContainer(container));
 
         // Version
-        ReturnErrorOnFailure(reader.Next(kTagVersion));
+        ReturnErrorOnFailure(reader.Next(chip::TLV::ContextTag(kTagVersion)));
         uint32_t version;
         ReturnErrorOnFailure(reader.Get(version));
         VerifyOrReturnError(version == kExampleAclStorageVersion, CHIP_ERROR_VERSION_MISMATCH);
@@ -1304,8 +1304,8 @@ private:
         writer.Init(buffer, sizeof(buffer));
         chip::DefaultStorageKeyAllocator key;
         chip::TLV::TLVType container;
-        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
-        ReturnErrorOnFailure(writer.Put(kTagVersion, kExampleAclStorageVersion));
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::TLVType::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTagVersion), kExampleAclStorageVersion));
         for (size_t i = 0; i < EntryStorage::kNumberOfFabrics * EntryStorage::kEntriesPerFabric; ++i)
         {
             ReturnErrorOnFailure(EntryStorage::acl[i].Serialize(mStorageDelegate, key.AccessControlEntry(i)));

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <type_traits>
 
 namespace {
@@ -1325,6 +1326,7 @@ AccessControl::Delegate & GetAccessControlDelegate()
 
 void SetAccessControlDelegateStorage(chip::PersistentStorageDelegate * storageDelegate)
 {
+    ChipLogDetail(DataManagement, "Examples::SetAccessControlDelegateStorage");
     AccessControlDelegate & accessControlDelegate = static_cast<AccessControlDelegate &>(GetAccessControlDelegate());
     accessControlDelegate.SetStorageDelegate(storageDelegate);
 }

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -586,7 +586,6 @@ public:
         }
         ReturnErrorOnFailure(reader.ExitContainer(innerContainer));
 
-        // mTargets
         ReturnErrorOnFailure(reader.Next(chip::TLV::TLVType::kTLVType_Array, chip::TLV::ContextTag(kTagTargets)));
         ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
         for (size_t i = 0; i < kMaxTargets; ++i)

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -1142,6 +1142,12 @@ public:
                         EntryStorage::ConvertIndex(*index, *fabricIndex, EntryStorage::ConvertDirection::kAbsoluteToRelative);
                     }
                 }
+
+                CHIP_ERROR saveError = SaveToFlash();
+                if (saveError != CHIP_NO_ERROR && saveError != CHIP_ERROR_INCORRECT_STATE)
+                {
+                    ChipLogDetail(DataManagement, "CreateEntry failed to save to flash");
+                }
             }
             return err;
         }
@@ -1166,7 +1172,16 @@ public:
     {
         if (auto * storage = EntryStorage::FindUsedInAcl(index, fabricIndex))
         {
-            return Copy(entry, *storage);
+            CHIP_ERROR err = Copy(entry, *storage);
+            if (err == CHIP_NO_ERROR)
+            {
+                CHIP_ERROR saveError = SaveToFlash();
+                if (saveError != CHIP_NO_ERROR && saveError != CHIP_ERROR_INCORRECT_STATE)
+                {
+                    ChipLogDetail(DataManagement, "UpdateEntry failed to save to flash");
+                }
+            }
+            return err;
         }
         return CHIP_ERROR_SENTINEL;
     }
@@ -1201,6 +1216,12 @@ public:
             for (auto & delegate : EntryIteratorDelegate::pool)
             {
                 delegate.FixAfterDelete(*storage);
+            }
+
+            CHIP_ERROR saveError = SaveToFlash();
+            if (saveError != CHIP_NO_ERROR && saveError != CHIP_ERROR_INCORRECT_STATE)
+            {
+                ChipLogDetail(DataManagement, "DeleteEntry failed to save to flash");
             }
             return CHIP_NO_ERROR;
         }

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -19,6 +19,8 @@
 #include "ExampleAccessControlDelegate.h"
 
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -125,6 +127,34 @@ public:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
+public:
+    static const chip::TLV::Tag kTagNode = chip::TLV::ContextTag(1);
+
+    CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
+    {
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+
+        ReturnErrorOnFailure(writer.Put(kTagNode, mNode));
+
+        return writer.EndContainer(container);
+    }
+
+    CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
+    {
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
+
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // mNode
+        ReturnErrorOnFailure(reader.Next(kTagNode));
+        ReturnErrorOnFailure(reader.Get(mNode));
+
+        return reader.ExitContainer(container);
+    }
+
 private:
     static bool IsValid(NodeId node) { return node != kUndefinedNodeId; }
 
@@ -178,6 +208,39 @@ public:
             return CHIP_NO_ERROR;
         }
         return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+public:
+    static const chip::TLV::Tag kTagCluster    = chip::TLV::ContextTag(1);
+    static const chip::TLV::Tag kTagDeviceType = chip::TLV::ContextTag(2);
+
+    CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer)
+    {
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+
+        ReturnErrorOnFailure(writer.Put(kTagCluster, mCluster));
+        ReturnErrorOnFailure(writer.Put(kTagDeviceType, mDeviceType));
+
+        return writer.EndContainer(container);
+    }
+
+    CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
+    {
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
+
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // mCluster
+        ReturnErrorOnFailure(reader.Next(kTagCluster));
+        ReturnErrorOnFailure(reader.Get(mCluster));
+        // mFabricIndex
+        ReturnErrorOnFailure(reader.Next(kTagDeviceType));
+        ReturnErrorOnFailure(reader.Get(mDeviceType));
+
+        return reader.ExitContainer(container);
     }
 
 private:
@@ -481,6 +544,100 @@ public:
             absoluteIndex++;
         }
         index = found ? toIndex : ArraySize(acl);
+    }
+
+public:
+    static const chip::TLV::Tag kTagInUse       = chip::TLV::ContextTag(1);
+    static const chip::TLV::Tag kTagFabricIndex = chip::TLV::ContextTag(2);
+    static const chip::TLV::Tag kTagAuthMode    = chip::TLV::ContextTag(3);
+    static const chip::TLV::Tag kTagPrivilege   = chip::TLV::ContextTag(4);
+    static const chip::TLV::Tag kTagSubjects    = chip::TLV::ContextTag(5);
+    static const chip::TLV::Tag kTagTargets     = chip::TLV::ContextTag(6);
+    static const size_t kStorageBufferSize      = 192;
+
+    CHIP_ERROR Serialize(chip::PersistentStorageDelegate * storage, const char * key)
+    {
+        uint8_t buffer[kStorageBufferSize] = { 0 };
+        chip::TLV::TLVWriter writer;
+        writer.Init(buffer, sizeof(buffer));
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+
+        ReturnErrorOnFailure(writer.Put(kTagInUse, mInUse));
+        ReturnErrorOnFailure(writer.Put(kTagFabricIndex, mFabricIndex));
+        ReturnErrorOnFailure(writer.Put(kTagAuthMode, mAuthMode));
+        ReturnErrorOnFailure(writer.Put(kTagPrivilege, mPrivilege));
+
+        chip::TLV::TLVType internalContainer;
+        ReturnErrorOnFailure(writer.StartContainer(kTagSubjects, chip::TLV::TLVType::kTLVType_Array, internalContainer));
+        for (size_t i = 0; i < kMaxSubjects; ++i)
+        {
+            ReturnErrorOnFailure(mSubjects[i].Serialize(writer));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(internalContainer));
+
+        ReturnErrorOnFailure(writer.StartContainer(kTagTargets, chip::TLV::TLVType::kTLVType_Array, internalContainer));
+        for (size_t i = 0; i < kMaxTargets; ++i)
+        {
+            ReturnErrorOnFailure(mTargets[i].Serialize(writer));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(internalContainer));
+
+        ReturnErrorOnFailure(writer.EndContainer(container));
+        ReturnErrorOnFailure(writer.Finalize());
+
+        return storage->SyncSetKeyValue(key, buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
+    }
+
+    CHIP_ERROR Deserialize(chip::PersistentStorageDelegate * storage, const char * key)
+    {
+        uint8_t buffer[kStorageBufferSize] = { 0 };
+        uint16_t bufferSize                = static_cast<uint16_t>(sizeof(buffer));
+        ReturnErrorOnFailure(storage->SyncGetKeyValue(key, buffer, bufferSize));
+        chip::TLV::TLVReader reader;
+        reader.Init(buffer, bufferSize);
+
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Structure, CHIP_ERROR_INTERNAL);
+
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // mInUse
+        ReturnErrorOnFailure(reader.Next(kTagInUse));
+        ReturnErrorOnFailure(reader.Get(mInUse));
+        // mFabricIndex
+        ReturnErrorOnFailure(reader.Next(kTagFabricIndex));
+        ReturnErrorOnFailure(reader.Get(mFabricIndex));
+        // mAuthMode
+        ReturnErrorOnFailure(reader.Next(kTagAuthMode));
+        ReturnErrorOnFailure(reader.Get(mAuthMode));
+        // mPrivilege
+        ReturnErrorOnFailure(reader.Next(kTagPrivilege));
+        ReturnErrorOnFailure(reader.Get(mPrivilege));
+
+        // mSubjects
+        chip::TLV::TLVType innerContainer;
+        ReturnErrorOnFailure(reader.Next(kTagSubjects));
+        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Array, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
+        for (size_t i = 0; i < kMaxSubjects; ++i)
+        {
+            ReturnErrorOnFailure(mSubjects[i].Deserialize(reader));
+        }
+        ReturnErrorOnFailure(reader.ExitContainer(innerContainer));
+
+        // mTargets
+        ReturnErrorOnFailure(reader.Next(kTagTargets));
+        VerifyOrReturnError(reader.GetType() == chip::TLV::TLVType::kTLVType_Array, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(reader.EnterContainer(innerContainer));
+        for (size_t i = 0; i < kMaxTargets; ++i)
+        {
+            ReturnErrorOnFailure(mTargets[i].Deserialize(reader));
+        }
+        ReturnErrorOnFailure(reader.ExitContainer(innerContainer));
+
+        return reader.ExitContainer(container);
     }
 
 public:
@@ -1095,10 +1252,69 @@ public:
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-private:
-    CHIP_ERROR LoadFromFlash() { return CHIP_NO_ERROR; }
+public:
+    void SetStorageDelegate(chip::PersistentStorageDelegate * storageDelegate) { mStorageDelegate = storageDelegate; }
 
-    CHIP_ERROR SaveToFlash() { return CHIP_NO_ERROR; }
+private:
+    chip::PersistentStorageDelegate * mStorageDelegate = nullptr;
+
+    // The version of the storage data format. Increment this key when the format of the data model changes.
+    static const uint32_t kExampleAclStorageVersion = 1;
+    static const size_t kStorageBufferSize          = 32;
+    static const chip::TLV::Tag kTagVersion         = chip::TLV::ContextTag(1);
+
+    CHIP_ERROR LoadFromFlash()
+    {
+        VerifyOrReturnError(mStorageDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        uint8_t buffer[kStorageBufferSize] = { 0 };
+        uint16_t size                      = static_cast<uint16_t>(sizeof(buffer));
+        chip::DefaultStorageKeyAllocator key;
+        ReturnErrorOnFailure(mStorageDelegate->SyncGetKeyValue(key.AccessControlList(), buffer, size));
+
+        chip::TLV::TLVReader reader;
+        reader.Init(buffer, size);
+
+        ReturnErrorOnFailure(reader.Next(chip::TLV::AnonymousTag));
+        VerifyOrReturnError(reader.GetType() == chip::TLV::kTLVType_Structure, CHIP_ERROR_INTERNAL);
+
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // Version
+        ReturnErrorOnFailure(reader.Next(kTagVersion));
+        uint32_t version;
+        ReturnErrorOnFailure(reader.Get(version));
+        VerifyOrReturnError(version == kExampleAclStorageVersion, CHIP_ERROR_VERSION_MISMATCH);
+
+        // Entries
+        for (size_t i = 0; i < EntryStorage::kNumberOfFabrics * EntryStorage::kEntriesPerFabric; ++i)
+        {
+            ReturnErrorOnFailure(EntryStorage::acl[i].Deserialize(mStorageDelegate, key.AccessControlEntry(i)));
+        }
+        return reader.ExitContainer(container);
+    }
+
+    CHIP_ERROR SaveToFlash()
+    {
+        VerifyOrReturnError(mStorageDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        uint8_t buffer[kStorageBufferSize] = { 0 };
+        chip::TLV::TLVWriter writer;
+        writer.Init(buffer, sizeof(buffer));
+        chip::DefaultStorageKeyAllocator key;
+        chip::TLV::TLVType container;
+        ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::TLVType::kTLVType_Structure, container));
+        ReturnErrorOnFailure(writer.Put(kTagVersion, kExampleAclStorageVersion));
+        for (size_t i = 0; i < EntryStorage::kNumberOfFabrics * EntryStorage::kEntriesPerFabric; ++i)
+        {
+            ReturnErrorOnFailure(EntryStorage::acl[i].Serialize(mStorageDelegate, key.AccessControlEntry(i)));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(container));
+        ReturnErrorOnFailure(writer.Finalize());
+
+        return mStorageDelegate->SyncSetKeyValue(key.AccessControlList(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
+    }
 };
 
 static_assert(std::is_pod<SubjectStorage>(), "Storage type must be POD");
@@ -1120,6 +1336,12 @@ AccessControl::Delegate & GetAccessControlDelegate()
 {
     static AccessControlDelegate accessControlDelegate;
     return accessControlDelegate;
+}
+
+void SetAccessControlDelegateStorage(chip::PersistentStorageDelegate * storageDelegate)
+{
+    AccessControlDelegate & accessControlDelegate = static_cast<AccessControlDelegate &>(GetAccessControlDelegate());
+    accessControlDelegate.SetStorageDelegate(storageDelegate);
 }
 
 } // namespace Examples

--- a/src/access/examples/ExampleAccessControlDelegate.h
+++ b/src/access/examples/ExampleAccessControlDelegate.h
@@ -17,12 +17,15 @@
 #pragma once
 
 #include "access/AccessControl.h"
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 
 namespace chip {
 namespace Access {
 namespace Examples {
 
 AccessControl::Delegate & GetAccessControlDelegate();
+
+void SetAccessControlDelegateStorage(chip::PersistentStorageDelegate * storageDelegate);
 
 } // namespace Examples
 } // namespace Access

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -37,6 +37,11 @@ public:
 
     const char * FabricTable(chip::FabricIndex fabric) { return Format("f/%x/t", fabric); }
 
+    // Access Control List
+
+    const char * AccessControlList() { return Format("acl"); }
+    const char * AccessControlEntry(size_t index) { return Format("acl/%x", index); }
+
     // Group Data Provider
 
     const char * FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -40,7 +40,7 @@ public:
     // Access Control List
 
     const char * AccessControlList() { return Format("acl"); }
-    const char * AccessControlEntry(size_t index) { return Format("acl/%x", index); }
+    const char * AccessControlEntry(size_t index) { return Format("acl/%zx", index); }
 
     // Group Data Provider
 


### PR DESCRIPTION
#### Problem
* The ACL module needs to be able to store ACL entries between runs of the device.

#### Change overview
* Adds support for ACL persistent storage. The ACL entries are saved to the persistent storage whenever an entry is created, updated, or deleted.
* Sets the ACL storage on Linux, backed by the KVS.

#### Testing
* Manually tested on Linux by mlepage-google. Procedure was to write an entry to ACL in chip-all-clusters-app, close the app, then re-open it and verify that the data loaded properly.
