### PR TITLE
DoorLock cluster events support

### DIFF
--- a/examples/door-lock-app/linux/include/LockEndpoint.h
+++ b/examples/door-lock-app/linux/include/LockEndpoint.h
@@ -42,8 +42,8 @@ public:
 
     inline chip::EndpointId GetEndpointId() { return mEndpointId; }
 
-    bool Lock(const Optional<chip::ByteSpan> & pin);
-    bool Unlock(const Optional<chip::ByteSpan> & pin);
+    bool Lock(const Optional<chip::ByteSpan> & pin, DlOperationError & err);
+    bool Unlock(const Optional<chip::ByteSpan> & pin, DlOperationError & err);
 
     bool GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user) const;
     bool SetUser(uint16_t userIndex, chip::FabricIndex creator, chip::FabricIndex modifier, const chip::CharSpan & userName,
@@ -64,7 +64,7 @@ public:
                          uint32_t localEndTime);
 
 private:
-    bool setLockState(DlLockState lockState, const Optional<chip::ByteSpan> & pin);
+    bool setLockState(DlLockState lockState, const Optional<chip::ByteSpan> & pin, DlOperationError & err);
     const char * lockStateToString(DlLockState lockState) const;
 
     chip::EndpointId mEndpointId;

--- a/examples/door-lock-app/linux/include/LockManager.h
+++ b/examples/door-lock-app/linux/include/LockManager.h
@@ -31,8 +31,8 @@ public:
 
     bool InitEndpoint(chip::EndpointId endpointId);
 
-    bool Lock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin);
-    bool Unlock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin);
+    bool Lock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin, DlOperationError & err);
+    bool Unlock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin, DlOperationError & err);
 
     bool GetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user);
     bool SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip::FabricIndex creator, chip::FabricIndex modifier,

--- a/examples/door-lock-app/linux/main.cpp
+++ b/examples/door-lock-app/linux/main.cpp
@@ -31,14 +31,15 @@ using namespace chip::app::Clusters::DoorLock;
 // should wait for door to be locked on lock command and return success) but
 // door lock server should check pin before even calling the lock-door
 // callback.
-bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode)
+bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
-    return LockManager::Instance().Lock(endpointId, pinCode);
+    return LockManager::Instance().Lock(endpointId, pinCode, err);
 }
 
-bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode)
+bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode,
+                                              DlOperationError & err)
 {
-    return LockManager::Instance().Unlock(endpointId, pinCode);
+    return LockManager::Instance().Unlock(endpointId, pinCode, err);
 }
 
 bool emberAfPluginDoorLockGetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user)

--- a/examples/door-lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/door-lock-app/linux/src/LockEndpoint.cpp
@@ -20,14 +20,14 @@
 
 using chip::to_underlying;
 
-bool LockEndpoint::Lock(const Optional<chip::ByteSpan> & pin)
+bool LockEndpoint::Lock(const Optional<chip::ByteSpan> & pin, DlOperationError & err)
 {
-    return setLockState(DlLockState::kLocked, pin);
+    return setLockState(DlLockState::kLocked, pin, err);
 }
 
-bool LockEndpoint::Unlock(const Optional<chip::ByteSpan> & pin)
+bool LockEndpoint::Unlock(const Optional<chip::ByteSpan> & pin, DlOperationError & err)
 {
-    return setLockState(DlLockState::kUnlocked, pin);
+    return setLockState(DlLockState::kUnlocked, pin, err);
 }
 
 bool LockEndpoint::GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user) const
@@ -286,7 +286,7 @@ DlStatus LockEndpoint::SetSchedule(uint8_t yearDayIndex, uint16_t userIndex, DlS
     return DlStatus::kSuccess;
 }
 
