### PR TITLE
add missing openocd install instructions

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1125,6 +1125,7 @@ XXXX
 XXXXXXXX
 xyz
 xz
+xzvf
 yaml
 yearday
 yml

--- a/examples/all-clusters-app/mbed/README.md
+++ b/examples/all-clusters-app/mbed/README.md
@@ -76,9 +76,21 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources and
-the **arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/examples/all-clusters-app/mbed/README.md
+++ b/examples/all-clusters-app/mbed/README.md
@@ -76,12 +76,12 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -90,8 +90,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/examples/lighting-app/mbed/README.md
+++ b/examples/lighting-app/mbed/README.md
@@ -89,12 +89,12 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -103,8 +103,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/examples/lighting-app/mbed/README.md
+++ b/examples/lighting-app/mbed/README.md
@@ -89,9 +89,21 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources and
-the **arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/examples/lock-app/mbed/README.md
+++ b/examples/lock-app/mbed/README.md
@@ -79,12 +79,12 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -93,8 +93,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/examples/lock-app/mbed/README.md
+++ b/examples/lock-app/mbed/README.md
@@ -79,9 +79,21 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources and
-the **arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/examples/ota-requestor-app/mbed/README.md
+++ b/examples/ota-requestor-app/mbed/README.md
@@ -82,8 +82,20 @@ using the following command:
     $ git submodule update --init
 
 Building the example application requires the use of **ARM Mbed-OS** sources and
-the **arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+ the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/examples/ota-requestor-app/mbed/README.md
+++ b/examples/ota-requestor-app/mbed/README.md
@@ -82,11 +82,11 @@ using the following command:
     $ git submodule update --init
 
 Building the example application requires the use of **ARM Mbed-OS** sources and
- the **arm-none-gnu-eabi** toolchain. 
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -95,8 +95,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/examples/pigweed-app/mbed/README.md
+++ b/examples/pigweed-app/mbed/README.md
@@ -54,12 +54,12 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -68,8 +68,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/examples/pigweed-app/mbed/README.md
+++ b/examples/pigweed-app/mbed/README.md
@@ -54,9 +54,21 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources and
-the **arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/examples/shell/mbed/README.md
+++ b/examples/shell/mbed/README.md
@@ -47,12 +47,12 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -61,8 +61,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/examples/shell/mbed/README.md
+++ b/examples/shell/mbed/README.md
@@ -47,9 +47,21 @@ using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources and
-the **arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/src/test_driver/mbed/integration_tests/README.md
+++ b/src/test_driver/mbed/integration_tests/README.md
@@ -82,9 +82,21 @@ following command:
 
     $ git submodule update --init
 
-Building the application requires the use of **ARM Mbed-OS** sources and the
-**arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode

--- a/src/test_driver/mbed/integration_tests/README.md
+++ b/src/test_driver/mbed/integration_tests/README.md
@@ -82,12 +82,12 @@ following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -96,8 +96,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/src/test_driver/mbed/unit_tests/README.md
+++ b/src/test_driver/mbed/unit_tests/README.md
@@ -42,12 +42,12 @@ submodules using the following command:
 
     $ git submodule update --init
 
-Building the example application requires the use of **ARM Mbed-OS** sources 
-and the **arm-none-gnu-eabi** toolchain. 
+Building the example application requires the use of **ARM Mbed-OS** sources and
+the **arm-none-gnu-eabi** toolchain.
 
-The Cypress OpenOCD package is required for flashing
-purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
-calling the flashing script.
+The Cypress OpenOCD package is required for flashing purpose. Install the
+Cypress OpenOCD and set env var `OPENOCD_PATH` before calling the flashing
+script.
 
 ```
 cd ~
@@ -56,8 +56,8 @@ tar xzvf openocd-4.3.0.1746-linux.tar.gz
 export OPENOCD_PATH=$HOME/openocd
 ```
 
-Some additional packages may be needed, depending on selected
-build target and its requirements.
+Some additional packages may be needed, depending on selected build target and
+its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode
 > devcontainer is the recommended way to interact with Arm Mbed-OS port of the

--- a/src/test_driver/mbed/unit_tests/README.md
+++ b/src/test_driver/mbed/unit_tests/README.md
@@ -42,9 +42,21 @@ submodules using the following command:
 
     $ git submodule update --init
 
-Building the application requires the use of **ARM Mbed-OS** sources and the
-**arm-none-gnu-eabi** toolchain. The OpenOCD package is used for flashing
-purpose. <br> Some additional packages may be needed, depending on selected
+Building the example application requires the use of **ARM Mbed-OS** sources 
+and the **arm-none-gnu-eabi** toolchain. 
+
+The Cypress OpenOCD package is required for flashing
+purpose. Install the Cypress OpenOCD and set env var `OPENOCD_PATH` before 
+calling the flashing script.
+
+```
+cd ~
+wget https://github.com/Infineon/openocd/releases/download/release-v4.3.0/openocd-4.3.0.1746-linux.tar.gz
+tar xzvf openocd-4.3.0.1746-linux.tar.gz
+export OPENOCD_PATH=$HOME/openocd
+```
+
+Some additional packages may be needed, depending on selected
 build target and its requirements.
 
 > **The VSCode devcontainer has these components pre-installed. Using the VSCode


### PR DESCRIPTION
#### Problem

- The Mbed OS examples did not provide the instructions for install OpenOCD
- The generic OpenOCD version one can download and build does not work with the build script, instead one must use the Cypress OpenOCD but it wasn't mentioned
- The script requires env var OPENOCD_PATH which needs to be set manually but wasn't mentioned

#### Change overview
Add instructions to docs to do all abovementioned issued

#### Testing
Manually tested the steps and the building/flashing was successful
