### PR TITLE
Use the XML-specified max length of ActiveLocale instead of hardcoding it.

### DIFF
--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -39,8 +39,6 @@ using namespace chip::app::Clusters::LocalizationConfiguration::Attributes;
 
 namespace {
 
-constexpr size_t kMaxActiveLocaleLength = 35;
-
 class LocalizationConfigurationAttrAccess : public AttributeAccessInterface
 {
 public:
@@ -153,7 +151,7 @@ void emberAfLocalizationConfigurationClusterServerInitCallback(EndpointId endpoi
     DeviceLayer::AttributeList<CharSpan, DeviceLayer::kMaxLanguageTags> supportedLocales;
     CharSpan validLocale;
 
-    char outBuffer[kMaxActiveLocaleLength];
+    char outBuffer[Attributes::ActiveLocale::TypeInfo::MaxLength()];
     MutableCharSpan activeLocale(outBuffer);
     EmberAfStatus status = ActiveLocale::Get(endpoint, activeLocale);
 


### PR DESCRIPTION
#### Problem
Cluster had a hardcoded size for the buffer for ActiveLocale.

#### Change overview
Use the generated value from cluster-objects, which comes from the XML.

#### Testing
No behavior changes; value is the same right now.