### PR TITLE
[chip-tool] Add write-by-id, command-by-id and a custom payload builder

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -26,12 +26,34 @@
 class ClusterCommand : public ModelCommand, public chip::app::CommandSender::Callback
 {
 public:
+    ClusterCommand() : ModelCommand("command-by-id")
+    {
+        AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
+        AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
+        AddArgument("payload", &mPayload);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        ModelCommand::AddArguments();
+    }
+
+    ClusterCommand(chip::ClusterId clusterId) : ModelCommand("command-by-id"), mClusterId(clusterId)
+    {
+        AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
+        AddArgument("payload", &mPayload);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        ModelCommand::AddArguments();
+    }
+
     ClusterCommand(const char * commandName) : ModelCommand(commandName)
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
     }
 
     ~ClusterCommand() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return ClusterCommand::SendCommand(device, endpointId, mClusterId, mCommandId, mPayload);
+    }
 
     /////////// CommandSender Callback Interface /////////
     virtual void OnResponse(chip::app::CommandSender * client, const chip::app::ConcreteCommandPath & path,
@@ -84,7 +106,10 @@ public:
     }
 
 private:
+    chip::ClusterId mClusterId;
+    chip::CommandId mCommandId;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
 
+    CustomArgument mPayload;
     std::unique_ptr<chip::app::CommandSender> mCommandSender;
 };

--- a/examples/chip-tool/commands/clusters/CustomArgument.h
+++ b/examples/chip-tool/commands/clusters/CustomArgument.h
@@ -1,0 +1,232 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <lib/support/SafeInt.h>
+
+namespace {
+static constexpr char kPayloadHexPrefix[]                 = "hex:";
+static constexpr char kPayloadSignedPrefix[]              = "s:";
+static constexpr char kPayloadUnkPayloadSignedPrefix[]    = "u:";
+static constexpr size_t kPayloadHexPrefixLen              = ArraySize(kPayloadHexPrefix) - 1;              // ignore null character
+static constexpr size_t kPayloadSignedPrefixLen           = ArraySize(kPayloadSignedPrefix) - 1;           // ignore null character
+static constexpr size_t kPayloadUnkPayloadSignedPrefixLen = ArraySize(kPayloadUnkPayloadSignedPrefix) - 1; // ignore null character
+} // namespace
+
+class CustomArgumentParser
+{
+public:
+    static CHIP_ERROR Put(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        if (value.isObject())
+        {
+            return CustomArgumentParser::PutObject(writer, tag, value);
+        }
+
+        if (value.isArray())
+        {
+            return CustomArgumentParser::PutArray(writer, tag, value);
+        }
+
+        if (value.isString())
+        {
+            if (IsOctetString(value))
+            {
+                return CustomArgumentParser::PutOctetString(writer, tag, value);
+            }
+            else if (IsUnsignedNumberPrefix(value))
+            {
+                return CustomArgumentParser::PutUnsignedFromString(writer, tag, value);
+            }
+            else if (IsSignedNumberPrefix(value))
+            {
+                return CustomArgumentParser::PutSignedFromString(writer, tag, value);
+            }
+
+            return CustomArgumentParser::PutCharString(writer, tag, value);
+        }
+
+        if (value.isNull())
+        {
+            return chip::app::DataModel::Encode(*writer, tag, chip::app::DataModel::Nullable<uint8_t>());
+        }
+
+        if (value.isBool())
+        {
+            return chip::app::DataModel::Encode(*writer, tag, value.asBool());
+        }
+
+        if (value.isUInt())
+        {
+            return chip::app::DataModel::Encode(*writer, tag, value.asLargestUInt());
+        }
+
+        if (value.isInt())
+        {
+            return chip::app::DataModel::Encode(*writer, tag, value.asLargestInt());
+        }
+
+        if (value.isNumeric())
+        {
+            return chip::app::DataModel::Encode(*writer, tag, value.asDouble());
+        }
+
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+private:
+    static CHIP_ERROR PutArray(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        chip::TLV::TLVType outer;
+        ReturnErrorOnFailure(writer->StartContainer(tag, chip::TLV::kTLVType_Array, outer));
+
+        Json::ArrayIndex size = value.size();
+
+        for (Json::ArrayIndex i = 0; i < size; i++)
+        {
+            ReturnErrorOnFailure(CustomArgumentParser::Put(writer, chip::TLV::AnonymousTag(), value[i]));
+        }
+
+        return writer->EndContainer(outer);
+    }
+
+    static CHIP_ERROR PutObject(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        chip::TLV::TLVType outer;
+        ReturnErrorOnFailure(writer->StartContainer(tag, chip::TLV::kTLVType_Structure, outer));
+
+        for (auto const & id : value.getMemberNames())
+        {
+            auto index = std::stoul(id, nullptr, 0);
+            VerifyOrReturnError(chip::CanCastTo<uint8_t>(index), CHIP_ERROR_INVALID_ARGUMENT);
+            ReturnErrorOnFailure(CustomArgumentParser::Put(writer, chip::TLV::ContextTag(static_cast<uint8_t>(index)), value[id]));
+        }
+
+        return writer->EndContainer(outer);
+    }
+
+    static CHIP_ERROR PutOctetString(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        size_t size = strlen(value.asCString());
+        VerifyOrReturnError(size % 2 == 0, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+        chip::Platform::ScopedMemoryBuffer<uint8_t> buffer;
+        VerifyOrReturnError(buffer.Calloc(size / 2), CHIP_ERROR_NO_MEMORY);
+        size_t octetCount = chip::Encoding::HexToBytes(value.asCString() + kPayloadHexPrefixLen, size - kPayloadHexPrefixLen,
+                                                       buffer.Get(), (size - kPayloadHexPrefixLen) / 2);
+        VerifyOrReturnError(octetCount != 0, CHIP_ERROR_NO_MEMORY);
+
+        return chip::app::DataModel::Encode(*writer, tag, chip::ByteSpan(buffer.Get(), octetCount));
+    }
+
+    static CHIP_ERROR PutCharString(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        size_t size = strlen(value.asCString());
+
+        chip::Platform::ScopedMemoryBuffer<char> buffer;
+        VerifyOrReturnError(buffer.Calloc(size), CHIP_ERROR_NO_MEMORY);
+        strncpy(buffer.Get(), value.asCString(), size);
+
+        return chip::app::DataModel::Encode(*writer, tag, chip::CharSpan(buffer.Get(), size));
+    }
+
+    static CHIP_ERROR PutUnsignedFromString(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        size_t size = strlen(value.asCString());
+        char numberAsString[21];
+
+        chip::Platform::ScopedMemoryBuffer<char> buffer;
+        strncpy(numberAsString, value.asCString() + kPayloadUnkPayloadSignedPrefixLen, size - kPayloadUnkPayloadSignedPrefixLen);
+
+        auto numberAsUint = std::stoull(numberAsString, nullptr, 0);
+        return chip::app::DataModel::Encode(*writer, tag, static_cast<uint64_t>(numberAsUint));
+    }
+
+    static CHIP_ERROR PutSignedFromString(chip::TLV::TLVWriter * writer, chip::TLV::Tag tag, Json::Value & value)
+    {
+        size_t size = strlen(value.asCString());
+        char numberAsString[21];
+
+        chip::Platform::ScopedMemoryBuffer<char> buffer;
+        strncpy(numberAsString, value.asCString() + kPayloadSignedPrefixLen, size - kPayloadSignedPrefixLen);
+
+        auto numberAsInt = std::stoll(numberAsString, nullptr, 0);
+        return chip::app::DataModel::Encode(*writer, tag, static_cast<int64_t>(numberAsInt));
+    }
+
+    static bool IsOctetString(Json::Value & value)
+    {
+        return (strncmp(value.asCString(), kPayloadHexPrefix, kPayloadHexPrefixLen) == 0);
+    }
+
+    static bool IsUnsignedNumberPrefix(Json::Value & value)
+    {
+        return (strncmp(value.asCString(), kPayloadUnkPayloadSignedPrefix, kPayloadUnkPayloadSignedPrefixLen) == 0);
+    }
+
+    static bool IsSignedNumberPrefix(Json::Value & value)
+    {
+        return (strncmp(value.asCString(), kPayloadSignedPrefix, kPayloadSignedPrefixLen) == 0);
+    }
+};
+
+class CustomArgument
+{
+public:
+    ~CustomArgument()
+    {
+        if (mData != nullptr)
+        {
+            chip::Platform::MemoryFree(mData);
+        }
+    }
+
+    CHIP_ERROR Parse(const char * label, const char * json)
+    {
+        Json::Reader reader;
+        Json::Value value;
+        reader.parse(json, value);
+
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        chip::TLV::TLVWriter writer;
+        writer.Init(mData, mDataMaxLen);
+
+        ReturnErrorOnFailure(CustomArgumentParser::Put(&writer, chip::TLV::AnonymousTag(), value));
+
+        mDataLen = writer.GetLengthWritten();
+        return writer.Finalize();
+    }
+
+    CHIP_ERROR Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const
+    {
+        chip::TLV::TLVReader reader;
+        reader.Init(mData, mDataLen);
+        reader.Next();
+
+        return writer.CopyElement(tag, reader);
+    }
+
+private:
+    uint8_t * mData                       = nullptr;
+    uint32_t mDataLen                     = 0;
+    static constexpr uint32_t mDataMaxLen = 4096;
+};

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -26,12 +26,34 @@
 class WriteAttribute : public ModelCommand, public chip::app::WriteClient::Callback
 {
 public:
+    WriteAttribute() : ModelCommand("write-by-id")
+    {
+        AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("attribute-value", &mAttributeValue);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        ModelCommand::AddArguments();
+    }
+
+    WriteAttribute(chip::ClusterId clusterId) : ModelCommand("write-by-id"), mClusterId(clusterId)
+    {
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("attribute-value", &mAttributeValue);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        ModelCommand::AddArguments();
+    }
+
     WriteAttribute(const char * attributeName) : ModelCommand("write")
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
     }
 
     ~WriteAttribute() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, mClusterId, mAttributeId, mAttributeValue);
+    }
 
     /////////// WriteClient Callback Interface /////////
     void OnResponse(const chip::app::WriteClient * client, const chip::app::ConcreteAttributePath & path,
@@ -79,7 +101,10 @@ public:
     }
 
 private:
