### PR TITLE
CI workflow for iMX

### DIFF
--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build example - i.MX Linux
+
+on:
+    push:
+    pull_request:
+
+concurrency:
+    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    imx:
+        name: Linux i.MX Build
+        timeout-minutes: 70
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-imx:0.5.52
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Build App
+              timeout-minutes: 10
+              run: |
+                  ./scripts/examples/imxlinux_example.sh \
+                  examples/lighting-app/linux/ examples/lighting-app/linux/out/aarch64
+            - name: Build chip-tool
+              timeout-minutes: 10
+              run: |
+                   ./scripts/examples/imxlinux_example.sh \
+                   examples/chip-tool examples/chip-tool/out/aarch64

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Examples - Linux Standalone](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20Linux%20Standalone/badge.svg)
 ![Examples - ESP32](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20ESP32/badge.svg)
 ![Examples - K32W with SE051](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20K32W%20with%20SE051/badge.svg)
+![Examples - i.MX Linux](https://github.com/project-chip/connectedhomeip/workflows/Build%20example%20-%20i.MX%20Linux/badge.svg)
 
 ![Android](https://github.com/project-chip/connectedhomeip/workflows/Android/badge.svg)
 

--- a/scripts/examples/imxlinux_example.sh
+++ b/scripts/examples/imxlinux_example.sh
@@ -34,20 +34,20 @@ then
         exit -1
     fi
 else
-    source $IMX_SDK_ROOT/environment-setup-cortexa53-crypto-poky-linux
+    source "$IMX_SDK_ROOT"/environment-setup-cortexa53-crypto-poky-linux
 fi
 env
 
 PLATFORM_CFLAGS='-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"'
-PKG_CONFIG_SYSROOT_DIR=${PKG_CONFIG_SYSROOT_DIR} \
-PKG_CONFIG_LIBDIR=${PKG_CONFIG_PATH} \
+PKG_CONFIG_SYSROOT_DIR=$PKG_CONFIG_SYSROOT_DIR \
+PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH" \
 gn gen --check --fail-on-unused-args --root="$1" "$2" --args="target_os=\"linux\" target_cpu=\"arm64\" arm_arch=\"armv8-a\"
 import(\"//build_overrides/build.gni\")
-target_cflags=[ \"--sysroot=${SDKTARGETSYSROOT}\", \"${PLATFORM_CFLAGS}\" ]
-target_ldflags = [ \"--sysroot=${SDKTARGETSYSROOT}\" ]
+target_cflags=[ \"--sysroot=$SDKTARGETSYSROOT\", \"$PLATFORM_CFLAGS\" ]
+target_ldflags = [ \"--sysroot=$SDKTARGETSYSROOT\" ]
 custom_toolchain=\"\${build_root}/toolchain/custom\"
-target_cc=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc\"
-target_cxx=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++\"
-target_ar=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar\""
+target_cc=\"$OECORE_NATIVE_SYSROOT/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc\"
+target_cxx=\"$OECORE_NATIVE_SYSROOT/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++\"
+target_ar=\"$OECORE_NATIVE_SYSROOT/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar\""
 
 ninja -C "$2"

--- a/scripts/examples/imxlinux_example.sh
+++ b/scripts/examples/imxlinux_example.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+
+set -e
+set -x
+if [ "$#" != 2 ]
+then
+exit -1
+fi
+
+source "$(dirname "$0")/../../scripts/activate.sh"
+
+if [ "$IMX_SDK_ROOT" = "" ]
+then
+    if [ "$CROSS_COMPILE" != "aarch64-poky-linux-" ]
+    then
+        echo "i.MX SDK root not aarch64"
+        exit -1
+    fi
+else
+    source $IMX_SDK_ROOT/environment-setup-cortexa53-crypto-poky-linux
+fi
+env
+
+PLATFORM_CFLAGS='-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"'
+PKG_CONFIG_SYSROOT_DIR=${PKG_CONFIG_SYSROOT_DIR} \
+PKG_CONFIG_LIBDIR=${PKG_CONFIG_PATH} \
+gn gen --check --fail-on-unused-args --root="$1" "$2" --args="target_os=\"linux\" target_cpu=\"arm64\" arm_arch=\"armv8-a\"
+import(\"//build_overrides/build.gni\")
+target_cflags=[ \"--sysroot=${SDKTARGETSYSROOT}\", \"${PLATFORM_CFLAGS}\" ]
+target_ldflags = [ \"--sysroot=${SDKTARGETSYSROOT}\" ]
+custom_toolchain=\"\${build_root}/toolchain/custom\"
+target_cc=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc\"
+target_cxx=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++\"
+target_ar=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar\""
+
+ninja -C "$2"
+

--- a/scripts/examples/imxlinux_example.sh
+++ b/scripts/examples/imxlinux_example.sh
@@ -16,20 +16,16 @@
 #    limitations under the License.
 #
 
-
 set -e
 set -x
-if [ "$#" != 2 ]
-then
-exit -1
+if [ "$#" != 2 ]; then
+    exit -1
 fi
 
 source "$(dirname "$0")/../../scripts/activate.sh"
 
-if [ "$IMX_SDK_ROOT" = "" ]
-then
-    if [ "$CROSS_COMPILE" != "aarch64-poky-linux-" ]
-    then
+if [ "$IMX_SDK_ROOT" = "" ]; then
+    if [ "$CROSS_COMPILE" != "aarch64-poky-linux-" ]; then
         echo "i.MX SDK root not aarch64"
         exit -1
     fi
@@ -40,8 +36,8 @@ env
 
 PLATFORM_CFLAGS='-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"'
 PKG_CONFIG_SYSROOT_DIR=$PKG_CONFIG_SYSROOT_DIR \
-PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH" \
-gn gen --check --fail-on-unused-args --root="$1" "$2" --args="target_os=\"linux\" target_cpu=\"arm64\" arm_arch=\"armv8-a\"
+    PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH" \
+    gn gen --check --fail-on-unused-args --root="$1" "$2" --args="target_os=\"linux\" target_cpu=\"arm64\" arm_arch=\"armv8-a\"
 import(\"//build_overrides/build.gni\")
 target_cflags=[ \"--sysroot=$SDKTARGETSYSROOT\", \"$PLATFORM_CFLAGS\" ]
 target_ldflags = [ \"--sysroot=$SDKTARGETSYSROOT\" ]

--- a/scripts/examples/imxlinux_example.sh
+++ b/scripts/examples/imxlinux_example.sh
@@ -51,4 +51,3 @@ target_cxx=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-li
 target_ar=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar\""
 
 ninja -C "$2"
-


### PR DESCRIPTION
#### Problem
Since i.MX Docker image enabled with PR #13245, so add workflow to validate the builds with SDK.

#### Change overview
Added a build script to handle i.MX Yocto SDK build Matter binaries
Add workflow yaml file to enable CI builds test.