### PR TITLE
Bump timeout for unit test builts

### DIFF
--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -80,10 +80,10 @@ jobs:
 
                   scripts/build/gn_gen.sh --args="$GN_ARGS"
             - name: Run Build
-              timeout-minutes: 8
+              timeout-minutes: 30 
               run: scripts/run_in_build_env.sh "ninja -C out/$BUILD_TYPE"
             - name: Run Tests
-              timeout-minutes: 15
+              timeout-minutes: 30
               run: scripts/tests/gn_tests.sh
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512


### PR DESCRIPTION
#### Problem
8 Minutes is not enough to compile on darwin (or right at the limit now):

https://github.com/project-chip/connectedhomeip/runs/4952439442?check_suite_focus=true

#### Change overview
Increase build and run time limits.

#### Testing
Safe change. CI will validate.
