### PR TITLE
[nrfconnect] Support Identify cluster in lighting-app

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -220,6 +220,11 @@ following states are possible:
 
 -   _Off_ &mdash; The light bulb is off.
 
+**LED 3** can be used to identify the device. The LED starts blinking evenly
+(500 ms on/500 ms off) when the Identify command of the Identify cluster is
+received. The command's argument can be used to specify the duration of the
+effect.
+
 **Button 1** can be used for the following purposes:
 
 -   _Pressed for 6 s_ &mdash; Initiates the factory reset of the device.

--- a/examples/lighting-app/nrfconnect/main/include/AppEvent.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppEvent.h
@@ -34,6 +34,8 @@ struct AppEvent
         kEventType_Lighting,
         kEventType_Install,
         kEventType_UpdateLedState,
+        kEventType_IdentifyStart,
+        kEventType_IdentifyStop,
 #ifdef CONFIG_MCUMGR_SMP_BT
         kEventType_StartSMPAdvertising,
 #endif

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -35,6 +35,7 @@
 #include <cstdint>
 
 struct k_timer;
+struct Identify;
 
 class AppTask
 {
@@ -44,6 +45,9 @@ public:
     void PostLightingActionRequest(LightingManager::Action_t aAction);
     void PostEvent(AppEvent * event);
     void UpdateClusterState();
+
+    static void IdentifyStartHandler(Identify *);
+    static void IdentifyStopHandler(Identify *);
 
 private:
 #ifdef CONFIG_CHIP_PW_RPC


### PR DESCRIPTION
#### Problem
nRF Connect lighting-app does not support Identify cluster which is mandatory for dimmable light device type.

#### Change overview
Add Identify cluster support to the example.

#### Testing
Sent Identify command to the nRF Connect lighting-app and verified it works.
