### PR TITLE
[chip-tool] Replace 'ReportAttribute' by 'ReportEvent' when using rea…

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -291,8 +291,7 @@ public:
     {
         ChipLogProgress(chipTool, "Sending ReadEvent to cluster " ChipLogFormatMEI " on endpoint %" PRIu16,
                         ChipLogValueMEI(mClusterId), endpointId);
-        return ReportCommand::ReportAttribute(device, endpointId, mClusterId, mEventId,
-                                              chip::app::ReadClient::InteractionType::Read);
+        return ReportCommand::ReportEvent(device, endpointId, mClusterId, mEventId, chip::app::ReadClient::InteractionType::Read);
     }
 
 private:


### PR DESCRIPTION
…d-event otherwise it does returns attributes

#### Problem

I have made a typo when landing wildcards. `read-event` is calling `ReportAttribute` instead of `ReadEvent`...
