### PR TITLE
Fix spake2p tool to compile on Darwin.

### DIFF
--- a/src/tools/spake2p/Cmd_GenVerifier.cpp
+++ b/src/tools/spake2p/Cmd_GenVerifier.cpp
@@ -29,6 +29,8 @@
 
 #include "spake2p.h"
 
+#include <errno.h>
+
 #include <CHIPVersion.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/Base64.h>


### PR DESCRIPTION
It's using errno but not including the header that defines it.

#### Problem
Can't compile.

#### Change overview
Include header so we compile.

#### Testing
Compiled locally using `./gn_build.sh` on Darwin.