-bool LockEndpoint::setLockState(DlLockState lockState, const Optional<chip::ByteSpan> & pin)
+bool LockEndpoint::setLockState(DlLockState lockState, const Optional<chip::ByteSpan> & pin, DlOperationError & err)
 {
     if (mLockState == lockState)
     {
@@ -329,6 +329,7 @@ bool LockEndpoint::setLockState(DlLockState lockState, const Optional<chip::Byte
                   "[endpointId=%d]",
                   lockStateToString(lockState), mEndpointId);
 
+    err = DlOperationError::kInvalidCredential;
     return false;
 }
 

--- a/examples/door-lock-app/linux/src/LockManager.cpp
+++ b/examples/door-lock-app/linux/src/LockManager.cpp
@@ -91,7 +91,7 @@ bool LockManager::InitEndpoint(chip::EndpointId endpointId)
     return true;
 }
 
-bool LockManager::Lock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin)
+bool LockManager::Lock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin, DlOperationError & err)
 {
     auto lockEndpoint = getEndpoint(endpointId);
     if (nullptr == lockEndpoint)
@@ -99,10 +99,10 @@ bool LockManager::Lock(chip::EndpointId endpointId, const Optional<chip::ByteSpa
         ChipLogError(Zcl, "Unable to lock the door - endpoint does not exist or not initialized [endpointId=%d]", endpointId);
         return false;
     }
-    return lockEndpoint->Lock(pin);
+    return lockEndpoint->Lock(pin, err);
 }
 
-bool LockManager::Unlock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin)
+bool LockManager::Unlock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin, DlOperationError & err)
 {
     auto lockEndpoint = getEndpoint(endpointId);
     if (nullptr == lockEndpoint)
@@ -110,7 +110,7 @@ bool LockManager::Unlock(chip::EndpointId endpointId, const Optional<chip::ByteS
         ChipLogError(Zcl, "Unable to unlock the door - endpoint does not exist or not initialized [endpointId=%d]", endpointId);
         return false;
     }
-    return lockEndpoint->Unlock(pin);
+    return lockEndpoint->Unlock(pin, err);
 }
 
 bool LockManager::GetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user)

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -25,6 +25,9 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/command-id.h>
+#include <app/EventLogging.h>
+#include <app/util/af-event.h>
 #include <app/util/af.h>
 #include <cinttypes>
 
@@ -35,6 +38,7 @@
 #include <lib/support/CodeUtils.h>
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::DoorLock;
 
@@ -64,23 +68,48 @@ void DoorLockServer::InitServer(chip::EndpointId endpointId)
 {
     emberAfDoorLockClusterPrintln("Door Lock cluster initialized at endpoint #%" PRIu16, endpointId);
 
-    SetLockState(endpointId, DlLockState::kLocked);
+    SetLockState(endpointId, DlLockState::kLocked, DlOperationSource::kUnspecified);
     SetActuatorEnabled(endpointId, true);
 }
 
-bool DoorLockServer::SetLockState(chip::EndpointId endpointId, DlLockState newLockState)
+bool DoorLockServer::SetLockState(chip::EndpointId endpointId, DlLockState newLockState, DlOperationSource opSource)
 {
     auto lockState = chip::to_underlying(newLockState);
 
     emberAfDoorLockClusterPrintln("Setting LockState to '%" PRIu8 "'", lockState);
     EmberAfStatus status = Attributes::LockState::Set(endpointId, newLockState);
+    bool success         = (EMBER_ZCL_STATUS_SUCCESS == status);
 
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    if (!success)
     {
         ChipLogError(Zcl, "Unable to set LockState attribute: status=0x%" PRIx8, status);
     }
 
-    return (EMBER_ZCL_STATUS_SUCCESS == status);
+    // Remote operations are handled separately as they use more data unavailable here
+    VerifyOrReturnError(DlOperationSource::kRemote != opSource, success);
+
+    // DlLockState::kNotFullyLocked has no appropriate event to send. Also it is unclear whether
+    // it should schedule auto-relocking. So skip it here. Check for supported states explicitly
+    // to handle possible enum extending in future.
+    VerifyOrReturnError(DlLockState::kLocked == newLockState || DlLockState::kUnlocked == newLockState, success);
+
+    // Send LockOperation event
+    auto opType = (DlLockState::kLocked == newLockState) ? DlLockOperationType::kLock : DlLockOperationType::kUnlock;
+
+    SendLockOperationEvent(endpointId, opType, opSource, DlOperationError::kUnspecified, Nullable<uint16_t>(),
+                           Nullable<chip::FabricIndex>(), Nullable<chip::NodeId>(), nullptr, 0, success);
+
+    // Schedule auto-relocking
+    if (success && DlLockOperationType::kUnlock == opType)
+    {
+        uint32_t autoRelockTime;
+
+        status  = Attributes::AutoRelockTime::Get(endpointId, &autoRelockTime);
+        success = (EMBER_ZCL_STATUS_SUCCESS == status);
+        // TODO: Handle AutoRelockTime here
+    }
+
+    return success;
 }
 
 bool DoorLockServer::SetActuatorEnabled(chip::EndpointId endpointId, bool newActuatorState)
