### PR TITLE
[chip-tool] Use subscribe instead of report since it has been commite…

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -201,7 +201,7 @@ private:
 class SubscribeAttribute : public ReportCommand
 {
 public:
-    SubscribeAttribute() : ReportCommand("report-by-id")
+    SubscribeAttribute() : ReportCommand("subscribe-by-id")
     {
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
@@ -211,7 +211,7 @@ public:
         ReportCommand::AddArguments();
     }
 
-    SubscribeAttribute(chip::ClusterId clusterId) : ReportCommand("report-by-id"), mClusterId(clusterId)
+    SubscribeAttribute(chip::ClusterId clusterId) : ReportCommand("subscribe-by-id"), mClusterId(clusterId)
     {
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -221,7 +221,7 @@ public:
     }
 
     SubscribeAttribute(chip::ClusterId clusterId, const char * attributeName, chip::AttributeId attributeId) :
-        ReportCommand("report"), mClusterId(clusterId), mAttributeId(attributeId)
+        ReportCommand("subscribe"), mClusterId(clusterId), mAttributeId(attributeId)
     {
         AddArgument("attr-name", attributeName);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -302,7 +302,7 @@ private:
 class SubscribeEvent : public ReportCommand
 {
 public:
-    SubscribeEvent() : ReportCommand("report-event-by-id")
+    SubscribeEvent() : ReportCommand("subscribe-event-by-id")
     {
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("event-id", 0, UINT32_MAX, &mEventId);
@@ -312,7 +312,7 @@ public:
         ReportCommand::AddArguments();
     }
 
-    SubscribeEvent(chip::ClusterId clusterId) : ReportCommand("report-event-by-id"), mClusterId(clusterId)
+    SubscribeEvent(chip::ClusterId clusterId) : ReportCommand("subscribe-event-by-id"), mClusterId(clusterId)
     {
         AddArgument("event-id", 0, UINT32_MAX, &mEventId);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
@@ -322,7 +322,7 @@ public:
     }
 
     SubscribeEvent(chip::ClusterId clusterId, const char * eventName, chip::EventId eventId) :
-        ReportCommand("report-event"), mClusterId(clusterId), mEventId(eventId)
+        ReportCommand("subscribe-event"), mClusterId(clusterId), mEventId(eventId)
     {
         AddArgument("attr-name", eventName);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);


### PR DESCRIPTION
…d in #14231 but #14361 has landed right after with the keyword 'report'

#### Problem
https://github.com/project-chip/connectedhomeip/pull/14231 has landed to use the word 'subscribe' instead of report and then https://github.com/project-chip/connectedhomeip/commit/40cc4216af91b9522291178b62ced728c5126658 has landed with the work "report" instead of subscribe !

That's not a big deal but "commands.cpp" checks for the word "subscribe" to avoid displaying it multiple times as it is a "global" commands, but now "report" is displayed multiple times...

#### Change overview
 * Rename 'report*' to 'subscribe*'

#### Testing
I have looked into the shell output that it works correctly.
