### PR TITLE
Make Darwin/Linux all-clusters-app use the correct VID/PID

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -222,9 +222,9 @@ class BaseTestHelper:
     def TestReadBasicAttributes(self, nodeid: int, endpoint: int, group: int):
         basic_cluster_attrs = {
             "VendorName": "TEST_VENDOR",
-            "VendorID": 9050,
+            "VendorID": 0xFFF1,
             "ProductName": "TEST_PRODUCT",
-            "ProductID": 65279,
+            "ProductID": 0x8000,
             "NodeLabel": "Test",
             "Location": "XX",
             "HardwareVersion": 0,

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -160,9 +160,14 @@
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
  *
  * The CHIP-assigned vendor id for the organization responsible for producing the device.
+ *
+ * Default is the Test VendorID of 0xFFF1.
+ *
+ * Un-overridden default must match the default test DAC
+ * (see src/credentials/examples/DeviceAttestationCredsExample.cpp).
  */
 #ifndef CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
-#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 9050
+#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
 #endif
 
 /**
@@ -179,9 +184,12 @@
  *
  * The unique id assigned by the device vendor to identify the product or device type.  This
  * number is scoped to the device vendor id.
+ *
+ * Un-overridden default must match the default test DAC
+ * (see src/credentials/examples/DeviceAttestationCredsExample.cpp)
  */
 #ifndef CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
-#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 65279
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8000
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
- The all-clusters-app used for all CI is using an arbitrary
  (and wrong) VID and PID.
- The VID/PID used and reported by BasicInformation cluster
  mismatch the VID/PID in the example DACs, which prevents
  enabling to-spec device attestation verification, since
  it would always fail in CI.
- The *only* valid VID for test apps are 0xFFF1..0xFFF4. The
  test DACs use 0xFFF1 today.

Issue #14434

#### Change overview
This change updates the default testing VID/PID to 0xFFF1:0x8000,
which is used only by all-clusters-app on Darwin/Linux since all
other examples/platforms override this to a different value that
is at their discretion.

This will allow adding to-spec support of DAC and CD chain
validation against correct VID/PID, which underpins
the entire Device Attestation and Certification Declaration
feature.

#### Testing
Testing done:
- Unit tests and integration tests in CI still pass
- all-cluster-linux app shows proper VID/PID matching DAC
```
[1643385932.182882][2056528:2056528] CHIP:DL:   Vendor Id: 65521 (0xFFF1)
[1643385932.182896][2056528:2056528] CHIP:DL:   Product Id: 32768 (0x8000)
```