@@ -108,6 +137,11 @@ bool DoorLockServer::SetDoorState(chip::EndpointId endpointId, DlDoorState newDo
     if (EMBER_ZCL_STATUS_SUCCESS != status)
     {
         ChipLogError(Zcl, "Unable to set DoorState attribute: status=0x%" PRIx8, status);
+    }
+    else
+    {
+        Events::DoorStateChange::Type event{ newDoorState };
+        SendEvent(endpointId, event);
     }
 
     return (EMBER_ZCL_STATUS_SUCCESS == status);
@@ -771,85 +805,6 @@ void DoorLockServer::ClearCredentialCommandHandler(
 
     emberAfSendImmediateDefaultResponse(
         clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, false));
-}
-
-void DoorLockServer::LockUnlockDoorCommandHandler(chip::app::CommandHandler * commandObj,
-                                                  const chip::app::ConcreteCommandPath & commandPath,
-                                                  DlLockOperationType operationType, const chip::Optional<chip::ByteSpan> & pinCode)
-{
-    chip::EndpointId endpoint = commandPath.mEndpointId;
-
-    VerifyOrDie(DlLockOperationType::kLock == operationType || DlLockOperationType::kUnlock == operationType);
-
-    EmberAfDoorLockLockUnlockCommand appCommandHandler = emberAfPluginDoorLockOnDoorLockCommand;
-    const char * commandNameStr                        = "LockDoor";
-    auto newLockState                                  = DlLockState::kLocked;
-    if (DlLockOperationType::kUnlock == operationType)
-    {
-        newLockState      = DlLockState::kUnlocked;
-        commandNameStr    = "UnlockDoor";
-        appCommandHandler = emberAfPluginDoorLockOnDoorUnlockCommand;
-    }
-    VerifyOrDie(nullptr != commandNameStr);
-    VerifyOrDie(nullptr != appCommandHandler);
-
-    emberAfDoorLockClusterPrintln("[%s] Received Lock Door command [endpointId=%d]", commandNameStr, endpoint);
-
-    bool require_pin = false;
-    auto status      = Attributes::RequirePINforRemoteOperation::Get(endpoint, &require_pin);
-    if (EMBER_ZCL_STATUS_SUCCESS != status)
-    {
-        emberAfDoorLockClusterPrintln(
-            "[%s] Unable to get value of RequirePINforRemoteOperation attribute, defaulting to 'true' [endpointId=%d,status=%d]",
-            commandNameStr, endpoint, status);
-
-        require_pin = true;
-    }
-
-    if (pinCode.HasValue() && !(SupportsPIN(endpoint) && SupportsUSR(endpoint)))
-    {
-        emberAfDoorLockClusterPrintln(
-            "[%s] PIN is supplied but USR and PIN features are disabled - ignoring command [endpointId=%d]", commandNameStr,
-            endpoint);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
-    }
-
-    if (require_pin && !pinCode.HasValue())
-    {
-        emberAfDoorLockClusterPrintln("[%s] PIN is required but not provided - ignoring command [endpointId=%d]", commandNameStr,
-                                      endpoint);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
-
-        return;
-    }
-
-    // Look up the user index and credential index -- it should be used in the Lock Operation event. However, I don't think we
-    // should prevent door lock/unlocking if we couldn't find credential associated with user - I think if the app thinks that PIN
-    // is correct the door should be unlocked.
-    uint16_t associatedUserIndex = 0;
-    uint16_t usedCredentialIndex = 0;
-    if (pinCode.HasValue())
-    {
-        if (!findUserIndexByCredential(endpoint, DlCredentialType::kPin, pinCode.Value(), associatedUserIndex, usedCredentialIndex))
-        {
-            emberAfDoorLockClusterPrintln("[%s] Provided credential is not associated with any user [endpointId=%d]",
-                                          commandNameStr, endpoint);
-        }
-    }
-
-    // The app is responsible to search through the list of PIN codes internally
-    if (!appCommandHandler(endpoint, pinCode))
-    {
-        ChipLogError(Zcl, "[%s] Unable to change the door state - internal error [endpointId=%d]", commandNameStr, endpoint);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-
-        return;
-    }
-
-    // TODO: Send lock operation change event
-    SetLockState(endpoint, newLockState);
-
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
 void DoorLockServer::SetWeekDayScheduleCommandHandler(
@@ -2700,6 +2655,146 @@ DlLockDataType DoorLockServer::credentialTypeToLockDataType(DlCredentialType cre
 
     return DlLockDataType::kUnspecified;
 }
+
+bool DoorLockServer::HandleRemoteLockOperation(chip::app::CommandHandler * commandObj,
+                                               const chip::app::ConcreteCommandPath & commandPath, DlLockOperationType opType,
+                                               RemoteLockOpHandler opHandler, const Optional<ByteSpan> & pinCode)
+{
+    VerifyOrDie(DlLockOperationType::kLock == opType || DlLockOperationType::kUnlock == opType);
+    VerifyOrDie(nullptr != opHandler);
+
+    DlLockState newLockState = (DlLockOperationType::kLock == opType) ? DlLockState::kLocked : DlLockState::kUnlocked;
+    EndpointId endpoint      = commandPath.mEndpointId;
+    DlOperationError reason  = DlOperationError::kUnspecified;
+    uint16_t pinUserIdx      = 0;
+    uint16_t pinCredIdx      = 0;
+    bool credentialsOk       = false;
+    bool operationOk         = false;
+
+    // appclusters.pdf 5.3.4.1:
+    // When the PINCode field is provided an invalid PIN will count towards the WrongCodeEntryLimit and the
+    // UserCodeTemporaryDisableTime will be triggered if the WrongCodeEntryLimit is exceeded. The lock SHALL ignore any attempts to
+    // lock/unlock the door until the UserCodeTemporaryDisableTime expires.
+    // TODO: check whether UserCodeTemporaryDisableTime expired or not.
+
+    if (pinCode.HasValue())
+    {
+        // appclusters.pdf 5.3.4.1:
+        // If the PINCode field is provided, the door lock SHALL verify PINCode before granting access regardless of the value of
+        // RequirePINForRemoteOperation attribute.
+        VerifyOrExit(SupportsPIN(endpoint) && SupportsUSR(endpoint),
+                     emberAfDoorLockClusterPrintln(
+                         "PIN code is supplied while USR/PIN features are disabled. Exiting [endpoint=%d, lock_op=%d]", endpoint,
+                         chip::to_underlying(opType)));
+
+        // Look up the user index and credential index -- it should be used in the Lock Operation event
+        findUserIndexByCredential(endpoint, DlCredentialType::kPin, pinCode.Value(), pinUserIdx, pinCredIdx);
+
+        // [EM]: I don't think we should prevent door lock/unlocking if we couldn't find credential associated with user. I
+        // think if the app thinks that PIN is correct the door should be unlocked.
+        //
+        // [DV]: let's app decide on PIN correctness, we will fail only if 'opHandler' returns false.
+        credentialsOk =
+            true; // findUserIndexByCredential(endpoint, DlCredentialType::kPin, pinCode.Value(), pinUserIdx, pinCredIdx);
+    }
+    else
+    {
+        // appclusters.pdf 5.3.4.1:
+        // If the RequirePINforRemoteOperation attribute is True then PINCode field SHALL be provided and the door lock SHALL NOT
+        // grant access if it is not provided.
+        bool requirePin = false;
+        auto err        = Attributes::RequirePINforRemoteOperation::Get(endpoint, &requirePin);
+
+        VerifyOrExit(
+            EMBER_ZCL_STATUS_SUCCESS == err,
+            emberAfDoorLockClusterPrintln("Failed to read 'RequirePINforRemoteOperations' attribute: status=0x%" PRIx8, err));
+        credentialsOk = !requirePin;
+    }
+
+    // TODO: increase WrongCodeEntryLimit if credentialsOk == false.
+    // TODO: If limit is exceeded, lock remote operations for UserCodeTemporaryDisableTime.
+    VerifyOrExit(credentialsOk, {
+        reason = DlOperationError::kInvalidCredential;
+        emberAfDoorLockClusterPrintln("Checking credentials failed: either PIN is invalid or not provided");
+    });
+
+    // credentials check succeeded, try to lock/unlock door
+    operationOk = opHandler(endpoint, pinCode, reason);
+    VerifyOrExit(operationOk, /* reason is set by the above call */);
+
+    // door locked, set cluster attribute
+    VerifyOrDie(SetLockState(endpoint, newLockState, DlOperationSource::kRemote));
+
+exit:
+    bool success = credentialsOk && operationOk;
+
+    // Send command response
+    emberAfSendImmediateDefaultResponse(success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
+
+    // Send LockOperation/LockOperationError event
+    LockOpCredentials foundCred[] = { { DlCredentialType::kPin, pinCredIdx } };
+    LockOpCredentials * credList  = nullptr;
+    size_t credListSize           = 0;
+
+    // appclusters.pdf 5.3.5.3, 5.3.5.4:
+    // The list of credentials used in performing the lock operation. This SHALL be null if no credentials were involved.
+    if (pinCode.HasValue())
+    {
+        credList     = foundCred;
+        credListSize = 1;
+    }
+
+    SendLockOperationEvent(endpoint, opType, DlOperationSource::kRemote, reason, Nullable<uint16_t>(pinUserIdx),
+                           Nullable<chip::FabricIndex>(getFabricIndex(commandObj)), Nullable<chip::NodeId>(getNodeId(commandObj)),
+                           credList, credListSize, success);
+    return success;
+}
+
+void DoorLockServer::SendLockOperationEvent(chip::EndpointId endpointId, DlLockOperationType opType, DlOperationSource opSource,
+                                            DlOperationError opErr, Nullable<uint16_t> userId,
+                                            Nullable<chip::FabricIndex> fabricIdx, Nullable<chip::NodeId> nodeId,
+                                            LockOpCredentials * credList, size_t credListSize, bool opSuccess)
+{
+    Nullable<List<const Structs::DlCredential::Type>> credentials{};
+
+    // appclusters.pdf 5.3.5.3, 5.3.5.4:
+    // The list of credentials used in performing the lock operation. This SHALL be null if no credentials were involved.
+    if (nullptr == credList || 0 == credListSize)
+    {
+        credentials.SetNull();
+    }
+    else
+    {
+        credentials.SetNonNull(List<const Structs::DlCredential::Type>(credList, credListSize));
+    }
+
+    // TODO: if [USR] feature is not supported then credentials should be omitted (Optional.HasValue()==false)?
+    // Spec just says that it should be NULL if no PIN were provided.
+
+    if (opSuccess)
+    {
+        Events::LockOperation::Type event{ opType, opSource, userId, fabricIdx, nodeId, MakeOptional(credentials) };
+        SendEvent(endpointId, event);
+    }
+    else
+    {
+        Events::LockOperationError::Type event{ opType, opSource, opErr, userId, fabricIdx, nodeId, MakeOptional(credentials) };
+        SendEvent(endpointId, event);
+    }
+}
+
+template <typename T>
+void DoorLockServer::SendEvent(chip::EndpointId endpointId, T & event)
+{
+    EventNumber eventNumber;
+    auto err = chip::app::LogEvent(event, endpointId, eventNumber);
+
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(Zcl, "Failed to log event: err=0x%" PRIx32 ", event_id=0x%" PRIx32, err.AsInteger(), event.GetEventId());
+    }
+}
+
 // =============================================================================
 // Cluster commands callbacks
 // =============================================================================
@@ -2708,8 +2803,9 @@ bool emberAfDoorLockClusterLockDoorCallback(chip::app::CommandHandler * commandO
                                             const chip::app::ConcreteCommandPath & commandPath,
                                             const chip::app::Clusters::DoorLock::Commands::LockDoor::DecodableType & commandData)
 {
-    DoorLockServer::Instance().LockUnlockDoorCommandHandler(commandObj, commandPath, DlLockOperationType::kLock,
-                                                            commandData.pinCode);
+    emberAfDoorLockClusterPrintln("Received command: LockDoor");
+    DoorLockServer::Instance().HandleRemoteLockOperation(commandObj, commandPath, DlLockOperationType::kLock,
+                                                         emberAfPluginDoorLockOnDoorLockCommand, commandData.pinCode);
     return true;
 }
 
@@ -2717,8 +2813,14 @@ bool emberAfDoorLockClusterUnlockDoorCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::UnlockDoor::DecodableType & commandData)
 {
-    DoorLockServer::Instance().LockUnlockDoorCommandHandler(commandObj, commandPath, DlLockOperationType::kUnlock,
-                                                            commandData.pinCode);
+    emberAfDoorLockClusterPrintln("Received command: UnlockDoor");
+
+    if (DoorLockServer::Instance().HandleRemoteLockOperation(commandObj, commandPath, DlLockOperationType::kUnlock,
+                                                             emberAfPluginDoorLockOnDoorUnlockCommand, commandData.pinCode))
+    {
+        // TODO: if AutoRelockTime is set, schedule automatic door locking
+    }
+
     return true;
 }
 
@@ -2726,10 +2828,14 @@ bool emberAfDoorLockClusterUnlockWithTimeoutCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::DecodableType & commandData)
 {
-    emberAfDoorLockClusterPrintln("UnlockWithTimeout: command not implemented");
+    emberAfDoorLockClusterPrintln("Received command: UnlockWithTimeout");
 
-    // TODO: Implement door unlocking with timeout
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+    if (DoorLockServer::Instance().HandleRemoteLockOperation(commandObj, commandPath, DlLockOperationType::kUnlock,
+                                                             emberAfPluginDoorLockOnDoorUnlockCommand, commandData.pinCode))
+    {
+        // TODO: Implement door locking with given timeout
+    }
+
     return true;
 }
 
