### PR TITLE
LwIP packet buffer pool type

### DIFF
--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -142,6 +142,7 @@ static_library("system") {
     "SystemMutex.h",
     "SystemPacketBuffer.cpp",
     "SystemPacketBuffer.h",
+    "SystemPacketBufferInternal.h",
     "SystemStats.cpp",
     "SystemStats.h",
     "SystemTimer.cpp",

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -321,6 +321,18 @@
 #endif /* CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE */
 
 /**
+ *  @def CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE
+ *
+ *  @brief
+ *      LwIP @pbuf_type for System::PacketBuffer allocations.
+ *
+ *      Note that this does not affect allocations by LwIP itself, e.g. the normal receive path.
+ */
+#ifndef CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE PBUF_POOL
+#endif /* CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE */
+
+/**
  *  @def CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX
  *
  *  @brief

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -52,14 +52,14 @@
 #include <lwip/pbuf.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
 #include <lib/support/CHIPMem.h>
 #endif
 
 namespace chip {
 namespace System {
 
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
 //
 // Pool allocation for PacketBuffer objects.
 //
@@ -102,12 +102,12 @@ PacketBuffer * PacketBuffer::BuildFreeList()
     return static_cast<PacketBuffer *>(lHead);
 }
 
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
 //
 // Heap allocation for PacketBuffer objects.
 //
 
-#if CHIP_CONFIG_MEMORY_DEBUG_CHECKS
+#if CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK
 void PacketBuffer::InternalCheck(const PacketBuffer * buffer)
 {
     if (buffer)
@@ -118,7 +118,7 @@ void PacketBuffer::InternalCheck(const PacketBuffer * buffer)
                            "packet buffer overflow %u < %u+%u", buffer->alloc_size, buffer->ReservedSize(), buffer->len);
     }
 }
-#endif // CHIP_CONFIG_MEMORY_DEBUG_CHECKS
+#endif // CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK
 
 // Number of unused bytes below which \c RightSize() won't bother reallocating.
 constexpr uint16_t kRightSizingThreshold = 16;
@@ -161,7 +161,7 @@ void PacketBufferHandle::InternalRightSize()
     mBuffer = newBuffer;
 }
 
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL
 
 void PacketBufferHandle::InternalRightSize()
 {
@@ -174,7 +174,7 @@ void PacketBufferHandle::InternalRightSize()
     }
 }
 
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE
+#endif
 
 #ifndef LOCK_BUF_POOL
 #define LOCK_BUF_POOL()                                                                                                            \
@@ -460,14 +460,14 @@ PacketBufferHandle PacketBufferHandle::New(size_t aAvailableSize, uint16_t aRese
         return PacketBufferHandle();
     }
 
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_POOL ||                                                  \
-    CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    lPacket = static_cast<PacketBuffer *>(pbuf_alloc(PBUF_RAW, static_cast<uint16_t>(lAllocSize), PBUF_POOL));
+    lPacket = static_cast<PacketBuffer *>(
+        pbuf_alloc(PBUF_RAW, static_cast<uint16_t>(lAllocSize), CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE));
 
     SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS();
 
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
 
     static_cast<void>(lBlockSize);
 
@@ -482,14 +482,14 @@ PacketBufferHandle PacketBufferHandle::New(size_t aAvailableSize, uint16_t aRese
 
     UNLOCK_BUF_POOL();
 
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
 
     lPacket = reinterpret_cast<PacketBuffer *>(chip::Platform::MemoryAlloc(lBlockSize));
     SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
 
 #else
-#error "Unimplemented CHIP_SYSTEM_PACKETBUFFER_STORE case"
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE
+#error "Unimplemented PacketBuffer storage case"
+#endif
 
     if (lPacket == nullptr)
     {
@@ -501,7 +501,7 @@ PacketBufferHandle PacketBufferHandle::New(size_t aAvailableSize, uint16_t aRese
     lPacket->len = lPacket->tot_len = 0;
     lPacket->next                   = nullptr;
     lPacket->ref                    = 1;
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
     lPacket->alloc_size = static_cast<uint16_t>(lAllocSize);
 #endif
 
@@ -538,8 +538,7 @@ PacketBufferHandle PacketBufferHandle::NewWithData(const void * aData, size_t aD
  */
 void PacketBuffer::Free(PacketBuffer * aPacket)
 {
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_POOL ||                                                  \
-    CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
 
     if (aPacket != nullptr)
     {
@@ -548,8 +547,7 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
         SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS();
     }
 
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL ||                                                \
-    CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
 
     LOCK_BUF_POOL();
 
@@ -563,16 +561,16 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
         if (aPacket->ref == 0)
         {
             SYSTEM_STATS_DECREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
             ::chip::Platform::MemoryDebugCheckPointer(aPacket, aPacket->alloc_size + kStructureSize);
 #endif
             aPacket->Clear();
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
             aPacket->next = sFreeList;
             sFreeList     = aPacket;
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
             chip::Platform::MemoryFree(aPacket);
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE
+#endif
             aPacket       = lNextPacket;
         }
         else
@@ -584,8 +582,8 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
     UNLOCK_BUF_POOL();
 
 #else
-#error "Unimplemented CHIP_SYSTEM_PACKETBUFFER_STORE case"
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE
+#error "Unimplemented PacketBuffer storage case"
+#endif
 }
 
 /**
@@ -597,7 +595,7 @@ void PacketBuffer::Clear()
 {
     tot_len = 0;
     len     = 0;
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
     alloc_size = 0;
 #endif
 }

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -26,7 +26,7 @@
 #pragma once
 
 // Include configuration header
-#include <system/SystemConfig.h>
+#include <system/SystemPacketBufferInternal.h>
 
 // Include dependent headers
 #include <lib/support/BufferWriter.h>
@@ -46,43 +46,6 @@
 
 class PacketBufferTest;
 
-/*
- * Preprocessor definitions related to packet buffer memory configuration.
- * These are not part of the public PacketBuffer interface; they are present
- * here so that certain public functions can have definitions optimized for
- * particular configurations.
- */
-
-#undef CHIP_SYSTEM_PACKETBUFFER_STORE                // One of the following constants:
-#define CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_POOL 1   //   Default lwIP allocation
-#define CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM 2 //   Custom lwIP allocation
-#define CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL 3   //   Internal fixed pool
-#define CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP 4   //   Platform::MemoryAlloc
-
-#undef CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE // True if RightSize() has a nontrivial implementation
-#undef CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK      // True if Check() has a nontrivial implementation
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if LWIP_PBUF_FROM_CUSTOM_POOLS
-#define CHIP_SYSTEM_PACKETBUFFER_STORE CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE 1
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK 0
-#else
-#define CHIP_SYSTEM_PACKETBUFFER_STORE CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_POOL
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE 0
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK 0
-#endif
-#else
-#if CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE
-#define CHIP_SYSTEM_PACKETBUFFER_STORE CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE 0
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK 0
-#else
-#define CHIP_SYSTEM_PACKETBUFFER_STORE CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE 1
-#define CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK CHIP_CONFIG_MEMORY_DEBUG_CHECKS
-#endif
-#endif
-
 namespace chip {
 namespace System {
 
@@ -96,7 +59,7 @@ struct pbuf
     uint16_t tot_len;
     uint16_t len;
     uint16_t ref;
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
     uint16_t alloc_size;
 #endif
 };
@@ -160,7 +123,7 @@ public:
     /**
      * The maximum size buffer an application can allocate with no protocol header reserve.
      */
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL
     static constexpr uint16_t kMaxSizeWithoutReserve = LWIP_MEM_ALIGN_SIZE(PBUF_POOL_BUFSIZE);
 #else
     static constexpr uint16_t kMaxSizeWithoutReserve = CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX;
@@ -187,20 +150,19 @@ public:
      */
     uint16_t AllocSize() const
     {
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_POOL ||                                                  \
-    CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_STANDARD_POOL || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
         return kMaxSizeWithoutReserve;
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
         return this->alloc_size;
-#elif CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM
+#elif CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL
         // Temporary workaround for custom pbufs by assuming size to be PBUF_POOL_BUFSIZE
         if (this->flags & PBUF_FLAG_IS_CUSTOM)
             return LWIP_MEM_ALIGN_SIZE(PBUF_POOL_BUFSIZE) - kStructureSize;
         else
             return LWIP_MEM_ALIGN_SIZE(memp_sizes[this->pool]) - kStructureSize;
 #else
-#error "Unimplemented CHIP_SYSTEM_PACKETBUFFER_STORE case"
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE
+#error "Unimplemented PacketBuffer storage case"
+#endif
     }
 
     /**
@@ -396,7 +358,7 @@ private:
     static constexpr uint16_t kBlockSize = PacketBuffer::kStructureSize + PacketBuffer::kMaxSizeWithoutReserve;
 
     // Note: this condition includes DOXYGEN to work around a Doxygen error. DOXYGEN is never defined in any actual build.
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL || defined(DOXYGEN)
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL || defined(DOXYGEN)
     typedef union
     {
         pbuf Header;
@@ -405,7 +367,7 @@ private:
     static BufferPoolElement sBufferPool[CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE];
     static PacketBuffer * sFreeList;
     static PacketBuffer * BuildFreeList();
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_POOL || defined(DOXYGEN)
+#endif // CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL || defined(DOXYGEN)
 
 #if CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK
     static void InternalCheck(const PacketBuffer * buffer);
@@ -582,7 +544,7 @@ public:
      */
     void RightSize()
     {
-#if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE
+#if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
         InternalRightSize();
 #endif
     }
@@ -719,7 +681,7 @@ private:
 
     bool operator==(const PacketBufferHandle & aOther) { return mBuffer == aOther.mBuffer; }
 
-#if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE
+#if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
     void InternalRightSize();
 #endif
 

--- a/src/system/SystemPacketBufferInternal.h
+++ b/src/system/SystemPacketBufferInternal.h
@@ -1,0 +1,116 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Preprocessor definitions related to packet buffer memory configuration.
+ *      These are not part of the public PacketBuffer interface.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPConfig.h>
+#include <system/SystemConfig.h>
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
+ *
+ * True if packet buffers are allocated in the SDK using Platform::MemoryAlloc.
+ */
+#if !CHIP_SYSTEM_CONFIG_USE_LWIP && (CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE == 0)
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP 0
+#endif
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
+ *
+ * True if packet buffers are allocated in the SDK using an internal pool.
+ */
+#if !CHIP_SYSTEM_CONFIG_USE_LWIP && (CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE > 0)
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL 0
+#endif
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL
+ *
+ * True if packet buffers are allocated from an LwIP pool (either standard or custom).
+ */
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && (CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE == PBUF_POOL)
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL 0
+#endif
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_STANDARD_POOL
+ *
+ * True if packet buffers are allocated from an LwIP custom pool.
+ */
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL && !LWIP_PBUF_FROM_CUSTOM_POOLS
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_STANDARD_POOL 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_STANDARD_POOL 0
+#endif
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL
+ *
+ * True if packet buffers are allocated from an LwIP custom pool.
+ */
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL && LWIP_PBUF_FROM_CUSTOM_POOLS
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL 0
+#endif
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
+ *
+ * True if RightSize() has a nontrivial implementation.
+ */
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
+#define CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE 0
+#endif
+
+/**
+ * CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK
+ *
+ * True if Check() has a nontrivial implementation.
+ */
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP && CHIP_CONFIG_MEMORY_DEBUG_CHECKS
+#define CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK 1
+#else
+#define CHIP_SYSTEM_PACKETBUFFER_HAS_CHECK 0
+#endif
+
+// Sanity checks
+
+#if (CHIP_SYSTEM_CONFIG_USE_LWIP + CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP + CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL) != 1
+#error "Inconsistent PacketBuffer allocation configuration"
+#endif
+
+#if (CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_STANDARD_POOL + CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_CUSTOM_POOL) !=                         \
+    CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL
+#error "Inconsistent PacketBuffer LwIP pool configuration"
+#endif

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -400,7 +400,7 @@ void PacketBufferTest::CheckNew(nlTestSuite * inSuite, void * inContext)
         }
     }
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE != 0
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
     // Use the rest of the buffer space
     std::vector<PacketBufferHandle> allocate_all_the_things;
     for (;;)
