### PR TITLE
Add a helper for creating a CharSpan from a C string.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -11,7 +11,7 @@ namespace {
 Structs::ModeOptionStruct::Type buildModeOptionStruct(const char * label, uint8_t mode, uint32_t semanticTag)
 {
     Structs::ModeOptionStruct::Type option;
-    option.label       = CharSpan(label, strlen(label));
+    option.label       = CharSpan::fromCharString(label);
     option.mode        = mode;
     option.semanticTag = semanticTag;
     return option;

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -178,8 +178,8 @@ void EncodeFixedLabel(const char * label, const char * value, uint8_t * buffer, 
 {
     _LabelStruct labelStruct;
 
-    labelStruct.label = chip::CharSpan(label, strlen(label));
-    labelStruct.value = chip::CharSpan(value, strlen(value));
+    labelStruct.label = chip::CharSpan::fromCharString(label);
+    labelStruct.value = chip::CharSpan::fromCharString(value);
 
     // TODO: Need to set up an AttributeAccessInterface to handle the lists here.
 }

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -120,7 +120,7 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
         // Only doing BDX transport for now
         MutableCharSpan uri(uriBuf, kUriMaxLen);
-        chip::bdx::MakeURI(nodeId, CharSpan(mOTAFilePath, strlen(mOTAFilePath)), uri);
+        chip::bdx::MakeURI(nodeId, CharSpan::fromCharString(mOTAFilePath), uri);
         ChipLogDetail(SoftwareUpdate, "Generated URI: %.*s", static_cast<int>(uri.size()), uri.data());
     }
 
@@ -166,9 +166,9 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     QueryImageResponse::Type response;
     response.status = queryStatus;
     response.delayedActionTime.Emplace(mDelayedActionTimeSec);
-    response.imageURI.Emplace(chip::CharSpan(uriBuf, strlen(uriBuf)));
+    response.imageURI.Emplace(chip::CharSpan::fromCharString(uriBuf));
     response.softwareVersion.Emplace(newSoftwareVersion);
-    response.softwareVersionString.Emplace(chip::CharSpan(kExampleSoftwareString, strlen(kExampleSoftwareString)));
+    response.softwareVersionString.Emplace(chip::CharSpan::fromCharString(kExampleSoftwareString));
     response.updateToken.Emplace(chip::ByteSpan(updateToken));
     response.userConsentNeeded.Emplace(userConsentNeeded);
     // Could also just not send metadataForRequestor at all.

--- a/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
@@ -46,6 +46,6 @@ Commands::GetSetupPINResponse::Type AccountLoginManager::HandleGetSetupPin(const
     ChipLogProgress(Zcl, "temporary account id: %s", tempAccountIdentifierString.c_str());
     // TODO: Insert your code here to handle get setup pin
     Commands::GetSetupPINResponse::Type response;
-    response.setupPIN = chip::CharSpan("tempPin123", strlen("tempPin123"));
+    response.setupPIN = chip::CharSpan::fromCharString("tempPin123");
     return response;
 }

--- a/examples/tv-app/android/include/application-basic/ApplicationBasicManager.cpp
+++ b/examples/tv-app/android/include/application-basic/ApplicationBasicManager.cpp
@@ -23,7 +23,7 @@ using namespace chip::app::Clusters::ApplicationBasic;
 
 chip::CharSpan ApplicationBasicManager::HandleGetVendorName()
 {
-    return chip::CharSpan("exampleVendorName1", strlen("exampleVendorName1"));
+    return chip::CharSpan::fromCharString("exampleVendorName1");
 }
 
 uint16_t ApplicationBasicManager::HandleGetVendorId()
@@ -33,7 +33,7 @@ uint16_t ApplicationBasicManager::HandleGetVendorId()
 
 chip::CharSpan ApplicationBasicManager::HandleGetApplicationName()
 {
-    return chip::CharSpan("exampleName1", strlen("exampleName1"));
+    return chip::CharSpan::fromCharString("exampleName1");
 }
 
 uint16_t ApplicationBasicManager::HandleGetProductId()
@@ -45,7 +45,7 @@ chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Typ
 {
     chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type application;
     application.catalogVendorId = 123;
-    application.applicationId   = chip::CharSpan("applicationId", strlen("applicationId"));
+    application.applicationId   = chip::CharSpan::fromCharString("applicationId");
     return application;
 }
 
@@ -56,7 +56,7 @@ ApplicationStatusEnum ApplicationBasicManager::HandleGetStatus()
 
 chip::CharSpan ApplicationBasicManager::HandleGetApplicationVersion()
 {
-    return chip::CharSpan("exampleVersion", strlen("exampleVersion"));
+    return chip::CharSpan::fromCharString("exampleVersion");
 }
 
 std::list<uint16_t> ApplicationBasicManager::HandleGetAllowedVendorList()

--- a/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
@@ -25,8 +25,8 @@ Structs::ApplicationEP::Type ApplicationLauncherManager::HandleGetCurrentApp()
 {
     Structs::ApplicationEP::Type currentApp;
     currentApp.application.catalogVendorId = 123;
-    currentApp.application.applicationId   = chip::CharSpan("applicationId", strlen("applicationId"));
-    currentApp.endpoint                    = chip::CharSpan("endpointId", strlen("endpointId"));
+    currentApp.application.applicationId   = chip::CharSpan::fromCharString("applicationId");
+    currentApp.endpoint                    = chip::CharSpan::fromCharString("endpointId");
     return currentApp;
 }
 
@@ -41,7 +41,7 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleLaunchApp(
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = StatusEnum::kSuccess;
     return response;
 }
@@ -51,7 +51,7 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleStopApp(
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = StatusEnum::kSuccess;
     return response;
 }
@@ -61,7 +61,7 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleHideApp(
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = StatusEnum::kSuccess;
     return response;
 }

--- a/examples/tv-app/android/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/android/include/audio-output/AudioOutputManager.cpp
@@ -36,7 +36,7 @@ std::list<Structs::OutputInfo::Type> AudioOutputManager::HandleGetOutputList()
     {
         chip::app::Clusters::AudioOutput::Structs::OutputInfo::Type outputInfo;
         outputInfo.outputType = chip::app::Clusters::AudioOutput::OutputTypeEnum::kHdmi;
-        outputInfo.name       = chip::CharSpan("exampleName", strlen("exampleName"));
+        outputInfo.name       = chip::CharSpan::fromCharString("exampleName");
         outputInfo.index      = static_cast<uint8_t>(1 + i);
         list.push_back(outputInfo);
     }

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -30,7 +30,7 @@ std::list<Structs::TargetInfo::Type> TargetNavigatorManager::HandleGetTargetList
     {
         Structs::TargetInfo::Type outputInfo;
         outputInfo.identifier = static_cast<uint8_t>(i + 1);
-        outputInfo.name       = chip::CharSpan("exampleName", strlen("exampleName"));
+        outputInfo.name       = chip::CharSpan::fromCharString("exampleName");
         list.push_back(outputInfo);
     }
     return list;
@@ -46,7 +46,7 @@ Commands::NavigateTargetResponse::Type TargetNavigatorManager::HandleNavigateTar
 {
     // TODO: Insert code here
     Commands::NavigateTargetResponse::Type response;
-    response.data   = chip::CharSpan("data response", strlen("data response"));
+    response.data   = chip::CharSpan::fromCharString("data response");
     response.status = chip::app::Clusters::TargetNavigator::StatusEnum::kSuccess;
     return response;
 }

--- a/examples/tv-app/linux/AppImpl.cpp
+++ b/examples/tv-app/linux/AppImpl.cpp
@@ -200,7 +200,7 @@ ApplicationLauncherImpl::LaunchApp(ApplicationLauncherApplication application, s
                     application.catalogVendorId, appId.c_str(), data.c_str());
 
     chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = chip::app::Clusters::ApplicationLauncher::StatusEnum::kSuccess;
 
     return response;
@@ -212,7 +212,7 @@ ContentLauncherImpl::LaunchContent(std::list<Parameter> parameterList, bool auto
     ChipLogProgress(DeviceLayer, "ContentLauncherImpl: LaunchContent autoplay=%d data=\"%s\"", autoplay ? 1 : 0, data.c_str());
 
     chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = chip::app::Clusters::ContentLauncher::StatusEnum::kSuccess;
     return response;
 }

--- a/examples/tv-app/linux/include/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/linux/include/account-login/AccountLoginManager.cpp
@@ -46,6 +46,6 @@ Commands::GetSetupPINResponse::Type AccountLoginManager::HandleGetSetupPin(const
     ChipLogProgress(Zcl, "temporary account id: %s", tempAccountIdentifierString.c_str());
     // TODO: Insert your code here to handle get setup pin
     Commands::GetSetupPINResponse::Type response;
-    response.setupPIN = chip::CharSpan("tempPin123", strlen("tempPin123"));
+    response.setupPIN = chip::CharSpan::fromCharString("tempPin123");
     return response;
 }

--- a/examples/tv-app/linux/include/application-basic/ApplicationBasicManager.cpp
+++ b/examples/tv-app/linux/include/application-basic/ApplicationBasicManager.cpp
@@ -23,7 +23,7 @@ using namespace chip::app::Clusters::ApplicationBasic;
 
 chip::CharSpan ApplicationBasicManager::HandleGetVendorName()
 {
-    return chip::CharSpan("exampleVendorName1", strlen("exampleVendorName1"));
+    return chip::CharSpan::fromCharString("exampleVendorName1");
 }
 
 uint16_t ApplicationBasicManager::HandleGetVendorId()
@@ -33,7 +33,7 @@ uint16_t ApplicationBasicManager::HandleGetVendorId()
 
 chip::CharSpan ApplicationBasicManager::HandleGetApplicationName()
 {
-    return chip::CharSpan("exampleName1", strlen("exampleName1"));
+    return chip::CharSpan::fromCharString("exampleName1");
 }
 
 uint16_t ApplicationBasicManager::HandleGetProductId()
@@ -45,7 +45,7 @@ chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Typ
 {
     chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type application;
     application.catalogVendorId = 123;
-    application.applicationId   = chip::CharSpan("applicationId", strlen("applicationId"));
+    application.applicationId   = chip::CharSpan::fromCharString("applicationId");
     return application;
 }
 
@@ -56,7 +56,7 @@ ApplicationStatusEnum ApplicationBasicManager::HandleGetStatus()
 
 chip::CharSpan ApplicationBasicManager::HandleGetApplicationVersion()
 {
-    return chip::CharSpan("exampleVersion", strlen("exampleVersion"));
+    return chip::CharSpan::fromCharString("exampleVersion");
 }
 
 std::list<uint16_t> ApplicationBasicManager::HandleGetAllowedVendorList()

--- a/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.cpp
@@ -25,8 +25,8 @@ Structs::ApplicationEP::Type ApplicationLauncherManager::HandleGetCurrentApp()
 {
     Structs::ApplicationEP::Type currentApp;
     currentApp.application.catalogVendorId = 123;
-    currentApp.application.applicationId   = chip::CharSpan("applicationId", strlen("applicationId"));
-    currentApp.endpoint                    = chip::CharSpan("endpointId", strlen("endpointId"));
+    currentApp.application.applicationId   = chip::CharSpan::fromCharString("applicationId");
+    currentApp.endpoint                    = chip::CharSpan::fromCharString("endpointId");
     return currentApp;
 }
 
@@ -41,7 +41,7 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleLaunchApp(
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = StatusEnum::kSuccess;
     return response;
 }
@@ -51,7 +51,7 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleStopApp(
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = StatusEnum::kSuccess;
     return response;
 }
@@ -61,7 +61,7 @@ Commands::LauncherResponse::Type ApplicationLauncherManager::HandleHideApp(
 {
     // TODO: Insert code here
     Commands::LauncherResponse::Type response;
-    response.data   = chip::CharSpan("data", strlen("data"));
+    response.data   = chip::CharSpan::fromCharString("data");
     response.status = StatusEnum::kSuccess;
     return response;
 }

--- a/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
@@ -36,7 +36,7 @@ std::list<Structs::OutputInfo::Type> AudioOutputManager::HandleGetOutputList()
     {
         chip::app::Clusters::AudioOutput::Structs::OutputInfo::Type outputInfo;
         outputInfo.outputType = chip::app::Clusters::AudioOutput::OutputTypeEnum::kHdmi;
-        outputInfo.name       = chip::CharSpan("exampleName", strlen("exampleName"));
+        outputInfo.name       = chip::CharSpan::fromCharString("exampleName");
         outputInfo.index      = static_cast<uint8_t>(1 + i);
         list.push_back(outputInfo);
     }

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -29,9 +29,9 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(chip::app::AttributeValueEncoder
         for (int i = 0; i < maximumVectorSize; ++i)
         {
             chip::app::Clusters::Channel::Structs::ChannelInfo::Type channelInfo;
-            channelInfo.affiliateCallSign = chip::CharSpan("exampleASign", strlen("exampleASign"));
-            channelInfo.callSign          = chip::CharSpan("exampleCSign", strlen("exampleCSign"));
-            channelInfo.name              = chip::CharSpan("exampleName", strlen("exampleName"));
+            channelInfo.affiliateCallSign = chip::CharSpan::fromCharString("exampleASign");
+            channelInfo.callSign          = chip::CharSpan::fromCharString("exampleCSign");
+            channelInfo.name              = chip::CharSpan::fromCharString("exampleName");
             channelInfo.majorNumber       = static_cast<uint8_t>(1 + i);
             channelInfo.minorNumber       = static_cast<uint16_t>(2 + i);
 
@@ -45,9 +45,9 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(chip::app::AttributeValueEncoder
 CHIP_ERROR ChannelManager::HandleGetLineup(chip::app::AttributeValueEncoder & aEncoder)
 {
     chip::app::Clusters::Channel::Structs::LineupInfo::Type lineup;
-    lineup.operatorName   = chip::CharSpan("operatorName", strlen("operatorName"));
-    lineup.lineupName     = chip::CharSpan("lineupName", strlen("lineupName"));
-    lineup.postalCode     = chip::CharSpan("postalCode", strlen("postalCode"));
+    lineup.operatorName   = chip::CharSpan::fromCharString("operatorName");
+    lineup.lineupName     = chip::CharSpan::fromCharString("lineupName");
+    lineup.postalCode     = chip::CharSpan::fromCharString("postalCode");
     lineup.lineupInfoType = chip::app::Clusters::Channel::LineupInfoTypeEnum::kMso;
 
     return aEncoder.Encode(lineup);
@@ -56,9 +56,9 @@ CHIP_ERROR ChannelManager::HandleGetLineup(chip::app::AttributeValueEncoder & aE
 CHIP_ERROR ChannelManager::HandleGetCurrentChannel(chip::app::AttributeValueEncoder & aEncoder)
 {
     chip::app::Clusters::Channel::Structs::ChannelInfo::Type currentChannel;
-    currentChannel.affiliateCallSign = chip::CharSpan("exampleASign", strlen("exampleASign"));
-    currentChannel.callSign          = chip::CharSpan("exampleCSign", strlen("exampleCSign"));
-    currentChannel.name              = chip::CharSpan("exampleName", strlen("exampleName"));
+    currentChannel.affiliateCallSign = chip::CharSpan::fromCharString("exampleASign");
+    currentChannel.callSign          = chip::CharSpan::fromCharString("exampleCSign");
+    currentChannel.name              = chip::CharSpan::fromCharString("exampleName");
     currentChannel.majorNumber       = 1;
     currentChannel.minorNumber       = 0;
 
@@ -72,9 +72,9 @@ void ChannelManager::HandleChangeChannel(
     Commands::ChangeChannelResponse::Type response;
     response.channelMatch.majorNumber       = 1;
     response.channelMatch.minorNumber       = 0;
-    response.channelMatch.name              = chip::CharSpan("name", strlen("name"));
-    response.channelMatch.callSign          = chip::CharSpan("callSign", strlen("callSign"));
-    response.channelMatch.affiliateCallSign = chip::CharSpan("affiliateCallSign", strlen("affiliateCallSign"));
+    response.channelMatch.name              = chip::CharSpan::fromCharString("name");
+    response.channelMatch.callSign          = chip::CharSpan::fromCharString("callSign");
+    response.channelMatch.affiliateCallSign = chip::CharSpan::fromCharString("affiliateCallSign");
     response.errorType                      = chip::app::Clusters::Channel::ErrorTypeEnum::kMultipleMatches;
 
     responser.Success(response);

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -43,7 +43,7 @@ void ContentLauncherManager::HandleLaunchContent(
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
     // TODO: Insert code here
-    response.data   = chip::CharSpan("exampleData", strlen("exampleData"));
+    response.data   = chip::CharSpan::fromCharString("exampleData");
     response.status = chip::app::Clusters::ContentLauncher::StatusEnum::kSuccess;
     responser.Success(response);
 }
@@ -60,7 +60,7 @@ void ContentLauncherManager::HandleLaunchUrl(
 
     // TODO: Insert code here
     Commands::LaunchResponse::Type response;
-    response.data   = chip::CharSpan("exampleData", strlen("exampleData"));
+    response.data   = chip::CharSpan::fromCharString("exampleData");
     response.status = chip::app::Clusters::ContentLauncher::StatusEnum::kSuccess;
     responser.Success(response);
 }
@@ -69,7 +69,7 @@ CHIP_ERROR ContentLauncherManager::HandleGetAcceptHeaderList(chip::app::Attribut
 {
     ChipLogProgress(Zcl, "ContentLauncherManager::HandleGetAcceptHeaderList");
     return aEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
-        chip::CharSpan data = chip::CharSpan("example", strlen("example"));
+        chip::CharSpan data = chip::CharSpan::fromCharString("example");
         ReturnErrorOnFailure(encoder.Encode(data));
         ReturnErrorOnFailure(encoder.Encode(data));
         return CHIP_NO_ERROR;

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -29,8 +29,8 @@ CHIP_ERROR MediaInputManager::HandleGetInputList(chip::app::AttributeValueEncode
         for (int i = 0; i < maximumVectorSize; ++i)
         {
             chip::app::Clusters::MediaInput::Structs::InputInfo::Type inputInfo;
-            inputInfo.description = chip::CharSpan("exampleDescription", strlen("exampleDescription"));
-            inputInfo.name        = chip::CharSpan("exampleName", strlen("exampleName"));
+            inputInfo.description = chip::CharSpan::fromCharString("exampleDescription");
+            inputInfo.name        = chip::CharSpan::fromCharString("exampleName");
             inputInfo.inputType   = chip::app::Clusters::MediaInput::InputTypeEnum::kHdmi;
             inputInfo.index       = static_cast<uint8_t>(1 + i);
 

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -30,7 +30,7 @@ std::list<Structs::TargetInfo::Type> TargetNavigatorManager::HandleGetTargetList
     {
         Structs::TargetInfo::Type outputInfo;
         outputInfo.identifier = static_cast<uint8_t>(i + 1);
-        outputInfo.name       = chip::CharSpan("exampleName", strlen("exampleName"));
+        outputInfo.name       = chip::CharSpan::fromCharString("exampleName");
         list.push_back(outputInfo);
     }
     return list;
@@ -46,7 +46,7 @@ Commands::NavigateTargetResponse::Type TargetNavigatorManager::HandleNavigateTar
 {
     // TODO: Insert code here
     Commands::NavigateTargetResponse::Type response;
-    response.data   = chip::CharSpan("data response", strlen("data response"));
+    response.data   = chip::CharSpan::fromCharString("data response");
     response.status = chip::app::Clusters::TargetNavigator::StatusEnum::kSuccess;
     return response;
 }

--- a/examples/tv-app/linux/include/wake-on-lan/WakeOnLanManager.cpp
+++ b/examples/tv-app/linux/include/wake-on-lan/WakeOnLanManager.cpp
@@ -23,5 +23,5 @@ using namespace chip::app::Clusters::WakeOnLan;
 
 CHIP_ERROR WakeOnLanManager::HandleGetMacAddress(chip::app::AttributeValueEncoder & aEncoder)
 {
-    return aEncoder.Encode(chip::CharSpan("00:00:00:00:00", strlen("00:00:00:00:00")));
+    return aEncoder.Encode(CharSpan::fromCharString("00:00:00:00:00"));
 }

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -253,8 +253,8 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
             return;
         }
         LaunchURLRequest::Type request;
-        request.contentURL          = chip::CharSpan(kContentUrl, strlen(kContentUrl));
-        request.displayString       = chip::CharSpan(kContentDisplayStr, strlen(kContentDisplayStr));
+        request.contentURL          = chip::CharSpan::fromCharString(kContentUrl);
+        request.displayString       = chip::CharSpan::fromCharString(kContentDisplayStr);
         request.brandingInformation = chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type();
         cluster.InvokeCommand(request, nullptr, OnContentLauncherSuccessResponse, OnContentLauncherFailureResponse);
     }

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -84,16 +84,16 @@ CHIP_ERROR BasicAttrAccess::ReadLocation(AttributeValueEncoder & aEncoder)
     {
         if (codeLen == 0)
         {
-            err = aEncoder.Encode(chip::CharSpan("XX", strlen("XX")));
+            err = aEncoder.Encode(chip::CharSpan::fromCharString("XX"));
         }
         else
         {
-            err = aEncoder.Encode(chip::CharSpan(location, strlen(location)));
+            err = aEncoder.Encode(chip::CharSpan::fromCharString(location));
         }
     }
     else
     {
-        err = aEncoder.Encode(chip::CharSpan("XX", strlen("XX")));
+        err = aEncoder.Encode(chip::CharSpan::fromCharString("XX"));
     }
 
     return err;
@@ -175,7 +175,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char nodeLabel[DeviceLayer::ConfigurationManager::kMaxNodeLabelLength + 1];
     if (ConfigurationMgr().GetNodeLabel(nodeLabel, sizeof(nodeLabel)) == CHIP_NO_ERROR)
     {
-        status = Attributes::NodeLabel::Set(endpoint, chip::CharSpan(nodeLabel, strlen(nodeLabel)));
+        status = Attributes::NodeLabel::Set(endpoint, chip::CharSpan::fromCharString(nodeLabel));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Node Label: 0x%02x", status));
     }
 
@@ -185,24 +185,24 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     {
         if (codeLen == 0)
         {
-            status = Attributes::Location::Set(endpoint, chip::CharSpan("XX", strlen("XX")));
+            status = Attributes::Location::Set(endpoint, chip::CharSpan::fromCharString("XX"));
         }
         else
         {
-            status = Attributes::Location::Set(endpoint, chip::CharSpan(location, strlen(location)));
+            status = Attributes::Location::Set(endpoint, chip::CharSpan::fromCharString(location));
         }
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
     }
     else
     {
-        status = Attributes::Location::Set(endpoint, chip::CharSpan("XX", strlen("XX")));
+        status = Attributes::Location::Set(endpoint, chip::CharSpan::fromCharString("XX"));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Location: 0x%02x", status));
     }
 
     char vendorName[DeviceLayer::ConfigurationManager::kMaxVendorNameLength + 1];
     if (ConfigurationMgr().GetVendorName(vendorName, sizeof(vendorName)) == CHIP_NO_ERROR)
     {
-        status = Attributes::VendorName::Set(endpoint, chip::CharSpan(vendorName, strlen(vendorName)));
+        status = Attributes::VendorName::Set(endpoint, chip::CharSpan::fromCharString(vendorName));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Name: 0x%02x", status));
     }
 
@@ -216,7 +216,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char productName[DeviceLayer::ConfigurationManager::kMaxProductNameLength + 1];
     if (ConfigurationMgr().GetProductName(productName, sizeof(productName)) == CHIP_NO_ERROR)
     {
-        status = Attributes::ProductName::Set(endpoint, chip::CharSpan(productName, strlen(productName)));
+        status = Attributes::ProductName::Set(endpoint, chip::CharSpan::fromCharString(productName));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Name: 0x%02x", status));
     }
 
@@ -230,7 +230,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char hardwareVersionString[DeviceLayer::ConfigurationManager::kMaxHardwareVersionStringLength + 1];
     if (ConfigurationMgr().GetHardwareVersionString(hardwareVersionString, sizeof(hardwareVersionString)) == CHIP_NO_ERROR)
     {
-        status = Attributes::HardwareVersionString::Set(endpoint, CharSpan(hardwareVersionString, strlen(hardwareVersionString)));
+        status = Attributes::HardwareVersionString::Set(endpoint, CharSpan::fromCharString(hardwareVersionString));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Hardware Version String: 0x%02x", status));
     }
 
@@ -244,7 +244,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char softwareVersionString[DeviceLayer::ConfigurationManager::kMaxSoftwareVersionLength + 1];
     if (ConfigurationMgr().GetSoftwareVersionString(softwareVersionString, sizeof(softwareVersionString)) == CHIP_NO_ERROR)
     {
-        status = Attributes::SoftwareVersionString::Set(endpoint, CharSpan(softwareVersionString, strlen(softwareVersionString)));
+        status = Attributes::SoftwareVersionString::Set(endpoint, CharSpan::fromCharString(softwareVersionString));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version String: 0x%02x", status));
     }
 
@@ -258,7 +258,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char serialNumberString[DeviceLayer::ConfigurationManager::kMaxSerialNumberLength + 1];
     if (ConfigurationMgr().GetSerialNumber(serialNumberString, sizeof(serialNumberString)) == CHIP_NO_ERROR)
     {
-        status = Attributes::SerialNumber::Set(endpoint, CharSpan(serialNumberString, strlen(serialNumberString)));
+        status = Attributes::SerialNumber::Set(endpoint, CharSpan::fromCharString(serialNumberString));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Serial Number String: 0x%02x", status));
     }
 
@@ -270,7 +270,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     {
         snprintf(manufacturingDateString, sizeof(manufacturingDateString), "%04" PRIu16 "-%02" PRIu8 "-%02" PRIu8,
                  manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
-        status = Attributes::ManufacturingDate::Set(endpoint, CharSpan(manufacturingDateString, strlen(manufacturingDateString)));
+        status = Attributes::ManufacturingDate::Set(endpoint, CharSpan::fromCharString(manufacturingDateString));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status,
                    ChipLogError(Zcl, "Error setting Manufacturing Date String: 0x%02x", status));
     }
@@ -278,21 +278,21 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char partNumber[DeviceLayer::ConfigurationManager::kMaxPartNumberLength + 1];
     if (ConfigurationMgr().GetPartNumber(partNumber, sizeof(partNumber)) == CHIP_NO_ERROR)
     {
-        status = Attributes::PartNumber::Set(endpoint, CharSpan(partNumber, strlen(partNumber)));
+        status = Attributes::PartNumber::Set(endpoint, CharSpan::fromCharString(partNumber));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Part Number: 0x%02x", status));
     }
 
     char productURL[DeviceLayer::ConfigurationManager::kMaxProductURLLength + 1];
     if (ConfigurationMgr().GetProductURL(productURL, sizeof(productURL)) == CHIP_NO_ERROR)
     {
-        status = Attributes::ProductURL::Set(endpoint, CharSpan(productURL, strlen(productURL)));
+        status = Attributes::ProductURL::Set(endpoint, CharSpan::fromCharString(productURL));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product URL: 0x%02x", status));
     }
 
     char productLabel[DeviceLayer::ConfigurationManager::kMaxProductURLLength + 1];
     if (ConfigurationMgr().GetProductLabel(productLabel, sizeof(productLabel)) == CHIP_NO_ERROR)
     {
-        status = Attributes::ProductLabel::Set(endpoint, CharSpan(productLabel, strlen(productLabel)));
+        status = Attributes::ProductLabel::Set(endpoint, CharSpan::fromCharString(productLabel));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Label: 0x%02x", status));
     }
 
@@ -313,7 +313,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     char uniqueId[DeviceLayer::ConfigurationManager::kMaxUniqueIDLength + 1];
     if (ConfigurationMgr().GetUniqueId(uniqueId, sizeof(uniqueId)) == CHIP_NO_ERROR)
     {
-        status = Attributes::UniqueID::Set(endpoint, CharSpan(uniqueId, strlen(uniqueId)));
+        status = Attributes::UniqueID::Set(endpoint, CharSpan::fromCharString(uniqueId));
         VerifyOrdo(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Unique Id: 0x%02x", status));
     }
 }

--- a/src/app/tests/TestDataModelSerialization.cpp
+++ b/src/app/tests/TestDataModelSerialization.cpp
@@ -869,7 +869,7 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
     myStruct.b = true;
     myStruct.c = TestCluster::SimpleEnum::kValueB;
     myStruct.d = ByteSpan(structBytes);
-    myStruct.e = CharSpan(structStr, strlen(structStr));
+    myStruct.e = CharSpan::fromCharString(structStr);
     myStruct.f = TestCluster::SimpleBitmap(2);
 
     TestCluster::SimpleEnum enumListVals[] = { TestCluster::SimpleEnum::kValueA, TestCluster::SimpleEnum::kValueC };
@@ -879,7 +879,7 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
     {
         // str needs to live until we call DataModel::Encode.
         const char str[] = "abc";
-        CharSpan strSpan(str, strlen(str));
+        CharSpan strSpan = CharSpan::fromCharString(str);
         Encodable encodable;
         if (encodeNulls)
         {
@@ -961,7 +961,7 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
         else if (encodeValues)
         {
             const char str[] = "abc";
-            CharSpan strSpan(str, strlen(str));
+            CharSpan strSpan = CharSpan::fromCharString(str);
 
             NL_TEST_ASSERT(apSuite, !decodable.nullableInt.IsNull());
             NL_TEST_ASSERT(apSuite, decodable.nullableInt.Value() == 5);

--- a/src/app/util/ContentApp.cpp
+++ b/src/app/util/ContentApp.cpp
@@ -243,7 +243,7 @@ app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::Type TargetNav
     ChipLogProgress(DeviceLayer, "TargetNavigator: NavigateTarget target=%d data=\"%s\"", target, data.c_str());
 
     app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::Type response;
-    response.data = chip::CharSpan("data response", strlen("data response"));
+    response.data = chip::CharSpan::fromCharString("data response");
 
     if (target >= mTargets.size())
     {

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -101,10 +101,11 @@ public:
         mDataLen = new_size;
     }
 
-    // Allow creating ByteSpans from ZCL octet strings, so we don't have to
-    // reinvent it various places.
+    // Allow creating ByteSpans and CharSpans from ZCL octet strings, so we
+    // don't have to reinvent it various places.
     template <class U,
-              typename = std::enable_if_t<std::is_same<T, const U>::value && std::is_same<uint8_t, std::remove_const_t<U>>::value>>
+              typename = std::enable_if_t<std::is_same<uint8_t, std::remove_const_t<U>>::value &&
+                                          (std::is_same<const uint8_t, T>::value || std::is_same<const char, T>::value)>>
     static Span fromZclString(U * bytes)
     {
         size_t length = bytes[0];
@@ -113,7 +114,15 @@ public:
         {
             length = 0;
         }
-        return Span(&bytes[1], length);
+        // Need reinterpret_cast if we're a CharSpan.
+        return Span(reinterpret_cast<T *>(&bytes[1]), length);
+    }
+
+    // Allow creating CharSpans from a character string.
+    template <class U, typename = std::enable_if_t<std::is_same<T, const U>::value && std::is_same<const char, T>::value>>
+    static Span fromCharString(U * chars)
+    {
+        return Span(chars, strlen(chars));
     }
 
     // operator== explicitly not implemented on Span, because its meaning

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -270,13 +270,36 @@ static void TestSubSpan(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, subspan.size() == 0);
 }
 
+static void TestFromZclString(nlTestSuite * inSuite, void * inContext)
+{
+    // Purposefully larger size than data.
+    constexpr uint8_t array[16] = { 3, 0x41, 0x63, 0x45 };
+
+    constexpr char str[] = "AcE";
+
+    ByteSpan s1 = ByteSpan::fromZclString(array);
+    NL_TEST_ASSERT(inSuite, s1.data_equal(ByteSpan(&array[1], 3)));
+
+    CharSpan s2 = CharSpan::fromZclString(array);
+    NL_TEST_ASSERT(inSuite, s2.data_equal(CharSpan(str, 3)));
+}
+
+static void TestFromCharString(nlTestSuite * inSuite, void * inContext)
+{
+    constexpr char str[] = "AcE";
+
+    CharSpan s1 = CharSpan::fromCharString(str);
+    NL_TEST_ASSERT(inSuite, s1.data_equal(CharSpan(str, 3)));
+}
+
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan),      NL_TEST_DEF_FN(TestMutableByteSpan),
-                                 NL_TEST_DEF_FN(TestFixedByteSpan), NL_TEST_DEF_FN(TestSpanOfPointers),
-                                 NL_TEST_DEF_FN(TestSubSpan),       NL_TEST_SENTINEL() };
+static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan),       NL_TEST_DEF_FN(TestMutableByteSpan),
+                                 NL_TEST_DEF_FN(TestFixedByteSpan),  NL_TEST_DEF_FN(TestSpanOfPointers),
+                                 NL_TEST_DEF_FN(TestSubSpan),        NL_TEST_DEF_FN(TestFromZclString),
+                                 NL_TEST_DEF_FN(TestFromCharString), NL_TEST_SENTINEL() };
 
 int TestSpan(void)
 {

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -137,7 +137,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             strncpy(ifp->Name, ifa->name, Inet::InterfaceId::kMaxIfNameLength);
             ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
 
-            ifp->name            = CharSpan(ifp->Name, strlen(ifp->Name));
+            ifp->name            = CharSpan::fromCharString(ifp->Name);
             ifp->fabricConnected = true;
             if ((ifa->flags) & NETIF_FLAG_ETHERNET)
                 ifp->type = EMBER_ZCL_INTERFACE_TYPE_ETHERNET;

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -137,15 +137,15 @@ CHIP_ERROR
 PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
 {
     // In Darwin simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.
-    supportedLocales.add(CharSpan("Test", strlen("Test")));
-    supportedLocales.add(CharSpan("en-US", strlen("en-US")));
-    supportedLocales.add(CharSpan("de-DE", strlen("de-DE")));
-    supportedLocales.add(CharSpan("fr-FR", strlen("fr-FR")));
-    supportedLocales.add(CharSpan("en-GB", strlen("en-GB")));
-    supportedLocales.add(CharSpan("es-ES", strlen("es-ES")));
-    supportedLocales.add(CharSpan("zh-CN", strlen("zh-CN")));
-    supportedLocales.add(CharSpan("it-IT", strlen("it-IT")));
-    supportedLocales.add(CharSpan("ja-JP", strlen("ja-JP")));
+    supportedLocales.add(CharSpan::fromCharString("Test"));
+    supportedLocales.add(CharSpan::fromCharString("en-US"));
+    supportedLocales.add(CharSpan::fromCharString("de-DE"));
+    supportedLocales.add(CharSpan::fromCharString("fr-FR"));
+    supportedLocales.add(CharSpan::fromCharString("en-GB"));
+    supportedLocales.add(CharSpan::fromCharString("es-ES"));
+    supportedLocales.add(CharSpan::fromCharString("zh-CN"));
+    supportedLocales.add(CharSpan::fromCharString("it-IT"));
+    supportedLocales.add(CharSpan::fromCharString("ja-JP"));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -209,7 +209,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             NetworkInterface * ifp = new NetworkInterface();
             strncpy(ifp->Name, esp_netif_get_ifkey(ifa), Inet::InterfaceId::kMaxIfNameLength);
             ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
-            ifp->name                                          = CharSpan(ifp->Name, strlen(ifp->Name));
+            ifp->name                                          = CharSpan::fromCharString(ifp->Name);
             ifp->fabricConnected                               = true;
             ifp->type                                          = GetInterfaceType(esp_netif_get_desc(ifa));
             ifp->offPremiseServicesReachableIPv4               = false;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -278,7 +278,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
             strncpy(thread->NameBuf, entry->d_name, kMaxThreadNameLength);
             thread->NameBuf[kMaxThreadNameLength] = '\0';
-            thread->name                          = CharSpan(thread->NameBuf, strlen(thread->NameBuf));
+            thread->name                          = CharSpan::fromCharString(thread->NameBuf);
             thread->id                            = atoi(entry->d_name);
 
             // TODO: Get stack info of each thread
@@ -432,7 +432,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
                 strncpy(ifp->Name, ifa->ifa_name, Inet::InterfaceId::kMaxIfNameLength);
                 ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
 
-                ifp->name                            = CharSpan(ifp->Name, strlen(ifp->Name));
+                ifp->name                            = CharSpan::fromCharString(ifp->Name);
                 ifp->fabricConnected                 = ifa->ifa_flags & IFF_RUNNING;
                 ifp->type                            = ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name);
                 ifp->offPremiseServicesReachableIPv4 = false;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -287,17 +287,17 @@ CHIP_ERROR PlatformManagerImpl::_GetFixedLabelList(
     FixedLabel::Structs::LabelStruct::Type floor;
     FixedLabel::Structs::LabelStruct::Type direction;
 
-    room.label = CharSpan("room", strlen("room"));
-    room.value = CharSpan("bedroom 2", strlen("bedroom 2"));
+    room.label = CharSpan::fromCharString("room");
+    room.value = CharSpan::fromCharString("bedroom 2");
 
-    orientation.label = CharSpan("orientation", strlen("orientation"));
-    orientation.value = CharSpan("North", strlen("North"));
+    orientation.label = CharSpan::fromCharString("orientation");
+    orientation.value = CharSpan::fromCharString("North");
 
-    floor.label = CharSpan("floor", strlen("floor"));
-    floor.value = CharSpan("2", strlen("2"));
+    floor.label = CharSpan::fromCharString("floor");
+    floor.value = CharSpan::fromCharString("2");
 
-    direction.label = CharSpan("direction", strlen("direction"));
-    direction.value = CharSpan("up", strlen("up"));
+    direction.label = CharSpan::fromCharString("direction");
+    direction.value = CharSpan::fromCharString("up");
 
     labelList.add(room);
     labelList.add(orientation);
@@ -325,17 +325,17 @@ PlatformManagerImpl::_GetUserLabelList(
     UserLabel::Structs::LabelStruct::Type floor;
     UserLabel::Structs::LabelStruct::Type direction;
 
-    room.label = CharSpan("room", strlen("room"));
-    room.value = CharSpan("bedroom 2", strlen("bedroom 2"));
+    room.label = CharSpan::fromCharString("room");
+    room.value = CharSpan::fromCharString("bedroom 2");
 
-    orientation.label = CharSpan("orientation", strlen("orientation"));
-    orientation.value = CharSpan("North", strlen("North"));
+    orientation.label = CharSpan::fromCharString("orientation");
+    orientation.value = CharSpan::fromCharString("North");
 
-    floor.label = CharSpan("floor", strlen("floor"));
-    floor.value = CharSpan("2", strlen("2"));
+    floor.label = CharSpan::fromCharString("floor");
+    floor.value = CharSpan::fromCharString("2");
 
-    direction.label = CharSpan("direction", strlen("direction"));
-    direction.value = CharSpan("up", strlen("up"));
+    direction.label = CharSpan::fromCharString("direction");
+    direction.value = CharSpan::fromCharString("up");
 
     labelList.add(room);
     labelList.add(orientation);
@@ -349,14 +349,14 @@ CHIP_ERROR
 PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
 {
     // In Linux simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.
-    supportedLocales.add(CharSpan("en-US", strlen("en-US")));
-    supportedLocales.add(CharSpan("de-DE", strlen("de-DE")));
-    supportedLocales.add(CharSpan("fr-FR", strlen("fr-FR")));
-    supportedLocales.add(CharSpan("en-GB", strlen("en-GB")));
-    supportedLocales.add(CharSpan("es-ES", strlen("es-ES")));
-    supportedLocales.add(CharSpan("zh-CN", strlen("zh-CN")));
-    supportedLocales.add(CharSpan("it-IT", strlen("it-IT")));
-    supportedLocales.add(CharSpan("ja-JP", strlen("ja-JP")));
+    supportedLocales.add(CharSpan::fromCharString("en-US"));
+    supportedLocales.add(CharSpan::fromCharString("de-DE"));
+    supportedLocales.add(CharSpan::fromCharString("fr-FR"));
+    supportedLocales.add(CharSpan::fromCharString("en-GB"));
+    supportedLocales.add(CharSpan::fromCharString("es-ES"));
+    supportedLocales.add(CharSpan::fromCharString("zh-CN"));
+    supportedLocales.add(CharSpan::fromCharString("it-IT"));
+    supportedLocales.add(CharSpan::fromCharString("ja-JP"));
 
     return CHIP_NO_ERROR;
 }
@@ -480,7 +480,7 @@ void PlatformManagerImpl::HandleSoftwareFault(uint32_t EventId)
         softwareFault.id = gettid();
         strncpy(threadName, std::to_string(softwareFault.id).c_str(), kMaxThreadNameLength);
         threadName[kMaxThreadNameLength] = '\0';
-        softwareFault.name               = CharSpan(threadName, strlen(threadName));
+        softwareFault.name               = CharSpan::fromCharString(threadName);
         softwareFault.faultRecording     = ByteSpan(Uint8::from_const_char("FaultRecording"), strlen("FaultRecording"));
 
         delegate->OnSoftwareFaultDetected(softwareFault);

--- a/src/platform/P6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/P6/DiagnosticDataProviderImpl.cpp
@@ -158,7 +158,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     if (net_interface)
     {
         /* Update Network Interface list */
-        ifp->name                            = CharSpan(net_interface->name, strlen(net_interface->name));
+        ifp->name                            = CharSpan::fromCharString(net_interface->name);
         ifp->fabricConnected                 = net_interface->flags & NETIF_FLAG_LINK_UP;
         ifp->type                            = EMBER_ZCL_INTERFACE_TYPE_WI_FI;
         ifp->offPremiseServicesReachableIPv4 = mipv4_offpremise;

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -170,7 +170,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         NetworkInterface * ifp = new NetworkInterface();
 
         interfaceIterator.GetInterfaceName(ifp->Name, Inet::InterfaceId::kMaxIfNameLength);
-        ifp->name            = CharSpan(ifp->Name, strlen(ifp->Name));
+        ifp->name            = CharSpan::fromCharString(ifp->Name);
         ifp->fabricConnected = true;
         Inet::InterfaceType interfaceType;
         if (interfaceIterator.GetInterfaceType(interfaceType) == CHIP_NO_ERROR)

--- a/src/protocols/bdx/tests/TestBdxUri.cpp
+++ b/src/protocols/bdx/tests/TestBdxUri.cpp
@@ -27,7 +27,7 @@ namespace {
 
 CharSpan ToSpan(const char * str)
 {
-    return CharSpan(str, strlen(str));
+    return CharSpan::fromCharString(str);
 }
 
 void TestParseURI(nlTestSuite * inSuite, void * inContext)

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -299,7 +299,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'c':
-        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, chip::CharSpan(arg, strlen(arg)));
+        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, chip::CharSpan::fromCharString(arg));
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add Common Name attribute to the subject DN: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
Hides the strlen people have to keep doing.

#### Problem
Lots of `CharSpan(foo, strlen(foo))`.

#### Change overview
Add `CharSpan::fromCharString`.

#### Testing
No behavior changes, just slightly cleaner code.