### PR TITLE
[WIP Please ignore] Add cli completion ability; implement for esp and nrf

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -61,7 +61,7 @@ static CHIP_ERROR SwitchCommandHandler(int argc, char ** argv)
 static void RegisterSwitchCommands()
 {
     static const shell_command_t sSwitchCommand = { SwitchCommandHandler, "switch", "Switch commands. Usage: switch [on|off]" };
-    Engine::Root().RegisterCommands(&sSwitchCommand, 1);
+    Engine::Root().RegisterCommands(&sSwitchCommand, 1, nullptr);
     return;
 }
 #endif // defined(ENABLE_CHIP_SHELL)

--- a/examples/all-clusters-app/esp32/main/OnOffCommands.cpp
+++ b/examples/all-clusters-app/esp32/main/OnOffCommands.cpp
@@ -90,12 +90,12 @@ void OnOffCommands::Register()
     static const shell_command_t subCommands[] = { { &OnLightHandler, "on", "Usage: OnOff on endpoint-id" },
                                                    { &OffLightHandler, "off", "Usage: OnOff off endpoint-id" },
                                                    { &ToggleLightHandler, "toggle", "Usage: OnOff toggle endpoint-id" } };
-    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands), "OnOff");
 
     // Register the root `OnOff` command in the top-level shell.
     static const shell_command_t onOffCommand = { &OnOffHandler, "OnOff", "OnOff commands" };
 
-    Engine::Root().RegisterCommands(&onOffCommand, 1);
+    Engine::Root().RegisterCommands(&onOffCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/examples/lighting-app/cyw30739/src/AppShellCommands.cpp
+++ b/examples/lighting-app/cyw30739/src/AppShellCommands.cpp
@@ -50,9 +50,9 @@ void RegisterAppShellCommands(void)
         .cmd_help = "App commands",
     };
 
-    sAppSubcommands.RegisterCommands(sAppSubCommands, ArraySize(sAppSubCommands));
+    sAppSubcommands.RegisterCommands(sAppSubCommands, ArraySize(sAppSubCommands), "app");
 
-    Engine::Root().RegisterCommands(&sAppCommand, 1);
+    Engine::Root().RegisterCommands(&sAppCommand, 1, nullptr);
 }
 
 CHIP_ERROR AppCommandHelpHandler(int argc, char * argv[])

--- a/examples/lock-app/cyw30739/src/AppShellCommands.cpp
+++ b/examples/lock-app/cyw30739/src/AppShellCommands.cpp
@@ -50,9 +50,9 @@ void RegisterAppShellCommands(void)
         .cmd_help = "App commands",
     };
 
-    sAppSubcommands.RegisterCommands(sAppSubCommands, ArraySize(sAppSubCommands));
+    sAppSubcommands.RegisterCommands(sAppSubCommands, ArraySize(sAppSubCommands), "app");
 
-    Engine::Root().RegisterCommands(&sAppCommand, 1);
+    Engine::Root().RegisterCommands(&sAppCommand, 1, nullptr);
 }
 
 CHIP_ERROR AppCommandHelpHandler(int argc, char * argv[])

--- a/examples/ota-provider-app/esp32/main/OTAProviderCommands.cpp
+++ b/examples/ota-provider-app/esp32/main/OTAProviderCommands.cpp
@@ -69,12 +69,12 @@ void OTAProviderCommands::Register()
           "Usage: OTAProvider delay <delay in seconds>" },
     };
 
-    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands), "OTAProvider");
 
     // Register the root `OTA Provider` command in the top-level shell.
     static const shell_command_t otaProviderCommand = { &OTAProviderHandler, "OTAProvider", "OTA Provider commands" };
 
-    Engine::Root().RegisterCommands(&otaProviderCommand, 1);
+    Engine::Root().RegisterCommands(&otaProviderCommand, 1, nullptr);
 }
 
 // Set Example OTA provider

