### PR TITLE
Fix possible exchange leak in session establishment

### DIFF
--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -35,11 +35,17 @@ CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddres
     Optional<SessionHandle> session = mInitParams.sessionManager->CreateUnauthenticatedSession(peerAddress, mrpConfig);
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_NO_MEMORY);
 
-    Messaging::ExchangeContext * exchange = mInitParams.exchangeMgr->NewContext(session.Value(), &mCASESession);
-    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
-
     uint16_t keyID = 0;
     ReturnErrorOnFailure(mInitParams.idAllocator->Allocate(keyID));
+
+    // Allocate the exchange immediately before calling PASESession::Pair.
+    //
+    // CASESession::EstablishSession takes ownership of the exchange and will
+    // free it on error, but can only do this if it is actually called.
+    // Allocating the exchange context right before calling EstablishSession
+    // ensures that if allocation succeeds, CASESession has taken ownership.
+    Messaging::ExchangeContext * exchange = mInitParams.exchangeMgr->NewContext(session.Value(), &mCASESession);
+    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
     ReturnErrorOnFailure(mCASESession.EstablishSession(peerAddress, mInitParams.fabricInfo, peer.GetNodeId(), keyID, exchange, this,
                                                        mInitParams.mrpLocalConfig));

--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -38,7 +38,7 @@ CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddres
     uint16_t keyID = 0;
     ReturnErrorOnFailure(mInitParams.idAllocator->Allocate(keyID));
 
-    // Allocate the exchange immediately before calling PASESession::Pair.
+    // Allocate the exchange immediately before calling CASESession::EstablishSession.
     //
     // CASESession::EstablishSession takes ownership of the exchange and will
     // free it on error, but can only do this if it is actually called.


### PR DESCRIPTION
#### Problem

The CASESession and PASESession objects take ownership of their exchange contexts once passed, and will free and / or close them as appropriate.  However, for this object lifecycle management to occur, exchange contexts must be passed to these objects in the first place.
    
The current session establishment calls do not do this if early-out failures occur between allocation of the exchange contexts and calls to the session establishment methods.

#### Change overview
   
This commit fixes this problem by allocating exchanges immediately before the calls to the session establishment methods.  This removes the possibility of early-out failures causing leaks.

Fixes #13422

#### Testing

Manual testing shows that session establishment is working as before.  CI will show the same.

Unfortunately, triggering the failure path requires additional code modification, and unit testing would not currently be feasible.

A better solution would be for the CASESession and PASESession to allocate their own sessions.  However, this fix is smaller and the possible leaks it fixes are very plainly obvious in the code.