### PR TITLE
[CI] In TC-DM-3.1 maxNetworks and networks attributes read is disabled

### DIFF
--- a/src/app/clusters/network-commissioning-old/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning-old/network-commissioning-ember.cpp
@@ -20,20 +20,52 @@
 
 #include <cstring>
 
-#include <app-common/zap-generated/att-storage.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/callback.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
-#include <app-common/zap-generated/enums.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/util/af.h>
+#include <app/util/attribute-storage.h>
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::Clusters::NetworkCommissioning;
+
+namespace {
+class NetworkCommissioningAttributeAccess : public AttributeAccessInterface
+{
+public:
+    NetworkCommissioningAttributeAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), Id) {}
+
+    CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override
+    {
+        switch (aPath.mAttributeId)
+        {
+        case Attributes::MaxNetworks::Id:
+            return aEncoder.Encode(static_cast<uint8_t>(0));
+        case Attributes::Networks::Id:
+            return aEncoder.EncodeEmptyList();
+        case Attributes::ScanMaxTimeSeconds::Id:
+            return aEncoder.Encode(static_cast<uint8_t>(0));
+        case Attributes::ConnectMaxTimeSeconds::Id:
+            return aEncoder.Encode(static_cast<uint8_t>(0));
+        case Attributes::InterfaceEnabled::Id:
+            return aEncoder.Encode(static_cast<bool>(false));
+        case Attributes::LastNetworkingStatus::Id:
+            return aEncoder.Encode(NetworkCommissioningStatus::kSuccess);
+        case Attributes::LastNetworkID::Id:
+            return aEncoder.Encode(ByteSpan());
+        case Attributes::LastConnectErrorValue::Id:
+            return aEncoder.Encode(Attributes::LastConnectErrorValue::TypeInfo::Type(static_cast<int32_t>(0)));
+        case Attributes::FeatureMap::Id:
+            return aEncoder.Encode(static_cast<uint32_t>(0));
+        default:
+            return CHIP_NO_ERROR;
+        }
+    }
+};
+} // namespace
 
 bool emberAfNetworkCommissioningClusterAddOrUpdateThreadNetworkCallback(
     app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
@@ -96,4 +128,8 @@ bool emberAfNetworkCommissioningClusterReorderNetworkCallback(app::CommandHandle
     return false;
 }
 
-void MatterNetworkCommissioningPluginServerInitCallback() {}
+NetworkCommissioningAttributeAccess gAttrAccess;
+void MatterNetworkCommissioningPluginServerInitCallback()
+{
+    registerAttributeAccessOverride(&gAttrAccess);
+}

--- a/src/app/tests/suites/certification/Test_TC_DM_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_3_1.yaml
@@ -26,7 +26,6 @@ tests:
     - label: "Query MaxNetworks"
       command: "readAttribute"
       attribute: "MaxNetworks"
-      disabled: true
       optional: true
       response:
           constraints:
@@ -35,7 +34,6 @@ tests:
     - label: "Query Networks"
       command: "readAttribute"
       attribute: "Networks"
-      disabled: true
       optional: true
       response:
           constraints:

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -10433,6 +10433,54 @@ CHIPDevice * GetConnectedDevice(void)
     WaitForCommissionee(expectation, queue);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
+- (void)testSendClusterTest_TC_DM_3_1_000001_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Query MaxNetworks"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestNetworkCommissioning * cluster = [[CHIPTestNetworkCommissioning alloc] initWithDevice:device endpoint:0 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeMaxNetworksWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Query MaxNetworks Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_DM_3_1_000002_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Query Networks"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestNetworkCommissioning * cluster = [[CHIPTestNetworkCommissioning alloc] initWithDevice:device endpoint:0 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeNetworksWithCompletionHandler:^(NSArray * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Query Networks Error: %@", err);
+
+        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            [expectation fulfill];
+            return;
+        }
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
 
 - (void)testSendClusterTest_TC_EMR_1_1_000000_WaitForCommissionee
 {


### PR DESCRIPTION
#### Problem

`TC-DM-3.1` has some disabled tests.

fixes #8147 
fixes #8148

#### Change overview
 * Enable them and add the missing pieces

#### Testing
2 new tests has been enabled.