### PR TITLE
Add support for out of tree LayerImpl implementation

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -124,6 +124,7 @@ if (chip_device_platform != "external") {
   chip_platform_config_include = ""
   chip_inet_platform_config_include = ""
   chip_system_platform_config_include = ""
+  chip_system_layer_impl_config_file = ""
 } else {
   declare_args() {
     chip_ble_platform_config_include = ""
@@ -131,6 +132,7 @@ if (chip_device_platform != "external") {
     chip_platform_config_include = ""
     chip_inet_platform_config_include = ""
     chip_system_platform_config_include = ""
+    chip_system_layer_impl_config_file = ""
   }
 }
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -96,7 +96,11 @@ buildconfig_header("system_buildconfig") {
     ]
   }
 
-  defines += [ "CHIP_SYSTEM_LAYER_IMPL_CONFIG_FILE=<system/SystemLayerImpl${chip_system_config_event_loop}.h>" ]
+  if (chip_system_layer_impl_config_file != "") {
+    defines += [ "CHIP_SYSTEM_LAYER_IMPL_CONFIG_FILE=${chip_system_layer_impl_config_file}" ]
+  } else {
+    defines += [ "CHIP_SYSTEM_LAYER_IMPL_CONFIG_FILE=<system/SystemLayerImpl${chip_system_config_event_loop}.h>" ]
+  }
 }
 
 config("system_config") {
@@ -135,8 +139,6 @@ static_library("system") {
     "SystemFaultInjection.h",
     "SystemLayer.cpp",
     "SystemLayer.h",
-    "SystemLayerImpl${chip_system_config_event_loop}.cpp",
-    "SystemLayerImpl${chip_system_config_event_loop}.h",
     "SystemLayerImpl.h",
     "SystemMutex.cpp",
     "SystemMutex.h",
@@ -152,6 +154,13 @@ static_library("system") {
     "WakeEvent.cpp",
     "WakeEvent.h",
   ]
+
+  if (chip_system_layer_impl_config_file == "") {
+    sources += [
+      "SystemLayerImpl${chip_system_config_event_loop}.cpp",
+      "SystemLayerImpl${chip_system_config_event_loop}.h",
+    ]
+  }
 
   cflags = [ "-Wconversion" ]
 


### PR DESCRIPTION
#### Problem
Embedders currently need to add local patches in order to provide an out of tree implementation of SystemLayerImpl.

#### Change overview
This change adds a GN flag allowing embedders to define CHIP_SYSTEM_LAYER_IMPL_CONFIG_FILE to point to whatever file they want.

#### Testing
`gn gen` and build without defining `chip_system_layer_impl_config_file` to verify that default configuration does not break.
`gn gen` and build with `chip_system_layer_impl_config_file` to verify that the file is correctly customized.
