### PR TITLE
Remove isList bits for attributes from codegen.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -420,7 +420,7 @@ public:
 {{#if isWritableAttribute}}
 {{! No list support for writing yet.  Need to figure out how to represent the
     values. }}
-{{#unless isList}}
+{{#unless isArray}}
 class Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
@@ -526,7 +526,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         {{#if isWritableAttribute}}
         {{! No list support for writing yet.  Need to figure out how to
             represent the values. }}
-        {{#unless isList}}
+        {{#unless isArray}}
         make_unique<Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/unless}}
         {{/if}}

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -218,7 +218,7 @@ function asChipCallback(item)
     return { name : 'CharString', type : 'const chip::CharSpan' };
   }
 
-  if (item.isList) {
+  if (item.isArray) {
     return { name : 'List', type : null };
   }
 
@@ -301,7 +301,6 @@ function handleList(item, [ atomics, enums, bitmaps, structs ])
     throw new Error(item.label, 'List[T] is missing type "T" information');
   }
 
-  item.isList  = true;
   item.isArray = true;
   item.type    = entryType;
   enhancedItem(item, [ atomics, enums, bitmaps, structs ]);
@@ -458,7 +457,6 @@ function enhancedEvents(events, types)
     const argument = {
       name : event.name,
       type : event.name,
-      isList : false,
       isArray : false,
       isEvent : true,
       isNullable : false,
@@ -484,8 +482,7 @@ function enhancedAttributes(attributes, globalAttributes, types)
       name : attribute.name,
       type : attribute.type,
       size : attribute.size,
-      isList : attribute.isList,
-      isArray : attribute.isList,
+      isArray : attribute.isArray,
       isEvent : false,
       isNullable : attribute.isNullable,
       chipType : attribute.chipType,

--- a/src/app/zap-templates/common/attributes/Accessors.js
+++ b/src/app/zap-templates/common/attributes/Accessors.js
@@ -33,7 +33,7 @@ function isUnsupportedType(type)
 
 function canHaveSimpleAccessors(attr)
 {
-  if (attr.isArray || attr.isList) {
+  if (attr.isArray) {
     return false;
   }
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -123,7 +123,7 @@ app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInsta
 {{#chip_client_clusters}}
 {{#if (chip_server_has_list_attributes)}}
 {{#chip_server_cluster_attributes}}
-{{#if isList}}
+{{#if isArray}}
 void {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}ListAttributeFilter(TLV::TLVReader * tlvData, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     {{zapTypeToDecodableClusterObjectType type ns=parent.name}} list;

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -29,7 +29,7 @@ typedef void (*{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}C
 // List specific responses
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
-{{#if isList}}
+{{#if isArray}}
 void {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}ListAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccessCallback, chip::Callback::Cancelable * onFailureCallback);
 typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
 {{/if}}

--- a/src/app/zap-templates/templates/app/MatterIDL.zapt
+++ b/src/app/zap-templates/templates/app/MatterIDL.zapt
@@ -51,7 +51,7 @@
         {{~/if~}}
       {{~/if~}}
     {{/unless}} {{asLowerCamelCase name~}}
-    {{~#if isList~}} [] {{~/if}} = {{code}};
+    {{~#if isArray~}} [] {{~/if}} = {{code}};
   {{/chip_server_cluster_attributes}}
   {{#chip_cluster_commands}}
   {{#if arguments}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -419,7 +419,7 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
   }
 
   let typeStr = await templateUtil.ensureZclPackageId(this).then(fn.bind(this));
-  if ((this.isList || this.isArray || this.entryType) && !options.hash.forceNotList) {
+  if ((this.isArray || this.entryType) && !options.hash.forceNotList) {
     passByReference = true;
     // If we did not have a namespace provided, we can assume we're inside
     // chip::app.
@@ -522,7 +522,7 @@ async function _zapTypeToPythonClusterObjectType(type, options)
   }
 
   let promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this));
-  if ((this.isList || this.isArray || this.entryType) && !options.hash.forceNotList) {
+  if ((this.isArray || this.entryType) && !options.hash.forceNotList) {
     promise = promise.then(typeStr => `typing.List[${typeStr}]`);
   }
 
@@ -602,7 +602,7 @@ async function _getPythonFieldDefault(type, options)
   }
 
   let promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this));
-  if ((this.isList || this.isArray || this.entryType) && !options.hash.forceNotList) {
+  if ((this.isArray || this.entryType) && !options.hash.forceNotList) {
     promise = promise.then(typeStr => `field(default_factory=lambda: [])`);
   }
 

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -170,7 +170,7 @@ async function if_in_global_responses(options)
   const globalResponses    = await getServerGlobalAttributeResponses(this);
   const responseTypeExists = globalResponses.find(
       // Some fields of item/attribute here may be undefined.
-      item => item.isList == attribute.isList && item.isStruct == attribute.isStruct && item.chipType == attribute.chipType
+      item => item.isArray == attribute.isArray && item.isStruct == attribute.isStruct && item.chipType == attribute.chipType
           && item.isNullable == attribute.isNullable && item.isOptional == attribute.isOptional)
 
   if (responseTypeExists)
@@ -188,10 +188,10 @@ function getServerGlobalAttributeResponses(context)
   const sorter = (a, b) => a.chipCallback.name.localeCompare(b.chipCallback.name, 'en', { numeric : true });
 
   const reducer = (unique, item) => {
-    const { type, size, isList, isOptional, isNullable, chipCallback, chipType } = item.response.arguments[0];
+    const { type, size, isArray, isOptional, isNullable, chipCallback, chipType } = item.response.arguments[0];
 
     // List-typed elements have a dedicated callback
-    if (isList) {
+    if (isArray) {
       return unique;
     }
 
@@ -315,7 +315,7 @@ function chip_server_has_list_attributes(options)
   const { clusterName } = checkIsInsideClusterBlock(this, 'chip_server_has_list_attributes');
   const attributes      = ensureClusters(this).getServerAttributes(clusterName);
 
-  const filter = attribute => attribute.isList;
+  const filter = attribute => attribute.isArray;
   return attributes.then(items => items.find(filter));
 }
 
@@ -332,7 +332,7 @@ function chip_client_has_list_attributes(options)
   const { clusterName } = checkIsInsideClusterBlock(this, 'chip_client_has_list_attributes');
   const attributes      = ensureClusters(this).getClientAttributes(clusterName);
 
-  const filter = attribute => attribute.isList;
+  const filter = attribute => attribute.isArray;
   return attributes.then(items => items.find(filter));
 }
 

--- a/src/controller/java/templates/CHIPCallbackTypes.zapt
+++ b/src/controller/java/templates/CHIPCallbackTypes.zapt
@@ -15,7 +15,7 @@ typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase nam
 {{! TODO: global response types?}}
 
 {{#chip_server_cluster_attributes}}
-{{#if isList}}
+{{#if isArray}}
 typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo::DecodableType &);
 {{else}}
 typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallbackType)(void *, chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo::DecodableArgType);

--- a/src/controller/java/templates/CHIPReadCallbacks-src.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks-src.zapt
@@ -116,7 +116,7 @@ CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::
 }
 {{/if_in_global_responses}}
 
-{{#if isList}}
+{{#if isArray}}
 void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list)
 {
     chip::DeviceLayer::StackUnlock unlock;

--- a/src/controller/java/templates/CHIPReadCallbacks.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks.zapt
@@ -55,7 +55,7 @@ public:
         }
     }
 
-    static void CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} {{#if isList}}list{{else}}value{{/if}});
+    static void CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} {{#if isArray}}list{{else}}value{{/if}});
     static void OnSubscriptionEstablished(void * context) {
         CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback *>(context)->javaCallbackRef);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -128,7 +128,7 @@ public class ChipClusters {
     {{! NOTE: asJavaType ends up sniffing for isArray on the context. Since we want the type of our _entry_, force isArray to
           false. }}
     {{~#*inline "asJavaTypeForEntry"}}{{asJavaType type null parent.name forceNotList=true}}{{/inline~}}
-    {{#if isList}}
+    {{#if isArray}}
       public interface {{asUpperCamelCase name}}AttributeCallback {
         void onSuccess({{#if isNullable}}@Nullable{{/if}} List<{{>asJavaTypeForEntry isArray=false}}> valueList);
         void onError(Exception ex);

--- a/src/controller/java/templates/ChipStructs-java.zapt
+++ b/src/controller/java/templates/ChipStructs-java.zapt
@@ -36,9 +36,7 @@ public {{asJavaType type null parent.parent.name includeAnnotations=true}} {{asL
     {{#zcl_struct_items}}
     {{! TODO: Print more descriptive types for optional, nullable, array, and struct. }}
     output.append("\t{{asLowerCamelCase name}}: ");
-    {{#if isList}}
-    output.append({{asLowerCamelCase name}});
-    {{else if isArray}}
+    {{#if isArray}}
     output.append({{asLowerCamelCase name}});
     {{else if (isOctetString type)}}
     output.append(Arrays.toString({{asLowerCamelCase name}}));

--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -236,7 +236,7 @@ public class ClusterInfoMapping {
 
   {{/chip_cluster_responses}}
       {{#chip_server_cluster_attributes}}
-      {{#if isList}}
+      {{#if isArray}}
       {{#if isStruct}}
 
       {{/if}}

--- a/src/controller/java/templates/ClusterInfo-read-interaction.zapt
+++ b/src/controller/java/templates/ClusterInfo-read-interaction.zapt
@@ -29,7 +29,7 @@ public class ClusterReadMapping {
               {{/if_in_global_responses}}) callback
             );
           },
-          {{#if isList}}
+          {{#if isArray}}
             () -> new ClusterInfoMapping.Delegated{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback(),
           {{else}}
             () -> new ClusterInfoMapping.Delegated{{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback(),

--- a/src/controller/java/templates/ClusterInfo-write-interaction.zapt
+++ b/src/controller/java/templates/ClusterInfo-write-interaction.zapt
@@ -19,7 +19,7 @@ public class ClusterWriteMapping {
         {{! TODO: Add support for struct-typed attributes }}
         {{#unless (isStrEqual chipCallback.name "Unsupported")}}
         {{#if isWritableAttribute}}
-        {{#unless isList}}
+        {{#unless isArray}}
         Map<String, CommandParameterInfo> write{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}CommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         CommandParameterInfo {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParameterInfo = new CommandParameterInfo("value", {{asJavaType type null parent.parent.name removeGenericType=true}}.class);
         write{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}CommandParams.put("value",{{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParameterInfo);

--- a/src/controller/java/templates/helper.js
+++ b/src/controller/java/templates/helper.js
@@ -217,7 +217,7 @@ async function asJavaType(type, zclType, cluster, options)
     classType += asJavaBoxedType(type, zclType);
   }
 
-  if (!options.hash.forceNotList && (this.isList || this.isArray || this.entryType)) {
+  if (!options.hash.forceNotList && (this.isArray || this.entryType)) {
     if (!options.hash.removeGenericType) {
       classType = 'ArrayList<' + classType + '>';
     } else {
@@ -271,7 +271,7 @@ async function asJniHelper(type, zclType, cluster, options)
     return { jniType : "jobject", jniSignature : signature, jniBoxedSignature : signature };
   }
 
-  if (this.isList || this.isArray) {
+  if (this.isArray) {
     const signature = "Ljava/util/ArrayList;"
     return { jniType : "jobject", jniSignature : signature, jniBoxedSignature : signature };
   }

--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -20,7 +20,7 @@ if ({{source}}.IsNull()) {
   while (iter_{{target}}_{{depth}}.Next())
   {
     auto & entry_{{depth}} = iter_{{target}}_{{depth}}.GetValue();
-    {{>decode_value target=(concat "newElement_" depth) source=(concat "entry_" depth) cluster=cluster depth=(incrementDepth depth) isList=false isArray=false forceNotList=true omitDeclaration=false}}
+    {{>decode_value target=(concat "newElement_" depth) source=(concat "entry_" depth) cluster=cluster depth=(incrementDepth depth) isArray=false forceNotList=true omitDeclaration=false}}
     chip::JniReferences::GetInstance().AddToArrayList({{target}}, newElement_{{depth}});
   }
 {{else}}

--- a/src/controller/java/templates/partials/encode_value.zapt
+++ b/src/controller/java/templates/partials/encode_value.zapt
@@ -25,7 +25,7 @@
       for (size_t i_{{depth}} = 0; i_{{depth}} < static_cast<size_t>({{source}}Size); ++i_{{depth}}) {
         jobject element_{{depth}};
         chip::JniReferences::GetInstance().GetArrayListItem({{source}}, i_{{depth}}, element_{{depth}});
-        {{>encode_value target=(concat "listHolder_" depth "->mList[i_" depth "]") source=(concat "element_" depth) cluster=cluster depth=(incrementDepth depth) isList=false isArray=false}}
+        {{>encode_value target=(concat "listHolder_" depth "->mList[i_" depth "]") source=(concat "element_" depth) cluster=cluster depth=(incrementDepth depth) isArray=false}}
       }
       {{target}} = ListType_{{depth}}(listHolder_{{depth}}->mList, {{source}}Size);
     } else {

--- a/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge-src.zapt
@@ -40,7 +40,7 @@
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
-{{#if isList}}
+{{#if isArray}}
 {{#>CHIPCallbackBridge ns=parent.name                                }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}ListAttributeCallback{{/CHIPCallbackBridge}}
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
@@ -60,7 +60,7 @@ typedef void (*Nullable{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
-{{#if isList}}
+{{#if isArray}}
 {{#>CHIPCallbackBridge header="1" ns=parent.name                                }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}ListAttributeCallback{{/CHIPCallbackBridge}}
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -87,7 +87,7 @@ using namespace chip::app::Clusters;
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
 {{#*inline "callbackName"}}
-  {{~#if isList~}}
+  {{~#if isArray~}}
     {{asUpperCamelCase ../name}}{{asUpperCamelCase name}}List
   {{~else~}}
     {{~#if isNullable}}Nullable{{/if~}}
@@ -146,7 +146,7 @@ using namespace chip::app::Clusters;
 {{#if isReportableAttribute}}
 {{! This callbackName bit is duplicated with the readAttribute code above. }}
 {{#*inline "callbackName"}}
-  {{~#if isList~}}
+  {{~#if isArray~}}
     {{asUpperCamelCase ../name}}{{asUpperCamelCase name}}List
   {{~else~}}
     {{~#if isNullable}}Nullable{{/if~}}

--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -132,7 +132,7 @@ async function asObjectiveCClass(type, cluster, options)
   let pkgId    = await templateUtil.ensureZclPackageId(this);
   let isStruct = await zclHelper.isStruct(this.global.db, type, pkgId).then(zclType => zclType != 'unknown');
 
-  if ((this.isList || this.isArray || this.entryType || options.hash.forceList) && !options.hash.forceNotList) {
+  if ((this.isArray || this.entryType || options.hash.forceList) && !options.hash.forceNotList) {
     return 'NSArray';
   }
 

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -59,11 +59,11 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
         XCTAssertEqual(testSendCluster{{parent.filename}}_{{asTestIndex waitForReport.index}}_{{asUpperCamelCase waitForReport.command}}_Fulfilled, true);
         [expectation fulfill];
       }
-                                                               reportHandler:^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isList}} * _Nullable value, NSError * _Nullable err) {
+                                                               reportHandler:^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isArray}} * _Nullable value, NSError * _Nullable err) {
     {{else if isWaitForReport}}
-    {{> subscribeDataCallback }} = ^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isList}} * _Nullable value, NSError * _Nullable err) {
+    {{> subscribeDataCallback }} = ^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isArray}} * _Nullable value, NSError * _Nullable err) {
     {{else if isReadAttribute}}
-    [cluster readAttribute{{asUpperCamelCase attribute}}WithCompletionHandler:^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isList}} * _Nullable value, NSError * _Nullable err) {
+    [cluster readAttribute{{asUpperCamelCase attribute}}WithCompletionHandler:^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isArray}} * _Nullable value, NSError * _Nullable err) {
     {{else if isWriteAttribute}}
     {{#chip_tests_item_parameters}}
     id {{asLowerCamelCase name}}Argument;


### PR DESCRIPTION
We're using isArray for lists elsewhere (struct fields, command
fields, etc), and attributes are already setting isArray anyway.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Reran codegen.  There are no changes in the generated code.