@@ -2985,18 +3091,26 @@ void MatterDoorLockPluginServerInitCallback()
 
 void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath) {}
 
-bool __attribute__((weak)) emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode)
+// =============================================================================
+// 'Default' callbacks for cluster commands
+// =============================================================================
+
+bool __attribute__((weak))
+emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
+    err = DlOperationError::kUnspecified;
     return false;
 }
 
-bool __attribute__((weak)) emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode)
+bool __attribute__((weak))
+emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
+    err = DlOperationError::kUnspecified;
     return false;
 }
 
 // =============================================================================
-// Pre-change callbacks for cluster attributes
+// 'Default' pre-change callbacks for cluster attributes
 // =============================================================================
 
 chip::Protocols::InteractionModel::Status __attribute__((weak))

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -27,7 +27,12 @@
 #include <app-common/zap-generated/af-structs.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandler.h>
+#include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
+
+#ifndef DOOR_LOCK_SERVER_ENDPOINT
+#define DOOR_LOCK_SERVER_ENDPOINT 1
+#endif
 
 using chip::Optional;
 using chip::app::Clusters::DoorLock::DlCredentialRule;
@@ -38,16 +43,18 @@ using chip::app::Clusters::DoorLock::DlDoorState;
 using chip::app::Clusters::DoorLock::DlLockDataType;
 using chip::app::Clusters::DoorLock::DlLockOperationType;
 using chip::app::Clusters::DoorLock::DlLockState;
