### PR TITLE
[SED] Review switching between polling modes

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -102,7 +102,7 @@ void ExchangeContext::UpdateSEDPollingMode()
     }
 
     VerifyOrReturn(address.GetTransportType() != Transport::Type::kBle);
-    UpdateSEDPollingMode(IsResponseExpected() || IsSendExpected() || IsMessageNotAcked() || IsAckPending());
+    UpdateSEDPollingMode(IsResponseExpected() || IsSendExpected() || IsMessageNotAcked());
 }
 
 void ExchangeContext::UpdateSEDPollingMode(bool fastPollingMode)

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -87,24 +87,30 @@ void ExchangeContext::SetResponseTimeout(Timeout timeout)
 #if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
 void ExchangeContext::UpdateSEDPollingMode()
 {
-    SessionHandle sessionHandle              = GetSessionHandle();
-    Transport::Session::SessionType sessType = sessionHandle->GetSessionType();
+    Transport::PeerAddress address;
 
-    // During PASE session, which happen on BLE, the session is kUnauthenticated
-    // So AsSecureSession() ends up faulting the system
-    if (sessType != Transport::Session::SessionType::kUnauthenticated)
+    switch (GetSessionHandle()->GetSessionType())
     {
-        if (sessionHandle->AsSecureSession()->GetPeerAddress().GetTransportType() != Transport::Type::kBle)
-        {
-            if (!IsResponseExpected() && !IsSendExpected() && (mExchangeMgr->GetNumActiveExchanges() == 1))
-            {
-                chip::DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(false);
-            }
-            else
-            {
-                chip::DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(true);
-            }
-        }
+    case Transport::Session::SessionType::kSecure:
+        address = GetSessionHandle()->AsSecureSession()->GetPeerAddress();
+        break;
+    case Transport::Session::SessionType::kUnauthenticated:
+        address = GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
+        break;
+    default:
+        return;
+    }
+
+    VerifyOrReturn(address.GetTransportType() != Transport::Type::kBle);
+    UpdateSEDPollingMode(IsResponseExpected() || IsSendExpected() || IsMessageNotAcked() || IsAckPending());
+}
+
+void ExchangeContext::UpdateSEDPollingMode(bool fastPollingMode)
+{
+    if (fastPollingMode != IsRequestingFastPollingMode())
+    {
+        SetRequestingFastPollingMode(fastPollingMode);
+        DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(fastPollingMode);
     }
 }
 #endif
@@ -286,6 +292,11 @@ ExchangeContext::~ExchangeContext()
 {
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() == 0);
     VerifyOrDie(!IsAckPending());
+
+#if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
+    // Make sure that the exchange withdraws the request for Sleepy End Device fast-polling mode.
+    UpdateSEDPollingMode(false);
+#endif
 
     // Ideally, in this scenario, the retransmit table should
     // be clear of any outstanding messages for this context and

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -245,16 +245,23 @@ private:
     void MessageHandled();
 
     /**
-     * Updates Sleepy End Device polling interval in the following way:
+     * Updates Sleepy End Device polling mode in the following way:
      * - does nothing for exchanges over Bluetooth LE
-     * - set IDLE polling mode if all conditions are met:
-     *   - device doesn't expect getting response nor sending message
-     *   - there is no other active exchange than the current one
-     * - set ACTIVE polling mode if any of the conditions is met:
-     *   - device expects getting response or sending message
-     *   - there is another active exchange
+     * - requests fast-polling (active) mode if there are more messages,
+     *   including MRP acknowledgements, expected to be sent or received on
+     *   this exchange.
+     * - withdraws the request for fast-polling (active) mode, otherwise.
      */
     void UpdateSEDPollingMode();
+
+    /**
+     * Requests or withdraws the request for Sleepy End Device fast-polling mode
+     * based on the argument value.
+     *
+     * Note that the device switches to the slow-polling (idle) mode if no
+     * exchange nor other component requests the fast-polling mode.
+     */
+    void UpdateSEDPollingMode(bool fastPollingMode);
 };
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -153,6 +153,12 @@ public:
     /// Set whether there is a message hasn't been acknowledged.
     void SetMessageNotAcked(bool messageNotAcked);
 
+    /// Set if this exchange is requesting Sleepy End Device fast-polling mode
+    void SetRequestingFastPollingMode(bool fastPollingMode);
+
+    /// Determine whether this exchange is requesting Sleepy End Device fast-polling mode
+    bool IsRequestingFastPollingMode() const;
+
     /**
      * Get the reliable message manager that corresponds to this reliable
      * message context.
@@ -194,8 +200,12 @@ protected:
 
         /// When set, signifies that we are currently in the middle of HandleMessage.
         kFlagHandlingMessage = (1u << 9),
+
         /// When set, we have had Close() or Abort() called on us already.
         kFlagClosed = (1u << 10),
+
+        /// When set, signifies that the exchange is requesting Sleepy End Device fast-polling mode.
+        kFlagFastPollingMode = (1u << 11),
     };
 
     BitFlags<Flags> mFlags; // Internal state flags
@@ -258,6 +268,11 @@ inline bool ReliableMessageContext::HasPiggybackAckPending() const
     return mFlags.Has(Flags::kFlagAckMessageCounterIsValid);
 }
 
+inline bool ReliableMessageContext::IsRequestingFastPollingMode() const
+{
+    return mFlags.Has(Flags::kFlagFastPollingMode);
+}
+
 inline void ReliableMessageContext::SetAutoRequestAck(bool autoReqAck)
 {
     mFlags.Set(Flags::kFlagAutoRequestAck, autoReqAck);
@@ -281,6 +296,11 @@ inline void ReliableMessageContext::SetDropAckDebug(bool inDropAckDebug)
 inline void ReliableMessageContext::SetMessageNotAcked(bool messageNotAcked)
 {
     mFlags.Set(Flags::kFlagMesageNotAcked, messageNotAcked);
+}
+
+inline void ReliableMessageContext::SetRequestingFastPollingMode(bool fastPollingMode)
+{
+    mFlags.Set(Flags::kFlagFastPollingMode, fastPollingMode);
 }
 
 } // namespace Messaging


### PR DESCRIPTION
#### Problem
Sleepy End Device polling mode switching behaves incorrectly in some scenarios.

#### Change overview
* Request fast-polling mode when commissioning window over IP (not BLE) is open only.
* Refactor the switching code in ExchangeContext to make sure that a single exchange can request fast-polling mode only
once and that the request is always withdrawn. Also, request the fast-polling while waiting for ACK.

#### Testing
Tested on nRF Connect-based SED (AFAIK there's currently no way to test SED on Linux).
