### PR TITLE
Group Cryptography: Message encryption implemented in the Group Data …

### DIFF
--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -146,22 +146,6 @@ public:
             VerifyOrReturnError(this->policy == other.policy && this->num_keys_used == other.num_keys_used, false);
             return !memcmp(this->epoch_keys, other.epoch_keys, this->num_keys_used * sizeof(EpochKey));
         }
-
-        ByteSpan GetCurrentKey()
-        {
-            // An epoch key update SHALL order the keys from oldest to newest,
-            // the current epoch key having the second newest time
-            switch (this->num_keys_used)
-            {
-            case 1:
-            case 2:
-                return ByteSpan(epoch_keys[0].key, EpochKey::kLengthBytes);
-            case 3:
-                return ByteSpan(epoch_keys[1].key, EpochKey::kLengthBytes);
-            default:
-                return ByteSpan(nullptr, 0);
-            }
-        }
     };
 
     /**
@@ -317,7 +301,8 @@ public:
     virtual CHIP_ERROR RemoveFabric(FabricIndex fabric_index) = 0;
 
     // Decryption
-    virtual GroupSessionIterator * IterateGroupSessions(uint16_t session_id) = 0;
+    virtual GroupSessionIterator * IterateGroupSessions(uint16_t session_id)                        = 0;
+    virtual Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex fabric_index, GroupId group_id) = 0;
 
     // Listener
     void SetListener(GroupListener * listener) { mListener = listener; };

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1601,9 +1601,10 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
     for (size_t i = 0; i < in_keyset.num_keys_used; ++i)
     {
         ByteSpan epoch_key(in_keyset.epoch_keys[i].key, Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES);
-        MutableByteSpan key(keyset.operational_keys[i].value, Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES);
-        ReturnErrorOnFailure(Crypto::DeriveGroupOperationalKey(epoch_key, key));
-        ReturnErrorOnFailure(Crypto::DeriveGroupSessionId(key, keyset.operational_keys[i].hash));
+        uint8_t key[Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
+        MutableByteSpan key_span(key, sizeof(key));
+        ReturnErrorOnFailure(Crypto::DeriveGroupOperationalKey(epoch_key, key_span));
+        ReturnErrorOnFailure(Crypto::DeriveGroupSessionId(ByteSpan(key, sizeof(key)), keyset.operational_keys[i].hash));
     }
 
     if (found)

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -83,6 +83,7 @@ public:
     CHIP_ERROR RemoveFabric(FabricIndex fabric_index) override;
 
     // Decryption
+    Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex fabric_index, GroupId group_id) override;
     GroupSessionIterator * IterateGroupSessions(uint16_t session_id) override;
 
 protected:
@@ -142,9 +143,20 @@ protected:
     class GroupKeyContext : public Crypto::SymmetricKeyContext
     {
     public:
-        GroupKeyContext() = default;
-        CHIP_ERROR SetKey(const ByteSpan & value);
-        void Clear();
+        GroupKeyContext(GroupDataProviderImpl & provider) : mProvider(provider) {}
+
+        GroupKeyContext(GroupDataProviderImpl & provider, const ByteSpan & key, uint16_t hash) : mProvider(provider)
+        {
+            SetKey(key, hash);
+        }
+
+        void SetKey(const ByteSpan & key, uint16_t hash)
+        {
+            mKeyHash = hash;
+            memcpy(mKeyValue, key.data(), std::min(key.size(), Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES));
+        }
+
+        uint16_t GetKeyHash() override { return mKeyHash; }
 
         CHIP_ERROR EncryptMessage(MutableByteSpan & plaintext, const ByteSpan & aad, const ByteSpan & nonce,
                                   MutableByteSpan & out_mic) const override;
@@ -155,8 +167,12 @@ protected:
         CHIP_ERROR DecryptPrivacy(MutableByteSpan & header, uint16_t session_id, const ByteSpan & payload,
                                   const ByteSpan & mic) const override;
 
+        void Release() override;
+
     protected:
-        uint8_t mKey[Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
+        GroupDataProviderImpl & mProvider;
+        uint16_t mKeyHash                                                 = 0;
+        uint8_t mKeyValue[Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES] = { 0 };
     };
 
     class KeySetIteratorImpl : public KeySetIterator
@@ -195,7 +211,7 @@ protected:
         uint16_t mKeyIndex       = 0;
         uint16_t mKeyCount       = 0;
         bool mFirstMap           = true;
-        GroupKeyContext mKey;
+        GroupKeyContext mKeyContext;
     };
     CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id);
 
@@ -206,6 +222,7 @@ protected:
     BitMapObjectPool<EndpointIteratorImpl, kIteratorsMax> mEndpointIterators;
     BitMapObjectPool<KeySetIteratorImpl, kIteratorsMax> mKeySetIterators;
     BitMapObjectPool<GroupSessionIteratorImpl, kIteratorsMax> mGroupSessionsIterator;
+    BitMapObjectPool<GroupKeyContext, kIteratorsMax> mKeyContexPool;
 };
 
 } // namespace Credentials

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -153,7 +153,7 @@ protected:
         void SetKey(const ByteSpan & key, uint16_t hash)
         {
             mKeyHash = hash;
-            memcpy(mKeyValue, key.data(), std::min(key.size(), Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES));
+            memcpy(mKeyValue, key.data(), std::min(key.size(), sizeof(mKeyValue)));
         }
 
         uint16_t GetKeyHash() override { return mKeyHash; }

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -1054,44 +1054,65 @@ void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup3Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup3Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 5, kGroup1Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 6, kGroup1Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 7, kGroup1Keyset3));
-
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3));
-
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet1));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet2));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet3));
 
-    const uint8_t kMessage[] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9 };
-    const uint8_t nonce[13]  = { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x1a, 0x1b, 0x1c };
-    const uint8_t aad[40]    = { 0x0a, 0x1a, 0x2a, 0x3a, 0x4a, 0x5a, 0x6a, 0x7a, 0x8a, 0x9a, 0x0b, 0x1b, 0x2b, 0x3b,
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup1Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup1Keyset2));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset2));
+
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset1));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset3));
+
+    const size_t kMessageLength            = 10;
+    const uint8_t kMessage[kMessageLength] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9 };
+    const uint8_t nonce[13]                = { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x1a, 0x1b, 0x1c };
+    const uint8_t aad[40]                  = { 0x0a, 0x1a, 0x2a, 0x3a, 0x4a, 0x5a, 0x6a, 0x7a, 0x8a, 0x9a, 0x0b, 0x1b, 0x2b, 0x3b,
                               0x4b, 0x5b, 0x6b, 0x7b, 0x8b, 0x9b, 0x0c, 0x1c, 0x2c, 0x3c, 0x4c, 0x5c, 0x6c, 0x7c,
                               0x8c, 0x9c, 0x0d, 0x1d, 0x2d, 0x3d, 0x4d, 0x5d, 0x6d, 0x7d, 0x8d, 0x9d };
-    uint8_t mic[16]          = {
+    uint8_t mic[16]                        = {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     };
-    uint8_t buffer[32];
 
-    std::set<std::pair<FabricIndex, GroupId>> expected = { { kFabric1, kGroup1 }, { kFabric1, kGroup3 }, { kFabric2, kGroup2 } };
+    uint8_t ciphertext_buffer[kMessageLength];
+    uint8_t plaintext_buffer[kMessageLength];
+    MutableByteSpan ciphertext(ciphertext_buffer, sizeof(ciphertext_buffer));
+    MutableByteSpan plaintext(plaintext_buffer, sizeof(plaintext_buffer));
+    MutableByteSpan tag(mic, sizeof(mic));
 
-    const uint16_t kSessionId = 0xbc66;
+    //
+    // Encrypt
+    //
+
+    // Load the plaintext to encrypt
+    memcpy(ciphertext_buffer, kMessage, sizeof(kMessage));
+
+    // Get the key context
+    Crypto::SymmetricKeyContext * key_context = provider->GetKeyContext(kFabric2, kGroup2);
+    NL_TEST_ASSERT(apSuite, nullptr != key_context);
+    uint16_t session_id = key_context->GetKeyHash();
+
+    // Encrypt the message
+    NL_TEST_ASSERT(apSuite,
+                   CHIP_NO_ERROR ==
+                       key_context->EncryptMessage(ciphertext, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag));
+
+    // The ciphertext must be different to the original message
+    NL_TEST_ASSERT(apSuite, memcmp(ciphertext.data(), kMessage, sizeof(kMessage)));
+    key_context->Release();
+
+    //
+    // Decrypt
+    //
+
+    const std::set<std::pair<FabricIndex, GroupId>> expected = { { kFabric2, kGroup2 } };
+
+    // Iterate all keys that matches the incoming session
     GroupSession session;
-    auto it      = provider->IterateGroupSessions(kSessionId);
+    auto it      = provider->IterateGroupSessions(session_id);
     size_t count = 0, total = 0;
 
     NL_TEST_ASSERT(apSuite, it);
@@ -1101,27 +1122,21 @@ void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)
         NL_TEST_ASSERT(apSuite, expected.size() == total);
         while (it->Next(session))
         {
-            std::pair<FabricIndex, GroupId> result(session.fabric_index, session.group_id);
-            NL_TEST_ASSERT(apSuite, expected.count(result) > 0);
+            std::pair<FabricIndex, GroupId> found(session.fabric_index, session.group_id);
+            NL_TEST_ASSERT(apSuite, expected.count(found) > 0);
             NL_TEST_ASSERT(apSuite, session.key != nullptr);
 
-            memcpy(buffer, kMessage, sizeof(kMessage));
-            MutableByteSpan message(buffer, sizeof(kMessage));
-            MutableByteSpan tag(mic, sizeof(mic));
+            // Load ciphertext to decrypt
+            memcpy(plaintext_buffer, ciphertext_buffer, sizeof(plaintext_buffer));
 
-            // Encrypt
+            // Decrypt de ciphertext
             NL_TEST_ASSERT(
                 apSuite,
                 CHIP_NO_ERROR ==
-                    session.key->EncryptMessage(message, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag));
-            NL_TEST_ASSERT(apSuite, memcmp(message.data(), kMessage, sizeof(kMessage)));
+                    session.key->DecryptMessage(plaintext, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag));
 
-            // Decrypt
-            NL_TEST_ASSERT(
-                apSuite,
-                CHIP_NO_ERROR ==
-                    session.key->DecryptMessage(message, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag));
-            NL_TEST_ASSERT(apSuite, 0 == memcmp(message.data(), kMessage, sizeof(kMessage)));
+            // The new plaintext must match the original message
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(plaintext.data(), kMessage, sizeof(kMessage)));
             count++;
         }
         NL_TEST_ASSERT(apSuite, count == total);

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1346,6 +1346,12 @@ CHIP_ERROR ExtractDNAttributeFromX509Cert(MatterOid matterOid, const ByteSpan & 
 class SymmetricKeyContext
 {
 public:
+    /**
+     * @brief Returns the symmetric key hash
+     * @return Group Key Hash
+     */
+    virtual uint16_t GetKeyHash() = 0;
+
     virtual ~SymmetricKeyContext() = default;
     /**
      * @brief Perform the message encryption as described in 4.7.2. (Security Processing of Outgoing Messages)
@@ -1389,6 +1395,11 @@ public:
      */
     virtual CHIP_ERROR DecryptPrivacy(MutableByteSpan & header, uint16_t session_id, const ByteSpan & payload,
                                       const ByteSpan & mic) const = 0;
+
+    /**
+     * @brief Release the dynamic memory used to allocate this instance of the SymmetricKeyContext
+     */
+    virtual void Release() = 0;
 };
 
 /**


### PR DESCRIPTION
#### Problem
The Group Data Provider is missing a method to obtain the key context required for encryption.

#### Change overview
* Two new methods added to the Crypto::SymmetricKeyContext: `GetKeyHash` used to obtain the key hash, and `Release` used to free the allocated memory.
* New method added to the `GroupDataProvider` interface to return the key context: `GetKeyContext`
* `GroupKeyContext` updated to the new interface.
* `GetKeyContext` implemented in `GroupDataProviderImpl`
* Unit test update to use the new `GetKeyContext` with the existing trial decryption loop.

#### Testing
* Unit tests ran successfully.
