### PR TITLE
ESP32: Update ESP-IDF in CHIP to v4.4 release

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -42,13 +42,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -84,13 +84,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/ipv6only-app/esp32/README.md
+++ b/examples/ipv6only-app/esp32/README.md
@@ -21,13 +21,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/lighting-app/esp32/README.md
+++ b/examples/lighting-app/esp32/README.md
@@ -32,13 +32,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
         $ mkdir ${HOME}/tools
         $ cd ${HOME}/tools
         $ git clone https://github.com/espressif/esp-idf.git
         $ cd esp-idf
-        $ git checkout v4.4-beta1
+        $ git checkout v4.4
         $ git submodule update --init
         $ ./install.sh
 

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -24,13 +24,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -43,13 +43,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -36,13 +36,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -24,13 +24,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4-beta1 pre-release](https://github.com/espressif/esp-idf/releases/tag/v4.4-beta1)
+    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4-beta1
+          $ git checkout v4.4
           $ git submodule update --init
           $ ./install.sh
 

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v4.4-beta1 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.52 Version bump reason: add python packages to zap image, for use by the python control scripts
+0.5.53 Version bump reason: Update ESP-IDF to v4.4 release


### PR DESCRIPTION
#### Problem
CHIP uses ESP-IDF v4.4-beta1 pre-release. [ESP-IDF v4.4](https://github.com/espressif/esp-idf/releases/tag/v4.4) is released yesterday, so need to update to use that.

#### Change overview
- Update the documentation to use v4.4 release tag
- Update docker to use v4.4

#### Testing
- Compilation of esp32/all-clusters-app with ESP32 and ESP32-C3
- Commissioning and cluster control with ESP32 and ESP32-C3