--- a/examples/platform/esp32/shell_extension/heap_trace.cpp
+++ b/examples/platform/esp32/shell_extension/heap_trace.cpp
@@ -137,7 +137,7 @@ void RegisterHeapTraceCommands()
         { &HeapTraceTaskHandler, "task", "Dump heap usage of each task" },
 #endif // CONFIG_HEAP_TASK_TRACKING
     };
-    sShellHeapSubCommands.RegisterCommands(sHeapSubCommands, ArraySize(sHeapSubCommands));
+    sShellHeapSubCommands.RegisterCommands(sHeapSubCommands, ArraySize(sHeapSubCommands), "heap-trace");
 
 #if CONFIG_HEAP_TRACING_STANDALONE
     ESP_ERROR_CHECK(heap_trace_init_standalone(sTraceRecords, kNumHeapTraceRecords));
@@ -145,7 +145,7 @@ void RegisterHeapTraceCommands()
 #endif // CONFIG_HEAP_TRACING_STANDALONE
 
     static const shell_command_t sHeapCommand = { &HeapTraceDispatch, "heap-trace", "Heap debug tracing" };
-    Engine::Root().RegisterCommands(&sHeapCommand, 1);
+    Engine::Root().RegisterCommands(&sHeapCommand, 1, nullptr);
 }
 
 } // namespace chip

--- a/examples/platform/linux/CommissioneeShellCommands.cpp
+++ b/examples/platform/linux/CommissioneeShellCommands.cpp
@@ -148,7 +148,7 @@ void RegisterCommissioneeCommands()
                                                    "Commissionee commands. Usage: commissionee [command_name]" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -305,7 +305,7 @@ void RegisterControllerCommands()
                                                    "Controller commands. Usage: controller [command_name]" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/examples/shell/shell_common/cmd_misc.cpp
