### PR TITLE
Group encryption/decryption enabled.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1523,7 +1523,7 @@ server cluster GroupKeyManagement = 63 {
     INT64U epochStartTime2 = 7;
   }
 
-  readonly attribute GroupKey groupKeyMap[] = 0;
+  attribute GroupKey groupKeyMap[] = 0;
   readonly attribute GroupInfo groupTable[] = 1;
   readonly attribute int16u maxGroupsPerFabric = 2;
   readonly attribute int16u maxGroupKeysPerFabric = 3;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -25,6 +25,7 @@
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/TestGroupData.h>
 
 void Commands::Register(const char * clusterName, commands_list commandsList)
 {
@@ -43,6 +44,9 @@ int Commands::Run(int argc, char ** argv)
 
     err = mStorage.Init();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Storage failure: %s", chip::ErrorStr(err)));
+
+    err = chip::GroupTesting::InitGroupData();
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Group Data failure: %s", chip::ErrorStr(err)));
 
     chip::Logging::SetLogFilter(mStorage.GetLoggingLevel());
 

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1054,10 +1054,6 @@ client cluster OnOff = 6 {
     int16u onTime = 1;
     int16u offWaitTime = 2;
   }
-
-  command OffWithEffect(OffWithEffectRequest): DefaultSuccess = 64;
-  command OnWithRecallGlobalScene(): DefaultSuccess = 65;
-  command OnWithTimedOff(OnWithTimedOffRequest): DefaultSuccess = 66;
 }
 
 server cluster OnOff = 6 {
@@ -1100,7 +1096,10 @@ server cluster OnOff = 6 {
   }
 
   command Off(): DefaultSuccess = 0;
+  command OffWithEffect(OffWithEffectRequest): DefaultSuccess = 64;
   command On(): DefaultSuccess = 1;
+  command OnWithRecallGlobalScene(): DefaultSuccess = 65;
+  command OnWithTimedOff(OnWithTimedOffRequest): DefaultSuccess = 66;
   command Toggle(): DefaultSuccess = 2;
 }
 

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1054,6 +1054,10 @@ client cluster OnOff = 6 {
     int16u onTime = 1;
     int16u offWaitTime = 2;
   }
+
+  command OffWithEffect(OffWithEffectRequest): DefaultSuccess = 64;
+  command OnWithRecallGlobalScene(): DefaultSuccess = 65;
+  command OnWithTimedOff(OnWithTimedOffRequest): DefaultSuccess = 66;
 }
 
 server cluster OnOff = 6 {
@@ -1096,10 +1100,7 @@ server cluster OnOff = 6 {
   }
 
   command Off(): DefaultSuccess = 0;
-  command OffWithEffect(OffWithEffectRequest): DefaultSuccess = 64;
   command On(): DefaultSuccess = 1;
-  command OnWithRecallGlobalScene(): DefaultSuccess = 65;
-  command OnWithTimedOff(OnWithTimedOffRequest): DefaultSuccess = 66;
   command Toggle(): DefaultSuccess = 2;
 }
 

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -341,7 +341,7 @@ server cluster GroupKeyManagement = 63 {
     CHAR_STRING<16> groupName = 3;
   }
 
-  readonly attribute GroupKey groupKeyMap[] = 0;
+  attribute GroupKey groupKeyMap[] = 0;
   readonly attribute GroupInfo groupTable[] = 1;
   readonly global attribute int16u clusterRevision = 65533;
 }

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -707,7 +707,7 @@ server cluster GroupKeyManagement = 63 {
     CHAR_STRING<16> groupName = 3;
   }
 
-  readonly attribute GroupKey groupKeyMap[] = 0;
+  attribute GroupKey groupKeyMap[] = 0;
   readonly attribute GroupInfo groupTable[] = 1;
   readonly global attribute int16u clusterRevision = 65533;
 }

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1373,7 +1373,7 @@ server cluster GroupKeyManagement = 63 {
     CHAR_STRING<16> groupName = 3;
   }
 
-  readonly attribute GroupKey groupKeyMap[] = 0;
+  attribute GroupKey groupKeyMap[] = 0;
   readonly attribute GroupInfo groupTable[] = 1;
   readonly global attribute int16u clusterRevision = 65533;
 }

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -186,8 +186,8 @@ private:
         ReturnErrorOnFailure(aDecoder.Decode(list));
         ReturnErrorOnFailure(list.ComputeSize(&new_count));
 
-        // Remove existing keys
-        ReturnErrorOnFailure(provider->RemoveGroupKeys(fabric_index));
+        // Remove existing keys, ignore errors
+        provider->RemoveGroupKeys(fabric_index);
 
         // Add the new keys
         auto iter = list.begin();
@@ -267,7 +267,7 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
         return true;
     }
 
