### PR TITLE
Clean up MessageFlagValues and SendMessageFlags.

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -146,10 +146,6 @@ private:
             VerifyOrReturnError(mExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
             chip::Messaging::SendFlags sendFlags;
-            if (event.msgTypeData.HasMessageType(chip::bdx::MessageType::ReceiveInit))
-            {
-                sendFlags.Set(chip::Messaging::SendMessageFlags::kFromInitiator);
-            }
             if (!event.msgTypeData.HasMessageType(chip::bdx::MessageType::BlockAckEOF) &&
                 !event.msgTypeData.HasMessageType(chip::Protocols::SecureChannel::MsgType::StatusReport))
             {

--- a/src/app/util/chip-message-send.cpp
+++ b/src/app/util/chip-message-send.cpp
@@ -118,15 +118,14 @@ EmberStatus chipSendUnicast(NodeId destination, EmberApsFrame * apsFrame, uint16
 
     // TODO(#5675): This code is temporary, and must be updated to use the IM API. Currently, we use a temporary Protocol
     // TempZCL to carry over legacy ZCL messages, use an ephemeral exchange to send message and use its unsolicited message
-    // handler to receive messages. We need to set flag kFromInitiator to allow receiver to deliver message to corresponding
-    // unsolicited message handler, and we also need to set flag kNoAutoRequestAck since there is no persistent exchange to
+    // handler to receive messages. We need to set flag kNoAutoRequestAck since there is no persistent exchange to
     // receive the ack message. This logic needs to be deleted after we convert all legacy ZCL messages to IM messages.
     DeviceExchangeDelegate delegate;
     exchange->SetDelegate(&delegate);
 
     Messaging::SendFlags sendFlags;
 
-    sendFlags.Set(Messaging::SendMessageFlags::kFromInitiator).Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
+    sendFlags.Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
 
     EmberStatus err = chipSendUnicast(exchange, apsFrame, messageLength, message, sendFlags);
 

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -37,20 +37,8 @@ namespace Messaging {
  */
 enum class MessageFlagValues : uint32_t
 {
-    /**< Indicates that the existing source node identifier must be reused. */
-    kReuseSourceId = 0x00000020,
-    /**< Indicates that the CHIP message is already encoded. */
-    kMessageEncoded = 0x00001000,
-    /**< Indicates that default IPv6 source address selection should be used when sending IPv6 multicast messages. */
-    kDefaultMulticastSourceAddress = 0x00002000,
     /**< Indicates that the message is a duplicate of a previously received message. */
-    kDuplicateMessage = 0x00004000,
-    /**< Indicates that the peer's group key message counter is not synchronized. */
-    kPeerGroupMessageCounterNotSynchronized = 0x00008000,
-    /**< Indicates that the source of the message is the initiator of the CHIP exchange. */
-    kFromInitiator = 0x00010000,
-    /**< Indicates that message is being sent/received via the local ephemeral UDP port. */
-    kViaEphemeralUDPPort = 0x00020000,
+    kDuplicateMessage = 0x00000001,
 };
 
 using MessageFlags = BitFlags<MessageFlagValues>;
@@ -58,20 +46,10 @@ using MessageFlags = BitFlags<MessageFlagValues>;
 enum class SendMessageFlags : uint16_t
 {
     kNone = 0x0000,
-    /**< Used to indicate that automatic retransmission is enabled. */
-    kAutoRetrans = 0x0001,
     /**< Used to indicate that a response is expected within a specified timeout. */
-    kExpectResponse = 0x0002,
-    /**< Used to indicate that the source node ID in the message header can be reused. */
-    kReuseSourceId = 0x0020,
-    /**< Used to indicate that the message is already encoded. */
-    kAlreadyEncoded = 0x0080,
-    /**< Used to indicate that default IPv6 source address selection should be used when sending IPv6 multicast messages. */
-    kDefaultMulticastSourceAddress = 0x0100,
-    /**< Used to indicate that the current message is the initiator of the exchange. */
-    kFromInitiator = 0x0200,
+    kExpectResponse = 0x0001,
     /**< Suppress the auto-request acknowledgment feature when sending a message. */
-    kNoAutoRequestAck = 0x0400,
+    kNoAutoRequestAck = 0x0002,
 };
 
 using SendFlags = BitFlags<SendMessageFlags>;


### PR DESCRIPTION
We had a bunch of unused flag values, including some that consumers
thought they needed to set that were then ignored.

Fixes https://github.com/project-chip/connectedhomeip/issues/5651

#### Problem
See above.

#### Change overview
See above.

#### Testing
Should be no behavior changes.