### PR TITLE
EFR32 Unit Test: Remove default install of py runner

### DIFF
--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -113,8 +113,11 @@ efr32_executable("efr32_device_tests") {
 }
 
 group("efr32") {
+  deps = [ ":efr32_device_tests" ]
+}
+
+group("runner") {
   deps = [
-    ":efr32_device_tests",
     "${efr32_project_dir}/py:nl_test_runner.install",
     "${efr32_project_dir}/py:nl_test_runner_wheel",
   ]

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -4,10 +4,9 @@ This builds and runs the NLUnitTest on the efr32 device
 
 <hr>
 
--   [CHIP EFR32 Test Driver](#chip-efr32-test-driver)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Running The Tests](#running-the-tests)
+-   [Introduction](#introduction)
+-   [Building](#building)
+-   [Running The Tests](#running-the-tests)
 
 <hr>
 
@@ -76,7 +75,13 @@ OR use GN/Ninja directly
 
 ## Running The Tests
 
-The included python test runner will be installed as part of building.
+Build the runner using gn:
+
+    $ gn gen out/debug
+    $ ninja -C out/debug runner
+
+The runner will be installed into the venv and python wheels will be packaged in
+the output folder for deploying.
 
 -   To run the tests:
 


### PR DESCRIPTION
#### Problem
Building the python runner is causing build flake within the GitHub CI. #14343 

#### Change overview
Remove building these as a default step for now, it can still be built manually by specifying the gn target.

#### Testing
- Built tests, and verified python whls were not in output.
- Built using the documented commands and verified the whls were generated and installed. 