### PR TITLE
Remove network index from defined endpoints.

### DIFF
--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -637,7 +637,6 @@ static void unenrollSecurityDevice(EndpointId endpoint)
 void emberAfPluginIasZoneServerStackStatusCallback(EmberStatus status)
 {
     EndpointId endpoint;
-    uint8_t networkIndex;
     uint8_t i;
 
     // If the device has left the network, unenroll all endpoints on the device
@@ -646,9 +645,8 @@ void emberAfPluginIasZoneServerStackStatusCallback(EmberStatus status)
     {
         for (i = 0; i < emberAfEndpointCount(); i++)
         {
-            endpoint     = emberAfEndpointFromIndex(i);
-            networkIndex = emberAfNetworkIndexFromEndpointIndex(i);
-            if (networkIndex == 0 /* emberGetCurrentNetwork() */ && emberAfContainsServer(endpoint, ZCL_IAS_ZONE_CLUSTER_ID))
+            endpoint = emberAfEndpointFromIndex(i);
+            if (emberAfContainsServer(endpoint, ZCL_IAS_ZONE_CLUSTER_ID))
             {
                 unenrollSecurityDevice(endpoint);
             }

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -383,6 +383,10 @@ typedef struct
      */
     uint8_t deviceVersion;
     /**
+     * Meta-data about the endpoint
+     */
+    EmberAfEndpointBitmask bitmask;
+    /**
      * Endpoint type for this endpoint.
      */
     const EmberAfEndpointType * endpointType;
@@ -391,14 +395,6 @@ typedef struct
      * endpoint
      */
     chip::DataVersion * dataVersions;
-    /**
-     * Network index for this endpoint.
-     */
-    uint8_t networkIndex;
-    /**
-     * Meta-data about the endpoint
-     */
-    EmberAfEndpointBitmask bitmask;
 } EmberAfDefinedEndpoint;
 
 // Cluster specific types

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -317,11 +317,6 @@ uint16_t emberAfFindClusterServerEndpointIndex(chip::EndpointId endpoint, chip::
 #define emberAfDeviceVersionFromIndex(index) (emAfEndpoints[(index)].deviceVersion)
 
 /**
- * @brief Macro that takes index of endpoint, and returns network index for it
- */
-#define emberAfNetworkIndexFromEndpointIndex(index) (emAfEndpoints[(index)].networkIndex)
-
-/**
  * @brief Macro that returns the primary endpoint.
  */
 #define emberAfPrimaryEndpoint() (emAfEndpoints[0].endpoint)
@@ -1364,53 +1359,6 @@ EmberStatus emberAfStartSearchForJoinableNetwork(void);
 #define emberAfStartSearchForJoinableNetwork() emberAfStartSearchForJoinableNetworkCallback()
 #endif
 
-/** @brief Sets the current network to that of the given index and adds it to
- * the stack of networks maintained by the framework.  Every call to this API
- * must be paired with a subsequent call to ::emberAfPopNetworkIndex.
- */
-
-EmberStatus emberAfPushNetworkIndex(uint8_t networkIndex);
-/** @brief Sets the current network to the callback network and adds it to
- * the stack of networks maintained by the framework.  Every call to this API
- * must be paired with a subsequent call to ::emberAfPopNetworkIndex.
- */
-
-EmberStatus emberAfPushCallbackNetworkIndex(void);
-/** @brief Sets the current network to that of the given endpoint and adds it
- * to the stack of networks maintained by the framework.  Every call to this
- * API must be paired with a subsequent call to ::emberAfPopNetworkIndex.
- */
-
-EmberStatus emberAfPushEndpointNetworkIndex(chip::EndpointId endpoint);
-/** @brief Removes the topmost network from the stack of networks maintained by
- * the framework and sets the current network to the new topmost network.
- * Every call to this API must be paired with a prior call to
- * ::emberAfPushNetworkIndex, ::emberAfPushCallbackNetworkIndex, or
- * ::emberAfPushEndpointNetworkIndex.
- */
-
-EmberStatus emberAfPopNetworkIndex(void);
-/** @brief Returns the primary endpoint of the given network index or 0xFF if
- * no endpoints belong to the network.
- */
-
-uint8_t emberAfPrimaryEndpointForNetworkIndex(uint8_t networkIndex);
-/** @brief Returns the primary endpoint of the current network index or 0xFF if
- * no endpoints belong to the current network.
- */
-
-uint8_t emberAfPrimaryEndpointForCurrentNetworkIndex(void);
-
-#if !defined(DOXYGEN_SHOULD_SKIP_THIS)
-/** @brief Initializes the stack of networks maintained by the framework,
- * including setting the default network.
- *
- * @return An ::EmberStatus value that indicates either that the network stack
- * has been successfully initialized or the reason for failure.
- */
-EmberStatus emAfInitializeNetworkIndexStack(void);
-void emAfAssertNetworkIndexStackIsEmpty(void);
-#endif
 /** @brief Basic initialization API to be invoked before ::emberAfMain.
  */
 void emberAfMainInit(void);

--- a/src/app/util/esi-management.cpp
+++ b/src/app/util/esi-management.cpp
@@ -249,8 +249,6 @@ uint8_t emberAfPluginEsiManagementUpdateEsiAndGetIndex(const EmberAfClusterComma
         return 0;
     }
 
-    emberAfPushNetworkIndex(cmd->networkIndex);
-
     /*emberLookupEui64ByNodeId(cmd->source, esiEui64); #2552*/
     esiEntry = emberAfPluginEsiManagementEsiLookUpByLongIdAndEndpoint(esiEui64, cmd->apsFrame->sourceEndpoint);
     // The source ESI is not in the ESI table.
@@ -284,7 +282,6 @@ uint8_t emberAfPluginEsiManagementUpdateEsiAndGetIndex(const EmberAfClusterComma
     }
 
     index = emberAfPluginEsiManagementIndexLookUpByLongIdAndEndpoint(esiEui64, cmd->apsFrame->sourceEndpoint);
-    emberAfPopNetworkIndex();
     return index;
 }
 


### PR DESCRIPTION
It's not used for anything and just takes up RAM.

#### Problem
Useless member.

#### Change overview
Remove it.  Also change member ordering to pack a bit better.

#### Testing
No behavior changes except smaller RAM usage expected.