### PR TITLE
Rename ephemeralKeypair to operationalKeypair

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -190,7 +190,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId f
     commissionerParams.storageDelegate                = &mCommissionerStorage;
     commissionerParams.fabricIndex                    = static_cast<chip::FabricIndex>(fabricId);
     commissionerParams.operationalCredentialsDelegate = mCredIssuerCmds->GetCredentialIssuer();
-    commissionerParams.ephemeralKeypair               = &ephemeralKey;
+    commissionerParams.operationalKeypair             = &ephemeralKey;
     commissionerParams.controllerRCAC                 = rcacSpan;
     commissionerParams.controllerICAC                 = icacSpan;
     commissionerParams.controllerNOC                  = nocSpan;

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -258,10 +258,10 @@ CHIP_ERROR InitCommissioner()
     ReturnErrorOnFailure(
         gOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
 
-    params.ephemeralKeypair = &ephemeralKey;
-    params.controllerRCAC   = rcacSpan;
-    params.controllerICAC   = icacSpan;
-    params.controllerNOC    = nocSpan;
+    params.operationalKeypair = &ephemeralKey;
+    params.controllerRCAC     = rcacSpan;
+    params.controllerICAC     = icacSpan;
+    params.controllerNOC      = nocSpan;
 
     auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
     ReturnErrorOnFailure(factory.Init(factoryParams));

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -717,7 +717,7 @@ bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(app::CommandHandle
         }
 
         keypair.Initialize();
-        SuccessOrExit(err = gFabricBeingCommissioned.SetEphemeralKey(&keypair));
+        SuccessOrExit(err = gFabricBeingCommissioned.SetOperationalKeypair(&keypair));
 
         // Generate the actual CSR from the ephemeral key
         VerifyOrExit(csr.Alloc(csrLength), err = CHIP_ERROR_NO_MEMORY);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -180,8 +180,8 @@ CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParam
 {
     FabricInfo newFabric;
 
-    ReturnErrorCodeIf(params.ephemeralKeypair == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    newFabric.SetEphemeralKey(params.ephemeralKeypair);
+    ReturnErrorCodeIf(params.operationalKeypair == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    newFabric.SetOperationalKeypair(params.operationalKeypair);
 
     constexpr uint32_t chipCertAllocatedLen = kMaxCHIPCertLength;
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -105,7 +105,7 @@ struct ControllerInitParams
 
     /* The following keypair must correspond to the public key used for generating
        controllerNOC. It's used by controller to establish CASE sessions with devices */
-    Crypto::P256Keypair * ephemeralKeypair = nullptr;
+    Crypto::P256Keypair * operationalKeypair = nullptr;
 
     /* The following certificates must be in x509 DER format */
     ByteSpan controllerNOC;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -168,7 +168,7 @@ void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controll
     controllerParams.deviceAddressUpdateDelegate = params.deviceAddressUpdateDelegate;
 #endif
     controllerParams.operationalCredentialsDelegate = params.operationalCredentialsDelegate;
-    controllerParams.ephemeralKeypair               = params.ephemeralKeypair;
+    controllerParams.operationalKeypair             = params.operationalKeypair;
     controllerParams.controllerNOC                  = params.controllerNOC;
     controllerParams.controllerICAC                 = params.controllerICAC;
     controllerParams.controllerRCAC                 = params.controllerRCAC;

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -48,7 +48,7 @@ struct SetupParams
 
     /* The following keypair must correspond to the public key used for generating
     controllerNOC. It's used by controller to establish CASE sessions with devices */
-    Crypto::P256Keypair * ephemeralKeypair = nullptr;
+    Crypto::P256Keypair * operationalKeypair = nullptr;
 
     /* The following certificates must be in x509 DER format */
     ByteSpan controllerNOC;

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -269,10 +269,10 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
         return nullptr;
     }
 
-    setupParams.ephemeralKeypair = &ephemeralKey;
-    setupParams.controllerRCAC   = rcacSpan;
-    setupParams.controllerICAC   = icacSpan;
-    setupParams.controllerNOC    = nocSpan;
+    setupParams.operationalKeypair = &ephemeralKey;
+    setupParams.controllerRCAC     = rcacSpan;
+    setupParams.controllerICAC     = icacSpan;
+    setupParams.controllerNOC      = nocSpan;
 
     *errInfoOnFailure = DeviceControllerFactory::GetInstance().Init(initParams);
     if (*errInfoOnFailure != CHIP_NO_ERROR)

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -234,7 +234,7 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
     initParams.deviceAddressUpdateDelegate    = &sDeviceAddressUpdateDelegate;
     initParams.pairingDelegate                = &sPairingDelegate;
     initParams.operationalCredentialsDelegate = &sOperationalCredentialsIssuer;
-    initParams.ephemeralKeypair               = &ephemeralKey;
+    initParams.operationalKeypair             = &ephemeralKey;
     initParams.controllerRCAC                 = rcacSpan;
     initParams.controllerICAC                 = icacSpan;
     initParams.controllerNOC                  = nocSpan;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -144,7 +144,7 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
             SuccessOrExit(err);
 
             commissionerParams.operationalCredentialsDelegate = &gOperationalCredentialsIssuer;
-            commissionerParams.ephemeralKeypair               = &ephemeralKey;
+            commissionerParams.operationalKeypair             = &ephemeralKey;
             commissionerParams.controllerRCAC                 = rcacSpan;
             commissionerParams.controllerICAC                 = icacSpan;
             commissionerParams.controllerNOC                  = nocSpan;

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -239,10 +239,10 @@ CHIP_ERROR FabricInfo::GenerateKey(FabricIndex id, char * key, size_t len)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR FabricInfo::SetEphemeralKey(const P256Keypair * key)
+CHIP_ERROR FabricInfo::SetOperationalKeypair(const P256Keypair * keyPair)
 {
     P256SerializedKeypair serialized;
-    ReturnErrorOnFailure(key->Serialize(serialized));
+    ReturnErrorOnFailure(keyPair->Serialize(serialized));
     if (mOperationalKey == nullptr)
     {
 #ifdef ENABLE_HSM_CASE_OPS_KEY
@@ -492,7 +492,7 @@ CHIP_ERROR FabricInfo::SetFabricInfo(FabricInfo & newFabric)
     validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
     validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kServerAuth);
 
-    SetEphemeralKey(newFabric.GetOperationalKey());
+    SetOperationalKeypair(newFabric.GetOperationalKey());
     SetRootCert(newFabric.mRootCert);
 
     ChipLogProgress(Discovery, "Verifying the received credentials");

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -172,7 +172,7 @@ public:
         }
         return mOperationalKey;
     }
-    CHIP_ERROR SetEphemeralKey(const Crypto::P256Keypair * key);
+    CHIP_ERROR SetOperationalKeypair(const Crypto::P256Keypair * keyPair);
 
     // TODO - Update these APIs to take ownership of the buffer, instead of copying
     //        internally.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -222,7 +222,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
             return;
         }
 
-        commissionerParams.ephemeralKeypair = &ephemeralKey;
+        commissionerParams.operationalKeypair = &ephemeralKey;
         commissionerParams.controllerRCAC = rcac;
         commissionerParams.controllerICAC = icac;
         commissionerParams.controllerNOC = noc;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -118,7 +118,7 @@ static CHIP_ERROR InitCredentialSets()
 
     P256Keypair opKey;
     ReturnErrorOnFailure(opKey.Deserialize(opKeysSerialized));
-    ReturnErrorOnFailure(commissionerFabric.SetEphemeralKey(&opKey));
+    ReturnErrorOnFailure(commissionerFabric.SetOperationalKeypair(&opKey));
 
     ReturnErrorOnFailure(commissionerFabric.SetRootCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len)));
     ReturnErrorOnFailure(commissionerFabric.SetICACert(ByteSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len)));
@@ -135,7 +135,7 @@ static CHIP_ERROR InitCredentialSets()
     ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
 
     ReturnErrorOnFailure(opKey.Deserialize(opKeysSerialized));
-    ReturnErrorOnFailure(deviceFabric.SetEphemeralKey(&opKey));
+    ReturnErrorOnFailure(deviceFabric.SetOperationalKeypair(&opKey));
 
     ReturnErrorOnFailure(deviceFabric.SetRootCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len)));
     ReturnErrorOnFailure(deviceFabric.SetICACert(ByteSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len)));


### PR DESCRIPTION
#### Problem
- Wherever ephemeralKeypair was used in a method name,
  it was actually the operational key pair. A keypair may
  be ephemeral at the caller, but it is not within
  the fabric table.
- This terminology caused semantic misunderstanding of the
  usage of the operational keys in chip-tool

Issue #13501

#### Change overview
- This PR simply renames the necessary fields and methods, with
  no functional changes. The semantics intended are now respected.

#### Testing
- Testing done: unit and cert tests still pass