+using chip::app::Clusters::DoorLock::DlOperationError;
 using chip::app::Clusters::DoorLock::DlOperationSource;
 using chip::app::Clusters::DoorLock::DlStatus;
 using chip::app::Clusters::DoorLock::DlUserStatus;
 using chip::app::Clusters::DoorLock::DlUserType;
 using chip::app::Clusters::DoorLock::DoorLockFeature;
+using chip::app::DataModel::List;
 using chip::app::DataModel::Nullable;
 
-#ifndef DOOR_LOCK_SERVER_ENDPOINT
-#define DOOR_LOCK_SERVER_ENDPOINT 1
-#endif
+using LockOpCredentials = chip::app::Clusters::DoorLock::Structs::DlCredential::Type;
+
+typedef bool (*RemoteLockOpHandler)(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode, DlOperationError & err);
 
 static constexpr size_t DOOR_LOCK_MAX_USER_NAME_SIZE = 10; /**< Maximum size of the user name (in characters). */
 static constexpr size_t DOOR_LOCK_USER_NAME_BUFFER_SIZE =
@@ -68,7 +75,7 @@ public:
 
     void InitServer(chip::EndpointId endpointId);
 
-    bool SetLockState(chip::EndpointId endpointId, DlLockState newLockState);
+    bool SetLockState(chip::EndpointId endpointId, DlLockState newLockState, DlOperationSource opSource);
     bool SetActuatorEnabled(chip::EndpointId endpointId, bool newActuatorState);
     bool SetDoorState(chip::EndpointId endpointId, DlDoorState newDoorState);
 