-    if (commandData.groupKeySet.epochKey0.empty() || (0 == commandData.groupKeySet.epochStartTime0))
+    if (commandData.groupKeySet.epochKey0.empty() || 0 == commandData.groupKeySet.epochStartTime0)
     {
         // If the EpochKey0 field is null or its associated EpochStartTime0 field is null,
         // then this command SHALL fail with an INVALID_COMMAND
@@ -285,7 +285,8 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
     // Epoch Key 1
     if (!commandData.groupKeySet.epochKey1.empty())
     {
-        if (commandData.groupKeySet.epochStartTime1 <= commandData.groupKeySet.epochStartTime0)
+        if (0 == commandData.groupKeySet.epochStartTime1 ||
+            commandData.groupKeySet.epochStartTime1 <= commandData.groupKeySet.epochStartTime0)
         {
             // If the EpochKey1 field is not null, its associated EpochStartTime1 field SHALL contain
             // a later epoch start time than the epoch start time found in the EpochStartTime0 field.
@@ -300,11 +301,13 @@ bool emberAfGroupKeyManagementClusterKeySetWriteCallback(
     // Epoch Key 2
     if (!commandData.groupKeySet.epochKey2.empty())
     {
-        keyset.num_keys_used++;
-        if (commandData.groupKeySet.epochStartTime2 <= commandData.groupKeySet.epochStartTime1)
+        if (commandData.groupKeySet.epochKey1.empty() || 0 == commandData.groupKeySet.epochStartTime2 ||
+            commandData.groupKeySet.epochStartTime2 <= commandData.groupKeySet.epochStartTime1)
         {
-            // If the EpochKey1 field is not null, its associated EpochStartTime1 field SHALL contain
-            // a later epoch start time than the epoch start time found in the EpochStartTime0 field.
+            // If the EpochKey2 field is not null then:
+            // * The EpochKey1 field SHALL NOT be null
+            // * Its associated EpochStartTime1 field SHALL contain a later epoch start time
+            //   than the epoch start time found in the EpochStartTime0 field.
             emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
             return true;
         }
@@ -364,35 +367,34 @@ bool emberAfGroupKeyManagementClusterKeySetReadCallback(
     if (keyset.num_keys_used > 0)
     {
         response.groupKeySet.epochStartTime0 = keyset.epoch_keys[0].start_time;
-        response.groupKeySet.epochKey0       = chip::ByteSpan(nullptr, 0);
     }
     else
     {
         response.groupKeySet.epochStartTime0 = 0;
-        response.groupKeySet.epochKey0       = chip::ByteSpan(nullptr, 0);
     }
+    response.groupKeySet.epochKey0 = ByteSpan();
+
     // Keyset 1
     if (keyset.num_keys_used > 1)
     {
         response.groupKeySet.epochStartTime1 = keyset.epoch_keys[1].start_time;
-        response.groupKeySet.epochKey1       = chip::ByteSpan(nullptr, 0);
     }
     else
     {
         response.groupKeySet.epochStartTime1 = 0;
-        response.groupKeySet.epochKey1       = chip::ByteSpan(nullptr, 0);
     }
+    response.groupKeySet.epochKey1 = ByteSpan();
+
     // Keyset 2
     if (keyset.num_keys_used > 2)
     {
         response.groupKeySet.epochStartTime2 = keyset.epoch_keys[2].start_time;
-        response.groupKeySet.epochKey2       = chip::ByteSpan(nullptr, 0);
     }
     else
     {
         response.groupKeySet.epochStartTime2 = 0;
-        response.groupKeySet.epochKey2       = chip::ByteSpan(nullptr, 0);
     }
+    response.groupKeySet.epochKey2 = ByteSpan();
 
     CHIP_ERROR err = commandObj->AddResponseData(commandPath, response);
     if (CHIP_NO_ERROR != err)

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -83,8 +83,11 @@ static EmberAfStatus GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, Gr
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, EMBER_ZCL_STATUS_NOT_FOUND);
 
-    provider->SetGroupInfo(fabricIndex, GroupDataProvider::GroupInfo(groupId, groupName));
-    CHIP_ERROR err = provider->AddEndpoint(fabricIndex, groupId, endpointId);
+    CHIP_ERROR err = provider->SetGroupInfo(fabricIndex, GroupDataProvider::GroupInfo(groupId, groupName));
+    if (CHIP_NO_ERROR == err)
+    {
+        err = provider->AddEndpoint(fabricIndex, groupId, endpointId);
+    }
     if (CHIP_NO_ERROR == err)
     {
         return EMBER_ZCL_STATUS_SUCCESS;

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -25,6 +25,7 @@
 #include <lib/core/CHIPTLVDebug.hpp>
 #include <lib/core/CHIPTLVUtilities.hpp>
 #include <lib/support/ErrorStr.h>
+#include <lib/support/TestGroupData.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <messaging/ExchangeContext.h>
@@ -417,12 +418,6 @@ void TestWriteInteraction::TestWriteRoundtrip(nlTestSuite * apSuite, void * apCo
 
 namespace {
 
-constexpr uint16_t kMaxGroupsPerFabric    = 5;
-constexpr uint16_t kMaxGroupKeysPerFabric = 8;
-
-static chip::TestPersistentStorageDelegate sDelegate;
-static chip::Credentials::GroupDataProviderImpl sProvider(sDelegate, kMaxGroupsPerFabric, kMaxGroupKeysPerFabric);
-
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -446,12 +441,11 @@ const nlTest sTests[] =
  */
 int Test_Setup(void * inContext)
 {
-    SetGroupDataProvider(&sProvider);
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
-    VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(), FAILURE);
-
 
     VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
+
+    VerifyOrReturnError(CHIP_NO_ERROR == chip::GroupTesting::InitGroupData(), FAILURE);
 
     return SUCCESS;
 }

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -23,6 +23,19 @@ tests:
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
 
+    - label: "Read maxGroupsPerFabric"
+      command: "readAttribute"
+      attribute: "maxGroupsPerFabric"
+      response:
+          constraints:
+              minValue: 2
+
+    - label: "Read maxGroupKeysPerFabric"
+      command: "readAttribute"
+      attribute: "maxGroupKeysPerFabric"
+      response:
+          value: 2
+
     - label: "Add Group 1"
       disabled: true
       cluster: "Groups"
@@ -167,15 +180,3 @@ tests:
                       groupName: "Group #1",
                   },
               ]
-
-    - label: "Read maxGroupsPerFabric"
-      command: "readAttribute"
-      attribute: "maxGroupsPerFabric"
-      response:
-          value: 1
-
-    - label: "Read maxGroupKeysPerFabric"
-      command: "readAttribute"
-      attribute: "maxGroupKeysPerFabric"
-      response:
-          value: 1

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -63,6 +63,53 @@ tests:
               - name: "groupId"
                 value: 0x0001
 
+    - label: "KeySet Write 1"
+      cluster: "Group Key Management"
+      command: "KeySetWrite"
+      arguments:
+          values:
+              - name: "GroupKeySet"
+                value:
+                    {
+                        groupKeySetID: 0x0101,
+                        securityPolicy: 0,
+                        epochKey0: "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
+                        epochStartTime0: 1110000,
+                        epochKey1: "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
+                        epochStartTime1: 1110001,
+                        epochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
+                        epochStartTime2: 1110002,
+                    }
+
+    - label: "KeySet Write 2"
+      cluster: "Group Key Management"
+      command: "KeySetWrite"
+      arguments:
+          values:
+              - name: "GroupKeySet"
+                value:
+                    {
+                        groupKeySetID: 0x0102,
+                        securityPolicy: 0,
+                        epochKey0: "\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf",
+                        epochStartTime0: 2220000,
+                        epochKey1: "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef",
+                        epochStartTime1: 2220001,
+                        epochKey2: "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
+                        epochStartTime2: 2220002,
+                    }
+
+    - label: "Write Group Keys"
+      cluster: "Group Key Management"
+      command: "writeAttribute"
+      attribute: "groupKeyMap"
+      arguments:
+          value:
+              [
+                  { fabricIndex: 1, groupId: 0x1234, groupKeySetID: 0x0101 },
+                  { fabricIndex: 1, groupId: 0x0001, groupKeySetID: 0x0102 },
+              ]
+
     # Test Pair 1 : Sends a Group Write Attribute
     - label: "Group Write Attribute"
       command: "writeAttribute"

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -56,7 +56,7 @@ limitations under the License.
     <code>0x003F</code>
     <define>GROUP_KEY_MANAGEMENT_CLUSTER</define>
     <description>The Group Key Management Cluster is the mechanism by which group keys are managed.</description>
-    <attribute side="server" code="0x0000" define="GROUP_KEY_MAP" type="ARRAY" length="254" entryType="GroupKey" writable="false" optional="false">groupKeyMap</attribute>
+    <attribute side="server" code="0x0000" define="GROUP_KEY_MAP" type="ARRAY" length="254" entryType="GroupKey" writable="true" optional="false">groupKeyMap</attribute>
     <attribute side="server" code="0x0001" define="GROUP_TABLE" type="ARRAY" length="254" entryType="GroupInfo" writable="false" optional="false">groupTable</attribute>
     <attribute side="server" code="0x0002" define="MAX_GROUPS_PER_FABRIC" type="INT16U" writable="false" optional="false">maxGroupsPerFabric</attribute>
     <attribute side="server" code="0x0003" define="MAX_GROUP_KEYS_PER_FABRIC" type="INT16U" writable="false" optional="false">maxGroupKeysPerFabric</attribute>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1838,7 +1838,7 @@ client cluster GroupKeyManagement = 63 {
     INT64U epochStartTime2 = 7;
   }
 
-  readonly attribute GroupKey groupKeyMap[] = 0;
+  attribute GroupKey groupKeyMap[] = 0;
   readonly attribute GroupInfo groupTable[] = 1;
   readonly attribute int16u maxGroupsPerFabric = 2;
   readonly attribute int16u maxGroupKeysPerFabric = 3;

--- a/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
@@ -1775,6 +1775,95 @@ JNI_METHOD(void, GeneralCommissioningCluster, writeBreadcrumbAttribute)
     onFailure.release();
 }
 
+JNI_METHOD(void, GroupKeyManagementCluster, writeGroupKeyMapAttribute)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
+{
+    chip::DeviceLayer::StackLock lock;
+    ListFreer listFreer;
+    using TypeInfo = chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo;
+    TypeInfo::Type cppValue;
+
+    std::vector<Platform::UniquePtr<JniByteArray>> cleanupByteArrays;
+    std::vector<Platform::UniquePtr<JniUtfString>> cleanupStrings;
+
+    {
+        using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
+        jint valueSize;
+        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        if (valueSize != 0)
+        {
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
+            listFreer.add(listHolder_0);
+
+            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            {
+                jobject element_0;
+                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                jobject element_0_fabricIndexItem_1;
+                chip::JniReferences::GetInstance().GetObjectField(element_0, "fabricIndex", "Ljava/lang/Integer;",
+                                                                  element_0_fabricIndexItem_1);
+                listHolder_0->mList[i_0].fabricIndex =
+                    static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].fabricIndex)>>(
+                        chip::JniReferences::GetInstance().IntegerToPrimitive(element_0_fabricIndexItem_1));
+                jobject element_0_groupIdItem_1;
+                chip::JniReferences::GetInstance().GetObjectField(element_0, "groupId", "Ljava/lang/Integer;",
+                                                                  element_0_groupIdItem_1);
+                listHolder_0->mList[i_0].groupId = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].groupId)>>(
+                    chip::JniReferences::GetInstance().IntegerToPrimitive(element_0_groupIdItem_1));
+                jobject element_0_groupKeySetIDItem_1;
+                chip::JniReferences::GetInstance().GetObjectField(element_0, "groupKeySetID", "Ljava/lang/Integer;",
+                                                                  element_0_groupKeySetIDItem_1);
+                listHolder_0->mList[i_0].groupKeySetID =
+                    static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].groupKeySetID)>>(
+                        chip::JniReferences::GetInstance().IntegerToPrimitive(element_0_groupKeySetIDItem_1));
+            }
+            cppValue = ListType_0(listHolder_0->mList, valueSize);
+        }
+        else
+        {
+            cppValue = ListType_0();
+        }
+    }
+
+    std::unique_ptr<CHIPDefaultSuccessCallback, void (*)(CHIPDefaultSuccessCallback *)> onSuccess(
+        Platform::New<CHIPDefaultSuccessCallback>(callback), Platform::Delete<CHIPDefaultSuccessCallback>);
+    VerifyOrReturn(onSuccess.get() != nullptr,
+                   chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY));
+
+    std::unique_ptr<CHIPDefaultFailureCallback, void (*)(CHIPDefaultFailureCallback *)> onFailure(
+        Platform::New<CHIPDefaultFailureCallback>(callback), Platform::Delete<CHIPDefaultFailureCallback>);
+    VerifyOrReturn(onFailure.get() != nullptr,
+                   chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native failure callback", CHIP_ERROR_NO_MEMORY));
+
+    CHIP_ERROR err                         = CHIP_NO_ERROR;
+    GroupKeyManagementCluster * cppCluster = reinterpret_cast<GroupKeyManagementCluster *>(clusterPtr);
+    VerifyOrReturn(cppCluster != nullptr,
+                   chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Could not get native cluster", CHIP_ERROR_INCORRECT_STATE));
+
+    auto successFn = chip::Callback::Callback<CHIPDefaultWriteSuccessCallbackType>::FromCancelable(onSuccess->Cancel());
+    auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
+
+    if (timedWriteTimeoutMs == nullptr)
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    }
+    else
+    {
+        err = cppCluster->WriteAttribute<TypeInfo>(cppValue, onSuccess->mContext, successFn->mCall, failureFn->mCall,
+                                                   chip::JniReferences::GetInstance().IntegerToPrimitive(timedWriteTimeoutMs));
+    }
+    VerifyOrReturn(
+        err == CHIP_NO_ERROR,
+        chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error writing attribute", err));
+
+    onSuccess.release();
+    onFailure.release();
+}
+
 JNI_METHOD(void, IdentifyCluster, writeIdentifyTimeAttribute)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject value, jobject timedWriteTimeoutMs)
 {

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -8381,6 +8381,19 @@ public class ChipClusters {
       readGroupKeyMapAttribute(chipClusterPtr, callback);
     }
 
+    public void writeGroupKeyMapAttribute(
+        DefaultClusterCallback callback,
+        ArrayList<ChipStructs.GroupKeyManagementClusterGroupKey> value) {
+      writeGroupKeyMapAttribute(chipClusterPtr, callback, value, null);
+    }
+
+    public void writeGroupKeyMapAttribute(
+        DefaultClusterCallback callback,
+        ArrayList<ChipStructs.GroupKeyManagementClusterGroupKey> value,
+        int timedWriteTimeoutMs) {
+      writeGroupKeyMapAttribute(chipClusterPtr, callback, value, timedWriteTimeoutMs);
+    }
+
     public void subscribeGroupKeyMapAttribute(
         GroupKeyMapAttributeCallback callback, int minInterval, int maxInterval) {
       subscribeGroupKeyMapAttribute(chipClusterPtr, callback, minInterval, maxInterval);
@@ -8455,6 +8468,12 @@ public class ChipClusters {
 
     private native void readGroupKeyMapAttribute(
         long chipClusterPtr, GroupKeyMapAttributeCallback callback);
+
+    private native void writeGroupKeyMapAttribute(
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        ArrayList<ChipStructs.GroupKeyManagementClusterGroupKey> value,
+        @Nullable Integer timedWriteTimeoutMs);
 
     private native void subscribeGroupKeyMapAttribute(
         long chipClusterPtr,

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -2611,6 +2611,7 @@ class ChipClusters:
                     "attributeId": 0x00000000,
                     "type": "",
                     "reportable": True,
+                    "writable": True,
                 },
                 0x00000001: {
                     "attributeName": "GroupTable",

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1102,9 +1102,11 @@ CHIP_ERROR GroupDataProviderImpl::AddEndpoint(chip::FabricIndex fabric_index, ch
     if (!group.Find(mStorage, fabric, group_id))
     {
         // New group
+        VerifyOrReturnError(fabric.group_count < mMaxGroupsPerFabric, CHIP_ERROR_INVALID_LIST_LENGTH);
         ReturnErrorOnFailure(EndpointData(fabric_index, group_id, endpoint_id).Save(mStorage));
         // Save the new group into the fabric
         group.group_id       = group_id;
+        group.name[0]        = 0;
         group.first_endpoint = endpoint_id;
         group.endpoint_count = 1;
         group.next           = fabric.first_group;

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1596,6 +1596,9 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
     keyset.policy     = in_keyset.policy;
     keyset.keys_count = in_keyset.num_keys_used;
     memset(keyset.operational_keys, 0x00, sizeof(keyset.operational_keys));
+    keyset.operational_keys[0].start_time = in_keyset.epoch_keys[0].start_time;
+    keyset.operational_keys[1].start_time = in_keyset.epoch_keys[1].start_time;
+    keyset.operational_keys[2].start_time = in_keyset.epoch_keys[2].start_time;
 
     // Store the operational keys and hash instead of the epoch keys
     for (size_t i = 0; i < in_keyset.num_keys_used; ++i)
@@ -1638,8 +1641,11 @@ CHIP_ERROR GroupDataProviderImpl::GetKeySet(chip::FabricIndex fabric_index, uint
     out_keyset.keyset_id     = keyset.keyset_id;
     out_keyset.policy        = keyset.policy;
     out_keyset.num_keys_used = keyset.keys_count;
-    // Epoch keys are not read back
+    // Epoch keys are not read back, only the times
     memset(out_keyset.epoch_keys, 0x00, sizeof(out_keyset.epoch_keys));
+    out_keyset.epoch_keys[0].start_time = keyset.operational_keys[0].start_time;
+    out_keyset.epoch_keys[1].start_time = keyset.operational_keys[1].start_time;
+    out_keyset.epoch_keys[2].start_time = keyset.operational_keys[2].start_time;
     return CHIP_NO_ERROR;
 }
 

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -99,7 +99,7 @@ static KeySet kKeySet1(kKeysetId1, KeySet::SecurityPolicy::kLowLatency, 1);
 static KeySet kKeySet2(kKeysetId2, KeySet::SecurityPolicy::kLowLatency, 2);
 static KeySet kKeySet3(kKeysetId3, KeySet::SecurityPolicy::kStandard, 3);
 
-uint8_t kZeroKeys[KeySet::kEpochKeysMax][EpochKey::kLengthBytes] = { { 0 }, { 0 }, { 0 } };
+uint8_t kZeroKey[EpochKey::kLengthBytes] = { 0 };
 
 class TestListener : public GroupDataProvider::GroupListener
 {
@@ -131,6 +131,19 @@ public:
     }
 };
 static TestListener sListener;
+
+bool CompareKeySets(const KeySet & keyset1, const KeySet & keyset2)
+{
+    VerifyOrReturnError(keyset1.policy == keyset2.policy, false);
+    VerifyOrReturnError(keyset1.num_keys_used == keyset2.num_keys_used, false);
+    VerifyOrReturnError(keyset1.epoch_keys[0].start_time == keyset2.epoch_keys[0].start_time, false);
+    VerifyOrReturnError(keyset1.epoch_keys[1].start_time == keyset2.epoch_keys[1].start_time, false);
+    VerifyOrReturnError(keyset1.epoch_keys[2].start_time == keyset2.epoch_keys[2].start_time, false);
+    VerifyOrReturnError(0 == memcmp(kZeroKey, keyset1.epoch_keys[0].key, EpochKey::kLengthBytes), false);
+    VerifyOrReturnError(0 == memcmp(kZeroKey, keyset1.epoch_keys[1].key, EpochKey::kLengthBytes), false);
+    VerifyOrReturnError(0 == memcmp(kZeroKey, keyset1.epoch_keys[2].key, EpochKey::kLengthBytes), false);
+    return true;
+}
 
 void TestStorageDelegate(nlTestSuite * apSuite, void * apContext)
 {
@@ -709,44 +722,28 @@ void TestKeySets(nlTestSuite * apSuite, void * apContext)
     // Get KeySets
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet3.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet3.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet3));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet3.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet3.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet3));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
     // Remove Keysets
 
@@ -759,30 +756,20 @@ void TestKeySets(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
     NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet3.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet3.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet3));
 
     NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keyset.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keyset.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
     // Remove all
 
@@ -844,7 +831,9 @@ void TestKeySetIterator(nlTestSuite * apSuite, void * apContext)
             NL_TEST_ASSERT(apSuite, expected_f1.count(keyset.keyset_id) > 0);
             NL_TEST_ASSERT(apSuite, keyset.keyset_id == expected_f1[keyset.keyset_id].keyset_id);
             NL_TEST_ASSERT(apSuite, keyset.policy == expected_f1[keyset.keyset_id].policy);
-            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKey, keyset.epoch_keys[0].key, sizeof(kZeroKey)));
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKey, keyset.epoch_keys[1].key, sizeof(kZeroKey)));
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKey, keyset.epoch_keys[2].key, sizeof(kZeroKey)));
             count++;
         }
         NL_TEST_ASSERT(apSuite, count == expected_f1.size());
