### PR TITLE
Fix Subscription Crash in REPL

### DIFF
--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -312,7 +312,6 @@ void pychip_ReadClient_Abort(ReadClient * apReadClient, ReadClientCallback * apC
     VerifyOrDie(apReadClient != nullptr);
     VerifyOrDie(apCallback != nullptr);
 
-    delete apReadClient;
     delete apCallback;
 }
 

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -147,6 +147,8 @@ class ClusterObjectTests:
         if not updated:
             raise AssertionError("Did not receive updated attribute")
 
+        sub.Shutdown()
+
     @classmethod
     async def TestReadAttributeRequests(cls, devCtrl):
         '''


### PR DESCRIPTION
With the new ownership model whereby Read callbacks own the ReadClient
as well (and consequently, free it upon completion of the
Read/Subscribe), we were over-zealously double deleting it during
Shutdown of a subscription, causing a crash.

Added a test as well to catch it.