+    chip::ClusterId mClusterId;
+    chip::AttributeId mAttributeId;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
 
+    CustomArgument mAttributeValue;
     std::unique_ptr<chip::app::WriteClient> mWriteClient;
 };

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -188,6 +188,11 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
         return CHIP_NO_ERROR == complexArgument->Parse(arg.name, argValue);
     }
 
+    case ArgumentType::Custom: {
+        auto customArgument = static_cast<CustomArgument *>(arg.value);
+        return CHIP_NO_ERROR == customArgument->Parse(arg.name, argValue);
+    }
+
     case ArgumentType::Attribute: {
         if (arg.isOptional() || arg.isNullable())
         {
@@ -490,6 +495,17 @@ size_t Command::AddArgument(const char * name, ComplexArgument * value)
     arg.type  = ArgumentType::Complex;
     arg.name  = name;
     arg.value = static_cast<void *>(value);
+    arg.flags = 0;
+
+    return AddArgumentToList(std::move(arg));
+}
+
+size_t Command::AddArgument(const char * name, CustomArgument * value)
+{
+    Argument arg;
+    arg.type  = ArgumentType::Custom;
+    arg.name  = name;
+    arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
     arg.flags = 0;
 
     return AddArgumentToList(std::move(arg));

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -20,6 +20,7 @@
 
 #include <app/data-model/Nullable.h>
 #include <commands/clusters/ComplexArgument.h>
+#include <commands/clusters/CustomArgument.h>
 #include <controller/CHIPDeviceController.h>
 #include <inet/InetInterface.h>
 #include <lib/core/Optional.h>
@@ -67,7 +68,8 @@ enum ArgumentType
     OctetString,
     Attribute,
     Address,
-    Complex
+    Complex,
+    Custom
 };
 
 struct Argument
@@ -127,6 +129,7 @@ public:
     size_t AddArgument(const char * name, chip::Span<const char> * value, uint8_t flags = 0);
     size_t AddArgument(const char * name, AddressWithInterface * out, uint8_t flags = 0);
     size_t AddArgument(const char * name, ComplexArgument * value);
+    size_t AddArgument(const char * name, CustomArgument * value);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, uint8_t flags = 0)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean, flags);

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -115,6 +115,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         {{#chip_cluster_commands}}
         make_unique<{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}>(), //
         {{/chip_cluster_commands}}
@@ -125,6 +126,7 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
         {{#chip_server_cluster_attributes}}
         make_unique<ReadAttribute>(Id, "{{asDelimitedCommand (asUpperCamelCase name)}}", Attributes::{{asUpperCamelCase name}}::Id), //
         {{/chip_server_cluster_attributes}}
+        make_unique<WriteAttribute>(Id), //
         {{#chip_server_cluster_attributes}}
         {{! TODO: Various types (floats, structs) not supported here. }}
         {{#unless (isStrEqual chipCallback.name "Unsupported")}}
@@ -161,7 +163,9 @@ void registerClusterAny(Commands & commands)
     const char * clusterName = "Any";
 
     commands_list clusterCommands = {
+        make_unique<ClusterCommand>(),  //
         make_unique<ReadAttribute>(),   //
+        make_unique<WriteAttribute>(),  //
         make_unique<SubscribeAttribute>(), //
         make_unique<ReadEvent>(),       //
         make_unique<SubscribeEvent>(),     //

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -8612,6 +8612,7 @@ void registerClusterAccessControl(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -8620,6 +8621,7 @@ void registerClusterAccessControl(Commands & commands)
         make_unique<ReadAttribute>(Id, "extension", Attributes::Extension::Id),                   //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteAccessControlAcl>(),                                                     //
         make_unique<WriteAccessControlExtension>(),                                               //
         make_unique<SubscribeAttribute>(Id),                                                      //
@@ -8650,6 +8652,7 @@ void registerClusterAccountLogin(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),               //
         make_unique<AccountLoginGetSetupPINRequest>(), //
         make_unique<AccountLoginLoginRequest>(),       //
         make_unique<AccountLoginLogoutRequest>(),      //
@@ -8659,6 +8662,7 @@ void registerClusterAccountLogin(Commands & commands)
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
         make_unique<SubscribeAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id), //
@@ -8681,6 +8685,7 @@ void registerClusterAdministratorCommissioning(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                                       //
         make_unique<AdministratorCommissioningOpenBasicCommissioningWindow>(), //
         make_unique<AdministratorCommissioningOpenCommissioningWindow>(),      //
         make_unique<AdministratorCommissioningRevokeCommissioning>(),          //
@@ -8693,6 +8698,7 @@ void registerClusterAdministratorCommissioning(Commands & commands)
         make_unique<ReadAttribute>(Id, "admin-vendor-id", Attributes::AdminVendorId::Id),            //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "window-status", Attributes::WindowStatus::Id),          //
         make_unique<SubscribeAttribute>(Id, "admin-fabric-index", Attributes::AdminFabricIndex::Id), //
@@ -8718,6 +8724,7 @@ void registerClusterApplicationBasic(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -8732,6 +8739,7 @@ void registerClusterApplicationBasic(Commands & commands)
         make_unique<ReadAttribute>(Id, "allowed-vendor-list", Attributes::AllowedVendorList::Id),       //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),            //
+        make_unique<WriteAttribute>(Id),                                                                //
         make_unique<SubscribeAttribute>(Id),                                                            //
         make_unique<SubscribeAttribute>(Id, "vendor-name", Attributes::VendorName::Id),                 //
         make_unique<SubscribeAttribute>(Id, "vendor-id", Attributes::VendorId::Id),                     //
@@ -8762,6 +8770,7 @@ void registerClusterApplicationLauncher(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                    //
         make_unique<ApplicationLauncherHideAppRequest>(),   //
         make_unique<ApplicationLauncherLaunchAppRequest>(), //
         make_unique<ApplicationLauncherStopAppRequest>(),   //
@@ -8772,6 +8781,7 @@ void registerClusterApplicationLauncher(Commands & commands)
         make_unique<ReadAttribute>(Id, "application-launcher-list", Attributes::ApplicationLauncherList::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                           //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                       //
+        make_unique<WriteAttribute>(Id),                                                                           //
         make_unique<SubscribeAttribute>(Id),                                                                       //
         make_unique<SubscribeAttribute>(Id, "application-launcher-list", Attributes::ApplicationLauncherList::Id), //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                      //
@@ -8795,6 +8805,7 @@ void registerClusterAudioOutput(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),               //
         make_unique<AudioOutputRenameOutputRequest>(), //
         make_unique<AudioOutputSelectOutputRequest>(), //
         //
@@ -8805,6 +8816,7 @@ void registerClusterAudioOutput(Commands & commands)
         make_unique<ReadAttribute>(Id, "current-audio-output", Attributes::CurrentAudioOutput::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                 //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),             //
+        make_unique<WriteAttribute>(Id),                                                                 //
         make_unique<SubscribeAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id, "audio-output-list", Attributes::AudioOutputList::Id),       //
         make_unique<SubscribeAttribute>(Id, "current-audio-output", Attributes::CurrentAudioOutput::Id), //
@@ -8829,6 +8841,7 @@ void registerClusterBarrierControl(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                        //
         make_unique<BarrierControlBarrierControlGoToPercent>(), //
         make_unique<BarrierControlBarrierControlStop>(),        //
         //
@@ -8841,6 +8854,7 @@ void registerClusterBarrierControl(Commands & commands)
         make_unique<ReadAttribute>(Id, "barrier-position", Attributes::BarrierPosition::Id),               //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                   //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),               //
+        make_unique<WriteAttribute>(Id),                                                                   //
         make_unique<SubscribeAttribute>(Id),                                                               //
         make_unique<SubscribeAttribute>(Id, "barrier-moving-state", Attributes::BarrierMovingState::Id),   //
         make_unique<SubscribeAttribute>(Id, "barrier-safety-status", Attributes::BarrierSafetyStatus::Id), //
@@ -8867,6 +8881,7 @@ void registerClusterBasic(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -8892,6 +8907,7 @@ void registerClusterBasic(Commands & commands)
         make_unique<ReadAttribute>(Id, "unique-id", Attributes::UniqueID::Id),                                     //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                           //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                       //
+        make_unique<WriteAttribute>(Id),                                                                           //
         make_unique<WriteBasicNodeLabel>(),                                                                        //
         make_unique<WriteBasicLocation>(),                                                                         //
         make_unique<WriteBasicLocalConfigDisabled>(),                                                              //
@@ -8944,6 +8960,7 @@ void registerClusterBinaryInputBasic(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -8953,6 +8970,7 @@ void registerClusterBinaryInputBasic(Commands & commands)
         make_unique<ReadAttribute>(Id, "status-flags", Attributes::StatusFlags::Id),              //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteBinaryInputBasicOutOfService>(),                                         //
         make_unique<WriteBinaryInputBasicPresentValue>(),                                         //
         make_unique<SubscribeAttribute>(Id),                                                      //
@@ -8980,14 +8998,16 @@ void registerClusterBinding(Commands & commands)
         //
         // Commands
         //
-        make_unique<BindingBind>(),   //
-        make_unique<BindingUnbind>(), //
+        make_unique<ClusterCommand>(Id), //
+        make_unique<BindingBind>(),      //
+        make_unique<BindingUnbind>(),    //
         //
         // Attributes
         //
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
         make_unique<SubscribeAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id), //
@@ -9010,6 +9030,7 @@ void registerClusterBooleanState(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9017,6 +9038,7 @@ void registerClusterBooleanState(Commands & commands)
         make_unique<ReadAttribute>(Id, "state-value", Attributes::StateValue::Id),                //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "state-value", Attributes::StateValue::Id),           //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
@@ -9042,6 +9064,7 @@ void registerClusterBridgedActions(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                          //
         make_unique<BridgedActionsDisableAction>(),               //
         make_unique<BridgedActionsDisableActionWithDuration>(),   //
         make_unique<BridgedActionsEnableAction>(),                //
@@ -9063,6 +9086,7 @@ void registerClusterBridgedActions(Commands & commands)
         make_unique<ReadAttribute>(Id, "setup-url", Attributes::SetupUrl::Id),                    //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "action-list", Attributes::ActionList::Id),           //
         make_unique<SubscribeAttribute>(Id, "endpoint-list", Attributes::EndpointList::Id),       //
@@ -9092,12 +9116,14 @@ void registerClusterBridgedDeviceBasic(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
         make_unique<SubscribeAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id), //
@@ -9120,6 +9146,7 @@ void registerClusterChannel(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                    //
         make_unique<ChannelChangeChannelByNumberRequest>(), //
         make_unique<ChannelChangeChannelRequest>(),         //
         make_unique<ChannelSkipChannelRequest>(),           //
@@ -9130,6 +9157,7 @@ void registerClusterChannel(Commands & commands)
         make_unique<ReadAttribute>(Id, "channel-list", Attributes::ChannelList::Id),              //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "channel-list", Attributes::ChannelList::Id),         //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
@@ -9153,6 +9181,7 @@ void registerClusterColorControl(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                           //
         make_unique<ColorControlColorLoopSet>(),                   //
         make_unique<ColorControlEnhancedMoveHue>(),                //
         make_unique<ColorControlEnhancedMoveToHue>(),              //
@@ -9230,6 +9259,7 @@ void registerClusterColorControl(Commands & commands)
         make_unique<ReadAttribute>(Id, "start-up-color-temperature-mireds", Attributes::StartUpColorTemperatureMireds::Id),       //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                                      //
+        make_unique<WriteAttribute>(Id),                                                                                          //
         make_unique<WriteColorControlColorControlOptions>(),                                                                      //
         make_unique<WriteColorControlWhitePointX>(),                                                                              //
         make_unique<WriteColorControlWhitePointY>(),                                                                              //
@@ -9318,6 +9348,7 @@ void registerClusterContentLauncher(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                    //
         make_unique<ContentLauncherLaunchContentRequest>(), //
         make_unique<ContentLauncherLaunchURLRequest>(),     //
         //
@@ -9328,6 +9359,7 @@ void registerClusterContentLauncher(Commands & commands)
         make_unique<ReadAttribute>(Id, "supported-streaming-protocols", Attributes::SupportedStreamingProtocols::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                   //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                               //
+        make_unique<WriteAttribute>(Id),                                                                                   //
         make_unique<WriteContentLauncherSupportedStreamingProtocols>(),                                                    //
         make_unique<SubscribeAttribute>(Id),                                                                               //
         make_unique<SubscribeAttribute>(Id, "accept-header-list", Attributes::AcceptHeaderList::Id),                       //
@@ -9353,6 +9385,7 @@ void registerClusterDescriptor(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9363,6 +9396,7 @@ void registerClusterDescriptor(Commands & commands)
         make_unique<ReadAttribute>(Id, "parts-list", Attributes::PartsList::Id),                  //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "device-list", Attributes::DeviceList::Id),           //
         make_unique<SubscribeAttribute>(Id, "server-list", Attributes::ServerList::Id),           //
@@ -9389,12 +9423,14 @@ void registerClusterDiagnosticLogs(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                  //
         make_unique<DiagnosticLogsRetrieveLogsRequest>(), //
         //
         // Attributes
         //
         make_unique<ReadAttribute>(Id),                                                       //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),      //
+        make_unique<WriteAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id),                                                  //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id), //
         //
@@ -9416,6 +9452,7 @@ void registerClusterDoorLock(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),            //
         make_unique<DoorLockClearCredential>(),     //
         make_unique<DoorLockClearUser>(),           //
         make_unique<DoorLockGetCredentialStatus>(), //
@@ -9446,6 +9483,7 @@ void registerClusterDoorLock(Commands & commands)
         make_unique<ReadAttribute>(Id, "wrong-code-entry-limit", Attributes::WrongCodeEntryLimit::Id),                       //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                     //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                                 //
+        make_unique<WriteAttribute>(Id),                                                                                     //
         make_unique<WriteDoorLockLanguage>(),                                                                                //
         make_unique<WriteDoorLockAutoRelockTime>(),                                                                          //
         make_unique<WriteDoorLockSoundVolume>(),                                                                             //
@@ -9501,6 +9539,7 @@ void registerClusterElectricalMeasurement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9518,6 +9557,7 @@ void registerClusterElectricalMeasurement(Commands & commands)
         make_unique<ReadAttribute>(Id, "active-power-max", Attributes::ActivePowerMax::Id),          //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "measurement-type", Attributes::MeasurementType::Id),    //
         make_unique<SubscribeAttribute>(Id, "total-active-power", Attributes::TotalActivePower::Id), //
@@ -9551,6 +9591,7 @@ void registerClusterEthernetNetworkDiagnostics(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                      //
         make_unique<EthernetNetworkDiagnosticsResetCounts>(), //
         //
         // Attributes
@@ -9568,6 +9609,7 @@ void registerClusterEthernetNetworkDiagnostics(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "phyrate", Attributes::PHYRate::Id),                  //
         make_unique<SubscribeAttribute>(Id, "full-duplex", Attributes::FullDuplex::Id),           //
@@ -9600,6 +9642,7 @@ void registerClusterFixedLabel(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9607,6 +9650,7 @@ void registerClusterFixedLabel(Commands & commands)
         make_unique<ReadAttribute>(Id, "label-list", Attributes::LabelList::Id),                  //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "label-list", Attributes::LabelList::Id),             //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
@@ -9630,6 +9674,7 @@ void registerClusterFlowMeasurement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9640,6 +9685,7 @@ void registerClusterFlowMeasurement(Commands & commands)
         make_unique<ReadAttribute>(Id, "tolerance", Attributes::Tolerance::Id),                      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "measured-value", Attributes::MeasuredValue::Id),        //
         make_unique<SubscribeAttribute>(Id, "min-measured-value", Attributes::MinMeasuredValue::Id), //
@@ -9666,6 +9712,7 @@ void registerClusterGeneralCommissioning(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                          //
         make_unique<GeneralCommissioningArmFailSafe>(),           //
         make_unique<GeneralCommissioningCommissioningComplete>(), //
         make_unique<GeneralCommissioningSetRegulatoryConfig>(),   //
@@ -9679,6 +9726,7 @@ void registerClusterGeneralCommissioning(Commands & commands)
         make_unique<ReadAttribute>(Id, "location-capability", Attributes::LocationCapability::Id),                        //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                  //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                              //
+        make_unique<WriteAttribute>(Id),                                                                                  //
         make_unique<WriteGeneralCommissioningBreadcrumb>(),                                                               //
         make_unique<SubscribeAttribute>(Id),                                                                              //
         make_unique<SubscribeAttribute>(Id, "breadcrumb", Attributes::Breadcrumb::Id),                                    //
@@ -9706,6 +9754,7 @@ void registerClusterGeneralDiagnostics(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9720,6 +9769,7 @@ void registerClusterGeneralDiagnostics(Commands & commands)
         make_unique<ReadAttribute>(Id, "active-network-faults", Attributes::ActiveNetworkFaults::Id),          //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                       //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                   //
+        make_unique<WriteAttribute>(Id),                                                                       //
         make_unique<SubscribeAttribute>(Id),                                                                   //
         make_unique<SubscribeAttribute>(Id, "network-interfaces", Attributes::NetworkInterfaces::Id),          //
         make_unique<SubscribeAttribute>(Id, "reboot-count", Attributes::RebootCount::Id),                      //
@@ -9758,6 +9808,7 @@ void registerClusterGroupKeyManagement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                       //
         make_unique<GroupKeyManagementKeySetRead>(),           //
         make_unique<GroupKeyManagementKeySetReadAllIndices>(), //
         make_unique<GroupKeyManagementKeySetRemove>(),         //
@@ -9772,6 +9823,7 @@ void registerClusterGroupKeyManagement(Commands & commands)
         make_unique<ReadAttribute>(Id, "max-group-keys-per-fabric", Attributes::MaxGroupKeysPerFabric::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                         //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                     //
+        make_unique<WriteAttribute>(Id),                                                                         //
         make_unique<SubscribeAttribute>(Id),                                                                     //
         make_unique<SubscribeAttribute>(Id, "group-key-map", Attributes::GroupKeyMap::Id),                       //
         make_unique<SubscribeAttribute>(Id, "group-table", Attributes::GroupTable::Id),                          //
@@ -9798,6 +9850,7 @@ void registerClusterGroups(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),            //
         make_unique<GroupsAddGroup>(),              //
         make_unique<GroupsAddGroupIfIdentifying>(), //
         make_unique<GroupsGetGroupMembership>(),    //
@@ -9811,6 +9864,7 @@ void registerClusterGroups(Commands & commands)
         make_unique<ReadAttribute>(Id, "name-support", Attributes::NameSupport::Id),              //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "name-support", Attributes::NameSupport::Id),         //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
@@ -9834,6 +9888,7 @@ void registerClusterIdentify(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),      //
         make_unique<IdentifyIdentify>(),      //
         make_unique<IdentifyIdentifyQuery>(), //
         make_unique<IdentifyTriggerEffect>(), //
@@ -9845,6 +9900,7 @@ void registerClusterIdentify(Commands & commands)
         make_unique<ReadAttribute>(Id, "identify-type", Attributes::IdentifyType::Id),            //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteIdentifyIdentifyTime>(),                                                 //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "identify-time", Attributes::IdentifyTime::Id),       //
@@ -9870,6 +9926,7 @@ void registerClusterIlluminanceMeasurement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -9881,6 +9938,7 @@ void registerClusterIlluminanceMeasurement(Commands & commands)
         make_unique<ReadAttribute>(Id, "light-sensor-type", Attributes::LightSensorType::Id),        //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "measured-value", Attributes::MeasuredValue::Id),        //
         make_unique<SubscribeAttribute>(Id, "min-measured-value", Attributes::MinMeasuredValue::Id), //
@@ -9908,6 +9966,7 @@ void registerClusterKeypadInput(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),          //
         make_unique<KeypadInputSendKeyRequest>(), //
         //
         // Attributes
@@ -9915,6 +9974,7 @@ void registerClusterKeypadInput(Commands & commands)
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
         make_unique<SubscribeAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id), //
@@ -9937,6 +9997,7 @@ void registerClusterLevelControl(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                 //
         make_unique<LevelControlMove>(),                 //
         make_unique<LevelControlMoveToLevel>(),          //
         make_unique<LevelControlMoveToLevelWithOnOff>(), //
@@ -9966,6 +10027,7 @@ void registerClusterLevelControl(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                    //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                //
+        make_unique<WriteAttribute>(Id),                                                                    //
         make_unique<WriteLevelControlOptions>(),                                                            //
         make_unique<WriteLevelControlOnOffTransitionTime>(),                                                //
         make_unique<WriteLevelControlOnLevel>(),                                                            //
@@ -10010,6 +10072,7 @@ void registerClusterLocalizationConfiguration(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10017,6 +10080,7 @@ void registerClusterLocalizationConfiguration(Commands & commands)
         make_unique<ReadAttribute>(Id, "active-locale", Attributes::ActiveLocale::Id),              //
         make_unique<ReadAttribute>(Id, "supported-locales", Attributes::SupportedLocales::Id),      //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),        //
+        make_unique<WriteAttribute>(Id),                                                            //
         make_unique<WriteLocalizationConfigurationActiveLocale>(),                                  //
         make_unique<SubscribeAttribute>(Id),                                                        //
         make_unique<SubscribeAttribute>(Id, "active-locale", Attributes::ActiveLocale::Id),         //
@@ -10041,13 +10105,15 @@ void registerClusterLowPower(Commands & commands)
         //
         // Commands
         //
-        make_unique<LowPowerSleep>(), //
+        make_unique<ClusterCommand>(Id), //
+        make_unique<LowPowerSleep>(),    //
         //
         // Attributes
         //
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
         make_unique<SubscribeAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id), //
@@ -10070,6 +10136,7 @@ void registerClusterMediaInput(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                 //
         make_unique<MediaInputHideInputStatusRequest>(), //
         make_unique<MediaInputRenameInputRequest>(),     //
         make_unique<MediaInputSelectInputRequest>(),     //
@@ -10082,6 +10149,7 @@ void registerClusterMediaInput(Commands & commands)
         make_unique<ReadAttribute>(Id, "current-media-input", Attributes::CurrentMediaInput::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),               //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),           //
+        make_unique<WriteAttribute>(Id),                                                               //
         make_unique<SubscribeAttribute>(Id),                                                           //
         make_unique<SubscribeAttribute>(Id, "media-input-list", Attributes::MediaInputList::Id),       //
         make_unique<SubscribeAttribute>(Id, "current-media-input", Attributes::CurrentMediaInput::Id), //
@@ -10106,6 +10174,7 @@ void registerClusterMediaPlayback(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                 //
         make_unique<MediaPlaybackFastForwardRequest>(),  //
         make_unique<MediaPlaybackNextRequest>(),         //
         make_unique<MediaPlaybackPauseRequest>(),        //
@@ -10129,6 +10198,7 @@ void registerClusterMediaPlayback(Commands & commands)
         make_unique<ReadAttribute>(Id, "seek-range-start", Attributes::SeekRangeStart::Id),       //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "playback-state", Attributes::PlaybackState::Id),     //
         make_unique<SubscribeAttribute>(Id, "start-time", Attributes::StartTime::Id),             //
@@ -10157,6 +10227,7 @@ void registerClusterModeSelect(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),       //
         make_unique<ModeSelectChangeToMode>(), //
         //
         // Attributes
@@ -10169,6 +10240,7 @@ void registerClusterModeSelect(Commands & commands)
         make_unique<ReadAttribute>(Id, "description", Attributes::Description::Id),               //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteModeSelectOnMode>(),                                                     //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "current-mode", Attributes::CurrentMode::Id),         //
@@ -10197,6 +10269,7 @@ void registerClusterNetworkCommissioning(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                             //
         make_unique<NetworkCommissioningAddOrUpdateThreadNetwork>(), //
         make_unique<NetworkCommissioningAddOrUpdateWiFiNetwork>(),   //
         make_unique<NetworkCommissioningConnectNetwork>(),           //
@@ -10217,6 +10290,7 @@ void registerClusterNetworkCommissioning(Commands & commands)
         make_unique<ReadAttribute>(Id, "last-connect-error-value", Attributes::LastConnectErrorValue::Id),      //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                              //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                    //
+        make_unique<WriteAttribute>(Id),                                                                        //
         make_unique<WriteNetworkCommissioningInterfaceEnabled>(),                                               //
         make_unique<SubscribeAttribute>(Id),                                                                    //
         make_unique<SubscribeAttribute>(Id, "max-networks", Attributes::MaxNetworks::Id),                       //
@@ -10248,6 +10322,7 @@ void registerClusterOtaSoftwareUpdateProvider(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                             //
         make_unique<OtaSoftwareUpdateProviderApplyUpdateRequest>(),  //
         make_unique<OtaSoftwareUpdateProviderNotifyUpdateApplied>(), //
         make_unique<OtaSoftwareUpdateProviderQueryImage>(),          //
@@ -10257,6 +10332,7 @@ void registerClusterOtaSoftwareUpdateProvider(Commands & commands)
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
         make_unique<SubscribeAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id), //
@@ -10279,6 +10355,7 @@ void registerClusterOtaSoftwareUpdateRequestor(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                              //
         make_unique<OtaSoftwareUpdateRequestorAnnounceOtaProvider>(), //
         //
         // Attributes
@@ -10290,6 +10367,7 @@ void registerClusterOtaSoftwareUpdateRequestor(Commands & commands)
         make_unique<ReadAttribute>(Id, "update-state-progress", Attributes::UpdateStateProgress::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                   //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),               //
+        make_unique<WriteAttribute>(Id),                                                                   //
         make_unique<WriteOtaSoftwareUpdateRequestorDefaultOtaProviders>(),                                 //
         make_unique<SubscribeAttribute>(Id),                                                               //
         make_unique<SubscribeAttribute>(Id, "default-ota-providers", Attributes::DefaultOtaProviders::Id), //
@@ -10323,6 +10401,7 @@ void registerClusterOccupancySensing(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10332,6 +10411,7 @@ void registerClusterOccupancySensing(Commands & commands)
         make_unique<ReadAttribute>(Id, "occupancy-sensor-type-bitmap", Attributes::OccupancySensorTypeBitmap::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                            //
+        make_unique<WriteAttribute>(Id),                                                                                //
         make_unique<SubscribeAttribute>(Id),                                                                            //
         make_unique<SubscribeAttribute>(Id, "occupancy", Attributes::Occupancy::Id),                                    //
         make_unique<SubscribeAttribute>(Id, "occupancy-sensor-type", Attributes::OccupancySensorType::Id),              //
@@ -10357,6 +10437,7 @@ void registerClusterOnOff(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),             //
         make_unique<OnOffOff>(),                     //
         make_unique<OnOffOffWithEffect>(),           //
         make_unique<OnOffOn>(),                      //
@@ -10375,6 +10456,7 @@ void registerClusterOnOff(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                 //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                       //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),             //
+        make_unique<WriteAttribute>(Id),                                                                 //
         make_unique<WriteOnOffOnTime>(),                                                                 //
         make_unique<WriteOnOffOffWaitTime>(),                                                            //
         make_unique<WriteOnOffStartUpOnOff>(),                                                           //
@@ -10406,6 +10488,7 @@ void registerClusterOnOffSwitchConfiguration(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10414,6 +10497,7 @@ void registerClusterOnOffSwitchConfiguration(Commands & commands)
         make_unique<ReadAttribute>(Id, "switch-actions", Attributes::SwitchActions::Id),          //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteOnOffSwitchConfigurationSwitchActions>(),                                //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "switch-type", Attributes::SwitchType::Id),           //
@@ -10439,6 +10523,7 @@ void registerClusterOperationalCredentials(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                                   //
         make_unique<OperationalCredentialsAddNOC>(),                       //
         make_unique<OperationalCredentialsAddTrustedRootCertificate>(),    //
         make_unique<OperationalCredentialsAttestationRequest>(),           //
@@ -10460,6 +10545,7 @@ void registerClusterOperationalCredentials(Commands & commands)
         make_unique<ReadAttribute>(Id, "current-fabric-index", Attributes::CurrentFabricIndex::Id),                //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                           //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                       //
+        make_unique<WriteAttribute>(Id),                                                                           //
         make_unique<SubscribeAttribute>(Id),                                                                       //
         make_unique<SubscribeAttribute>(Id, "nocs", Attributes::NOCs::Id),                                         //
         make_unique<SubscribeAttribute>(Id, "fabrics-list", Attributes::FabricsList::Id),                          //
@@ -10488,6 +10574,7 @@ void registerClusterPowerSource(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10504,6 +10591,7 @@ void registerClusterPowerSource(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                           //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                                 //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                       //
+        make_unique<WriteAttribute>(Id),                                                                           //
         make_unique<SubscribeAttribute>(Id),                                                                       //
         make_unique<SubscribeAttribute>(Id, "status", Attributes::Status::Id),                                     //
         make_unique<SubscribeAttribute>(Id, "order", Attributes::Order::Id),                                       //
@@ -10536,6 +10624,7 @@ void registerClusterPowerSourceConfiguration(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10543,6 +10632,7 @@ void registerClusterPowerSourceConfiguration(Commands & commands)
         make_unique<ReadAttribute>(Id, "sources", Attributes::Sources::Id),                       //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "sources", Attributes::Sources::Id),                  //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),     //
@@ -10566,6 +10656,7 @@ void registerClusterPressureMeasurement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10575,6 +10666,7 @@ void registerClusterPressureMeasurement(Commands & commands)
         make_unique<ReadAttribute>(Id, "max-measured-value", Attributes::MaxMeasuredValue::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "measured-value", Attributes::MeasuredValue::Id),        //
         make_unique<SubscribeAttribute>(Id, "min-measured-value", Attributes::MinMeasuredValue::Id), //
@@ -10600,6 +10692,7 @@ void registerClusterPumpConfigurationAndControl(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10631,6 +10724,7 @@ void registerClusterPumpConfigurationAndControl(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                         //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                               //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                     //
+        make_unique<WriteAttribute>(Id),                                                                         //
         make_unique<WritePumpConfigurationAndControlLifetimeRunningHours>(),                                     //
         make_unique<WritePumpConfigurationAndControlLifetimeEnergyConsumed>(),                                   //
         make_unique<WritePumpConfigurationAndControlOperationMode>(),                                            //
@@ -10716,6 +10810,7 @@ void registerClusterRelativeHumidityMeasurement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10726,6 +10821,7 @@ void registerClusterRelativeHumidityMeasurement(Commands & commands)
         make_unique<ReadAttribute>(Id, "tolerance", Attributes::Tolerance::Id),                      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "measured-value", Attributes::MeasuredValue::Id),        //
         make_unique<SubscribeAttribute>(Id, "min-measured-value", Attributes::MinMeasuredValue::Id), //
@@ -10752,6 +10848,7 @@ void registerClusterScenes(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),         //
         make_unique<ScenesAddScene>(),           //
         make_unique<ScenesGetSceneMembership>(), //
         make_unique<ScenesRecallScene>(),        //
@@ -10770,6 +10867,7 @@ void registerClusterScenes(Commands & commands)
         make_unique<ReadAttribute>(Id, "name-support", Attributes::NameSupport::Id),              //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),          //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "scene-count", Attributes::SceneCount::Id),           //
         make_unique<SubscribeAttribute>(Id, "current-scene", Attributes::CurrentScene::Id),       //
@@ -10797,6 +10895,7 @@ void registerClusterSoftwareDiagnostics(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                   //
         make_unique<SoftwareDiagnosticsResetWatermarks>(), //
         //
         // Attributes
@@ -10809,6 +10908,7 @@ void registerClusterSoftwareDiagnostics(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                              //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                                    //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                          //
+        make_unique<WriteAttribute>(Id),                                                                              //
         make_unique<SubscribeAttribute>(Id),                                                                          //
         make_unique<SubscribeAttribute>(Id, "thread-metrics", Attributes::ThreadMetrics::Id),                         //
         make_unique<SubscribeAttribute>(Id, "current-heap-free", Attributes::CurrentHeapFree::Id),                    //
@@ -10838,6 +10938,7 @@ void registerClusterSwitch(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10848,6 +10949,7 @@ void registerClusterSwitch(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),               //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                     //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),           //
+        make_unique<WriteAttribute>(Id),                                                               //
         make_unique<SubscribeAttribute>(Id),                                                           //
         make_unique<SubscribeAttribute>(Id, "number-of-positions", Attributes::NumberOfPositions::Id), //
         make_unique<SubscribeAttribute>(Id, "current-position", Attributes::CurrentPosition::Id),      //
@@ -10888,6 +10990,7 @@ void registerClusterTargetNavigator(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                     //
         make_unique<TargetNavigatorNavigateTargetRequest>(), //
         //
         // Attributes
@@ -10897,6 +11000,7 @@ void registerClusterTargetNavigator(Commands & commands)
         make_unique<ReadAttribute>(Id, "current-navigator-target", Attributes::CurrentNavigatorTarget::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                         //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                     //
+        make_unique<WriteAttribute>(Id),                                                                         //
         make_unique<SubscribeAttribute>(Id),                                                                     //
         make_unique<SubscribeAttribute>(Id, "target-navigator-list", Attributes::TargetNavigatorList::Id),       //
         make_unique<SubscribeAttribute>(Id, "current-navigator-target", Attributes::CurrentNavigatorTarget::Id), //
@@ -10921,6 +11025,7 @@ void registerClusterTemperatureMeasurement(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -10931,6 +11036,7 @@ void registerClusterTemperatureMeasurement(Commands & commands)
         make_unique<ReadAttribute>(Id, "tolerance", Attributes::Tolerance::Id),                      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),             //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),         //
+        make_unique<WriteAttribute>(Id),                                                             //
         make_unique<SubscribeAttribute>(Id),                                                         //
         make_unique<SubscribeAttribute>(Id, "measured-value", Attributes::MeasuredValue::Id),        //
         make_unique<SubscribeAttribute>(Id, "min-measured-value", Attributes::MinMeasuredValue::Id), //
@@ -10957,6 +11063,7 @@ void registerClusterTestCluster(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                                   //
         make_unique<TestClusterSimpleStructEchoRequest>(),                 //
         make_unique<TestClusterTest>(),                                    //
         make_unique<TestClusterTestAddArguments>(),                        //
@@ -11061,6 +11168,7 @@ void registerClusterTestCluster(Commands & commands)
         make_unique<ReadAttribute>(Id, "nullable-range-restricted-int16s", Attributes::NullableRangeRestrictedInt16s::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                        //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                                    //
+        make_unique<WriteAttribute>(Id),                                                                                        //
         make_unique<WriteTestClusterBoolean>(),                                                                                 //
         make_unique<WriteTestClusterBitmap8>(),                                                                                 //
         make_unique<WriteTestClusterBitmap16>(),                                                                                //
@@ -11245,6 +11353,7 @@ void registerClusterThermostat(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),              //
         make_unique<ThermostatClearWeeklySchedule>(), //
         make_unique<ThermostatGetRelayStatusLog>(),   //
         make_unique<ThermostatGetWeeklySchedule>(),   //
@@ -11274,6 +11383,7 @@ void registerClusterThermostat(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                  //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                                        //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                              //
+        make_unique<WriteAttribute>(Id),                                                                                  //
         make_unique<WriteThermostatOccupiedCoolingSetpoint>(),                                                            //
         make_unique<WriteThermostatOccupiedHeatingSetpoint>(),                                                            //
         make_unique<WriteThermostatMinHeatSetpointLimit>(),                                                               //
@@ -11323,6 +11433,7 @@ void registerClusterThermostatUserInterfaceConfiguration(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -11332,6 +11443,7 @@ void registerClusterThermostatUserInterfaceConfiguration(Commands & commands)
         make_unique<ReadAttribute>(Id, "schedule-programming-visibility", Attributes::ScheduleProgrammingVisibility::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                       //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                                   //
+        make_unique<WriteAttribute>(Id),                                                                                       //
         make_unique<WriteThermostatUserInterfaceConfigurationTemperatureDisplayMode>(),                                        //
         make_unique<WriteThermostatUserInterfaceConfigurationKeypadLockout>(),                                                 //
         make_unique<WriteThermostatUserInterfaceConfigurationScheduleProgrammingVisibility>(),                                 //
@@ -11360,6 +11472,7 @@ void registerClusterThreadNetworkDiagnostics(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                    //
         make_unique<ThreadNetworkDiagnosticsResetCounts>(), //
         //
         // Attributes
@@ -11432,6 +11545,7 @@ void registerClusterThreadNetworkDiagnostics(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                     //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                                           //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                                 //
+        make_unique<WriteAttribute>(Id),                                                                                     //
         make_unique<SubscribeAttribute>(Id),                                                                                 //
         make_unique<SubscribeAttribute>(Id, "channel", Attributes::Channel::Id),                                             //
         make_unique<SubscribeAttribute>(Id, "routing-role", Attributes::RoutingRole::Id),                                    //
@@ -11521,6 +11635,7 @@ void registerClusterTimeFormatLocalization(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -11529,6 +11644,7 @@ void registerClusterTimeFormatLocalization(Commands & commands)
         make_unique<ReadAttribute>(Id, "active-calendar-type", Attributes::ActiveCalendarType::Id),              //
         make_unique<ReadAttribute>(Id, "supported-calendar-types", Attributes::SupportedCalendarTypes::Id),      //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                     //
+        make_unique<WriteAttribute>(Id),                                                                         //
         make_unique<WriteTimeFormatLocalizationHourFormat>(),                                                    //
         make_unique<WriteTimeFormatLocalizationActiveCalendarType>(),                                            //
         make_unique<SubscribeAttribute>(Id),                                                                     //
@@ -11555,6 +11671,7 @@ void registerClusterUnitLocalization(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -11562,6 +11679,7 @@ void registerClusterUnitLocalization(Commands & commands)
         make_unique<ReadAttribute>(Id, "temperature-unit", Attributes::TemperatureUnit::Id),      //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteUnitLocalizationTemperatureUnit>(),                                      //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "temperature-unit", Attributes::TemperatureUnit::Id), //
@@ -11586,12 +11704,14 @@ void registerClusterUserLabel(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
         make_unique<ReadAttribute>(Id),                                                           //
         make_unique<ReadAttribute>(Id, "label-list", Attributes::LabelList::Id),                  //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),      //
+        make_unique<WriteAttribute>(Id),                                                          //
         make_unique<WriteUserLabelLabelList>(),                                                   //
         make_unique<SubscribeAttribute>(Id),                                                      //
         make_unique<SubscribeAttribute>(Id, "label-list", Attributes::LabelList::Id),             //
@@ -11615,6 +11735,7 @@ void registerClusterWakeOnLan(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id), //
         //
         // Attributes
         //
@@ -11622,6 +11743,7 @@ void registerClusterWakeOnLan(Commands & commands)
         make_unique<ReadAttribute>(Id, "wake-on-lan-mac-address", Attributes::WakeOnLanMacAddress::Id),      //
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                     //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                 //
+        make_unique<WriteAttribute>(Id),                                                                     //
         make_unique<SubscribeAttribute>(Id),                                                                 //
         make_unique<SubscribeAttribute>(Id, "wake-on-lan-mac-address", Attributes::WakeOnLanMacAddress::Id), //
         make_unique<SubscribeAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                //
@@ -11645,6 +11767,7 @@ void registerClusterWiFiNetworkDiagnostics(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                  //
         make_unique<WiFiNetworkDiagnosticsResetCounts>(), //
         //
         // Attributes
@@ -11666,6 +11789,7 @@ void registerClusterWiFiNetworkDiagnostics(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                          //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                                //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                      //
+        make_unique<WriteAttribute>(Id),                                                                          //
         make_unique<SubscribeAttribute>(Id),                                                                      //
         make_unique<SubscribeAttribute>(Id, "bssid", Attributes::Bssid::Id),                                      //
         make_unique<SubscribeAttribute>(Id, "security-type", Attributes::SecurityType::Id),                       //
@@ -11708,6 +11832,7 @@ void registerClusterWindowCovering(Commands & commands)
         //
         // Commands
         //
+        make_unique<ClusterCommand>(Id),                 //
         make_unique<WindowCoveringDownOrClose>(),        //
         make_unique<WindowCoveringGoToLiftPercentage>(), //
         make_unique<WindowCoveringGoToLiftValue>(),      //
@@ -11740,6 +11865,7 @@ void registerClusterWindowCovering(Commands & commands)
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id),                                         //
         make_unique<ReadAttribute>(Id, "feature-map", Attributes::FeatureMap::Id),                                               //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id),                                     //
+        make_unique<WriteAttribute>(Id),                                                                                         //
         make_unique<WriteWindowCoveringMode>(),                                                                                  //
         make_unique<SubscribeAttribute>(Id),                                                                                     //
         make_unique<SubscribeAttribute>(Id, "type", Attributes::Type::Id),                                                       //
@@ -11782,7 +11908,9 @@ void registerClusterAny(Commands & commands)
     const char * clusterName = "Any";
 
     commands_list clusterCommands = {
+        make_unique<ClusterCommand>(),     //
         make_unique<ReadAttribute>(),      //
+        make_unique<WriteAttribute>(),     //
         make_unique<SubscribeAttribute>(), //
         make_unique<ReadEvent>(),          //
         make_unique<SubscribeEvent>(),     //


### PR DESCRIPTION
#### Problem

`chip-tool` can not issue commands to cluster or commands that are not enabled into the `zap` file.
This PR exposes adds `command-by-id` and `write-by-id` that lets you build commands from the command line directly.

As an example one could do: 
```
$ ./out/debug/standalone/chip-tool onoff write-by-id 0x0 '"u:5"' 0x12345 1 # You need "u:" to specify that it is an unsigned
or much more complex such as:
$ ./out/debug/standalone/chip-tool testcluster write-by-id 0x8000 '[{"255": "2"}, {"1": "hex:0000010202", "3": {"4": [1, 2, 3, {"1": "foo"]} }]' 0x12345 1
```

#### Change overview
 * Add `command-by-id`
 * Add `write-by-id`
 * Add a custom payload parser that allow building a payload directly from a json-like value on the command line

#### Testing
I have manually validated that those commands are properly generated and does what is expected. Not as good as building some YAMLs tests but I still need to convert the YAML framework to uses delegates instead of `Invoke` like calls that strongly typed in order to add some tests...