### PR TITLE
Add tracing dependencies for build chip module for nrf

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -74,6 +74,10 @@ macro(chip_gn_arg_cflags ARG CFLAGS)
     string(APPEND CHIP_GN_ARGS "--arg-cflags\n${ARG}\n${CFLAGS}\n")
 endmacro()
 
+macro(chip_gn_arg ARG VALUE)
+    string(APPEND CHIP_GN_ARGS "--arg\n${ARG}\n${VALUE}\n")
+endmacro()
+
 # ==============================================================================
 # Prepare CHIP configuration based on the project Kconfig configuration
 # ==============================================================================
@@ -214,6 +218,15 @@ if (BOARD STREQUAL "native_posix")
     chip_gn_arg_string("target_cpu" "x86")
 elseif (BOARD STREQUAL "native_posix_64")
     chip_gn_arg_string("target_cpu" "x64")
+endif()
+
+if (CONFIG_CHIP_PW_RPC)
+    set(PIGWEED_DIR "//third_party/pigweed/repo")
+    chip_gn_arg_bool("chip_build_pw_trace_lib" "true")
+    chip_gn_arg_string("pw_trace_BACKEND" ${PIGWEED_DIR}/pw_trace_tokenized)
+    chip_gn_arg_string("pw_assert_BACKEND" ${PIGWEED_DIR}/pw_assert_log)
+    chip_gn_arg_string("pw_log_BACKEND" ${PIGWEED_DIR}/pw_log_basic)
+    chip_gn_arg("pw_build_LINK_DEPS" [\"${PIGWEED_DIR}/pw_assert:impl\",\ \"${PIGWEED_DIR}/pw_log:impl\"])
 endif()
 
 file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/args.tmp" CONTENT ${CHIP_GN_ARGS})

--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -566,7 +566,6 @@ From within the console you can then invoke rpcs:
 
         rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))
 
-
 ## Device Tracing
 
 Device tracing is available to analyze the device performance. To turn on

--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -42,6 +42,7 @@ into an existing Matter network and can be controlled by this network.
 -   [Testing the example](#testing-the-example)
     -   [Testing using CHIPTool](#testing-using-chiptool)
     -   [Testing Device Firmware Upgrade](#testing-device-firmware-upgrade)
+    -   [Device Tracing](#device-tracing)
 
 <hr>
 
@@ -564,3 +565,17 @@ From within the console you can then invoke rpcs:
         rpcs.chip.rpc.Lighting.Get()
 
         rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))
+
+
+## Device Tracing
+
+Device tracing is available to analyze the device performance. To turn on
+tracing, build with RPC enabled. See
+[Using the RPC console](#building-with-pigweed-rpcs).
+
+Obtain tracing json file.
+
+```
+    $ ./{PIGWEED_REPO}/pw_trace_tokenized/py/pw_trace_tokenized/get_trace.py -d {PORT} -o {OUTPUT_FILE} \
+    -t {ELF_FILE} {PIGWEED_REPO}/pw_trace_tokenized/pw_trace_protos/trace_rpc.proto
+```


### PR DESCRIPTION
To Enable tracing in nrf board. Added trace related dependencies. Also instructions to obtain trace from device.

#### Testing
tested nrf lighting app on device and get trace file after commisioning.