@@ -413,7 +413,7 @@ void PacketBufferTest::CheckNew(nlTestSuite * inSuite, void * inContext)
         // Hold on to the buffer, to use up all the buffer space.
         allocate_all_the_things.push_back(std::move(buffer));
     }
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE != 0
+#endif // CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
 }
 
 /**
@@ -1793,20 +1793,20 @@ void PacketBufferTest::CheckHandleRightSize(nlTestSuite * inSuite, void * inCont
         NL_TEST_ASSERT(inSuite, handle.mBuffer == buffer);
     }
 
-#if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE
+#if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
 
     handle.RightSize();
     NL_TEST_ASSERT(inSuite, handle.mBuffer != buffer);
     NL_TEST_ASSERT(inSuite, handle->DataLength() == sizeof kPayload);
     NL_TEST_ASSERT(inSuite, memcmp(handle->Start(), kPayload, sizeof kPayload) == 0);
 
-#else // CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE
+#else // CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
 
     // For this configuration, RightSize() does nothing.
     handle.RightSize();
     NL_TEST_ASSERT(inSuite, handle.mBuffer == buffer);
 
-#endif // CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHT_SIZE
+#endif // CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
 }
 
 void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inContext)
@@ -1884,7 +1884,7 @@ void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inCont
         }
     }
 
-#if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#if CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
 
     // It is possible for a packet buffer allocation to return a larger block than requested (e.g. when using a shared pool)
     // and in particular to return a larger block than it is possible to request from PackBufferHandle::New().
@@ -1930,7 +1930,7 @@ void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inCont
     // Free the packet buffer memory ourselves, since we allocated it ourselves.
     chip::Platform::MemoryFree(std::move(handle).UnsafeRelease());
 
-#endif // CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_CHIP_HEAP
+#endif // CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
 }
 
 void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem

For LwIP builds, `PacketBuffer` allocations use `PBUF_POOL`, but LwIP
documentation recommends against this, suggesting `PBUF_RAM`, so
`PBUF_RAM` should be an available option.

#### Change overview

- Added `CHIP_SYSTEM_CONFIG_PACKETBUFFER_LWIP_PBUF_TYPE`, defaulting
  to `PBUF_POOL` to preserve current behaviour.

- Revised internal #defines for packet buffer code to follow the style
  used by CHIP config files.

#### Testing

CI
