### PR TITLE
Fix infinite reset loop in m5stack init

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -538,6 +538,17 @@ AppCallbacks sCallbacks;
 
 } // namespace
 
+static void InitOTARequestor(void)
+{
+#if CONFIG_ENABLE_OTA_REQUESTOR
+    SetRequestorInstance(&gRequestorCore);
+    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gImageProcessor.SetOTADownloader(&gDownloader);
+    gDownloader.SetImageProcessorDelegate(&gImageProcessor);
+    gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
+#endif
+}
+
 static void InitServer(intptr_t context)
 {
     // Init ZCL Data Model and CHIP App Server
@@ -548,17 +559,7 @@ static void InitServer(intptr_t context)
     NetWorkCommissioningInstInit();
     SetupPretendDevices();
     InitBindingHandlers();
-}
-
-static void InitOTARequestor(void)
-{
-#if CONFIG_ENABLE_OTA_REQUESTOR
-    SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
-    gImageProcessor.SetOTADownloader(&gDownloader);
-    gDownloader.SetImageProcessorDelegate(&gImageProcessor);
-    gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
-#endif
+    InitOTARequestor();
 }
 
 extern "C" void app_main()
@@ -620,8 +621,6 @@ extern "C" void app_main()
 
     // Print QR Code URL
     PrintOnboardingCodes(chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
-
-    InitOTARequestor();
 
 #if CONFIG_HAVE_DISPLAY
     std::string qrCodeText;


### PR DESCRIPTION
#### Problem

Some new OTA code is causing the m5stack all-clusters-app to reset
during init, which results in an infinite reset loop.

#### Change overview

Root cause is that InitServer is dispatched to the work queue.  But InitOTARequestor is executed immediately after this is dispatched, and yet depends upon InitServer.  The solution is to call InitOTARequestor from InitServer.

Fixes #14267

#### Testing

Manually tested.   m5stack all-clusters-app no longer exhibits the infinite reset loop with the fix.