### PR TITLE
[zephyr] Drop BLE connection on endpoint close

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -767,7 +767,7 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
 {
-    // Intentionally empty.
+    CloseConnection(conId);
 }
 
 bool BLEManagerImpl::IsSubscribed(bt_conn * conn)


### PR DESCRIPTION

#### Problem
When a BLE endpoint is closed on the peripheral side, the associated connection is not automatically closed. Instead, BlePlatformDelegate::NotifyChipConnectionClosed() is called, but the function is empty for Zephyr and many other platforms.


#### Change overview
Implement connection closing for Zephyr platform.

#### Testing
Tested on nRF Connect examples that `CASEServer.cpp` code which closes all BLE endpoints in reponse to `Sigma1` message now truly closes the BLE connection.
