### PR TITLE
Remove the use of emberAfCurrentCommand in moveToLevelHandler

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -107,8 +107,8 @@ static EmberAfLevelControlState stateTable[EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER
 
 static EmberAfLevelControlState * getState(EndpointId endpoint);
 
-static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t level, uint16_t transitionTimeDs,
-                               uint8_t optionMask, uint8_t optionOverride, uint16_t storedLevel);
+static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t level, uint16_t transitionTimeDs,
+                                        uint8_t optionMask, uint8_t optionOverride, uint16_t storedLevel);
 static void moveHandler(CommandId commandId, uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride);
 static void stepHandler(CommandId commandId, uint8_t stepMode, uint8_t stepSize, uint16_t transitionTimeDs, uint8_t optionMask,
                         uint8_t optionOverride);
@@ -408,8 +408,12 @@ bool emberAfLevelControlClusterMoveToLevelCallback(app::CommandHandler * command
 
     emberAfLevelControlClusterPrintln("%pMOVE_TO_LEVEL %x %2x %x %x", "RX level-control:", level, transitionTime, optionMask,
                                       optionOverride);
-    moveToLevelHandler(commandPath.mEndpointId, Commands::MoveToLevel::Id, level, transitionTime, optionMask, optionOverride,
-                       INVALID_STORED_LEVEL); // Don't revert to the stored level
+    EmberAfStatus status =
+        moveToLevelHandler(commandPath.mEndpointId, Commands::MoveToLevel::Id, level, transitionTime, optionMask, optionOverride,
+                           INVALID_STORED_LEVEL); // Don't revert to the stored level
+
+    emberAfSendImmediateDefaultResponse(status);
+
     return true;
 }
 
@@ -421,8 +425,12 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(app::CommandHandler 
     auto & transitionTime = commandData.transitionTime;
 
     emberAfLevelControlClusterPrintln("%pMOVE_TO_LEVEL_WITH_ON_OFF %x %2x", "RX level-control:", level, transitionTime);
-    moveToLevelHandler(commandPath.mEndpointId, Commands::MoveToLevelWithOnOff::Id, level, transitionTime, 0xFF, 0xFF,
-                       INVALID_STORED_LEVEL); // Don't revert to the stored level
+    EmberAfStatus status =
+        moveToLevelHandler(commandPath.mEndpointId, Commands::MoveToLevelWithOnOff::Id, level, transitionTime, 0xFF, 0xFF,
+                           INVALID_STORED_LEVEL); // Don't revert to the stored level
+
+    emberAfSendImmediateDefaultResponse(status);
+
     return true;
 }
 
@@ -495,8 +503,8 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(app::CommandHandler * comma
     return true;
 }
 
-static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t level, uint16_t transitionTimeDs,
-                               uint8_t optionMask, uint8_t optionOverride, uint16_t storedLevel)
+static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t level, uint16_t transitionTimeDs,
+                                        uint8_t optionMask, uint8_t optionOverride, uint16_t storedLevel)
 {
     EmberAfLevelControlState * state = getState(endpoint);
     EmberAfStatus status;
@@ -505,14 +513,12 @@ static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t
 
     if (state == NULL)
     {
-        status = EMBER_ZCL_STATUS_FAILURE;
-        goto send_default_response;
+        return EMBER_ZCL_STATUS_FAILURE;
     }
 
     if (!shouldExecuteIfOff(endpoint, commandId, optionMask, optionOverride))
     {
-        status = EMBER_ZCL_STATUS_SUCCESS;
-        goto send_default_response;
+        return EMBER_ZCL_STATUS_SUCCESS;
     }
 
     // Cancel any currently active command before fiddling with the state.
@@ -522,7 +528,7 @@ static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfLevelControlClusterPrintln("ERR: reading current level %x", status);
-        goto send_default_response;
+        return status;
     }
 
     state->commandId = commandId;
@@ -554,8 +560,7 @@ static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t
         }
         if (currentLevel == state->moveToLevel)
         {
-            status = EMBER_ZCL_STATUS_SUCCESS;
-            goto send_default_response;
+            return EMBER_ZCL_STATUS_SUCCESS;
         }
         state->increasing = true;
         actualStepSize    = static_cast<uint8_t>(state->moveToLevel - currentLevel);
@@ -580,7 +585,7 @@ static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t
             if (status != EMBER_ZCL_STATUS_SUCCESS)
             {
                 emberAfLevelControlClusterPrintln("ERR: reading on/off transition time %x", status);
-                goto send_default_response;
+                return status;
             }
 
             // Transition time comes in (or is stored, in the case of On/Off Transition
@@ -629,11 +634,7 @@ static void moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8_t
         }
     }
 
-send_default_response:
-    if (emberAfCurrentCommand()->apsFrame->clusterId == LevelControl::Id)
-    {
-        emberAfSendImmediateDefaultResponse(status);
-    }
+    return status;
 }
 
 static void moveHandler(CommandId commandId, uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride)


### PR DESCRIPTION
#### Problem
MoveToLevelHandler can be called from a non-command (e.g: at init). In such cases, emberAfCurrentCommand returns a null pointer which will result in unexpected behaviour or crash with the current implementation.

#### Change overview
Remove the use of emberAfCurrentCommand.
moveToLevelHandler now returns a EmberAfStatus. The caller deals with sending the immediate response if need be.

#### Testing
Tested with EFR32 Lighting app
 - At boot up, the cluster init when the Startup level attribute is enabled exercises this path.
 - With chip-tool send a move-to-level command to the device.
 - With chip-tool send an OnOff command to the device which also exercises this path with the OnOff LevelControl Effect.
CI also confirms the functionality stayed the same.
