### PR TITLE
[IDL] add timed tag to IDL

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2819,7 +2819,7 @@ server cluster TestCluster = 1295 {
   command TestSimpleOptionalArgumentRequest(TestSimpleOptionalArgumentRequestRequest): DefaultSuccess = 19;
   command TestSpecific(): TestSpecificResponse = 2;
   command TestStructArgumentRequest(TestStructArgumentRequestRequest): BooleanResponse = 7;
-  command TimedInvokeRequest(): DefaultSuccess = 18;
+  timed command TimedInvokeRequest(): DefaultSuccess = 18;
 }
 
 server cluster Thermostat = 513 {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -22,9 +22,9 @@ server cluster AccountLogin = 1294 {
     CHAR_STRING setupPIN = 0;
   }
 
-  command GetSetupPINRequest(GetSetupPINRequestRequest): GetSetupPINResponse = 0;
+  timed command GetSetupPINRequest(GetSetupPINRequestRequest): GetSetupPINResponse = 0;
   command LoginRequest(LoginRequestRequest): DefaultSuccess = 2;
-  command LogoutRequest(): DefaultSuccess = 3;
+  timed command LogoutRequest(): DefaultSuccess = 3;
 }
 
 server cluster AdministratorCommissioning = 60 {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -18,9 +18,9 @@ client cluster AccountLogin = 1294 {
     CHAR_STRING setupPIN = 1;
   }
 
-  command GetSetupPINRequest(GetSetupPINRequestRequest): GetSetupPINResponse = 0;
+  timed command GetSetupPINRequest(GetSetupPINRequestRequest): GetSetupPINResponse = 0;
   command LoginRequest(LoginRequestRequest): DefaultSuccess = 2;
-  command LogoutRequest(): DefaultSuccess = 3;
+  timed command LogoutRequest(): DefaultSuccess = 3;
 }
 
 server cluster AdministratorCommissioning = 60 {

--- a/scripts/idl/matter_grammar.lark
+++ b/scripts/idl/matter_grammar.lark
@@ -15,7 +15,9 @@ attribute_tag: "readonly"i -> attr_readonly
 request_struct: "request"i struct
 response_struct: "response"i struct
 
-command: "command"i id "(" id? ")" ":" id "=" number ";"
+command_attribute: "timed"i -> timed_command
+command_attributes: command_attribute*
+command: command_attributes "command"i id "(" id? ")" ":" id "=" number ";"
 
 cluster: cluster_side "cluster"i id "=" number "{" (enum|event|attribute|struct|request_struct|response_struct|command)* "}"
 ?cluster_side: "server"i -> server_cluster

--- a/scripts/idl/matter_idl_parser.py
+++ b/scripts/idl/matter_idl_parser.py
@@ -100,6 +100,13 @@ class MatterIdlTransformer(Transformer):
     def endpoint_binding_to_cluster(self, _):
         return EndpointContentType.CLIENT_BINDING
 
+    def timed_command(self, _):
+        return CommandAttribute.TIMED_INVOKE
+
+    def command_attributes(self, attrs):
+        # List because attrs is a tuple
+        return set(list(attrs))
+
     def struct_field(self, args):
         # Last argument is the named_member, the rest
         # are attributes
@@ -114,12 +121,14 @@ class MatterIdlTransformer(Transformer):
         return ClusterSide.CLIENT
 
     def command(self, args):
-        # A command has 3 arguments if no input or
-        # 4 arguments if input parameter is available
+        # A command has 4 arguments if no input or
+        # 5 arguments if input parameter is available
         param_in = None
-        if len(args) > 3:
-            param_in = args[1]
-        return Command(name=args[0], input_param=param_in, output_param=args[-2], code=args[-1])
+        if len(args) > 4:
+            param_in = args[2]
+
+        return Command(
+            attributes=args[0], name=args[1], input_param=param_in, output_param=args[-2], code=args[-1])
 
     def event(self, args):
         return Event(priority=args[0], name=args[1], code=args[2], fields=args[3:], )

--- a/scripts/idl/matter_idl_types.py
+++ b/scripts/idl/matter_idl_types.py
@@ -9,6 +9,10 @@ class FieldAttribute(enum.Enum):
     NULLABLE = enum.auto()
 
 
+class CommandAttribute(enum.Enum):
+    TIMED_INVOKE = enum.auto()
+
+
 class AttributeTag(enum.Enum):
     READABLE = enum.auto()
     WRITABLE = enum.auto()
@@ -57,7 +61,7 @@ class Field:
 @dataclass
 class Attribute:
     definition: Field
-    tags: Set[AttributeTag] = field(default_factory=set())
+    tags: Set[AttributeTag] = field(default_factory=set)
 
     @property
     def is_readable(self):
@@ -106,6 +110,11 @@ class Command:
     code: int
     input_param: str
     output_param: str
+    attributes: Set[CommandAttribute] = field(default_factory=set)
+
+    @property
+    def is_timed_invoke(self):
+        return CommandAttribute.TIMED_INVOKE in self.attributes
 
 
 @dataclass

--- a/scripts/idl/test_matter_idl_parser.py
+++ b/scripts/idl/test_matter_idl_parser.py
@@ -152,6 +152,7 @@ class TestParser(unittest.TestCase):
 
                 command WithoutArg(): DefaultSuccess = 123;
                 command InOutStuff(InParam): OutParam = 222;
+                timed command TimedCommand(InParam): DefaultSuccess = 0xab;
             }
         """)
         expected = Idl(clusters=[
@@ -170,6 +171,9 @@ class TestParser(unittest.TestCase):
                                 input_param=None, output_param="DefaultSuccess"),
                         Command(name="InOutStuff", code=222,
                                 input_param="InParam", output_param="OutParam"),
+                        Command(name="TimedCommand", code=0xab,
+                                input_param="InParam", output_param="DefaultSuccess",
+                                attributes=set([CommandAttribute.TIMED_INVOKE])),
                     ],
                     )])
         self.assertEqual(actual, expected)

--- a/src/app/zap-templates/templates/app/MatterIDL.zapt
+++ b/src/app/zap-templates/templates/app/MatterIDL.zapt
@@ -77,7 +77,11 @@
   {{#first}}
 
   {{/first}}
-  command {{asUpperCamelCase name}}(
+  {{#if mustUseTimedInvoke}}
+  timed command
+  {{~else}}
+  command
+  {{~/if}} {{asUpperCamelCase name}}(
     {{~#if arguments~}}
        {{asUpperCamelCase name}}Request
     {{~/if~}}

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -85,9 +85,9 @@ client cluster AccountLogin = 1294 {
     CHAR_STRING setupPIN = 0;
   }
 
-  command GetSetupPINRequest(GetSetupPINRequestRequest): GetSetupPINResponse = 0;
+  timed command GetSetupPINRequest(GetSetupPINRequestRequest): GetSetupPINResponse = 0;
   command LoginRequest(LoginRequestRequest): DefaultSuccess = 2;
-  command LogoutRequest(): DefaultSuccess = 3;
+  timed command LogoutRequest(): DefaultSuccess = 3;
 }
 
 client cluster AdministratorCommissioning = 60 {
@@ -3055,7 +3055,7 @@ client cluster TestCluster = 1295 {
   command TestSpecific(): TestSpecificResponse = 2;
   command TestStructArgumentRequest(TestStructArgumentRequestRequest): BooleanResponse = 7;
   command TestUnknownCommand(): DefaultSuccess = 3;
-  command TimedInvokeRequest(): DefaultSuccess = 18;
+  timed command TimedInvokeRequest(): DefaultSuccess = 18;
 }
 
 client cluster Thermostat = 513 {


### PR DESCRIPTION
#### Problem
Timed command handling requires special consideration in code (we have a mustUseTimedInvoke helper). This parameter of a command is not visible in the IDL.

#### Change overview
Use `mustUseTimedInvoke` to add a separate tag to the IDL. make the IDL parse it.

#### Testing
Unit test updated.