@@ -867,7 +856,9 @@ void TestKeySetIterator(nlTestSuite * apSuite, void * apContext)
             NL_TEST_ASSERT(apSuite, expected_f2.count(keyset.keyset_id) > 0);
             NL_TEST_ASSERT(apSuite, keyset.keyset_id == expected_f2[keyset.keyset_id].keyset_id);
             NL_TEST_ASSERT(apSuite, keyset.policy == expected_f2[keyset.keyset_id].policy);
-            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keyset.epoch_keys, sizeof(kZeroKeys)));
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKey, keyset.epoch_keys[0].key, sizeof(kZeroKey)));
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKey, keyset.epoch_keys[1].key, sizeof(kZeroKey)));
+            NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKey, keyset.epoch_keys[2].key, sizeof(kZeroKey)));
             count++;
         }
         NL_TEST_ASSERT(apSuite, count == expected_f2.size());
@@ -935,7 +926,7 @@ void TestPerFabricData(nlTestSuite * apSuite, void * apContext)
 
     // Keys
 
-    KeySet keys;
+    KeySet keyset;
 
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet0));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet2));
@@ -944,35 +935,23 @@ void TestPerFabricData(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kKeySet2));
     NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet2.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet2.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
     //
     // Remove Fabric
@@ -1005,24 +984,15 @@ void TestPerFabricData(nlTestSuite * apSuite, void * apContext)
 
     // Keys
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet1.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet1.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keys));
-    NL_TEST_ASSERT(apSuite, kKeySet0.policy == keys.policy);
-    NL_TEST_ASSERT(apSuite, kKeySet0.num_keys_used == keys.num_keys_used);
-    NL_TEST_ASSERT(apSuite, 0 == memcmp(kZeroKeys, keys.epoch_keys, sizeof(kZeroKeys)));
-
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 202, keys));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 404, keys));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 606, keys));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 202, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 404, keyset));
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 606, keyset));
 }
 
 void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1246,8 +1246,8 @@ CHIP_ERROR GenerateCompressedFabricId(const Crypto::P256PublicKey & root_public_
  *        records from a Node's root public key and Fabric ID.  This is a conveniance
  *        overload that writes to a uint64_t (CompressedFabricId) type.
  *
- * @param[in] root_public_key The root public key associated with the node's fabric
- * @param[in] fabric_id The fabric ID associated with the node's fabric
+ * @param[in] rootPublicKey The root public key associated with the node's fabric
+ * @param[in] fabricId The fabric ID associated with the node's fabric
  * @param[out] compressedFabricId output location for compressed fabric ID
  * @returns a CHIP_ERROR on failure or CHIP_NO_ERROR otherwise.
  */
@@ -1355,7 +1355,7 @@ public:
     virtual ~SymmetricKeyContext() = default;
     /**
      * @brief Perform the message encryption as described in 4.7.2. (Security Processing of Outgoing Messages)
-     * @param[inout] plaintext     Outgoing message payload.
+     * @param[in,out] plaintext     Outgoing message payload.
      * @param[in] aad           Additional data (message header contents)
      * @param[in] nonce         Nonce (Security Flags | Message Counter | Source Node ID)
      * @param[out] out_mic      Outgoing Message Integrity Check
@@ -1365,10 +1365,10 @@ public:
                                       MutableByteSpan & out_mic) const = 0;
     /**
      * @brief Perform the message decryption as described in 4.7.3.(Security Processing of Incoming Messages)
-     * @param ciphertext[inout] Incoming encrypted payload
-     * @param aad[in]   Additional data (message header contents)
-     * @param nonce[in] Nonce (Security Flags | Message Counter | Source Node ID)
-     * @param mic[in]   Incoming Message Integrity Check
+     * @param[in,out] ciphertext Incoming encrypted payload
+     * @param[in] aad   Additional data (message header contents)
+     * @param[in] nonce Nonce (Security Flags | Message Counter | Source Node ID)
+     * @param[in] mic   Incoming Message Integrity Check
      * @return CHIP_ERROR
      */
     virtual CHIP_ERROR DecryptMessage(MutableByteSpan & ciphertext, const ByteSpan & aad, const ByteSpan & nonce,
@@ -1376,10 +1376,10 @@ public:
 
     /**
      * @brief Perform privacy encoding as described in 4.8.2. (Privacy Processing of Outgoing Messages)
-     * @param header[in/out]    Message header to encrypt
-     * @param session_id[in]    Outgoing SessionID
-     * @param payload[in]       Encrypted payload
-     * @param mic[in]       Outgoing Message Integrity Check
+     * @param[in,out] header    Message header to encrypt
+     * @param[in] session_id    Outgoing SessionID
+     * @param[in] payload       Encrypted payload
+     * @param[in] mic       Outgoing Message Integrity Check
      * @return CHIP_ERROR
      */
     virtual CHIP_ERROR EncryptPrivacy(MutableByteSpan & header, uint16_t session_id, const ByteSpan & payload,
@@ -1387,10 +1387,10 @@ public:
 
     /**
      * @brief Perform privacy decoding as described in 4.8.3. (Privacy Processing of Incoming Messages)
-     * @param header[in/out]    Message header to decrypt
-     * @param session_id[in]    Incoming SessionID
-     * @param payload[in]       Encrypted payload
-     * @param mic[in]           Outgoing Message Integrity Check
+     * @param[in,out] header    Message header to decrypt
+     * @param[in] session_id    Incoming SessionID
+     * @param[in] payload       Encrypted payload
+     * @param[in] mic           Outgoing Message Integrity Check
      * @return CHIP_ERROR
      */
     virtual CHIP_ERROR DecryptPrivacy(MutableByteSpan & header, uint16_t session_id, const ByteSpan & payload,

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -2657,6 +2657,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeGroupKeyMapWithCompletionHandler:(void (^)(
                                                           NSArray * _Nullable value, NSError * _Nullable error))completionHandler;
+- (void)writeAttributeGroupKeyMapWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
 - (void)subscribeAttributeGroupKeyMapWithMinInterval:(uint16_t)minInterval
                                          maxInterval:(uint16_t)maxInterval
                              subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -10839,6 +10839,47 @@ using namespace chip::app::Clusters;
         });
 }
 
+- (void)writeAttributeGroupKeyMapWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(
+        self.callbackQueue,
+        ^(id _Nullable ignored, NSError * _Nullable error) {
+            completionHandler(error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            ListFreer listFreer;
+            using TypeInfo = GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo;
+            TypeInfo::Type cppValue;
+            {
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
+                if (value.count != 0) {
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
+                    if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    listFreer.add(listHolder_0);
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPGroupKeyManagementClusterGroupKey class]]) {
+                            // Wrong kind of value.
+                            return CHIP_ERROR_INVALID_ARGUMENT;
+                        }
+                        auto element_0 = (CHIPGroupKeyManagementClusterGroupKey *) value[i_0];
+                        listHolder_0->mList[i_0].fabricIndex = element_0.fabricIndex.unsignedCharValue;
+                        listHolder_0->mList[i_0].groupId = element_0.groupId.unsignedShortValue;
+                        listHolder_0->mList[i_0].groupKeySetID = element_0.groupKeySetID.unsignedShortValue;
+                    }
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
+                } else {
+                    cppValue = ListType_0();
+                }
+            }
+            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
 - (void)subscribeAttributeGroupKeyMapWithMinInterval:(uint16_t)minInterval
                                          maxInterval:(uint16_t)maxInterval
                              subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.h
