### PR TITLE
[commissioner] Drop BLE connection before CASE

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1854,6 +1854,9 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     }
     break;
     case CommissioningStage::kFindOperational: {
+#if CONFIG_NETWORK_LAYER_BLE
+        CloseBleConnection();
+#endif
         CHIP_ERROR err = UpdateDevice(proxy->GetDeviceId());
         if (err != CHIP_NO_ERROR)
         {


### PR DESCRIPTION
#### Problem
The commissioner starts operational node discovery and CASE with the commissionee without dropping the BLE connection
and it's the reposibility of the commissionee to drop the BLE connection upon reception of Sigma 1.

Exchanging quite big Sigma messages while still maintaining the BLE connection may cause frame drops on a Thread Sleepy End Device depending on the device BLE configuration.

#### Change overview
Drop the BLE connection on the commissioner side as soon as it's no longer needed.

#### Testing
Ran lots of `chip-tool paring ble-thread` commands against a nRF Connect Sleepy End Device.
