### PR TITLE
[OTA] Use default country code in the QueryImage command if the local value is corrupted

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -554,12 +554,13 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
 
     char location[DeviceLayer::ConfigurationManager::kMaxLocationLength];
     size_t codeLen = 0;
-    if ((DeviceLayer::ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR) && (codeLen > 0))
+    if ((DeviceLayer::ConfigurationMgr().GetCountryCode(location, sizeof(location), codeLen) == CHIP_NO_ERROR) && (codeLen == 2))
     {
         args.location.SetValue(CharSpan(location, codeLen));
     }
     else
     {
+        // Country code unavailable or invalid, use default
         args.location.SetValue(CharSpan("XX", strlen("XX")));
     }
 


### PR DESCRIPTION
#### Problem
Due to https://github.com/project-chip/connectedhomeip/issues/14500 the Requestor may send out an invalid CountryCode value (less than 2 bytes) in the QueryImage command. The Provider then rejects the command failing the OTA Update scenario.

#### Change overview
Use default country code in the QueryImage command if the local value is corrupted

#### Testing
Verified OTA Update flow on EFR32 over Thread