### PR TITLE
Fix null-deref crash in OnSessionEstablishmentError.

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -105,7 +105,7 @@ void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
     ChipLogError(AppServer, "Commissioning failed (attempt %d): %s", mFailedCommissioningAttempts, ErrorStr(err));
 
 #if CONFIG_NETWORK_LAYER_BLE
-    mServer->getBleLayerObject()->mBleEndPoint->ReleaseBleConnection();
+    mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
     if (mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
     {

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -81,7 +81,7 @@ public:
     TransportMgrBase & GetTransportManager() { return mTransports; }
 
 #if CONFIG_NETWORK_LAYER_BLE
-    Ble::BleLayer * getBleLayerObject() { return mBleLayer; }
+    Ble::BleLayer * GetBleLayerObject() { return mBleLayer; }
 #endif
 
     CommissioningWindowManager & GetCommissioningWindowManager() { return mCommissioningWindowManager; }

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -107,7 +107,6 @@ public:
     bool ConnectionObjectIs(BLE_CONNECTION_OBJECT connObj) { return connObj == mConnObj; }
     void Close();
     void Abort();
-    void ReleaseBleConnection();
 
 private:
     BleLayer * mBle; ///< [READ-ONLY] Pointer to the BleLayer object that owns this object.
@@ -224,6 +223,7 @@ private:
     // Close functions:
     void DoCloseCallback(uint8_t state, uint8_t flags, CHIP_ERROR err);
     void FinalizeClose(uint8_t state, uint8_t flags, CHIP_ERROR err);
+    void ReleaseBleConnection();
     void Free();
     void FreeBtpEngine();
 

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -288,7 +288,6 @@ CHIP_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleConnectionD
 #if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = NULL;
 #endif
-    mBleEndPoint = NULL;
 
     return CHIP_NO_ERROR;
 }
@@ -427,7 +426,6 @@ CHIP_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_O
 #if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = *retEndPoint;
 #endif
-    mBleEndPoint = *retEndPoint;
 
     return CHIP_NO_ERROR;
 }

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -320,8 +320,6 @@ public:
     BLEEndPoint * mTestBleEndPoint;
 #endif
 
-    BLEEndPoint * mBleEndPoint;
-
 private:
     // Private data members:
 

--- a/src/transport/raw/BLE.h
+++ b/src/transport/raw/BLE.h
@@ -91,8 +91,6 @@ public:
 
     CHIP_ERROR SetEndPoint(Ble::BLEEndPoint * endPoint) override;
 
-    Ble::BLEEndPoint * GetEndPoint() { return mBleEndPoint; }
-
 private:
     void ClearState();
 


### PR DESCRIPTION
We ended up crashing because
mServer->getBleLayerObject()->mBleEndPoint was null.

The changes mostly remove the changes from #9845 because those changes
made us try to close some random "whatever last BLE endpoint was
created", even if it's already closed or has nothing to do with our
PASE session.

So instead, just do the same thing as we do for CASE establishment and
tear down all BLE sessions, if we need to tear down anything at all.

The remaining changes are making ReleaseBleConnection private again
and removing the broken mBleEndPoint member from BleLayer.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Not entirely sure how to test this.  #9845 did not have clear test steps.... @sweetymhaiske 