### PR TITLE
[EFR32 OTA] Update the efr32_sdk submodule pointer 

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -938,6 +938,7 @@ SoftwareVersion
 SoftwareVersionString
 softwareVersionValid
 SPI
+spiflash
 spinel
 src
 SRP

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -80,7 +80,11 @@ See `examples/lighting-app/efr32/README.md`
 
 -   Build or download the Gecko Bootloader binary. Bootloader should be built
     with the Gecko SDK version 3.2.1 or earlier, type "external SPI" configured
-    with a single slot of at least 1000 KB. Using the commander tool upload the
+    with a single slot of at least 1000 KB. Pre-built binaries should be available in 
+
+           third_party/efr32_sdk/repo/platform/bootloader/sample-apps/bootloader-storage-spiflash-single
+
+-   Using the commander tool upload the
     bootloader to the device running the requestor application.
 
 -   Create a bootable image file:

--- a/examples/ota-requestor-app/efr32/README.md
+++ b/examples/ota-requestor-app/efr32/README.md
@@ -80,12 +80,13 @@ See `examples/lighting-app/efr32/README.md`
 
 -   Build or download the Gecko Bootloader binary. Bootloader should be built
     with the Gecko SDK version 3.2.1 or earlier, type "external SPI" configured
-    with a single slot of at least 1000 KB. Pre-built binaries should be available in 
+    with a single slot of at least 1000 KB. Pre-built binaries should be
+    available in
 
            third_party/efr32_sdk/repo/platform/bootloader/sample-apps/bootloader-storage-spiflash-single
 
--   Using the commander tool upload the
-    bootloader to the device running the requestor application.
+-   Using the commander tool upload the bootloader to the device running the
+    requestor application.
 
 -   Create a bootable image file:
 

--- a/examples/ota-requestor-app/efr32/args.gni
+++ b/examples/ota-requestor-app/efr32/args.gni
@@ -25,5 +25,4 @@ chip_openthread_ftd = false
 
 declare_args() {
   chip_enable_ota_requestor = true
-  chip_build_libshell = true
 }


### PR DESCRIPTION
#### Problem
Need to make pre-built bootloader binaries available in the efr32_sdk repo

#### Change overview
Update the efr32_sdk submodule pointer to include a commit that pushed pre-built EFR32 bootloader binaries. 

Also update the EFR32 ota-requestor-app README. Also exclude the chip-shell from being compiled in this app by default.

#### Testing
Verified that the EFR32 ota-requestor-app successfully builds and loads. 