### PR TITLE
Fix mbedos commissioning docs to mention node id.

### DIFF
--- a/docs/guides/mbedos_commissioning.md
+++ b/docs/guides/mbedos_commissioning.md
@@ -168,12 +168,12 @@ In order to send commands to a device, it must be paired with the client and
 connected to the network.
 
 To run the commissioning process via BLE, run the built executable and pass it
-the network ssid and password, discriminator and pairing code of the remote
-device.
+the node id to assign to the newly-commissioned node, network ssid and password,
+discriminator and pairing code of the remote device.
 
 Example:
 
-    $ chip-tool pairing ble-wifi network_ssid network_password 20202021 3840
+    $ chip-tool pairing ble-wifi node_id_to_assign network_ssid network_password 20202021 3840
 
 ## Sending ZCL commands
 


### PR DESCRIPTION
ble-wifi pairing needs a node id.

#### Problem
Incorrect docs.

#### Change overview
Fix the docs.

#### Testing
Need a guinea pig to read the docs.