@@ -252,6 +259,63 @@ private:
 
     DlLockDataType credentialTypeToLockDataType(DlCredentialType credentialType);
 
+    /**
+     * @brief Common handler for LockDoor, UnlockDoor, UnlockWithTimeout commands
+     *
+     * @param commandObj    original command context
+     * @param commandPath   original command path
+     * @param opType        remote operation type (lock, unlock)
+     * @param opHandler     plugin handler for specified command
+     * @param pinCode       pin code passed by client
+     * @return true         if locking/unlocking was successfull
+     * @return false        if error happenned during lock/unlock
+     */
+    bool HandleRemoteLockOperation(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                   DlLockOperationType opType, RemoteLockOpHandler opHandler,
+                                   const chip::Optional<chip::ByteSpan> & pinCode);
+
+    /**
+     * @brief Send LockOperation event if opSuccess is true, otherwise send LockOperationError with given opErr code
+     *
+     * @param endpointId    endpoint where DoorLockServer is running
+     * @param opType        lock operation type (lock, unlock, etc)
+     * @param opSource      operation source (remote, keypad, auto, etc)
+     * @param opErr         operation error code (if opSuccess == false)
+     * @param userId        user id
+     * @param fabricIdx     fabric index
+     * @param nodeId        node id
+     * @param credList      list of credentials used in lock operation (can be NULL if no credentials were used)
+     * @param credListSize  size of credentials list (if 0, then no credentials were used)
+     * @param opSuccess     flags if operation was successfull or not
+     */
+    void SendLockOperationEvent(chip::EndpointId endpointId, DlLockOperationType opType, DlOperationSource opSource,
+                                DlOperationError opErr, Nullable<uint16_t> userId, Nullable<chip::FabricIndex> fabricIdx,
+                                Nullable<chip::NodeId> nodeId, LockOpCredentials * credList, size_t credListSize,
+                                bool opSuccess = true);
+
+    /**
+     * @brief Send generic event
+     *
+     * @tparam T            Any event type supported by Matter
+     * @param endpointId    endpoint where DoorLockServer is running
+     * @param event         event object built by caller
+     */
+    template <typename T>
+    void SendEvent(chip::EndpointId endpointId, T & event);
+
+    friend bool
+    emberAfDoorLockClusterLockDoorCallback(chip::app::CommandHandler * commandObj,
+                                           const chip::app::ConcreteCommandPath & commandPath,
+                                           const chip::app::Clusters::DoorLock::Commands::LockDoor::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterUnlockDoorCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::UnlockDoor::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterUnlockWithTimeoutCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::DecodableType & commandData);
+
     static DoorLockServer instance;
 };
 