@@ -568,7 +568,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestGroupKeyManagement : CHIPGroupKeyManagement
 
-- (void)writeAttributeGroupKeyMapWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeGroupTableWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeMaxGroupsPerFabricWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeMaxGroupKeysPerFabricWithValue:(NSNumber * _Nonnull)value

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -6839,47 +6839,6 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)writeAttributeGroupKeyMapWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
-{
-    new CHIPDefaultSuccessCallbackBridge(
-        self.callbackQueue,
-        ^(id _Nullable ignored, NSError * _Nullable error) {
-            completionHandler(error);
-        },
-        ^(Cancelable * success, Cancelable * failure) {
-            ListFreer listFreer;
-            using TypeInfo = GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo;
-            TypeInfo::Type cppValue;
-            {
-                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
-                if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
-                    if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
-                        return CHIP_ERROR_INVALID_ARGUMENT;
-                    }
-                    listFreer.add(listHolder_0);
-                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
-                        if (![value[i_0] isKindOfClass:[CHIPGroupKeyManagementClusterGroupKey class]]) {
-                            // Wrong kind of value.
-                            return CHIP_ERROR_INVALID_ARGUMENT;
-                        }
-                        auto element_0 = (CHIPGroupKeyManagementClusterGroupKey *) value[i_0];
-                        listHolder_0->mList[i_0].fabricIndex = element_0.fabricIndex.unsignedCharValue;
-                        listHolder_0->mList[i_0].groupId = element_0.groupId.unsignedShortValue;
-                        listHolder_0->mList[i_0].groupKeySetID = element_0.groupKeySetID.unsignedShortValue;
-                    }
-                    cppValue = ListType_0(listHolder_0->mList, value.count);
-                } else {
-                    cppValue = ListType_0();
-                }
-            }
-            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
-            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
-        });
-}
-
 - (void)writeAttributeGroupTableWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
 {
     new CHIPDefaultSuccessCallbackBridge(

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -41706,7 +41706,9 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
         {
             id actualValue = value;
-            XCTAssertEqual([actualValue unsignedShortValue], 1U);
+            if (actualValue != nil) {
+                XCTAssertGreaterThanOrEqual([actualValue unsignedShortValue], 2U);
+            }
         }
 
         [expectation fulfill];
@@ -41730,7 +41732,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
         {
             id actualValue = value;
-            XCTAssertEqual([actualValue unsignedShortValue], 1U);
+            XCTAssertEqual([actualValue unsignedShortValue], 2U);
         }
 
         [expectation fulfill];
@@ -49223,6 +49225,31 @@ ResponseHandler test_TestSubscribe_OnOff_OnOff_Reported = nil;
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+- (void)testSendClusterGroupKeyManagementWriteAttributeGroupKeyMapWithValue
+{
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    XCTestExpectation * connectedExpectation =
+        [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
+    WaitForCommissionee(connectedExpectation, queue);
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+
+    CHIPDevice * device = GetConnectedDevice();
+    CHIPGroupKeyManagement * cluster = [[CHIPGroupKeyManagement alloc] initWithDevice:device endpoint:0 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    XCTestExpectation * expectation = [self expectationWithDescription:@"GroupKeyManagementWriteAttributeGroupKeyMapWithValue"];
+
+    NSArray * _Nonnull value = [NSArray array];
+    [cluster writeAttributeGroupKeyMapWithValue:value
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"GroupKeyManagement GroupKeyMap Error: %@", err);
+                                  XCTAssertEqual(err.code, 0);
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
 - (void)testSendClusterGroupKeyManagementReadAttributeGroupTableWithCompletionHandler
 {
     dispatch_queue_t queue = dispatch_get_main_queue();

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1503,7 +1503,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * Binds to number of GroupState entries to support per fabric
  */
 #ifndef CHIP_CONFIG_MAX_GROUPS_PER_FABRIC
-#define CHIP_CONFIG_MAX_GROUPS_PER_FABRIC 1
+#define CHIP_CONFIG_MAX_GROUPS_PER_FABRIC 2
 #endif
 
 /**
@@ -1514,7 +1514,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * Binds to number of GroupState entries to support per fabric
  */
 #ifndef CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC
-#define CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC 1
+#define CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC 2
 #endif
 
 /**

--- a/src/lib/support/TestGroupData.h
+++ b/src/lib/support/TestGroupData.h
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <credentials/GroupDataProviderImpl.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+
+namespace {
+
+constexpr uint16_t kMaxGroupsPerFabric    = 5;
+constexpr uint16_t kMaxGroupKeysPerFabric = 8;
+
+static chip::TestPersistentStorageDelegate sDeviceStorage;
+static chip::Credentials::GroupDataProviderImpl sGroupsProvider(sDeviceStorage, kMaxGroupsPerFabric, kMaxGroupKeysPerFabric);
+
+static const chip::FabricIndex kFabric1 = 1;
+static const chip::GroupId kGroup1      = 0x1234;
+static const chip::GroupId kGroup2      = 0x0001;
+static const chip::KeysetId kKeySet1    = 0x0101;
+static const chip::KeysetId kKeySet2    = 0x0102;
+
+} // namespace
+
+namespace chip {
+
+namespace GroupTesting {
+
+CHIP_ERROR InitGroupData()
+{
+    ReturnErrorOnFailure(sGroupsProvider.Init());
+    chip::Credentials::SetGroupDataProvider(&sGroupsProvider);
+
+    // Groups
+
+    const chip::Credentials::GroupDataProvider::GroupInfo group1(kGroup1, "Group #1");
+    ReturnErrorOnFailure(sGroupsProvider.SetGroupInfo(kFabric1, group1));
+    ReturnErrorOnFailure(sGroupsProvider.AddEndpoint(kFabric1, group1.group_id, 1));
+
+    const chip::Credentials::GroupDataProvider::GroupInfo group2(kGroup2, "Group #2");
+    ReturnErrorOnFailure(sGroupsProvider.SetGroupInfo(kFabric1, group2));
+    ReturnErrorOnFailure(sGroupsProvider.AddEndpoint(kFabric1, group2.group_id, 0));
+
+    // Key Sets
+
+    chip::Credentials::GroupDataProvider::KeySet keyset1(
+        kKeySet1, chip::Credentials::GroupDataProvider::KeySet::SecurityPolicy::kStandard, 3);
+    const chip::Credentials::GroupDataProvider::EpochKey epoch_keys1[] = {
+        { 1110000, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
+        { 1110001, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
+        { 1110002, { 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf } },
+    };
+    memcpy(keyset1.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
+    CHIP_ERROR err = sGroupsProvider.SetKeySet(kFabric1, keyset1);
+    ReturnErrorOnFailure(err);
+
+    chip::Credentials::GroupDataProvider::KeySet keyset2(
+        kKeySet2, chip::Credentials::GroupDataProvider::KeySet::SecurityPolicy::kStandard, 3);
+    const chip::Credentials::GroupDataProvider::EpochKey epoch_keys2[] = {
+        { 2220000, { 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf } },
+        { 2220001, { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef } },
+        { 2220002, { 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff } },
+    };
+    memcpy(keyset2.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
+    err = sGroupsProvider.SetKeySet(kFabric1, keyset2);
+    ReturnErrorOnFailure(err);
+
+    sGroupsProvider.SetGroupKeyAt(kFabric1, 0, chip::Credentials::GroupDataProvider::GroupKey(kGroup1, kKeySet1));
+    sGroupsProvider.SetGroupKeyAt(kFabric1, 1, chip::Credentials::GroupDataProvider::GroupKey(kGroup2, kKeySet2));
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace GroupTesting
+
+} // namespace chip

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -151,7 +151,7 @@ private:
     NodeId mAliceNodeId     = 111222333;
     uint16_t mBobKeyId      = 1;
     uint16_t mAliceKeyId    = 2;
-    GroupId mFriendsGroupId = 517;
+    GroupId mFriendsGroupId = 0x1234;
     Transport::PeerAddress mAliceAddress;
     Transport::PeerAddress mBobAddress;
     SecurePairingUsingTestSecret mPairingAliceToBob;

--- a/src/transport/CryptoContext.h
+++ b/src/transport/CryptoContext.h
@@ -39,6 +39,7 @@ public:
     ~CryptoContext();
     CryptoContext(CryptoContext &&)      = default;
     CryptoContext(const CryptoContext &) = default;
+    CryptoContext(Crypto::SymmetricKeyContext * context) : mKeyContext(context){};
     CryptoContext & operator=(const CryptoContext &) = default;
     CryptoContext & operator=(CryptoContext &&) = default;
 
@@ -140,6 +141,7 @@ private:
 
     bool mKeyAvailable;
     CryptoKey mKeys[KeyUsage::kNumCryptoKeys];
+    Crypto::SymmetricKeyContext * mKeyContext = nullptr;
 
     static CHIP_ERROR GetIV(const PacketHeader & header, uint8_t * iv, size_t len);
 

--- a/src/transport/SecureMessageCodec.h
+++ b/src/transport/SecureMessageCodec.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <transport/CryptoContext.h>
 #include <transport/SecureSession.h>
 
 namespace chip {
@@ -48,7 +49,7 @@ namespace SecureMessageCodec {
  *                      the encrypted message.
  * @return A CHIP_ERROR value consistent with the result of the encryption operation
  */
-CHIP_ERROR Encrypt(Transport::SecureSession * session, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
+CHIP_ERROR Encrypt(const CryptoContext & context, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
                    System::PacketBufferHandle & msgBuf);
 
 /**
@@ -65,7 +66,7 @@ CHIP_ERROR Encrypt(Transport::SecureSession * session, PayloadHeader & payloadHe
  *                      the decrypted message.
  * @return A CHIP_ERROR value consistent with the result of the decryption operation
  */
-CHIP_ERROR Decrypt(Transport::SecureSession * session, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
+CHIP_ERROR Decrypt(const CryptoContext & context, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
                    System::PacketBufferHandle & msgBuf);
 
 } // namespace SecureMessageCodec

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -136,18 +136,6 @@ public:
 
     CryptoContext & GetCryptoContext() { return mCryptoContext; }
 
-    CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
-                                 MessageAuthenticationCode & mac) const
-    {
-        return mCryptoContext.Encrypt(input, input_length, output, header, mac);
-    }
-
-    CHIP_ERROR DecryptOnReceive(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
-                                const MessageAuthenticationCode & mac) const
-    {
-        return mCryptoContext.Decrypt(input, input_length, output, header, mac);
-    }
-
     SessionMessageCounter & GetSessionMessageCounter() { return mSessionMessageCounter; }
 
 private:

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -124,9 +124,13 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
     switch (sessionHandle->GetSessionType())
     {
     case Transport::Session::SessionType::kGroup: {
+        auto groupSession = sessionHandle->AsGroupSession();
+        auto * groups     = Credentials::GetGroupDataProvider();
+        VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INTERNAL);
+
         // TODO : #11911
         // For now, just set the packetHeader with the correct data.
-        packetHeader.SetDestinationGroupId(sessionHandle->AsGroupSession()->GetGroupId());
+        packetHeader.SetDestinationGroupId(groupSession->GetGroupId());
         packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
         packetHeader.SetSessionType(Header::SessionType::kGroupSession);
         // TODO : Replace the PeerNodeId with Our nodeId
@@ -140,8 +144,14 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         // Trace before any encryption
         CHIP_TRACE_MESSAGE_SENT(payloadHeader, packetHeader, message->Start(), message->TotalLength());
 
-        // TODO #11911 Update SecureMessageCodec::Encrypt for Group
-        ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(message));
+        Crypto::SymmetricKeyContext * keyContext =
+            groups->GetKeyContext(groupSession->GetFabricIndex(), groupSession->GetGroupId());
+        VerifyOrReturnError(nullptr != keyContext, CHIP_ERROR_INTERNAL);
+
+        packetHeader.SetSessionId(keyContext->GetKeyHash());
+        CHIP_ERROR err = SecureMessageCodec::Encrypt(CryptoContext(keyContext), payloadHeader, packetHeader, message);
+        keyContext->Release();
+        ReturnErrorOnFailure(err);
 
 #if CHIP_PROGRESS_LOGGING
         destination = kUndefinedNodeId;
@@ -166,7 +176,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         // Trace before any encryption
         CHIP_TRACE_MESSAGE_SENT(payloadHeader, packetHeader, message->Start(), message->TotalLength());
 
-        ReturnErrorOnFailure(SecureMessageCodec::Encrypt(session, payloadHeader, packetHeader, message));
+        ReturnErrorOnFailure(SecureMessageCodec::Encrypt(session->GetCryptoContext(), payloadHeader, packetHeader, message));
         ReturnErrorOnFailure(counter.Advance());
 
 #if CHIP_PROGRESS_LOGGING
@@ -497,7 +507,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 
     Transport::SecureSession * secureSession = session.Value()->AsSecureSession();
     // Decrypt and verify the message before message counter verification or any further processing.
-    if (SecureMessageCodec::Decrypt(secureSession, payloadHeader, packetHeader, msg) != CHIP_NO_ERROR)
+    if (SecureMessageCodec::Decrypt(secureSession->GetCryptoContext(), payloadHeader, packetHeader, msg) != CHIP_NO_ERROR)
     {
         ChipLogError(Inet, "Secure transport received message, but failed to decode/authenticate it, discarding");
         return;
@@ -553,7 +563,8 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
 {
     PayloadHeader payloadHeader;
     SessionMessageDelegate::DuplicateMessage isDuplicate = SessionMessageDelegate::DuplicateMessage::No;
-    // Credentials::GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    Credentials::GroupDataProvider * groups              = Credentials::GetGroupDataProvider();
+    VerifyOrReturn(nullptr != groups);
 
     if (!packetHeader.GetDestinationGroupId().HasValue())
     {
@@ -573,12 +584,22 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
         return;
     }
 
-    // Trial decryption with GroupDataProvider. TODO: Implement the GroupDataProvider Class
-    // TODO retrieve also the fabricIndex with the GroupDataProvider.
-    // VerifyOrExit(CHIP_NO_ERROR == groups->DecryptMessage(packetHeader, payloadHeader, msg),
-    //     ChipLogError(Inet, "Secure transport received group message, but failed to decode it, discarding"));
+    // Trial decryption with GroupDataProvider
+    Credentials::GroupDataProvider::GroupSession groupContext;
+    auto iter = groups->IterateGroupSessions(packetHeader.GetSessionId());
+    VerifyOrReturn(nullptr != iter);
 
-    ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
+    System::PacketBufferHandle msgCopy;
+    bool decrypted = false;
+    while (!decrypted && iter->Next(groupContext))
+    {
+        msgCopy = msg.CloneData();
+        decrypted =
+            (CHIP_NO_ERROR == SecureMessageCodec::Decrypt(CryptoContext(groupContext.key), payloadHeader, packetHeader, msgCopy));
+    }
+    iter->Release();
+    VerifyOrReturn(decrypted);
+    msg = std::move(msgCopy);
 
     // MCSP check
     if (packetHeader.IsValidMCSPMsg())
@@ -617,8 +638,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
 
     if (mCB != nullptr)
     {
-        // TODO : remove hard coded fabric index once GroupDataProvider->Decrypt is implemented
-        Optional<SessionHandle> session = CreateGroupSession(packetHeader.GetDestinationGroupId().Value(), 1);
+        Optional<SessionHandle> session = CreateGroupSession(groupContext.group_id, groupContext.fabric_index);
 
         VerifyOrReturn(session.HasValue(), ChipLogError(Inet, "Error when creating group session handle."));
         Transport::GroupSession * groupSession = session.Value()->AsGroupSession();

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -288,13 +288,11 @@ CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode
         .Set(Header::MsgFlagValues::kDestinationGroupIdPresent, mDestinationGroupId.HasValue());
 
     uint8_t msgFlags = (kMsgHeaderVersion << kVersionShift) | (messageFlags.Raw() & kMsgFlagsMask);
-    uint8_t secFlags = mSecFlags.Raw();
-    secFlags |= static_cast<uint8_t>(mSessionType);
 
     uint8_t * p = data;
     Write8(p, msgFlags);
     LittleEndian::Write16(p, mSessionId);
-    Write8(p, secFlags);
+    Write8(p, mSecFlags.Raw());
     LittleEndian::Write32(p, mMessageCounter);
     if (mSourceNodeId.HasValue())
     {

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -50,7 +50,7 @@ typedef int PacketHeaderFlags;
 
 namespace Header {
 
-enum class SessionType
+enum class SessionType : uint8_t
 {
     kUnicastSession = 0,
     kGroupSession   = 1,
@@ -288,7 +288,9 @@ public:
 
     PacketHeader & SetSessionType(Header::SessionType type)
     {
-        mSessionType = type;
+        mSessionType     = type;
+        uint8_t typeMask = to_underlying(Header::kSessionTypeMask);
+        mSecFlags.SetRaw(static_cast<uint8_t>((mSecFlags.Raw() & ~typeMask) | (to_underlying(type) & typeMask)));
         return *this;
     }
 

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -1741,7 +1741,8 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Group Key Management (server) */                                                              \
-            { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* groupKeyMap */       \
+            { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                 \
+              ZAP_EMPTY_DEFAULT() },                                                                       /* groupKeyMap */       \
             { 0x00000001, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* groupTable */        \
             { 0x00000002, ZAP_TYPE(INT16U), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                               \
               ZAP_EMPTY_DEFAULT() }, /* maxGroupsPerFabric */                                                                      \

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -3334,6 +3334,30 @@ private:
     TypedComplexArgument<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeySet::Type> mComplex_GroupKeySet;
 };
 
+class WriteGroupKeyManagementGroupKeyMap : public WriteAttribute
+{
+public:
+    WriteGroupKeyManagementGroupKeyMap(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("GroupKeyMap", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "group-key-map");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteGroupKeyManagementGroupKeyMap() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x0000003F, 0x00000000, mValue);
+    }
+
+private:
+    chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::Type> mValue;
+    TypedComplexArgument<chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::Type>>
+        mComplex;
+};
+
 /*----------------------------------------------------------------------------*\
 | Cluster Groups                                                      | 0x0004 |
 |------------------------------------------------------------------------------|
@@ -10776,6 +10800,7 @@ void registerClusterGroupKeyManagement(Commands & commands, CredentialIssuerComm
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),                  //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig),              //
         make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                                  //
+        make_unique<WriteGroupKeyManagementGroupKeyMap>(credsIssuerConfig),                                                  //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                              //
         make_unique<SubscribeAttribute>(Id, "group-key-map", Attributes::GroupKeyMap::Id, credsIssuerConfig),                //
         make_unique<SubscribeAttribute>(Id, "group-table", Attributes::GroupTable::Id, credsIssuerConfig),                   //

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -83527,29 +83527,41 @@ public:
             err = TestAddGroup2Endpoint0_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Group Write Attribute\n");
-            err = TestGroupWriteAttribute_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : KeySet Write 1\n");
+            err = TestKeySetWrite1_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Read back Attribute\n");
-            err = TestReadBackAttribute_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : KeySet Write 2\n");
+            err = TestKeySetWrite2_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Restore initial location value\n");
-            err = TestRestoreInitialLocationValue_5();
+            ChipLogProgress(chipTool, " ***** Test Step 5 : Write Group Keys\n");
+            err = TestWriteGroupKeys_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Read back Attribute\n");
-            err = TestReadBackAttribute_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Group Write Attribute\n");
+            err = TestGroupWriteAttribute_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Turn On the light to see attribute change\n");
-            err = TestTurnOnTheLightToSeeAttributeChange_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Read back Attribute\n");
+            err = TestReadBackAttribute_7();
             break;
         case 8:
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Restore initial location value\n");
+            err = TestRestoreInitialLocationValue_8();
+            break;
+        case 9:
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Read back Attribute\n");
+            err = TestReadBackAttribute_9();
+            break;
+        case 10:
+            ChipLogProgress(chipTool, " ***** Test Step 10 : Turn On the light to see attribute change\n");
+            err = TestTurnOnTheLightToSeeAttributeChange_10();
+            break;
+        case 11:
             ChipLogProgress(chipTool,
-                            " ***** Test Step 8 : Check on/off attribute value is true after on command for endpoint 1\n");
-            err = TestCheckOnOffAttributeValueIsTrueAfterOnCommandForEndpoint1_8();
+                            " ***** Test Step 11 : Check on/off attribute value is true after on command for endpoint 1\n");
+            err = TestCheckOnOffAttributeValueIsTrueAfterOnCommandForEndpoint1_11();
             break;
         }
 
@@ -83562,31 +83574,10 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 9;
+    const uint16_t mTestCount = 12;
 
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-
-    static void OnDoneCallback_3(void * context) { (static_cast<TestGroupMessaging *>(context))->OnDoneResponse_3(); }
-
-    static void OnFailureCallback_3(void * context, CHIP_ERROR error)
-    {
-        (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_3(error);
-    }
-
-    static void OnSuccessCallback_3(void * context) { (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_3(); }
-
-    static void OnFailureCallback_4(void * context, CHIP_ERROR error)
-    {
-        (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_4(error);
-    }
-
-    static void OnSuccessCallback_4(void * context, chip::CharSpan location)
-    {
-        (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_4(location);
-    }
-
-    static void OnDoneCallback_5(void * context) { (static_cast<TestGroupMessaging *>(context))->OnDoneResponse_5(); }
 
     static void OnFailureCallback_5(void * context, CHIP_ERROR error)
     {
@@ -83595,24 +83586,52 @@ private:
 
     static void OnSuccessCallback_5(void * context) { (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_5(); }
 
+    static void OnDoneCallback_6(void * context) { (static_cast<TestGroupMessaging *>(context))->OnDoneResponse_6(); }
+
     static void OnFailureCallback_6(void * context, CHIP_ERROR error)
     {
         (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_6(error);
     }
 
-    static void OnSuccessCallback_6(void * context, chip::CharSpan location)
+    static void OnSuccessCallback_6(void * context) { (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_6(); }
+
+    static void OnFailureCallback_7(void * context, CHIP_ERROR error)
     {
-        (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_6(location);
+        (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_7(error);
     }
+
+    static void OnSuccessCallback_7(void * context, chip::CharSpan location)
+    {
+        (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_7(location);
+    }
+
+    static void OnDoneCallback_8(void * context) { (static_cast<TestGroupMessaging *>(context))->OnDoneResponse_8(); }
 
     static void OnFailureCallback_8(void * context, CHIP_ERROR error)
     {
         (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_8(error);
     }
 
-    static void OnSuccessCallback_8(void * context, bool onOff)
+    static void OnSuccessCallback_8(void * context) { (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_8(); }
+
+    static void OnFailureCallback_9(void * context, CHIP_ERROR error)
     {
-        (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_8(onOff);
+        (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_9(error);
+    }
+
+    static void OnSuccessCallback_9(void * context, chip::CharSpan location)
+    {
+        (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_9(location);
+    }
+
+    static void OnFailureCallback_11(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_11(error);
+    }
+
+    static void OnSuccessCallback_11(void * context, bool onOff)
+    {
+        (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_11(onOff);
     }
 
     //
@@ -83697,17 +83716,40 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestGroupWriteAttribute_3()
+    CHIP_ERROR TestKeySetWrite1_3()
     {
-        const chip::GroupId groupId = 1;
-        chip::Controller::BasicClusterTest cluster;
-        cluster.AssociateWithGroup(mDevices[kIdentityAlpha], groupId);
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
+        using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
-        chip::CharSpan locationArgument;
-        locationArgument = chip::Span<const char>("USgarbage: not in length on purpose", 2);
+        RequestType request;
 
-        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
-            locationArgument, this, OnSuccessCallback_3, OnFailureCallback_3, OnDoneCallback_3));
+        request.groupKeySet.groupKeySetID  = 257U;
+        request.groupKeySet.securityPolicy = static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(0);
+        request.groupKeySet.epochKey0 =
+            chip::ByteSpan(chip::Uint8::from_const_char(
+                               "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xafgarbage: not in length on purpose"),
+                           16);
+        request.groupKeySet.epochStartTime0 = 1110000ULL;
+        request.groupKeySet.epochKey1 =
+            chip::ByteSpan(chip::Uint8::from_const_char(
+                               "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbfgarbage: not in length on purpose"),
+                           16);
+        request.groupKeySet.epochStartTime1 = 1110001ULL;
+        request.groupKeySet.epochKey2 =
+            chip::ByteSpan(chip::Uint8::from_const_char(
+                               "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcfgarbage: not in length on purpose"),
+                           16);
+        request.groupKeySet.epochStartTime2 = 1110002ULL;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_3();
+        };
+
+        auto failure = [](void * context, CHIP_ERROR error) {
+            (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_3(error);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
@@ -83719,16 +83761,40 @@ private:
 
     void OnSuccessResponse_3() { NextTest(); }
 
-    void OnDoneResponse_3() { NextTest(); }
-
-    CHIP_ERROR TestReadBackAttribute_4()
+    CHIP_ERROR TestKeySetWrite2_4()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+        using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
-            this, OnSuccessCallback_4, OnFailureCallback_4));
+        RequestType request;
+
+        request.groupKeySet.groupKeySetID  = 258U;
+        request.groupKeySet.securityPolicy = static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(0);
+        request.groupKeySet.epochKey0 =
+            chip::ByteSpan(chip::Uint8::from_const_char(
+                               "\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdfgarbage: not in length on purpose"),
+                           16);
+        request.groupKeySet.epochStartTime0 = 2220000ULL;
+        request.groupKeySet.epochKey1 =
+            chip::ByteSpan(chip::Uint8::from_const_char(
+                               "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xefgarbage: not in length on purpose"),
+                           16);
+        request.groupKeySet.epochStartTime1 = 2220001ULL;
+        request.groupKeySet.epochKey2 =
+            chip::ByteSpan(chip::Uint8::from_const_char(
+                               "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xffgarbage: not in length on purpose"),
+                           16);
+        request.groupKeySet.epochStartTime2 = 2220002ULL;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_4();
+        };
+
+        auto failure = [](void * context, CHIP_ERROR error) {
+            (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_4(error);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
@@ -83738,24 +83804,30 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_4(chip::CharSpan location)
+    void OnSuccessResponse_4() { NextTest(); }
+
+    CHIP_ERROR TestWriteGroupKeys_5()
     {
-        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("US", 2)));
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
+        chip::Controller::GroupKeyManagementClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        NextTest();
-    }
+        chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::Type> groupKeyMapArgument;
 
-    CHIP_ERROR TestRestoreInitialLocationValue_5()
-    {
-        const chip::GroupId groupId = 1;
-        chip::Controller::BasicClusterTest cluster;
-        cluster.AssociateWithGroup(mDevices[kIdentityAlpha], groupId);
+        chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::Type groupKeyMapList_0[2];
 
-        chip::CharSpan locationArgument;
-        locationArgument = chip::Span<const char>("XXgarbage: not in length on purpose", 2);
+        groupKeyMapList_0[0].fabricIndex   = 1;
+        groupKeyMapList_0[0].groupId       = 4660U;
+        groupKeyMapList_0[0].groupKeySetID = 257U;
 
-        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
-            locationArgument, this, OnSuccessCallback_5, OnFailureCallback_5, OnDoneCallback_5));
+        groupKeyMapList_0[1].fabricIndex   = 1;
+        groupKeyMapList_0[1].groupId       = 1U;
+        groupKeyMapList_0[1].groupKeySetID = 258U;
+
+        groupKeyMapArgument = groupKeyMapList_0;
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
+            groupKeyMapArgument, this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
     }
 
@@ -83767,16 +83839,17 @@ private:
 
     void OnSuccessResponse_5() { NextTest(); }
 
-    void OnDoneResponse_5() { NextTest(); }
-
-    CHIP_ERROR TestReadBackAttribute_6()
+    CHIP_ERROR TestGroupWriteAttribute_6()
     {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
+        const chip::GroupId groupId = 1;
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+        cluster.AssociateWithGroup(mDevices[kIdentityAlpha], groupId);
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
-            this, OnSuccessCallback_6, OnFailureCallback_6));
+        chip::CharSpan locationArgument;
+        locationArgument = chip::Span<const char>("USgarbage: not in length on purpose", 2);
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
+            locationArgument, this, OnSuccessCallback_6, OnFailureCallback_6, OnDoneCallback_6));
         return CHIP_NO_ERROR;
     }
 
@@ -83786,32 +83859,18 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_6(chip::CharSpan location)
+    void OnSuccessResponse_6() { NextTest(); }
+
+    void OnDoneResponse_6() { NextTest(); }
+
+    CHIP_ERROR TestReadBackAttribute_7()
     {
-        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("XX", 2)));
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
+        chip::Controller::BasicClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
-        NextTest();
-    }
-
-    CHIP_ERROR TestTurnOnTheLightToSeeAttributeChange_7()
-    {
-        const chip::GroupId groupId = 4660;
-        using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
-
-        RequestType request;
-
-        auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_7();
-        };
-
-        auto failure = [](void * context, CHIP_ERROR error) {
-            (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_7(error);
-        };
-
-        auto done = [](void * context) { (static_cast<TestGroupMessaging *>(context))->OnDoneResponse_7(); };
-
-        ReturnErrorOnFailure(
-            chip::Controller::InvokeGroupCommand(mDevices[kIdentityAlpha], this, success, failure, done, groupId, request));
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
     }
 
@@ -83821,18 +83880,24 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_7() { NextTest(); }
-
-    void OnDoneResponse_7() { NextTest(); }
-
-    CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommandForEndpoint1_8()
+    void OnSuccessResponse_7(chip::CharSpan location)
     {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("US", 2)));
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
-            this, OnSuccessCallback_8, OnFailureCallback_8));
+        NextTest();
+    }
+
+    CHIP_ERROR TestRestoreInitialLocationValue_8()
+    {
+        const chip::GroupId groupId = 1;
+        chip::Controller::BasicClusterTest cluster;
+        cluster.AssociateWithGroup(mDevices[kIdentityAlpha], groupId);
+
+        chip::CharSpan locationArgument;
+        locationArgument = chip::Span<const char>("XXgarbage: not in length on purpose", 2);
+
+        ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
+            locationArgument, this, OnSuccessCallback_8, OnFailureCallback_8, OnDoneCallback_8));
         return CHIP_NO_ERROR;
     }
 
@@ -83842,7 +83907,84 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_8(bool onOff)
+    void OnSuccessResponse_8() { NextTest(); }
+
+    void OnDoneResponse_8() { NextTest(); }
+
+    CHIP_ERROR TestReadBackAttribute_9()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
+        chip::Controller::BasicClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
+            this, OnSuccessCallback_9, OnFailureCallback_9));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_9(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_9(chip::CharSpan location)
+    {
+        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("XX", 2)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestTurnOnTheLightToSeeAttributeChange_10()
+    {
+        const chip::GroupId groupId = 4660;
+        using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
+
+        RequestType request;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestGroupMessaging *>(context))->OnSuccessResponse_10();
+        };
+
+        auto failure = [](void * context, CHIP_ERROR error) {
+            (static_cast<TestGroupMessaging *>(context))->OnFailureResponse_10(error);
+        };
+
+        auto done = [](void * context) { (static_cast<TestGroupMessaging *>(context))->OnDoneResponse_10(); };
+
+        ReturnErrorOnFailure(
+            chip::Controller::InvokeGroupCommand(mDevices[kIdentityAlpha], this, success, failure, done, groupId, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_10(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_10() { NextTest(); }
+
+    void OnDoneResponse_10() { NextTest(); }
+
+    CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommandForEndpoint1_11()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::OnOffClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_11(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_11(bool onOff)
     {
         VerifyOrReturn(CheckValue("onOff", onOff, 1));
 
@@ -85397,8 +85539,7 @@ private:
 
     void OnSuccessResponse_1(uint16_t maxGroupsPerFabric)
     {
-        VerifyOrReturn(CheckValue("maxGroupsPerFabric", maxGroupsPerFabric, 1U));
-
+        VerifyOrReturn(CheckConstraintMinValue<uint16_t>("maxGroupsPerFabric", maxGroupsPerFabric, 2U));
         NextTest();
     }
 
@@ -85422,7 +85563,7 @@ private:
 
     void OnSuccessResponse_2(uint16_t maxGroupKeysPerFabric)
     {
-        VerifyOrReturn(CheckValue("maxGroupKeysPerFabric", maxGroupKeysPerFabric, 1U));
+        VerifyOrReturn(CheckValue("maxGroupKeysPerFabric", maxGroupKeysPerFabric, 2U));
 
         NextTest();
     }

--- a/zzz_generated/thermostat/zap-generated/endpoint_config.h
+++ b/zzz_generated/thermostat/zap-generated/endpoint_config.h
@@ -875,9 +875,9 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Group Key Management (server) */                                                              \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(367) }, /* groupKeyMap */                               \
-            { 0x00000001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(621) }, /* groupTable */                                \
-            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* ClusterRevision */                           \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_LONG_DEFAULTS_INDEX(367) }, /* groupKeyMap */    \
+            { 0x00000001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(621) },                            /* groupTable */     \
+            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Fixed Label (server) */                                                                       \
             { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* label list */        \

--- a/zzz_generated/tv-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-app/zap-generated/endpoint_config.h
@@ -1242,9 +1242,9 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Group Key Management (server) */                                                              \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(371) }, /* groupKeyMap */                               \
-            { 0x00000001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(625) }, /* groupTable */                                \
-            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* ClusterRevision */                           \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_LONG_DEFAULTS_INDEX(371) }, /* groupKeyMap */    \
+            { 0x00000001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(625) },                            /* groupTable */     \
+            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Fixed Label (server) */                                                                       \
             { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* label list */        \

--- a/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
@@ -1082,9 +1082,9 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Group Key Management (server) */                                                              \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(367) }, /* groupKeyMap */                               \
-            { 0x00000001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(621) }, /* groupTable */                                \
-            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* ClusterRevision */                           \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_LONG_DEFAULTS_INDEX(367) }, /* groupKeyMap */    \
+            { 0x00000001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(621) },                            /* groupTable */     \
+            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Fixed Label (server) */                                                                       \
             { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* label list */        \


### PR DESCRIPTION
#### Problem
Group messages are currently not encrypted.

#### Change overview
* SecureMessageCodec modified to take a CryptoContext as argument instead of a Session.
* CryptoContext modified to support keys from a SymmetricKeyContext.
* SessionManager modified to use group encryption.
* CHIPTool app modified to use test group data. 
* YAML tests updated to add the KeySets.
* GroupDataProvider tests updated.

#### Testing
Group and GroupKeyManagement cluster tests ran successfully.
Group messaging test ran successfully.