+++ b/examples/shell/shell_common/cmd_misc.cpp
@@ -68,5 +68,5 @@ static shell_command_t cmds_misc[] = {
 
 void cmd_misc_init()
 {
-    Engine::Root().RegisterCommands(cmds_misc, ArraySize(cmds_misc));
+    Engine::Root().RegisterCommands(cmds_misc, ArraySize(cmds_misc), nullptr);
 }

--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -193,6 +193,6 @@ void cmd_otcli_init()
 #endif
 
     // Register the root otcli command with the top-level shell.
-    Engine::Root().RegisterCommands(&cmds_otcli_root, 1);
+    Engine::Root().RegisterCommands(&cmds_otcli_root, 1, nullptr);
 #endif // CHIP_ENABLE_OPENTHREAD
 }

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -483,5 +483,5 @@ static shell_command_t cmds_ping[] = {
 
 void cmd_ping_init()
 {
-    Engine::Root().RegisterCommands(cmds_ping, ArraySize(cmds_ping));
+    Engine::Root().RegisterCommands(cmds_ping, ArraySize(cmds_ping), nullptr);
 }

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -406,5 +406,5 @@ static shell_command_t cmds_send[] = {
 
 void cmd_send_init()
 {
-    Engine::Root().RegisterCommands(cmds_send, ArraySize(cmds_send));
+    Engine::Root().RegisterCommands(cmds_send, ArraySize(cmds_send), nullptr);
 }

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -228,8 +228,8 @@ void cmd_app_server_init()
     std::atexit(CmdAppServerAtExit);
 
     // Register `server` subcommands with the local shell dispatcher.
-    sShellServerSubcommands.RegisterCommands(sServerSubCommands, ArraySize(sServerSubCommands));
+    sShellServerSubcommands.RegisterCommands(sServerSubCommands, ArraySize(sServerSubCommands), "server");
 
     // Register the root `server` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sServerComand, 1);
+    Engine::Root().RegisterCommands(&sServerComand, 1, nullptr);
 }

--- a/examples/tv-app/linux/AppPlatformShellCommands.cpp
+++ b/examples/tv-app/linux/AppPlatformShellCommands.cpp
@@ -218,7 +218,7 @@ void RegisterAppPlatformCommands()
     static const shell_command_t sDeviceComand = { &AppPlatformHandler, "app", "App commands. Usage: app [command_name]" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -21,10 +21,9 @@
  *      Source implementation for a generic shell API for CHIP examples.
  */
 
-#include <lib/shell/Engine.h>
-
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Commands.h>
+#include <lib/shell/Engine.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -35,7 +34,6 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 
 using namespace chip::Logging;
 
@@ -43,6 +41,7 @@ namespace chip {
 namespace Shell {
 
 Engine Engine::theEngineRoot;
+shell_map * Engine::theShellMapListHead = NULL;
 
 int Engine::Init()
 {
@@ -56,47 +55,194 @@ int Engine::Init()
 
 void Engine::ForEachCommand(shell_command_iterator_t * on_command, void * arg)
 {
-    for (unsigned i = 0; i < _commandSetCount; i++)
+    for (unsigned i = 0; i < _commandCount; i++)
     {
-        for (unsigned j = 0; j < _commandSetSize[i]; j++)
+        if (on_command(_commands[i], arg) != CHIP_NO_ERROR)
         {
-            if (on_command(&_commandSet[i][j], arg) != CHIP_NO_ERROR)
-            {
-                return;
-            }
+            return;
         }
     }
 }
 
-void Engine::RegisterCommands(shell_command_t * command_set, unsigned count)
+void Engine::RegisterCommands(shell_command_t * command_set, unsigned count, const char * prefix)
 {
-    if (_commandSetCount >= CHIP_SHELL_MAX_MODULES)
+    if (this == &Engine::Root() || prefix == nullptr)
     {
-        ChipLogError(Shell, "Max number of modules reached\n");
+        prefix = "";
+    }
+
+    if (_commandCount + count > CHIP_SHELL_MAX_MODULES)
+    {
+        ChipLogError(Shell, "Max number of commands registered to this shell");
         assert(0);
     }
 
-    _commandSet[_commandSetCount]     = command_set;
-    _commandSetSize[_commandSetCount] = count;
-    ++_commandSetCount;
+    for (unsigned i = 0; i < count; i++)
+    {
+        _commands[_commandCount + i] = &command_set[i];
+    }
+    _commandCount += count;
+
+    Engine::InsertShellMap(prefix, this);
+}
+
+void Engine::InsertShellMap(char const * prefix, Engine * shell)
+{
+    shell_map_t * map = Engine::theShellMapListHead;
+    while (map != NULL)
+    {
+        if (strcmp(prefix, map->prefix) == 0)
+        {
+            for (size_t i = 0; i < map->enginec; i++)
+            {
+                if (map->enginev[i] == shell)
+                {
+                    return;
+                }
+            }
+            if (map->enginec == sizeof(map->enginev))
+            {
+                ChipLogError(Shell, "Max number of shells registered under this prefix");
+                assert(0);
+            }
+            map->enginev[map->enginec] = shell;
+            map->enginec++;
+            return;
+        }
+        map = map->next;
+    }
+    shell_map_t * new_map       = new shell_map_t;
+    new_map->prefix             = prefix;
+    new_map->enginev[0]         = shell;
+    new_map->enginec            = 1;
+    new_map->next               = Engine::theShellMapListHead;
+    Engine::theShellMapListHead = new_map;
+}
+
+CHIP_ERROR Engine::GetCommandCompletions(cmd_completion_context * context)
+{
+
+    if (Engine::theShellMapListHead == NULL)
+    {
+        ChipLogDetail(Shell, "There isn't any command registered yet.");
+        return CHIP_NO_ERROR;
+    }
+    const char * buf = context->line_buf;
+    if (buf == nullptr)
+    {
+        buf = "";
+    }
+
+    int last_space_idx = -1;
+    int buf_len        = strlen(buf);
+
+    // find space in buf
+    for (int i = buf_len - 1; i > -1; i--)
+    {
+        if (buf[i] == ' ')
+        {
+            last_space_idx = i;
+            break;
+        }
+    }
+
+    // check whether the buf exactly matches a prefix
+    bool exact_match  = false;
+    shell_map_t * map = Engine::theShellMapListHead;
+
+    while (map != NULL)
+    {
+
+        if (strcmp(buf, map->prefix) == 0)
+        {
+            exact_match = true;
+            break;
+        }
+        map = map->next;
+    }
+
+    char * buf_prefix;
+    char * incomplete_cmd;
+
+    if (exact_match)
+    {
+        // If it's a perfect match
+        // - use the whole buf as the prefix
+        // - there is no "incomplete command" so set it to empty
+        buf_prefix     = new char[buf_len + 1];
+        incomplete_cmd = new char[1];
+        strcpy(buf_prefix, buf);
+        strcpy(incomplete_cmd, "");
+    }
+    else
+    {
+        // If it's not a perfect match:
+        // - prefix is up to the last space
+        // - incomplete_cmd is what's after the last space
+        bool pad_space_len        = (last_space_idx == -1) ? 1 : 0;
+        size_t buf_prefix_len     = last_space_idx + 1 + pad_space_len;
+        buf_prefix                = new char[buf_prefix_len];
+        size_t incomplete_cmd_len = buf_len - last_space_idx;
+        incomplete_cmd            = new char[incomplete_cmd_len];
+
+        strncpy(buf_prefix, buf, buf_prefix_len);
+        memset(&buf_prefix[buf_prefix_len - 1], 0, 1);
+        strncpy(incomplete_cmd, &buf[last_space_idx + 1], incomplete_cmd_len);
+        memset(&incomplete_cmd[incomplete_cmd_len - 1], 0, 1);
+    }
+
+    // Array to pass arguments into the ForEachCommand call
+    void * lambda_args[] = { context, incomplete_cmd };
+    map                  = Engine::theShellMapListHead;
+
+    while (map != NULL && context->cmdc < CHIP_SHELL_MAX_CMD_COMPLETIONS)
+    {
+        if (strcmp(buf_prefix, map->prefix) == 0)
+        {
+            context->ret_prefix = map->prefix;
+            for (unsigned i = 0; i < map->enginec; i++)
+            {
+                map->enginev[i]->ForEachCommand(
+                    [](shell_command_t * cmd, void * arg) -> CHIP_ERROR {
+                        cmd_completion_context * ctx = (cmd_completion_context *) ((void **) arg)[0];
+                        char * _incomplete_cmd       = (char *) ((void **) arg)[1];
+                        // For end nodes like "ble adv", need to avoid duplicate returns.
+                        // Return for prefix="ble adv" cmd=""; reject for prefix="ble" cmd="adv"
+                        if ((strcmp(cmd->cmd_name, _incomplete_cmd) != 0 &&
+                             strncmp(cmd->cmd_name, _incomplete_cmd, strlen(_incomplete_cmd)) == 0) ||
+                            strcmp(_incomplete_cmd, "") == 0)
+                        {
+                            ctx->cmdc++;
+                            ctx->cmdv[ctx->cmdc - 1] = cmd;
+                        }
+                        return CHIP_NO_ERROR;
+                    },
+                    lambda_args);
+            }
+            break;
+        }
+
+        map = map->next;
+    }
+
+    free((char *) buf_prefix);
+    free((char *) incomplete_cmd);
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Engine::ExecCommand(int argc, char * argv[])
 {
     CHIP_ERROR retval = CHIP_ERROR_INVALID_ARGUMENT;
-
     VerifyOrReturnError(argc > 0, retval);
     // Find the command
-    for (unsigned i = 0; i < _commandSetCount; i++)
+    for (unsigned i = 0; i < _commandCount; i++)
     {
-        for (unsigned j = 0; j < _commandSetSize[i]; j++)
+        if (strcmp(argv[0], _commands[i]->cmd_name) == 0)
         {
-            if (strcmp(argv[0], _commandSet[i][j].cmd_name) == 0)
-            {
-                // Execute the command!
-                retval = _commandSet[i][j].cmd_func(argc - 1, argv + 1);
-                break;
-            }
+            // Execute the command!
+            retval = _commands[i]->cmd_func(argc - 1, argv + 1);
+            break;
         }
     }
 

--- a/src/lib/shell/Engine.h
+++ b/src/lib/shell/Engine.h
@@ -110,7 +110,7 @@ class Engine;
  *              or "dns resolve".
  *  enginev:    An array of the shells that have registered commands under the preifx.
  *  enginec:    The number of shells that have registered commands under the preifx.
- *  next:       The next shell in the list.
+ *  next:       The next shell map in the list.
  *
  */
 typedef struct shell_map
@@ -125,9 +125,10 @@ typedef struct shell_map
  * A context object for passing request and receiving results with GetCmdCompletion.
  *
  *  line_buf:           The user input command to request for completion. If the applications prepends
- *                      "matter " to all matter commands, please remove the "matter " prefix from the buffer.
+ *                      "matter " to all matter commands, please remove the "matter " prefix and only use
+ *                      the string after it.
  *  ret_prefix:         The returned command prefix (up until the last space, not included).
- *  cmdv:               The returned command completion candidates unter the prefix in "ret_prefix".
+ *  cmdv:               The returned command completion candidates under the prefix in "ret_prefix".
  *  cmdc:               The returned number of command completion candidates in cmdv.
  *
  * Initialization:

--- a/src/lib/shell/MainLoopZephyr.cpp
+++ b/src/lib/shell/MainLoopZephyr.cpp
@@ -14,14 +14,20 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <cstring>
 #include <init.h>
 #include <shell/shell.h>
+#include <stdio.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Engine.h>
 #include <lib/shell/streamer_zephyr.h>
+#include <lib/support/CodeUtils.h>
 
+using chip::Shell::cmd_completion_context;
 using chip::Shell::Engine;
+using chip::Shell::shell_command_t;
+using chip::Shell::shell_map_t;
 
 static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
 {
@@ -29,15 +35,96 @@ static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
     return (Engine::Root().ExecCommand(argc - 1, argv + 1) == CHIP_NO_ERROR) ? 0 : -ENOEXEC;
 }
 
+/**
+ * This recursive function obtains all sub-commands (possbile completions) for a command node
+ * and build it into a tree of Zephyr's shell_static_entry structure.
+ *
+ * @param prefix                  The path/prefix until the root command node of the tree, without tailing space.
+ *                                e.g. "dns browse". Set to emptry string "" if building tree for a root-level command.
+ * @param syntax                  The single-word command name/syntax for the root node of the tree. e.g. "resolve".
+ *                                Set to emptry string "" if calling to build from the root (to include all commands).
+ * @param help                    The help text for the command at roote node of the tree. Set to NULL if none.
+ *
+ * @return                        The shell_static_entry structure tree that chains all the sub-commands from the
+ *                                requested command node.
+ *
+ */
+const struct shell_static_entry * build_command_tree(const char * prefix, const char * syntax, const char * help)
+{
+
+    char * sub_prefix = new char[strlen(prefix) + strlen(syntax) + 2];
+    size_t pos        = 0;
+    if (strcmp(prefix, "") != 0)
+    {
+        strncpy(&sub_prefix[pos], prefix, strlen(prefix));
+        pos += strlen(prefix);
+        strncpy(&sub_prefix[pos], " ", 1);
+        pos += 1;
+    }
+    strncpy(&sub_prefix[pos], syntax, strlen(syntax) + 1);
+
+    cmd_completion_context context = cmd_completion_context(sub_prefix);
+    CHIP_ERROR ret                 = Engine::GetCommandCompletions(&context);
+
+    const struct shell_static_entry * static_entry;
+    if (ret == CHIP_NO_ERROR && context.cmdc != 0)
+    {
+        const struct shell_static_entry * sub_static_entry = new shell_static_entry[context.cmdc + 1];
+        for (size_t i = 0; i < context.cmdc; i++)
+        {
+            shell_command_t * subcmd                    = context.cmdv[i];
+            const struct shell_static_entry * sub_entry = build_command_tree(sub_prefix, subcmd->cmd_name, subcmd->cmd_help);
+            if (sub_entry == nullptr)
+            {
+                // leaf node, the command should require no argument but can accept optional arguments
+                const struct shell_static_entry leaf_entry = {
+                    .syntax = subcmd->cmd_name, .help = subcmd->cmd_help, .subcmd = NULL, .handler = NULL, .args = { 0, 10 }
+                };
+                memcpy((shell_static_entry *) &sub_static_entry[i], &leaf_entry, sizeof(struct shell_static_entry));
+                continue;
+            }
+            memcpy((shell_static_entry *) &sub_static_entry[i], sub_entry, sizeof(struct shell_static_entry));
+        }
+
+        // Zephyr's shell_cmd_entry.u.entry needs an additional NULL element to terminate the array.
+        memset((shell_static_entry *) &sub_static_entry[context.cmdc], 0, sizeof(struct shell_static_entry));
+
+        const struct shell_cmd_entry * sub_cmd_entry =
+            new const shell_cmd_entry{ .is_dynamic = false,
+                                       .u          = { .entry = (const struct shell_static_entry *) sub_static_entry } };
+
+        // The non-leaf nodes should require at least 1 required argument (for its child)
+        // Set the root command to use syntax "matter"
+        // Only the root "matter" node should have a handler function in Zephry-shell, so that all commands are sent
+        // to be dispatched by their registered Engine instances.
+        static_entry = new const shell_static_entry{ .syntax  = (strcmp(syntax, "") == 0) ? "matter" : syntax,
+                                                     .help    = help,
+                                                     .subcmd  = (const struct shell_cmd_entry *) sub_cmd_entry,
+                                                     .handler = (strcmp(syntax, "") == 0) ? cmd_matter : NULL,
+                                                     .args    = { 1, 10 } };
+    }
+    else
+    {
+        static_entry = nullptr;
+    }
+    delete[] sub_prefix;
+    return static_entry;
+}
+
+static void register_matter_command_to_zephyr()
+{
+    static const struct shell_static_entry _shell_matter = *build_command_tree("", "", "Matter commands");
+    static const struct shell_cmd_entry shell_cmd_matter __attribute__((section("." STRINGIFY(shell_root_cmd_matter))))
+    __attribute__((used)) = { .is_dynamic = false, .u = { .entry = &_shell_matter } };
+}
+
 static int RegisterCommands(const struct device * dev)
 {
     Engine::Root().RegisterDefaultCommands();
+    register_matter_command_to_zephyr();
     return 0;
 }
-
-SYS_INIT(RegisterCommands, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-
-SHELL_CMD_ARG_REGISTER(matter, NULL, "Matter commands", cmd_matter, 1, 10);
+SYS_INIT(RegisterCommands, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 namespace chip {
 namespace Shell {

--- a/src/lib/shell/commands/BLE.cpp
+++ b/src/lib/shell/commands/BLE.cpp
@@ -111,10 +111,10 @@ void RegisterBLECommands()
     static const shell_command_t sBLECommand = { &BLEDispatch, "ble", "BLE transport commands" };
 
     // Register `device` subcommands with the local shell dispatcher.
-    sShellDeviceSubcommands.RegisterCommands(sBLESubCommands, ArraySize(sBLESubCommands));
+    sShellDeviceSubcommands.RegisterCommands(sBLESubCommands, ArraySize(sBLESubCommands), "ble");
 
     // Register the root `btp` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sBLECommand, 1);
+    Engine::Root().RegisterCommands(&sBLECommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Base64.cpp
+++ b/src/lib/shell/commands/Base64.cpp
@@ -88,10 +88,10 @@ void RegisterBase64Commands()
     static const shell_command_t sBase64Command = { &Base64Dispatch, "base64", "Base64 encode / decode utilities" };
 
     // Register `base64` subcommands with the local shell dispatcher.
-    sShellBase64Commands.RegisterCommands(sBase64SubCommands, ArraySize(sBase64SubCommands));
+    sShellBase64Commands.RegisterCommands(sBase64SubCommands, ArraySize(sBase64SubCommands), "base64");
 
     // Register the root `base64` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sBase64Command, 1);
+    Engine::Root().RegisterCommands(&sBase64Command, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Config.cpp
+++ b/src/lib/shell/commands/Config.cpp
@@ -191,7 +191,6 @@ static CHIP_ERROR ConfigHandler(int argc, char ** argv)
 
 void RegisterConfigCommands()
 {
-
     static const shell_command_t sConfigComand = { &ConfigHandler, "config",
                                                    "Manage device configuration. Usage to dump value: config [param_name] and "
                                                    "to set some values (discriminator): config [param_name] [param_value]." };
@@ -206,10 +205,9 @@ void RegisterConfigCommands()
     };
 
     // Register `config` subcommands with the local shell dispatcher.
-    sShellConfigSubcommands.RegisterCommands(sConfigSubCommands, ArraySize(sConfigSubCommands));
-
+    sShellConfigSubcommands.RegisterCommands(sConfigSubCommands, ArraySize(sConfigSubCommands), "config");
     // Register the root `config` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sConfigComand, 1);
+    Engine::Root().RegisterCommands(&sConfigComand, 1, nullptr);
     return;
 }
 

--- a/src/lib/shell/commands/Device.cpp
+++ b/src/lib/shell/commands/Device.cpp
@@ -65,10 +65,10 @@ void RegisterDeviceCommands()
     static const shell_command_t sDeviceComand = { &DeviceHandler, "device", "Device management commands" };
 
     // Register `device` subcommands with the local shell dispatcher.
-    sShellDeviceSubcommands.RegisterCommands(sDeviceSubCommands, ArraySize(sDeviceSubCommands));
+    sShellDeviceSubcommands.RegisterCommands(sDeviceSubCommands, ArraySize(sDeviceSubCommands), "device");
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -250,13 +250,13 @@ void RegisterDnsCommands()
     static const shell_command_t sDnsCommand = { &DnsHandler, "dns", "Dns client commands" };
 
     // Register `dns browse` subcommands
-    sShellDnsBrowseSubcommands.RegisterCommands(sDnsBrowseSubCommands, ArraySize(sDnsBrowseSubCommands));
+    sShellDnsBrowseSubcommands.RegisterCommands(sDnsBrowseSubCommands, ArraySize(sDnsBrowseSubCommands), "dns browse");
 
     // Register `dns` subcommands with the local shell dispatcher.
-    sShellDnsSubcommands.RegisterCommands(sDnsSubCommands, ArraySize(sDnsSubCommands));
+    sShellDnsSubcommands.RegisterCommands(sDnsSubCommands, ArraySize(sDnsSubCommands), "dns");
 
     // Register the root `dns` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDnsCommand, 1);
+    Engine::Root().RegisterCommands(&sDnsCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/Meta.cpp
+++ b/src/lib/shell/commands/Meta.cpp
@@ -71,7 +71,7 @@ void RegisterMetaCommands()
 
     std::atexit(AtExitShell);
 
-    Engine::Root().RegisterCommands(sCmds, ArraySize(sCmds));
+    Engine::Root().RegisterCommands(sCmds, ArraySize(sCmds), nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/NFC.cpp
+++ b/src/lib/shell/commands/NFC.cpp
@@ -90,7 +90,7 @@ void RegisterNFCCommands()
                                                    "Start, stop or get nfc emulation state. Usage: nfc <start|stop|state>" };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/OnboardingCodes.cpp
+++ b/src/lib/shell/commands/OnboardingCodes.cpp
@@ -169,7 +169,7 @@ void RegisterOnboardingCodesCommands()
     };
 
     // Register the root `device` command with the top-level shell.
-    Engine::Root().RegisterCommands(&sDeviceComand, 1);
+    Engine::Root().RegisterCommands(&sDeviceComand, 1, nullptr);
     return;
 }
 

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -198,12 +198,12 @@ void RegisterOtaCommands()
         { &ProgressHandler, "progress", "Gets progress of a current image update process. Usage: ota progress" }
     };
 
-    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));
+    sSubShell.RegisterCommands(subCommands, ArraySize(subCommands), "ota");
 
     // Register the root `ota` command in the top-level shell.
     static const shell_command_t otaCommand = { &OtaHandler, "ota", "OTA commands" };
 
-    Engine::Root().RegisterCommands(&otaCommand, 1);
+    Engine::Root().RegisterCommands(&otaCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -138,8 +138,8 @@ void RegisterWiFiCommands()
     };
     static const shell_command_t sWiFiCommand = { &WiFiDispatch, "wifi", "Usage: wifi <subcommand>" };
 
-    sShellWiFiSubCommands.RegisterCommands(sWiFiSubCommands, ArraySize(sWiFiSubCommands));
-    Engine::Root().RegisterCommands(&sWiFiCommand, 1);
+    sShellWiFiSubCommands.RegisterCommands(sWiFiSubCommands, ArraySize(sWiFiSubCommands), "wifi");
+    Engine::Root().RegisterCommands(&sWiFiCommand, 1, nullptr);
 }
 
 } // namespace Shell

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -59,13 +59,14 @@ void get_command_completion(const char * buf, linenoiseCompletions * lc)
 
     const char * matter_prefix = "matter";
 
-    // the commands are prefixed wit "matter"
+    // the commands are prefixed with "matter"
     if (len >= 6 && strncmp(buf, matter_prefix, 6) == 0)
     {
         // remove "matter " prefix for completion lookup as the command
         // registeration in general are done without "matter" prefix
         char * line = new char[len - strlen(matter_prefix) + trailing_space + 1];
         strcpy((char *) line, &buf[7]);
+
         cmd_completion_context context = cmd_completion_context(line);
         CHIP_ERROR err_code            = Engine::GetCommandCompletions(&context);
         if (err_code == CHIP_NO_ERROR)
@@ -74,8 +75,8 @@ void get_command_completion(const char * buf, linenoiseCompletions * lc)
             {
 
                 // example: "matter" + " " + "config" + " " + "productid" + " " + '\0'
-                char * cmd_completion = new char[strlen(matter_prefix) + 1 + strlen(context.ret_prefix) + 1 +
-                                                 strlen(context.cmdv[i]->cmd_name) + trailing_space + 1];
+                char * cmd_completion =
+                    new char[strlen(matter_prefix) + 1 + strlen(context.ret_prefix) + 1 + strlen(context.cmdv[i]->cmd_name) + 1];
 
                 // Write "matter "
                 size_t pos = 0;


### PR DESCRIPTION
#### Problem
* Fixes #13269 
* There is currently no method to provide autocompletion for CLI, when there is a change(e.g. addition/removal) in the commands, developers won't know and there is no place to lookup. Autocompletion gives the ability to check all the available commands.

#### Change overview

- Require command prefix/path as argument at time of command registration (e.g. "dns" is prefix for "dns resolve" and "dns browse")
- Add `Engine::GetCmdCompletion` to provide command completion based on command prefixes
- Implement the tab autocompletion for nRF Connect and ESP32 platforms
Previously #13630 reverted due to racing changes with other command additions.

#### Testing
Build and tested manually with 

nRF52840dk with lighting-app example
![nrf](https://user-images.githubusercontent.com/1249037/151490297-b3f0d1df-779f-4d42-ae14-400ec58eab30.gif)

esp32c3 with all-clusters-app example
![esp](https://user-images.githubusercontent.com/1249037/151490307-d66b0c33-eb8c-4d68-9a7c-7908a906f34d.gif)