@@ -403,33 +467,6 @@ DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t w
 DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
                                           DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime);
 
-typedef bool (*EmberAfDoorLockLockUnlockCommand)(chip::EndpointId endpointId, const chip::Optional<chip::ByteSpan> & pinCode);
-
-/**
- * @brief This callback is called when Door Lock cluster needs to issue command to lock the door.
- *
- * @param endpointId ID of the endpoint which contains the lock.
- * @param[in] pinCode PIN code that is used to lock the door. Could be absent if attribute RequirePINforRemoteOperation is not set
- * or set to false.
- *
- * @return true if the door was locked, false in case of any failure.
- */
-bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode);
-
-/**
- * @brief This callback is called when Door Lock cluster needs to issue command to unlock the door.
- *
- * @param endpointId ID of the endpoint which contains the lock.
- * @param[in[ pinCode PIN code that is used to unlock the door. Could be absent if attribute RequirePINforRemoteOperation is not set
- * or set to false.
- *
- * @return true if the door was unlocked, false in case of any failure.
- */
-bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode);
-
-bool emberAfPluginDoorLockOnDoorUnlockWithTimeoutCommand(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode,
-                                                         uint16_t timeout);
-
 // =============================================================================
 // Pre-change callbacks for cluster attributes
 // =============================================================================
