### PR TITLE
Resolve chip app segmentation fault on simulated device

### DIFF
--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -66,6 +66,14 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    static void ScheduleNextTest(intptr_t context)
+    {
+        TestCommand * command = reinterpret_cast<TestCommand *>(context);
+        command->isRunning    = true;
+        command->NextTest();
+        chip::DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, context);
+    }
+
     CHIP_ERROR WaitForCommissioning()
     {
         isRunning = false;
@@ -78,11 +86,7 @@ public:
         {
         case chip::DeviceLayer::DeviceEventType::kCommissioningComplete:
             ChipLogProgress(chipTool, "Commissioning complete");
-
-            TestCommand * command = reinterpret_cast<TestCommand *>(arg);
-            command->isRunning    = true;
-            command->NextTest();
-            chip::DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEvent, arg);
+            chip::DeviceLayer::PlatformMgr().ScheduleWork(ScheduleNextTest, arg);
             break;
         }
     }


### PR DESCRIPTION
#### Problem
After pairing, the simulated device will crash due to removal of event.
https://github.com/chip-csg/connectedhomeip/issues/68

#### Change overview
- Use `ScheduleWork` to perform tasks in a operate thread so that `RemoveEventHandler` doesn't deallocate any context while running.

#### Testing
- Built simulated device and paired several times.