### PR TITLE
Set ICAC to nullable to align with spec

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2086,7 +2086,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -548,7 +548,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/door-lock-app/door-lock-common/door-lock-app.matter
+++ b/examples/door-lock-app/door-lock-common/door-lock-app.matter
@@ -776,7 +776,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1080,7 +1080,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -472,7 +472,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -276,7 +276,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -382,7 +382,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -521,7 +521,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -541,7 +541,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -437,7 +437,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -686,7 +686,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -1333,7 +1333,7 @@ client cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {
@@ -1431,7 +1431,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1854,7 +1854,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -458,7 +458,7 @@ server cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -112,8 +112,15 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadNOCs(EndpointId endpoint, Attri
 
             if (accessingFabricIndex == fabricInfo.GetFabricIndex())
             {
+                ByteSpan icac;
+
                 ReturnErrorOnFailure(fabricInfo.GetNOCCert(noc.noc));
-                ReturnErrorOnFailure(fabricInfo.GetICACert(noc.icac));
+                ReturnErrorOnFailure(fabricInfo.GetICACert(icac));
+
+                if (!icac.empty())
+                {
+                    noc.icac.SetNonNull(icac);
+                }
             }
 
             ReturnErrorOnFailure(encoder.Encode(noc));

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -45,7 +45,7 @@ limitations under the License.
     <cluster code="0x003E"/>
     <item name="FabricIndex" type="fabric_idx"/>
     <item name="NOC" type="OCTET_STRING"/>
-    <item name="ICAC" type="OCTET_STRING"/>    
+    <item name="ICAC" type="OCTET_STRING" isNullable="true"/>    
   </struct>
 
   <cluster>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2306,7 +2306,7 @@ client cluster OperationalCredentials = 62 {
   struct NOCStruct {
     fabric_idx fabricIndex = 0;
     OCTET_STRING noc = 1;
-    OCTET_STRING icac = 2;
+    nullable OCTET_STRING icac = 2;
   }
 
   struct FabricDescriptor {

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -6849,10 +6849,17 @@ void CHIPOperationalCredentialsNOCsAttributeCallback::CallbackFn(
                                 reinterpret_cast<const jbyte *>(entry_0.noc.data()));
         newElement_0_noc = newElement_0_nocByteArray;
         jobject newElement_0_icac;
-        jbyteArray newElement_0_icacByteArray = env->NewByteArray(static_cast<jsize>(entry_0.icac.size()));
-        env->SetByteArrayRegion(newElement_0_icacByteArray, 0, static_cast<jsize>(entry_0.icac.size()),
-                                reinterpret_cast<const jbyte *>(entry_0.icac.data()));
-        newElement_0_icac = newElement_0_icacByteArray;
+        if (entry_0.icac.IsNull())
+        {
+            newElement_0_icac = nullptr;
+        }
+        else
+        {
+            jbyteArray newElement_0_icacByteArray = env->NewByteArray(static_cast<jsize>(entry_0.icac.Value().size()));
+            env->SetByteArrayRegion(newElement_0_icacByteArray, 0, static_cast<jsize>(entry_0.icac.Value().size()),
+                                    reinterpret_cast<const jbyte *>(entry_0.icac.Value().data()));
+            newElement_0_icac = newElement_0_icacByteArray;
+        }
 
         jclass NOCStructStructClass;
         err = chip::JniReferences::GetInstance().GetClassRef(

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
@@ -1175,9 +1175,10 @@ public class ChipStructs {
   public static class OperationalCredentialsClusterNOCStruct {
     public Integer fabricIndex;
     public byte[] noc;
-    public byte[] icac;
+    public @Nullable byte[] icac;
 
-    public OperationalCredentialsClusterNOCStruct(Integer fabricIndex, byte[] noc, byte[] icac) {
+    public OperationalCredentialsClusterNOCStruct(
+        Integer fabricIndex, byte[] noc, @Nullable byte[] icac) {
       this.fabricIndex = fabricIndex;
       this.noc = noc;
       this.icac = icac;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -12671,12 +12671,12 @@ class OperationalCredentials(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=0, Type=uint),
                             ClusterObjectFieldDescriptor(Label="noc", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="icac", Tag=2, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="icac", Tag=2, Type=typing.Union[Nullable, bytes]),
                     ])
 
             fabricIndex: 'uint' = 0
             noc: 'bytes' = b""
-            icac: 'bytes' = b""
+            icac: 'typing.Union[Nullable, bytes]' = NullValue
 
 
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -5004,7 +5004,11 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 newElement_0 = [CHIPOperationalCredentialsClusterNOCStruct new];
                 newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
                 newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
-                newElement_0.icac = [NSData dataWithBytes:entry_0.icac.data() length:entry_0.icac.size()];
+                if (entry_0.icac.IsNull()) {
+                    newElement_0.icac = nil;
+                } else {
+                    newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+                }
                 [array_0 addObject:newElement_0];
             }
             { // Scope for the error so we will know what it's named

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -3493,7 +3493,11 @@ void CHIPOperationalCredentialsNOCsListAttributeCallbackBridge::OnSuccessFn(void
         newElement_0 = [CHIPOperationalCredentialsClusterNOCStruct new];
         newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
         newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
-        newElement_0.icac = [NSData dataWithBytes:entry_0.icac.data() length:entry_0.icac.size()];
+        if (entry_0.icac.IsNull()) {
+            newElement_0.icac = nil;
+        } else {
+            newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+        }
         [array_0 addObject:newElement_0];
     }
     { // Scope for the error so we will know what it's named

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -252,7 +252,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPOperationalCredentialsClusterNOCStruct : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @property (strong, nonatomic) NSData * _Nonnull noc;
-@property (strong, nonatomic) NSData * _Nonnull icac;
+@property (strong, nonatomic) NSData * _Nullable icac;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -506,7 +506,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _noc = [NSData data];
 
-        _icac = [NSData data];
+        _icac = nil;
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -6761,7 +6761,12 @@ using namespace chip::app::Clusters;
                         auto element_0 = (CHIPOperationalCredentialsClusterNOCStruct *) value[i_0];
                         listHolder_0->mList[i_0].fabricIndex = element_0.fabricIndex.unsignedCharValue;
                         listHolder_0->mList[i_0].noc = [self asByteSpan:element_0.noc];
-                        listHolder_0->mList[i_0].icac = [self asByteSpan:element_0.icac];
+                        if (element_0.icac == nil) {
+                            listHolder_0->mList[i_0].icac.SetNull();
+                        } else {
+                            auto & nonNullValue_2 = listHolder_0->mList[i_0].icac.SetNonNull();
+                            nonNullValue_2 = [self asByteSpan:element_0.icac];
+                        }
                     }
                     cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -14695,7 +14695,7 @@ struct Type
 public:
     chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
     chip::ByteSpan noc;
-    chip::ByteSpan icac;
+    DataModel::Nullable<chip::ByteSpan> icac;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* If no ICAC is present in the chain, this field SHALL be set to null per spec

* Fixes #13769

#### Change overview
Set ICAC to nullable to align with spec

#### Testing
How was this tested? (at least one bullet point required)
* yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool operationalcredentials read nocs 12344321 0
....
[1643298865.210951][573608:573613] CHIP:DMG: ReportDataMessage =
[1643298865.210956][573608:573613] CHIP:DMG: {
[1643298865.210961][573608:573613] CHIP:DMG: 	AttributeReportIBs =
[1643298865.210969][573608:573613] CHIP:DMG: 	[
[1643298865.210975][573608:573613] CHIP:DMG: 		AttributeReportIB =
[1643298865.210983][573608:573613] CHIP:DMG: 		{
[1643298865.210989][573608:573613] CHIP:DMG: 			AttributeDataIB =
[1643298865.210996][573608:573613] CHIP:DMG: 			{
[1643298865.211003][573608:573613] CHIP:DMG: 				DataVersion = 0x0,
[1643298865.211011][573608:573613] CHIP:DMG: 				AttributePathIB =
[1643298865.211019][573608:573613] CHIP:DMG: 				{
[1643298865.211027][573608:573613] CHIP:DMG: 					Endpoint = 0x0,
[1643298865.211035][573608:573613] CHIP:DMG: 					Cluster = 0x3e,
[1643298865.211043][573608:573613] CHIP:DMG: 					Attribute = 0x0000_0000,
[1643298865.211050][573608:573613] CHIP:DMG: 				}
[1643298865.211058][573608:573613] CHIP:DMG: 					
[1643298865.211065][573608:573613] CHIP:DMG: 					Data = [
[1643298865.211072][573608:573613] CHIP:DMG: 						
[1643298865.211079][573608:573613] CHIP:DMG: 					],
[1643298865.211085][573608:573613] CHIP:DMG: 			},
[1643298865.211093][573608:573613] CHIP:DMG: 			
[1643298865.211098][573608:573613] CHIP:DMG: 		},
[1643298865.211110][573608:573613] CHIP:DMG: 		
[1643298865.211128][573608:573613] CHIP:DMG: 		AttributeReportIB =
[1643298865.211176][573608:573613] CHIP:DMG: 		{
[1643298865.211181][573608:573613] CHIP:DMG: 			AttributeDataIB =
[1643298865.211187][573608:573613] CHIP:DMG: 			{
[1643298865.211193][573608:573613] CHIP:DMG: 				DataVersion = 0x0,
[1643298865.211198][573608:573613] CHIP:DMG: 				AttributePathIB =
[1643298865.211205][573608:573613] CHIP:DMG: 				{
[1643298865.211211][573608:573613] CHIP:DMG: 					Endpoint = 0x0,
[1643298865.211218][573608:573613] CHIP:DMG: 					Cluster = 0x3e,
[1643298865.211226][573608:573613] CHIP:DMG: 					Attribute = 0x0000_0000,
[1643298865.211234][573608:573613] CHIP:DMG: 					ListIndex = Null,
[1643298865.211242][573608:573613] CHIP:DMG: 				}
[1643298865.211250][573608:573613] CHIP:DMG: 					
[1643298865.211257][573608:573613] CHIP:DMG: 					Data = 
[1643298865.211265][573608:573613] CHIP:DMG: 					{
[1643298865.211272][573608:573613] CHIP:DMG: 						0x0 = 1, 
[1643298865.211281][573608:573613] CHIP:DMG: 						0x1 = [
[1643298865.211298][573608:573613] CHIP:DMG: 							0x15, 0x30, 0x1, 0x1, 0x1, 0x24, 0x2, 0x1, 0x37, 0x3, 0x24, 0x13, 0x1, 0x18, 0x26, 0x4, 0x80, 0x22, 0x81, 0x27, 0x26, 0x5, 0x80, 0x25, 0x4d, 0x3a, 0x37, 0x6, 0x24, 0x15, 0x1, 0x26, 0x11, 0x1, 0x5c, 0xbc, 0x0, 0x18, 0x24, 0x7, 0x1, 0x24, 0x8, 0x1, 0
[1643298865.211308][573608:573613] CHIP:DMG: 						]
[1643298865.211316][573608:573613] CHIP:DMG: 						0x2 = [
[1643298865.211333][573608:573613] CHIP:DMG: 							0x15, 0x30, 0x1, 0x1, 0x0, 0x24, 0x2, 0x1, 0x37, 0x3, 0x24, 0x14, 0x0, 0x18, 0x26, 0x4, 0x80, 0x22, 0x81, 0x27, 0x26, 0x5, 0x80, 0x25, 0x4d, 0x3a, 0x37, 0x6, 0x24, 0x13, 0x1, 0x18, 0x24, 0x7, 0x1, 0x24, 0x8, 0x1, 0x30, 0x9, 0x41, 0x4, 0x60, 0xaa, 0
[1643298865.211342][573608:573613] CHIP:DMG: 						]
[1643298865.211350][573608:573613] CHIP:DMG: 					},
[1643298865.211357][573608:573613] CHIP:DMG: 			},
[1643298865.211367][573608:573613] CHIP:DMG: 			
[1643298865.211372][573608:573613] CHIP:DMG: 		},
[1643298865.211381][573608:573613] CHIP:DMG: 		
[1643298865.211386][573608:573613] CHIP:DMG: 	],
[1643298865.211399][573608:573613] CHIP:DMG: 	
[1643298865.211404][573608:573613] CHIP:DMG: 	SuppressResponse = true, 
[1643298865.211409][573608:573613] CHIP:DMG: }
[1643298865.211503][573608:573613] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_003E Attribute 0x0000_0000
[1643298865.211525][573608:573613] CHIP:TOO:   NOCs: 1 entries
[1643298865.211549][573608:573613] CHIP:TOO:     [1]: {
[1643298865.211555][573608:573613] CHIP:TOO:       FabricIndex: 1
[1643298865.211563][573608:573613] CHIP:TOO:       Noc: Elided value too large of size 244
[1643298865.211570][573608:573613] CHIP:TOO:       Icac: Elided value too large of size 231
[1643298865.211576][573608:573613] CHIP:TOO:      }
