### PR TITLE
Stop incorrectly flagging door lock events as fabric-scoped.

### DIFF
--- a/src/app/EventLogging.h
+++ b/src/app/EventLogging.h
@@ -61,14 +61,9 @@ private:
  * @param[out] aEventNumber The event Number if the event was written to the
  *                         log, 0 otherwise. The Event number is expected to monotonically increase.
  *
- * TODO: Revisit spec foc nullable fabric index in event.
- *
  * @return CHIP_ERROR  CHIP Error Code
  */
-template <typename T,
-          std::enable_if_t<DataModel::IsFabricScoped<T>::value &&
-                               std::is_same<decltype(std::declval<T>().GetFabricIndex()), FabricIndex>::value,
-                           bool> = true>
+template <typename T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, bool> = true>
 CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber,
                     EventOptions::Type aUrgent = EventOptions::Type::kNotUrgent)
 {
@@ -80,24 +75,6 @@ CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aE
     eventOptions.mPath        = path;
     eventOptions.mPriority    = aEventData.GetPriorityLevel();
     eventOptions.mFabricIndex = aEventData.GetFabricIndex();
-    return logMgmt.LogEvent(&eventData, eventOptions, aEventNumber);
-}
-
-template <typename T,
-          std::enable_if_t<DataModel::IsFabricScoped<T>::value &&
-                               std::is_same<decltype(std::declval<T>().GetFabricIndex()), DataModel::Nullable<FabricIndex>>::value,
-                           bool> = true>
-CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber,
-                    EventOptions::Type aUrgent = EventOptions::Type::kNotUrgent)
-{
-    EventLogger<T> eventData(aEventData);
-    ConcreteEventPath path(aEndpoint, aEventData.GetClusterId(), aEventData.GetEventId());
-    EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
-    EventOptions eventOptions;
-    eventOptions.mUrgent      = aUrgent;
-    eventOptions.mPath        = path;
-    eventOptions.mPriority    = aEventData.GetPriorityLevel();
-    eventOptions.mFabricIndex = aEventData.GetFabricIndex().IsNull() ? kUndefinedFabricIndex : aEventData.GetFabricIndex().Value();
     return logMgmt.LogEvent(&eventData, eventOptions, aEventNumber);
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -19731,7 +19731,7 @@ public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return Events::LockOperation::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
-    static constexpr bool kIsFabricScoped = true;
+    static constexpr bool kIsFabricScoped = false;
 
     DlLockOperationType lockOperationType = static_cast<DlLockOperationType>(0);
     DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
@@ -19739,8 +19739,6 @@ public:
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
     Optional<DataModel::Nullable<DataModel::List<const Structs::DlCredential::Type>>> credentials;
-
-    auto GetFabricIndex() const { return fabricIndex; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19782,7 +19780,7 @@ public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return Events::LockOperationError::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
-    static constexpr bool kIsFabricScoped = true;
+    static constexpr bool kIsFabricScoped = false;
 
     DlLockOperationType lockOperationType = static_cast<DlLockOperationType>(0);
     DlOperationSource operationSource     = static_cast<DlOperationSource>(0);
@@ -19791,8 +19789,6 @@ public:
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
     Optional<DataModel::Nullable<DataModel::List<const Structs::DlCredential::Type>>> credentials;
-
-    auto GetFabricIndex() const { return fabricIndex; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19835,7 +19831,7 @@ public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return Events::LockUserChange::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
-    static constexpr bool kIsFabricScoped = true;
+    static constexpr bool kIsFabricScoped = false;
 
     DlLockDataType lockDataType           = static_cast<DlLockDataType>(0);
     DlDataOperationType dataOperationType = static_cast<DlDataOperationType>(0);
@@ -19844,8 +19840,6 @@ public:
     DataModel::Nullable<chip::FabricIndex> fabricIndex;
     DataModel::Nullable<chip::NodeId> sourceNode;
     DataModel::Nullable<uint16_t> dataIndex;
-
-    auto GetFabricIndex() const { return fabricIndex; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/14365
Fixes https://github.com/project-chip/connectedhomeip/issues/14573

#### Problem
See above.

#### Change overview
See above.

#### Testing
Looked at resulting codegen.