### PR TITLE
[binding] remove binding when corresponding fabric removed

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -67,6 +67,11 @@ void CASESessionManager::ReleaseSession(PeerId peerId)
     ReleaseSession(FindExistingSession(peerId));
 }
 
+void CASESessionManager::ReleaseSessionForFabric(CompressedFabricId compressedFabricId)
+{
+    mConfig.devicePool->ReleaseDeviceForFabric(compressedFabricId);
+}
+
 CHIP_ERROR CASESessionManager::ResolveDeviceAddress(FabricInfo * fabric, NodeId nodeId)
 {
     VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -86,6 +86,8 @@ public:
 
     void ReleaseSession(PeerId peerId);
 
+    void ReleaseSessionForFabric(CompressedFabricId compressedFabricId);
+
     /**
      * This API triggers the DNS-SD resolution for the given node ID. The node ID will be looked up
      * on the fabric that was configured for the CASESessionManager object.

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -37,6 +37,8 @@ public:
 
     virtual OperationalDeviceProxy * FindDevice(PeerId peerId) = 0;
 
+    virtual void ReleaseDeviceForFabric(CompressedFabricId compressedFabricId) = 0;
+
     virtual ~OperationalDeviceProxyPoolDelegate() {}
 };
 
@@ -87,6 +89,17 @@ public:
         });
 
         return foundDevice;
+    }
+
+    void ReleaseDeviceForFabric(CompressedFabricId compressedFabricId) override
+    {
+        mDevicePool.ForEachActiveObject([&](auto * activeDevice) {
+            if (activeDevice->GetPeerId().GetCompressedFabricId() == compressedFabricId)
+            {
+                Release(activeDevice);
+            }
+            return Loop::Continue;
+        });
     }
 
 private:

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -281,8 +281,9 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
 {
 
     // Gets called when a fabric is deleted from KVS store
-    void OnFabricDeletedFromStorage(FabricIndex fabricId) override
+    void OnFabricDeletedFromStorage(CompressedFabricId compressedFabricId, FabricIndex fabricId) override
     {
+        printf("OpCredsFabricTableDelegate::OnFabricDeletedFromStorage\n");
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%" PRIu8 " was deleted from fabric storage.", fabricId);
         fabricListChanged();
 
@@ -332,7 +333,7 @@ void MatterOperationalCredentialsPluginServerInitCallback(void)
 
     registerAttributeAccessOverride(&gAttrAccess);
 
-    Server::GetInstance().GetFabricTable().SetFabricDelegate(&gFabricDelegate);
+    Server::GetInstance().GetFabricTable().AddFabricDelegate(&gFabricDelegate);
 }
 
 namespace {

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -486,7 +486,12 @@ exit:
     if (err == CHIP_NO_ERROR && mDelegate != nullptr)
     {
         ChipLogProgress(Discovery, "Fabric (%d) persisted to storage. Calling OnFabricPersistedToStorage", index);
-        mDelegate->OnFabricPersistedToStorage(fabric);
+        FabricTableDelegate * delegate = mDelegate;
+        while (delegate)
+        {
+            delegate->OnFabricPersistedToStorage(fabric);
+            delegate = delegate->mNext;
+        }
     }
     return err;
 }
@@ -500,11 +505,13 @@ CHIP_ERROR FabricTable::LoadFromStorage(FabricInfo * fabric)
         ReturnErrorOnFailure(fabric->LoadFromStorage(mStorage));
     }
 
-    if (mDelegate != nullptr)
+    FabricTableDelegate * delegate = mDelegate;
+    while (delegate)
     {
         ChipLogProgress(Discovery, "Fabric (%d) loaded from storage. Calling OnFabricRetrievedFromStorage",
                         fabric->GetFabricIndex());
-        mDelegate->OnFabricRetrievedFromStorage(fabric);
+        delegate->OnFabricRetrievedFromStorage(fabric);
+        delegate = delegate->mNext;
     }
     return CHIP_NO_ERROR;
 }
@@ -588,31 +595,31 @@ CHIP_ERROR FabricTable::AddNewFabric(FabricInfo & newFabric, FabricIndex * outpu
 
 CHIP_ERROR FabricTable::Delete(FabricIndex index)
 {
-    FabricInfo * fabric      = nullptr;
-    CHIP_ERROR err           = CHIP_NO_ERROR;
-    bool fabricIsInitialized = false;
-    VerifyOrExit(mStorage != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    fabric              = FindFabricWithIndex(index);
-    fabricIsInitialized = fabric != nullptr && fabric->IsInitialized();
-    err                 = FabricInfo::DeleteFromStorage(mStorage, index); // Delete from storage regardless
+    FabricInfo * fabric      = FindFabricWithIndex(index);
+    bool fabricIsInitialized = fabric != nullptr && fabric->IsInitialized();
+    CompressedFabricId compressedFabricId =
+        fabricIsInitialized ? fabric->GetPeerId().GetCompressedFabricId() : kUndefinedCompressedFabricId;
+    ReturnErrorOnFailure(FabricInfo::DeleteFromStorage(mStorage, index)); // Delete from storage regardless
 
-exit:
-    if (err == CHIP_NO_ERROR)
+    ReleaseFabricIndex(index);
+    if (mDelegate != nullptr && fabricIsInitialized)
     {
-        ReleaseFabricIndex(index);
-        if (mDelegate != nullptr && fabricIsInitialized)
+        if (mFabricCount == 0)
         {
-            if (mFabricCount == 0)
-            {
-                ChipLogError(Discovery, "!!Trying to delete a fabric, but the current fabric count is already 0");
-            }
-            else
-            {
-                mFabricCount--;
-            }
-            ChipLogProgress(Discovery, "Fabric (%d) deleted. Calling OnFabricDeletedFromStorage", index);
-            mDelegate->OnFabricDeletedFromStorage(index);
+            ChipLogError(Discovery, "!!Trying to delete a fabric, but the current fabric count is already 0");
+        }
+        else
+        {
+            mFabricCount--;
+        }
+        ChipLogProgress(Discovery, "Fabric (%d) deleted. Calling OnFabricDeletedFromStorage", index);
+        FabricTableDelegate * delegate = mDelegate;
+        while (delegate)
+        {
+            delegate->OnFabricDeletedFromStorage(compressedFabricId, index);
+            delegate = delegate->mNext;
         }
     }
     return CHIP_NO_ERROR;
@@ -649,11 +656,19 @@ CHIP_ERROR FabricTable::Init(FabricStorage * storage)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR FabricTable::SetFabricDelegate(FabricTableDelegate * delegate)
+CHIP_ERROR FabricTable::AddFabricDelegate(FabricTableDelegate * delegate)
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    mDelegate = delegate;
-    ChipLogDetail(Discovery, "Set the fabric pairing table delegate");
+    for (FabricTableDelegate * iter = mDelegate; iter != nullptr; iter = iter->mNext)
+    {
+        if (iter == delegate)
+        {
+            return CHIP_NO_ERROR;
+        }
+    }
+    delegate->mNext = mDelegate;
+    mDelegate       = delegate;
+    ChipLogDetail(Discovery, "Add fabric pairing table delegate");
     return CHIP_NO_ERROR;
 }
 

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -320,7 +320,7 @@ public:
     /**
      * Gets called when a fabric is deleted from KVS store.
      **/
-    virtual void OnFabricDeletedFromStorage(CompressedFabricId compreessedId, FabricIndex fabricIndex) = 0;
+    virtual void OnFabricDeletedFromStorage(CompressedFabricId compressedId, FabricIndex fabricIndex) = 0;
 
     /**
      * Gets called when a fabric is loaded into Fabric Table from KVS store.

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -313,12 +313,14 @@ private:
 // TODO: Reimplement FabricTable to only have one backing store.
 class DLL_EXPORT FabricTableDelegate
 {
+    friend class FabricTable;
+
 public:
     virtual ~FabricTableDelegate() {}
     /**
      * Gets called when a fabric is deleted from KVS store.
      **/
-    virtual void OnFabricDeletedFromStorage(FabricIndex fabricIndex) = 0;
+    virtual void OnFabricDeletedFromStorage(CompressedFabricId compreessedId, FabricIndex fabricIndex) = 0;
 
     /**
      * Gets called when a fabric is loaded into Fabric Table from KVS store.
@@ -329,6 +331,9 @@ public:
      * Gets called when a fabric in Fabric Table is persisted to KVS store.
      **/
     virtual void OnFabricPersistedToStorage(FabricInfo * fabricInfo) = 0;
+
+private:
+    FabricTableDelegate * mNext = nullptr;
 };
 
 /**
@@ -431,7 +436,7 @@ public:
     void Reset();
 
     CHIP_ERROR Init(FabricStorage * storage);
-    CHIP_ERROR SetFabricDelegate(FabricTableDelegate * delegate);
+    CHIP_ERROR AddFabricDelegate(FabricTableDelegate * delegate);
 
     uint8_t FabricCount() const { return mFabricCount; }
 
@@ -447,7 +452,6 @@ private:
     FabricInfo mStates[CHIP_CONFIG_MAX_DEVICE_ADMINS];
     FabricStorage * mStorage = nullptr;
 
-    // TODO: Fabric table should be backed by a single backing store (attribute store), remove delegate callbacks #6419
     FabricTableDelegate * mDelegate = nullptr;
 
     FabricIndex mNextAvailableFabricIndex = kMinValidFabricIndex;


### PR DESCRIPTION
#### Problem

Binding table entries are not correctly removed when fabric is removed.

#### Change overview

* Make `FabricTableDelegate` a linked list to support multiple handlers.
* Remove the bindint table entries when corresponding fabric removed.

#### Testing

```
chip-tool pairing ethernet 2 20202021 3840 172.17.0.3 5540
chip-tool binding bind 1 0 1 6 2 1
chip-tool operationalcredentials remove-fabric 1 2 0
```

Can observe binding removed log in the output.
