### PR TITLE
[Group] [Yaml] Add error if GroupId field isn't used properly in yaml test

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -174,6 +174,13 @@ function setDefaultTypeForCommand(test)
     break;
   }
 
+  // Sanity Check for GroupId usage
+  // Only two types of actions can be send to Group : Write attribute, and Commands
+  // Spec : Action 8.2.4
+  if ((kGroupId in test) && !test.isGroupCommand) {
+    printErrorAndExit(this, 'Wrong Yaml configuration. Action : ' + test.commandName + " can't be send to group " + test[kGroupId]);
+  }
+
   test.isWait = false;
 }
 

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -178,7 +178,7 @@ function setDefaultTypeForCommand(test)
   // Only two types of actions can be send to Group : Write attribute, and Commands
   // Spec : Action 8.2.4
   if ((kGroupId in test) && !test.isGroupCommand) {
-    printErrorAndExit(this, 'Wrong Yaml configuration. Action : ' + test.commandName + " can't be send to group " + test[kGroupId]);
+    printErrorAndExit(this, 'Wrong Yaml configuration. Action : ' + test.commandName + " can't be sent to group " + test[kGroupId]);
   }
 
   test.isWait = false;


### PR DESCRIPTION
#### Problem
No sanity check in ClusterTestGeneration for the usage of the GroupId field
Fix : #11851 

#### Change overview
Error out is a GroupId is set for an action that doesn't support Group.

#### Testing
Tested by regenerating everything with a GroupId in a Read action (failed as expected)
