### PR TITLE
[CI] Increase the timeout to wait for the process to be terminated

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -155,4 +155,4 @@ class TestDefinition:
         finally:
             if app_process:
                 app_process.kill()
-                app_process.wait(3)
+                app_process.wait(10)


### PR DESCRIPTION
#### Problem

Seems like the timeout for waiting the process to finished is too short in the CI runner.

#### Change overview
 Increase timeout from 3 to 10
