### PR TITLE
[chip-tool] Get chip-tool template to generate write commands for struct attributes now that complex types are supported

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -58,8 +58,6 @@ private:
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-{{! TODO: Various types (floats, structs) not supported here. }}
-{{#unless (isStrEqual chipCallback.name "Unsupported")}}
 {{#if isWritableAttribute}}
 class Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public WriteAttribute
 {
@@ -92,7 +90,6 @@ private:
 };
 
 {{/if}}
-{{/unless}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
 
@@ -123,12 +120,9 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands, CredentialIss
         {{/chip_server_cluster_attributes}}
         make_unique<WriteAttribute>(Id, credsIssuerConfig), //
         {{#chip_server_cluster_attributes}}
-        {{! TODO: Various types (floats, structs) not supported here. }}
-        {{#unless (isStrEqual chipCallback.name "Unsupported")}}
         {{#if isWritableAttribute}}
         make_unique<Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(credsIssuerConfig), //
         {{/if}}
-        {{/unless}}
         {{/chip_server_cluster_attributes}}
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig), //
         {{#chip_server_cluster_attributes}}

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -360,6 +360,29 @@ private:
 | Events:                                                             |        |
 \*----------------------------------------------------------------------------*/
 
+class WriteApplicationBasicApplicationApp : public WriteAttribute
+{
+public:
+    WriteApplicationBasicApplicationApp(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("ApplicationApp", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "application-app");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteApplicationBasicApplicationApp() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x0000050D, 0x00000004, mValue);
+    }
+
+private:
+    chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type mValue;
+    TypedComplexArgument<chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::Type> mComplex;
+};
+
 /*----------------------------------------------------------------------------*\
 | Cluster ApplicationLauncher                                         | 0x050C |
 |------------------------------------------------------------------------------|
@@ -7211,6 +7234,29 @@ private:
     chip::app::Clusters::TestCluster::SimpleEnum mValue;
 };
 
+class WriteTestClusterStructAttr : public WriteAttribute
+{
+public:
+    WriteTestClusterStructAttr(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("StructAttr", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "struct-attr");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteTestClusterStructAttr() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x0000050F, 0x00000025, mValue);
+    }
+
+private:
+    chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type mValue;
+    TypedComplexArgument<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type> mComplex;
+};
+
 class WriteTestClusterRangeRestrictedInt8u : public WriteAttribute
 {
 public:
@@ -7997,6 +8043,29 @@ public:
 
 private:
     chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> mValue;
+};
+
+class WriteTestClusterNullableStruct : public WriteAttribute
+{
+public:
+    WriteTestClusterNullableStruct(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("NullableStruct", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "nullable-struct");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteTestClusterNullableStruct() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x0000050F, 0x00008025, mValue);
+    }
+
+private:
+    chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type> mValue;
+    TypedComplexArgument<chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>> mComplex;
 };
 
 class WriteTestClusterNullableRangeRestrictedInt8u : public WriteAttribute
@@ -9186,6 +9255,7 @@ void registerClusterApplicationBasic(Commands & commands, CredentialIssuerComman
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),                //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig),            //
         make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                                //
+        make_unique<WriteApplicationBasicApplicationApp>(credsIssuerConfig),                                               //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                            //
         make_unique<SubscribeAttribute>(Id, "vendor-name", Attributes::VendorName::Id, credsIssuerConfig),                 //
         make_unique<SubscribeAttribute>(Id, "vendor-id", Attributes::VendorId::Id, credsIssuerConfig),                     //
@@ -11713,6 +11783,7 @@ void registerClusterTestCluster(Commands & commands, CredentialIssuerCommands * 
         make_unique<WriteTestClusterVendorId>(credsIssuerConfig),                                                     //
         make_unique<WriteTestClusterListNullablesAndOptionalsStruct>(credsIssuerConfig),                              //
         make_unique<WriteTestClusterEnumAttr>(credsIssuerConfig),                                                     //
+        make_unique<WriteTestClusterStructAttr>(credsIssuerConfig),                                                   //
         make_unique<WriteTestClusterRangeRestrictedInt8u>(credsIssuerConfig),                                         //
         make_unique<WriteTestClusterRangeRestrictedInt8s>(credsIssuerConfig),                                         //
         make_unique<WriteTestClusterRangeRestrictedInt16u>(credsIssuerConfig),                                        //
@@ -11749,6 +11820,7 @@ void registerClusterTestCluster(Commands & commands, CredentialIssuerCommands * 
         make_unique<WriteTestClusterNullableOctetString>(credsIssuerConfig),                                          //
         make_unique<WriteTestClusterNullableCharString>(credsIssuerConfig),                                           //
         make_unique<WriteTestClusterNullableEnumAttr>(credsIssuerConfig),                                             //
+        make_unique<WriteTestClusterNullableStruct>(credsIssuerConfig),                                               //
         make_unique<WriteTestClusterNullableRangeRestrictedInt8u>(credsIssuerConfig),                                 //
         make_unique<WriteTestClusterNullableRangeRestrictedInt8s>(credsIssuerConfig),                                 //
         make_unique<WriteTestClusterNullableRangeRestrictedInt16u>(credsIssuerConfig),                                //


### PR DESCRIPTION
#### Problem

`chip-tool` template does not generate `write` commands for attributes of type `struct`. Since complex types are not supported there is no reason to not generate those.

#### Change overview
 * Remove the template bits that prevents `write` commands to be generated for attribute of type `struct`
 * Update the generated code.

#### Testing
 I have manually validated that it works with the command:
```
$ ./out/debug/standalone/chip-tool testcluster write struct-attr '{"a": 1, "b": true, "c": 2, "d":"0001", "e":"", "f":4, "g": 3.2, "h": -3.2}' 0x12345 1
```