### PR TITLE
Fix reading attribute activeLocale failure

### DIFF
--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -39,6 +39,8 @@ using namespace chip::app::Clusters::LocalizationConfiguration::Attributes;
 
 namespace {
 
+constexpr size_t kMaxActiveLocaleLength = 35;
+
 class LocalizationConfigurationAttrAccess : public AttributeAccessInterface
 {
 public:
@@ -150,7 +152,9 @@ void emberAfLocalizationConfigurationClusterServerInitCallback(EndpointId endpoi
 {
     DeviceLayer::AttributeList<CharSpan, DeviceLayer::kMaxLanguageTags> supportedLocales;
     CharSpan validLocale;
-    MutableCharSpan activeLocale;
+
+    char outBuffer[kMaxActiveLocaleLength] = "";
+    MutableCharSpan activeLocale(outBuffer, kMaxActiveLocaleLength);
     EmberAfStatus status = ActiveLocale::Get(endpoint, activeLocale);
 
     VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Failed to read ActiveLocale with error: 0x%02x", status));

--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -153,8 +153,8 @@ void emberAfLocalizationConfigurationClusterServerInitCallback(EndpointId endpoi
     DeviceLayer::AttributeList<CharSpan, DeviceLayer::kMaxLanguageTags> supportedLocales;
     CharSpan validLocale;
 
-    char outBuffer[kMaxActiveLocaleLength] = "";
-    MutableCharSpan activeLocale(outBuffer, kMaxActiveLocaleLength);
+    char outBuffer[kMaxActiveLocaleLength];
+    MutableCharSpan activeLocale(outBuffer);
     EmberAfStatus status = ActiveLocale::Get(endpoint, activeLocale);
 
     VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Failed to read ActiveLocale with error: 0x%02x", status));


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Always fails to read activeLocale in emberAfLocalizationConfigurationClusterServerInitCallback, the reason is we pass a null pointer with a zero-sized buffer to EmberAfStatus status = ActiveLocale::Get(endpoint, activeLocale)
* Fix https://github.com/project-chip/connectedhomeip/issues/13771

#### Change overview
Fix reading attribute activeLocale failure

#### Testing
How was this tested? (at least one bullet point required)
* During bootup, check the log and confirm no error message Failed to read ActiveLocale with error during initialization in the log.
