### PR TITLE
Fix fuzzing handling of too-large inputs.

### DIFF
--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -61,6 +61,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     Transport::PeerAddress peerAddr;
     System::PacketBufferHandle buf =
         System::PacketBufferHandle::NewWithData(aData, aSize, /* aAdditionalSize = */ 0, /* aReservedSize = */ 0);
+    if (buf.IsNull())
+    {
+        // Too big; we couldn't represent this as a packetbuffer to start with.
+        return 0;
+    }
 
     // Ignoring the return value from OnMessageReceived, because we might be
     // passing it all sorts of garbage that will cause it to fail.


### PR DESCRIPTION
If we can't put it in a PacketBuffer, we can't do anything with it.

Fixes https://github.com/project-chip/connectedhomeip/issues/14348

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran on the fuzzer testcase that triggered https://github.com/project-chip/connectedhomeip/issues/14348 and it no longer crashes.