### PR TITLE
[CI] Raise some delays for level control certifications tests

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_LVL_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_3_1.yaml
@@ -81,13 +81,13 @@ tests:
               - name: "optionOverride"
                 value: 1
 
-    - label: "Wait 200ms"
+    - label: "Wait a second"
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 200
+                value: 1000
 
     - label: "reads CurrentLevel attribute from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_5_1.yaml
@@ -42,13 +42,13 @@ tests:
               - name: "optionOverride"
                 value: 0
 
-    - label: "Wait 3000ms"
+    - label: "Wait 4000ms"
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 3000
+                value: 4000
 
     - label: "Reads current level attribute from DUT"
       command: "readAttribute"
@@ -71,13 +71,13 @@ tests:
               - name: "optionOverride"
                 value: 0
 
-    - label: "Wait 3000ms"
+    - label: "Wait 4000ms"
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 3000
+                value: 4000
 
     - label: "Reads current level attribute from DUT"
       command: "readAttribute"
@@ -100,13 +100,13 @@ tests:
               - name: "optionOverride"
                 value: 0
 
-    - label: "Wait 3000ms"
+    - label: "Wait 4000ms"
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 3000
+                value: 4000
 
     - label: "Reads current level attribute from DUT"
       command: "readAttribute"

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -12141,11 +12141,11 @@ CHIPDevice * GetConnectedDevice(void)
 }
 - (void)testSendClusterTest_TC_LVL_3_1_000008_WaitForMs
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 200ms"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait a second"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForMs(expectation, queue, 200);
-    [self waitForExpectationsWithTimeout:(200 / 1000) + kTimeoutInSeconds handler:nil];
+    WaitForMs(expectation, queue, 1000);
+    [self waitForExpectationsWithTimeout:(1000 / 1000) + kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_3_1_000009_ReadAttribute
 {
@@ -12683,11 +12683,11 @@ CHIPDevice * GetConnectedDevice(void)
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000003_WaitForMs
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 3000ms"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 4000ms"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForMs(expectation, queue, 3000);
-    [self waitForExpectationsWithTimeout:(3000 / 1000) + kTimeoutInSeconds handler:nil];
+    WaitForMs(expectation, queue, 4000);
+    [self waitForExpectationsWithTimeout:(4000 / 1000) + kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000004_ReadAttribute
 {
@@ -12741,11 +12741,11 @@ CHIPDevice * GetConnectedDevice(void)
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000006_WaitForMs
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 3000ms"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 4000ms"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForMs(expectation, queue, 3000);
-    [self waitForExpectationsWithTimeout:(3000 / 1000) + kTimeoutInSeconds handler:nil];
+    WaitForMs(expectation, queue, 4000);
+    [self waitForExpectationsWithTimeout:(4000 / 1000) + kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000007_ReadAttribute
 {
@@ -12799,11 +12799,11 @@ CHIPDevice * GetConnectedDevice(void)
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000009_WaitForMs
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 3000ms"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 4000ms"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForMs(expectation, queue, 3000);
-    [self waitForExpectationsWithTimeout:(3000 / 1000) + kTimeoutInSeconds handler:nil];
+    WaitForMs(expectation, queue, 4000);
+    [self waitForExpectationsWithTimeout:(4000 / 1000) + kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000010_ReadAttribute
 {

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -20829,8 +20829,8 @@ public:
             err = TestSendsAMoveToLevelCommand_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Wait 200ms\n");
-            err = TestWait200ms_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Wait a second\n");
+            err = TestWaitASecond_8();
             break;
         case 9:
             ChipLogProgress(chipTool, " ***** Test Step 9 : reads CurrentLevel attribute from DUT\n");
@@ -21120,10 +21120,10 @@ private:
 
     void OnSuccessResponse_7() { NextTest(); }
 
-    CHIP_ERROR TestWait200ms_8()
+    CHIP_ERROR TestWaitASecond_8()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForMs(200);
+        return WaitForMs(1000);
     }
 
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_9()
@@ -21870,8 +21870,8 @@ public:
             err = TestPreconditionDutLevelIsSetTo0x80_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait 3000ms\n");
-            err = TestWait3000ms_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait 4000ms\n");
+            err = TestWait4000ms_3();
             break;
         case 4:
             ChipLogProgress(chipTool, " ***** Test Step 4 : Reads current level attribute from DUT\n");
@@ -21882,8 +21882,8 @@ public:
             err = TestSendsStepDownCommandToDut_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Wait 3000ms\n");
-            err = TestWait3000ms_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Wait 4000ms\n");
+            err = TestWait4000ms_6();
             break;
         case 7:
             ChipLogProgress(chipTool, " ***** Test Step 7 : Reads current level attribute from DUT\n");
@@ -21894,8 +21894,8 @@ public:
             err = TestSendsAStepUpCommand_8();
             break;
         case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Wait 3000ms\n");
-            err = TestWait3000ms_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Wait 4000ms\n");
+            err = TestWait4000ms_9();
             break;
         case 10:
             ChipLogProgress(chipTool, " ***** Test Step 10 : Reads current level attribute from DUT\n");
@@ -22028,10 +22028,10 @@ private:
 
     void OnSuccessResponse_2() { NextTest(); }
 
-    CHIP_ERROR TestWait3000ms_3()
+    CHIP_ERROR TestWait4000ms_3()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForMs(3000);
+        return WaitForMs(4000);
     }
 
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_4()
@@ -22090,10 +22090,10 @@ private:
 
     void OnSuccessResponse_5() { NextTest(); }
 
-    CHIP_ERROR TestWait3000ms_6()
+    CHIP_ERROR TestWait4000ms_6()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForMs(3000);
+        return WaitForMs(4000);
     }
 
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_7()
@@ -22152,10 +22152,10 @@ private:
 
     void OnSuccessResponse_8() { NextTest(); }
 
-    CHIP_ERROR TestWait3000ms_9()
+    CHIP_ERROR TestWait4000ms_9()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForMs(3000);
+        return WaitForMs(4000);
     }
 
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_10()


### PR DESCRIPTION
#### Problem

The `LVL` control certification tests are failing very often on darwin due to some timers. It needs to be properly fixed but in the meantime I would like to raise the timeout so I don't have to relaunch the whole YAML CI a few times just because of it.

#### Change overview
 * Raise some yaml tests timeout for level control
 