### PR TITLE
Fix Popen Syscalls in REPL

### DIFF
--- a/docs/guides/repl/Matter - Access Control.ipynb
+++ b/docs/guides/repl/Matter - Access Control.ipynb
@@ -29,6 +29,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "be8d3d64-e3d3-46b9-bbea-29aba67aee3b",
+   "metadata": {},
+   "source": [
+    "## Clear Persisted Storage\n",
+    "\n",
+    "Let's clear out our persisted storage (if one exists) to start from a clean slate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "59352193-6c8f-4bda-9a3c-d84317b63c30",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1;36m0\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import os, subprocess\n",
+    "\n",
+    "if os.path.isfile('/tmp/repl-storage.json'):\n",
+    "    os.remove('/tmp/repl-storage.json')\n",
+    "\n",
+    "# So that the all-clusters-app won't boot with stale prior state.\n",
+    "os.system('rm -rf /tmp/chip_*')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "99ce2877",
    "metadata": {
     "tags": []
@@ -43,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "id": "bad327b7-c78a-4c46-b224-077fe7539ee1",
    "metadata": {},
    "outputs": [
@@ -107,16 +149,6 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-01-25 16:59:51 johnsj-macbookpro1.roam.corp.google.com root[28183] CRITICAL Loading configuration from /tmp/repl-storage.json...\n",
-      "2022-01-25 16:59:51 johnsj-macbookpro1.roam.corp.google.com chip.DL[28183] ERROR MAC is not known, using a default.\n",
-      "2022-01-25 16:59:51 johnsj-macbookpro1.roam.corp.google.com chip.DL[28183] ERROR Register (kDNSServiceErr_NameConflict)\n",
-      "2022-01-25 16:59:51 johnsj-macbookpro1.roam.corp.google.com chip.DIS[28183] ERROR Failed to advertise unprovisioned commissionable node: ../../src/platform/Darwin/DnssdImpl.cpp:302: CHIP Error 0x000000AC: Internal error\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
@@ -149,26 +181,6 @@
      "output_type": "stream",
      "text": [
       "New FabricAdmin: FabricId: 1(1)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #af00ff; text-decoration-color: #af00ff\">Restoring FabricAdmin from storage to manage FabricId </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">2</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">, FabricIndex </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">2</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">...</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[38;5;129mRestoring FabricAdmin from storage to manage FabricId \u001b[0m\u001b[1;38;5;129m2\u001b[0m\u001b[38;5;129m, FabricIndex \u001b[0m\u001b[1;38;5;129m2\u001b[0m\u001b[38;5;129m...\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New FabricAdmin: FabricId: 2(2)\n"
      ]
     },
     {
@@ -268,18 +280,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "id": "52ccd8c6",
    "metadata": {},
    "outputs": [],
    "source": [
     "import time, os\n",
     "import subprocess\n",
-    "subprocess.Popen(['pkill', '-f', 'chip-all-clusters-app'])\n",
-    "time.sleep(1)\n",
-    "\n",
-    "# So that the all-clusters-app won't boot with stale prior state.    \n",
-    "subprocess.Popen(['rm', '-rf', '/tmp/chip_*'])\n",
+    "os.system('pkill -f chip-all-clusters-app')\n",
     "time.sleep(1)\n",
     "\n",
     "# The location of the all-clusters-app in the cloud playground is one level higher - adjust for this by testing for file presence.\n",
@@ -287,7 +295,7 @@
     "    appPath = '../../../out/debug/chip-all-clusters-app'\n",
     "else:\n",
     "    appPath = '../../../../out/debug/chip-all-clusters-app'\n",
-    "    \n",
+    "\n",
     "process = subprocess.Popen(appPath, stdout=subprocess.DEVNULL)\n",
     "time.sleep(1)"
    ]
@@ -304,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "id": "5e964fe3",
    "metadata": {
     "tags": []
@@ -314,8 +322,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-01-25 16:59:54 johnsj-macbookpro1.roam.corp.google.com chip.CTL[28183] ERROR Unable to find country code, defaulting to WW\n",
-      "2022-01-25 16:59:54 johnsj-macbookpro1.roam.corp.google.com chip.SC[28183] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
+      "2022-01-29 16:01:43 johnsj-macbookpro1.roam.corp.google.com chip.SC[9915] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
      ]
     },
     {
@@ -364,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "id": "058504b3",
    "metadata": {},
    "outputs": [

--- a/docs/guides/repl/Matter - Basic Interactions.ipynb
+++ b/docs/guides/repl/Matter - Basic Interactions.ipynb
@@ -19,6 +19,45 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d2ed9fe9-e4a7-4540-a434-8f4ee1362bc6",
+   "metadata": {},
+   "source": [
+    "## Clear Persisted Storage\n",
+    "\n",
+    "Let's clear out our persisted storage (if one exists) to start from a clean slate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "06c609a5-1d5c-4ae2-85f0-39a280d1bf2c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os, subprocess\n",
+    "\n",
+    "if os.path.isfile('/tmp/repl-storage.json'):\n",
+    "    os.remove('/tmp/repl-storage.json')\n",
+    "\n",
+    "# So that the all-clusters-app won't boot with stale prior state.\n",
+    "os.system('rm -rf /tmp/chip_*')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "99ce2877",
    "metadata": {
     "tags": []
@@ -35,12 +74,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "bad327b7-c78a-4c46-b224-077fe7539ee1",
    "metadata": {
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0;34m[1643499271185] [10607:4156252] CHIP: [DL] _Init\u001b[0m\n",
+      "\u001b[0;32m[1643499271185] [10607:4156669] CHIP: [DL] Platform main loop started.\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -104,32 +151,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-01-25 16:58:28 johnsj-macbookpro1.roam.corp.google.com root[27801] CRITICAL Loading configuration from /tmp/repl-storage.json...\n"
+      "2022-01-29 15:34:31 johnsj-macbookpro1.roam.corp.google.com root[10607] ERROR [Errno 2] No such file or directory: '/tmp/repl-storage.json'\n",
+      "2022-01-29 15:34:31 johnsj-macbookpro1.roam.corp.google.com root[10607] WARNING Could not load configuration from /tmp/repl-storage.json - resetting configuration...\n"
      ]
     },
     {
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "\n",
+       "<span style=\"color: #af00ff; text-decoration-color: #af00ff\">No previous fabric admins discovered in persistent storage - creating a new one...</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\n",
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #af00ff; text-decoration-color: #af00ff\">Restoring FabricAdmin from storage to manage FabricId </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">1</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">, FabricIndex </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">1</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">...</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[38;5;129mRestoring FabricAdmin from storage to manage FabricId \u001b[0m\u001b[1;38;5;129m1\u001b[0m\u001b[38;5;129m, FabricIndex \u001b[0m\u001b[1;38;5;129m1\u001b[0m\u001b[38;5;129m...\u001b[0m\n"
+       "\u001b[38;5;129mNo previous fabric admins discovered in persistent storage - creating a new one\u001b[0m\u001b[38;5;129m...\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -141,41 +176,6 @@
      "text": [
       "New FabricAdmin: FabricId: 1(1)\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #af00ff; text-decoration-color: #af00ff\">Restoring FabricAdmin from storage to manage FabricId </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">2</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">, FabricIndex </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">2</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">...</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[38;5;129mRestoring FabricAdmin from storage to manage FabricId \u001b[0m\u001b[1;38;5;129m2\u001b[0m\u001b[38;5;129m, FabricIndex \u001b[0m\u001b[1;38;5;129m2\u001b[0m\u001b[38;5;129m...\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New FabricAdmin: FabricId: 2(2)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">Fabric Admins have been loaded and are available at </span><span style=\"color: #800000; text-decoration-color: #800000\">fabricAdmins</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n",
-       "\u001b[34mFabric Admins have been loaded and are available at \u001b[0m\u001b[31mfabricAdmins\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -595,7 +595,6 @@
    "cell_type": "markdown",
    "id": "322ebc15-ae5d-4e84-bb66-a5d77d1e04c6",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -630,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "52ccd8c6",
    "metadata": {},
    "outputs": [],
@@ -639,11 +638,7 @@
     "import subprocess\n",
     "\n",
     "# So that the all-clusters-app won't boot with stale prior state.    \n",
-    "subprocess.Popen(['rm', '-rf', '/tmp/chip_*'])\n",
-    "time.sleep(1)\n",
-    "\n",
-    "subprocess.Popen(['pkill', '-f', 'chip-all-clusters-app'])\n",
-    "time.sleep(1)\n",
+    "os.system('pkill -f chip-all-clusters-app')\n",
     "\n",
     "# The location of the all-clusters-app in the cloud playground is one level higher - adjust for this by testing for file presence.\n",
     "if (os.path.isfile('../../../out/debug/chip-all-clusters-app')):\n",
@@ -667,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "5e964fe3",
    "metadata": {
     "tags": []
@@ -677,8 +672,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-01-25 16:58:31 johnsj-macbookpro1.roam.corp.google.com chip.CTL[27801] ERROR Unable to find country code, defaulting to WW\n",
-      "2022-01-25 16:58:31 johnsj-macbookpro1.roam.corp.google.com chip.SC[27801] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
+      "2022-01-29 15:34:45 johnsj-macbookpro1.roam.corp.google.com chip.SC[10607] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
      ]
     },
     {
@@ -730,7 +724,7 @@
    },
    "outputs": [],
    "source": [
-    "devCtrl.CommissionThreadBle(3840, 20202021, 2, b'\\x01\\x03\\xff')"
+    "devCtrl.CommissionThread(3840, 20202021, 2, b'\\x01\\x03\\xff')"
    ]
   },
   {
@@ -787,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "bed38512-91f8-4d4e-b6e1-b30749137bbd",
    "metadata": {},
    "outputs": [],

--- a/docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb
+++ b/docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb
@@ -65,7 +65,7 @@
     "    os.remove('/tmp/repl-storage.json')\n",
     "\n",
     "# So that the all-clusters-app won't boot with stale prior state.    \n",
-    "subprocess.Popen(['rm', '-rf', '/tmp/chip_*'])"
+    "os.system('rm -rf /tmp/chip_*')"
    ]
   },
   {
@@ -332,7 +332,7 @@
    "source": [
     "import time, os\n",
     "import subprocess\n",
-    "subprocess.Popen(['pkill', '-f', 'chip-all-clusters-app'])\n",
+    "os.system('pkill -f chip-all-clusters-app')\n",
     "time.sleep(1)\n",
     "\n",
     "# The location of the all-clusters-app in the cloud playground is one level higher - adjust for this by testing for file presence.\n",
@@ -340,7 +340,7 @@
     "    appPath = '../../../out/debug/chip-all-clusters-app'\n",
     "else:\n",
     "    appPath = '../../../../out/debug/chip-all-clusters-app'\n",
-    "    \n",
+    "\n",
     "process = subprocess.Popen(appPath, stdout=subprocess.DEVNULL)\n",
     "time.sleep(1)"
    ]


### PR DESCRIPTION
Some of the calls in the Jupyter Notebooks to clear out the configuration files
didn't really remove them. For some reason, calling `subprocess.Popen` to execute the 'rm -rf' command doesn't seem to actually remove them.

Using `os.system` however seems to do the trick.