### PR TITLE
Bump timeout - we are getting timeout at 80 mins

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
                     CHIP_ROOT_PATH="$CHIP_ROOT_PATH" BUILD_TYPE="$BUILD_TYPE" scripts/build/gn_gen.sh --args="$GN_ARGS"
                     scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE"
             - name: Setup Build, Run Build and Run Tests
-              timeout-minutes: 80
+              timeout-minutes: 90
               run: |
                   for BUILD_TYPE  in fake gcc_release clang mbedtls; do
                       case $BUILD_TYPE in
@@ -292,7 +292,7 @@ jobs:
                     CHIP_ROOT_PATH="$CHIP_ROOT_PATH" BUILD_TYPE="$BUILD_TYPE" scripts/build/gn_gen.sh --args="$GN_ARGS"
                     scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE"
             - name: Setup Build, Run Build and Run Tests
-              timeout-minutes: 80
+              timeout-minutes: 120
               # Just go ahead and do the "all" build; on Darwin that's fairly
               # fast.  If this ever becomes slow, we can think about ways to do
               # the examples-linux-standalone.yaml tests on darwin without too


### PR DESCRIPTION
#### Problem
Build timeouts, like https://github.com/project-chip/connectedhomeip/runs/4940732439?check_suite_focus=true

#### Change overview
Move the timeout even higher.
Note that the fact that our builds take so long is quite concerning. We expect to add more tests in time which probably takes even more build and run time

#### Testing
CI will validate, but generally this is a safe change 