@@ -535,6 +572,37 @@ chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUserCodeTempora
 chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUnhandledAttributeChange(chip::EndpointId EndpointId,
                                                                                           EmberAfAttributeType attrType,
                                                                                           uint16_t attrSize, uint8_t * attrValue);
+
+// =============================================================================
+// Plugin callbacks that are called by cluster server and should be implemented
+// by the server app
+// =============================================================================
+
+/**
+ * @brief User handler for LockDoor command (server)
+ *
+ * @param   endpointId      endpoint for which LockDoor command is called
+ * @param   pinCode         PIN code (optional)
+ * @param   err             error code if door locking failed (set only if retval==false)
+ *
+ * @retval true on success
+ * @retval false if error happenned (err should be set to appropriate error code)
+ */
+bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode,
+                                            DlOperationError & err);
+
+/**
+ * @brief User handler for UnlockDoor command (server)
+ *
+ * @param   endpointId      endpoint for which UnlockDoor command is called
+ * @param   pinCode         PIN code (optional)
+ * @param   err             error code if door unlocking failed (set only if retval==false)
+ *
+ * @retval true on success
+ * @retval false if error happenned (err should be set to appropriate error code)
+ */
+bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode,
+                                              DlOperationError & err);
 
 /**
  * @brief This callback is called when Door Lock cluster needs to access the users database.


### PR DESCRIPTION
#### Change overview
1. Supported events: DoorStateChange, LockOperation, LockOperationError;
2. Refactored commands: LockDoor, UnlockDoor, UnlockWithTimeout - implemented common logic for remote locking/unlocking and appropriate events sending;
3. Updated linux door-lock-app to fit cluster changes.

#### Testing
* Before merging with Users and Credentials feature: manual testing using chip-tool (lock/unlock door, check that appropriate event is sent and contains actual data);
* After merging with Users and Credentials feature: automated test execution - DL_UserAndCredentials, DL_LockUnlock. Read events using chip-tool, chech that appropriate data was sent.