### PR TITLE
Remove the 'z' format specifier in the storage key names.

### DIFF
--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -40,7 +40,7 @@ public:
     // Access Control List
 
     const char * AccessControlList() { return Format("acl"); }
-    const char * AccessControlEntry(size_t index) { return Format("acl/%zx", index); }
+    const char * AccessControlEntry(size_t index) { return Format("acl/%x", static_cast<unsigned int>(index)); }
 
     // Group Data Provider
 

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -40,7 +40,11 @@ public:
     // Access Control List
 
     const char * AccessControlList() { return Format("acl"); }
-    const char * AccessControlEntry(size_t index) { return Format("acl/%x", static_cast<unsigned int>(index)); }
+    const char * AccessControlEntry(size_t index)
+    {
+        // This cast will never overflow because the number of ACL entries will be low.
+        return Format("acl/%x", static_cast<unsigned int>(index));
+    }
 
     // Group Data Provider
 


### PR DESCRIPTION
#### Problem
PR #14253 introduced two new storage key names. One of them uses a size_t value and the 'z' format specifier to convert it into a string, but the 'z' format specifier isn't defined on all platforms.

#### Change overview
* Replace the 'z' format specifier with a static cast to a common type.

#### Testing
* Build and ran the all-clusters-app on MacOS.