### PR TITLE
Fix FabricTable memory leak in DeviceControllerSystemState

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -284,6 +284,12 @@ CHIP_ERROR DeviceControllerSystemState::Shutdown()
         mSessionMgr = nullptr;
     }
 
+    if (mFabrics != nullptr)
+    {
+        chip::Platform::Delete(mFabrics);
+        mFabrics = nullptr;
+    }
+
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed? 
Fix FabricTable memory leak in DeviceControllerSystemState

#### Change overview
FabricTable is instantiated in [DeviceControllerFactory::InitSystemState](https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CHIPDeviceControllerFactory.cpp#L134)
as shown below

```
    stateParams.fabricTable           = chip::Platform::New<FabricTable>();
```

stateParams (type: DeviceControllerSystemStateParams) is then passed
onto DeviceControllerFactory::mSystemState (type: DeviceControllerSystemState), where [stateParams.fabricTable is now stored in mSystemState.mFabrics.](https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CHIPDeviceControllerSystemState.h#L87)

We need to ensure that the original memory allocated in the initial step
is now freed in DeviceControllerSystemState::Shutdown()

#### Testing
How was this tested? (at least one bullet point required) 
**Answer: This was validated through memory sanitizer**
* If unit tests were added, how do they cover this issue?
** No Unit test check for similar memory leaks. 

