### PR TITLE
Fix merge issues in CHIPDeviceCommissioner.

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -831,30 +831,21 @@ private:
     void ReleaseCommissioneeDevice(CommissioneeDeviceProxy * device);
 
     template <typename ClusterObjectT, typename RequestObjectT>
-    CHIP_ERROR SendCommand(DeviceProxy * device, RequestObjectT request,
+    CHIP_ERROR SendCommand(DeviceProxy * device, const RequestObjectT & request,
                            CommandResponseSuccessCallback<typename RequestObjectT::ResponseType> successCb,
                            CommandResponseFailureCallback failureCb)
     {
-        ClusterObjectT cluster;
-        cluster.Associate(device, 0);
-
-        return cluster.InvokeCommand(request, this, successCb, failureCb);
+        return SendCommand<ClusterObjectT>(device, request, successCb, failureCb, 0, NullOptional);
     }
 
     template <typename ClusterObjectT, typename RequestObjectT>
-    CHIP_ERROR SendCommand(DeviceProxy * device, RequestObjectT request,
+    CHIP_ERROR SendCommand(DeviceProxy * device, const RequestObjectT & request,
                            CommandResponseSuccessCallback<typename RequestObjectT::ResponseType> successCb,
-                           CommandResponseFailureCallback failureCb, chip::Optional<chip::System::Clock::Timeout> timeout)
+                           CommandResponseFailureCallback failureCb, EndpointId endpoint, Optional<System::Clock::Timeout> timeout)
     {
         ClusterObjectT cluster;
-        cluster.Associate(device, 0);
-
-        if (timeout.HasValue())
-        {
-            VerifyOrReturnError(chip::CanCastTo<uint16_t>(timeout.Value().count()), CHIP_ERROR_INVALID_ARGUMENT);
-            chip::Optional<uint16_t> timedInvokeRequestTimeoutInMs(static_cast<uint16_t>(timeout.Value().count()));
-            return cluster.InvokeCommand(request, this, successCb, failureCb, timedInvokeRequestTimeoutInMs);
-        }
+        cluster.Associate(device, endpoint);
+        cluster.SetCommandTimeout(timeout);
 
         return cluster.InvokeCommand(request, this, successCb, failureCb);
     }


### PR DESCRIPTION
A combination of changes to the state machine, changes to require timed interactions for opening commissioning windows and PR #13371 landed, and the merge does not compile.

Specific fixes:

1. Pass a timed invoke timeout when opening commissioning windows.

2. Restore the endpoint and command timeout bits for those commands
   that used to have them.  This is a different timeout, not a timed
   invoke timeout.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Compiled and it at least compiled....

Going to land as a hotfix, but @cecille @vivien-apple please review this carefully?