### PR TITLE
Add Pairing Commands to chip-tool-darwin

### DIFF
--- a/examples/chip-tool-darwin/.gn
+++ b/examples/chip-tool-darwin/.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2022 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/chip-tool-darwin/BUILD.gn
+++ b/examples/chip-tool-darwin/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2022 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,14 +20,24 @@ import("${chip_root}/build/chip/tools.gni")
 assert(chip_build_tools)
 
 executable("chip-tool-darwin") {
-  sources = [ "main.m" ]
+  sources = [
+    "commands/common/CHIPCommandBridge.mm",
+    "commands/pairing/Commands.h",
+    "commands/pairing/PairingCommandBridge.mm",
+    "commands/pairing/PairingDelegateBridge.mm",
+    "main.mm",
+  ]
+
+  include_dirs = [ "." ]
 
   deps = [
+    "${chip_root}/examples/chip-tool:chip-tool-utils",
     "${chip_root}/src/app/server",
     "${chip_root}/src/darwin/Framework/CHIP",
     "${chip_root}/src/lib",
     "${chip_root}/src/platform",
     "${chip_root}/third_party/inipp",
+    "${chip_root}/third_party/jsoncpp",
   ]
 
   cflags = [
@@ -36,4 +46,22 @@ executable("chip-tool-darwin") {
   ]
 
   output_dir = root_out_dir
+}
+
+action("codesign") {
+  script = "entitlements/codesign.py"
+  sources = [ "entitlements/chip-tool-darwin.entitlements" ]
+  public_deps = [ ":chip-tool-darwin" ]
+
+  args = [
+    "--target_path",
+    rebase_path("${root_build_dir}/chip-tool-darwin", root_build_dir),
+    "--entitlements_path",
+    rebase_path("entitlements/chip-tool-darwin.entitlements", root_build_dir),
+    "--log_path",
+    rebase_path("${root_build_dir}/codesign_log.txt", root_build_dir),
+  ]
+
+  output_name = "codesign_log.txt"
+  outputs = [ "${root_build_dir}/${output_name}" ]
 }

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
@@ -1,0 +1,80 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+#import <CHIP/CHIPDeviceController.h>
+#include <commands/common/Command.h>
+#include <commands/common/CredentialIssuerCommands.h>
+
+#pragma once
+
+class CHIPCommandBridge : public Command
+{
+public:
+    CHIPCommandBridge(const char * commandName) : Command(commandName) {}
+
+    CHIPCommandBridge(const char * commandName, CredentialIssuerCommands * credIssuerCmds) : CHIPCommandBridge(commandName) {}
+
+    /////////// Command Interface /////////
+    CHIP_ERROR Run() override;
+
+    void SetCommandExitStatus(CHIP_ERROR status)
+    {
+        mCommandExitStatus = status;
+        ShutdownCommissioner();
+        StopWaiting();
+    }
+
+protected:
+    // Will be called in a setting in which it's safe to touch the CHIP
+    // stack. The rules for Run() are as follows:
+    //
+    // 1) If error is returned, Run() must not call SetCommandExitStatus.
+    // 2) If success is returned Run() must either have called
+    //    SetCommandExitStatus() or scheduled async work that will do that.
+    virtual CHIP_ERROR RunCommand() = 0;
+
+    // Get the wait duration, in seconds, before the command times out.
+    virtual chip::System::Clock::Timeout GetWaitDuration() const = 0;
+
+    // Shut down the command, in case any work needs to be done after the event
+    // loop has been stopped.
+    virtual void Shutdown() {}
+
+    void SetIdentity(const char * name);
+
+    // This method returns the commissioner instance to be used for running the command.
+    CHIPDeviceController * CurrentCommissioner();
+
+private:
+    CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId);
+    CHIP_ERROR ShutdownCommissioner();
+    uint16_t CurrentCommissionerIndex();
+
+    CHIP_ERROR mCommandExitStatus = CHIP_ERROR_INTERNAL;
+
+    CHIP_ERROR StartWaiting(chip::System::Clock::Timeout seconds);
+    void StopWaiting();
+    CHIPDeviceController * mController;
+
+#if CONFIG_USE_SEPARATE_EVENTLOOP
+    std::condition_variable cvWaitingForResponse;
+    std::mutex cvWaitingForResponseMutex;
+    bool mWaitingForResponse{ true };
+#endif // CONFIG_USE_SEPARATE_EVENTLOOP
+};

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
@@ -1,0 +1,91 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CHIPCommandBridge.h"
+
+#import <CHIP/CHIPDeviceController.h>
+#include <core/CHIPBuildConfig.h>
+#include <lib/support/CodeUtils.h>
+
+const uint16_t kListenPort = 5541;
+
+CHIP_ERROR CHIPCommandBridge::Run()
+{
+    NSLog(@"Running Command");
+
+    mController = [CHIPDeviceController sharedController];
+    [mController setListenPort:kListenPort];
+    [mController startup:nil vendorId:0 nocSigner:nil];
+
+    RunCommand();
+    ReturnLogErrorOnFailure(StartWaiting(GetWaitDuration()));
+    return CHIP_NO_ERROR;
+}
+
+CHIPDeviceController * CHIPCommandBridge::CurrentCommissioner() { return mController; }
+
+CHIP_ERROR CHIPCommandBridge::ShutdownCommissioner()
+{
+    NSLog(@"Shutting down controller");
+    BOOL result = [CurrentCommissioner() shutdown];
+    if (!result) {
+        NSLog(@"Unable to shut down controller");
+        return CHIP_ERROR_INTERNAL;
+    }
+    return CHIP_NO_ERROR;
+}
+
+#if !CONFIG_USE_SEPARATE_EVENTLOOP
+static void OnResponseTimeout(chip::System::Layer *, void * appState)
+{
+    (reinterpret_cast<CHIPCommandBridge *>(appState))->SetCommandExitStatus(CHIP_ERROR_TIMEOUT);
+}
+#endif // !CONFIG_USE_SEPARATE_EVENTLOOP
+
+CHIP_ERROR CHIPCommandBridge::StartWaiting(chip::System::Clock::Timeout duration)
+{
+#if CONFIG_USE_SEPARATE_EVENTLOOP
+    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
+    auto waitingUntil = std::chrono::system_clock::now() + std::chrono::duration_cast<std::chrono::seconds>(duration);
+    {
+        std::unique_lock<std::mutex> lk(cvWaitingForResponseMutex);
+        if (!cvWaitingForResponse.wait_until(lk, waitingUntil, [this]() { return !this->mWaitingForResponse; })) {
+            mCommandExitStatus = CHIP_ERROR_TIMEOUT;
+        }
+    }
+    LogErrorOnFailure(chip::DeviceLayer::PlatformMgr().StopEventLoopTask());
+#else
+    ReturnLogErrorOnFailure(chip::DeviceLayer::SystemLayer().StartTimer(duration, OnResponseTimeout, this));
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+#endif // CONFIG_USE_SEPARATE_EVENTLOOP
+
+    return mCommandExitStatus;
+}
+
+void CHIPCommandBridge::StopWaiting()
+{
+#if CONFIG_USE_SEPARATE_EVENTLOOP
+    {
+        std::lock_guard<std::mutex> lk(cvWaitingForResponseMutex);
+        mWaitingForResponse = false;
+    }
+    cvWaitingForResponse.notify_all();
+#else // CONFIG_USE_SEPARATE_EVENTLOOP
+    LogErrorOnFailure(chip::DeviceLayer::PlatformMgr().StopEventLoopTask());
+#endif // CONFIG_USE_SEPARATE_EVENTLOOP
+}

--- a/examples/chip-tool-darwin/commands/pairing/Commands.h
+++ b/examples/chip-tool-darwin/commands/pairing/Commands.h
@@ -1,0 +1,59 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "PairingCommandBridge.h"
+
+class Unpair : public PairingCommandBridge
+{
+public:
+    Unpair() : PairingCommandBridge("unpair", PairingMode::None) {}
+};
+
+class PairQRCode : public PairingCommandBridge
+{
+public:
+    PairQRCode() : PairingCommandBridge("qrcode", PairingMode::QRCode) {}
+};
+
+class PairManualCode : public PairingCommandBridge
+{
+public:
+    PairManualCode() : PairingCommandBridge("manualcode", PairingMode::ManualCode) {}
+};
+
+class PairWithIPAddress : public PairingCommandBridge
+{
+public:
+    PairWithIPAddress() : PairingCommandBridge("ethernet", PairingMode::Ethernet) {}
+};
+
+void registerCommandsPairing(Commands & commands)
+{
+    const char * clusterName = "Pairing";
+
+    commands_list clusterCommands = {
+        make_unique<Unpair>(),
+        make_unique<PairQRCode>(),
+        make_unique<PairManualCode>(),
+        make_unique<PairWithIPAddress>(),
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}

--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.h
@@ -1,0 +1,75 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+#include "../common/CHIPCommandBridge.h"
+#import <CHIP/CHIPClustersObjc.h>
+#import <CHIP/CHIPDevicePairingDelegate.h>
+
+enum class PairingMode
+{
+    None,
+    QRCode,
+    ManualCode,
+    Ethernet
+};
+
+class PairingCommandBridge : public CHIPCommandBridge
+{
+public:
+    PairingCommandBridge(const char * commandName, PairingMode mode) : CHIPCommandBridge(commandName), mPairingMode(mode)
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+
+        switch (mode)
+        {
+        case PairingMode::None:
+            break;
+        case PairingMode::QRCode:
+            AddArgument("payload", &mOnboardingPayload);
+            break;
+        case PairingMode::ManualCode:
+            AddArgument("payload", &mOnboardingPayload);
+            break;
+        case PairingMode::Ethernet:
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            AddArgument("device-remote-ip", &ipAddress);
+            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
+            break;
+        }
+    }
+
+    /////////// CHIPCommandBridge Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(120); }
+
+private:
+    void PairWithCode(NSError * error);
+    void PairWithIPAddress(NSError * error);
+    void Unpair(NSError * error);
+    void SetUpPairingDelegate();
+
+    const PairingMode mPairingMode;
+    chip::NodeId mNodeId;
+    uint16_t mRemotePort;
+    uint16_t mDiscriminator;
+    uint32_t mSetupPINCode;
+    char * mOnboardingPayload;
+    char * ipAddress;
+};

--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
@@ -1,0 +1,89 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#import <CHIP/CHIPError_Internal.h>
+
+#include "../common/CHIPCommandBridge.h"
+#include "PairingCommandBridge.h"
+#include "PairingDelegateBridge.h"
+#include "platform/PlatformManager.h"
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace ::chip;
+using namespace ::chip::Controller;
+
+void PairingCommandBridge::SetUpPairingDelegate()
+{
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.pairing", DISPATCH_QUEUE_SERIAL);
+    CHIPToolPairingDelegate * pairing = [[CHIPToolPairingDelegate alloc] init];
+
+    pairing.deviceID = mNodeId;
+    pairing.commandBridge = this;
+
+    [CurrentCommissioner() setPairingDelegate:pairing queue:callbackQueue];
+}
+
+CHIP_ERROR PairingCommandBridge::RunCommand()
+{
+    NSError * error;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    switch (mPairingMode) {
+    case PairingMode::None:
+        Unpair(error);
+        err = [CHIPError errorToCHIPErrorCode:error];
+        SetCommandExitStatus(err);
+        return err;
+    case PairingMode::QRCode:
+    case PairingMode::ManualCode:
+        PairWithCode(error);
+        break;
+    case PairingMode::Ethernet:
+        PairWithIPAddress(error);
+        break;
+    }
+    err = [CHIPError errorToCHIPErrorCode:error];
+    if (err != CHIP_NO_ERROR) {
+        ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(err));
+    }
+    return err;
+}
+
+void PairingCommandBridge::PairWithCode(NSError * error)
+{
+    NSString * payload = [NSString stringWithUTF8String:mOnboardingPayload];
+
+    SetUpPairingDelegate();
+    [CurrentCommissioner() pairDevice:mNodeId onboardingPayload:payload error:&error];
+}
+
+void PairingCommandBridge::PairWithIPAddress(NSError * error)
+{
+    SetUpPairingDelegate();
+    [CurrentCommissioner() pairDevice:mNodeId
+                              address:[NSString stringWithUTF8String:ipAddress]
+                                 port:mRemotePort
+                        discriminator:mDiscriminator
+                         setupPINCode:mSetupPINCode
+                                error:&error];
+}
+
+void PairingCommandBridge::Unpair(NSError * error)
+{
+    [CurrentCommissioner() unpairDevice:mNodeId error:&error];
+    NSLog(@"Upairing error: %@", error);
+}

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.h
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.h
@@ -1,0 +1,28 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#pragma once
+#include "PairingCommandBridge.h"
+
+@interface CHIPToolPairingDelegate : NSObject <CHIPDevicePairingDelegate>
+@property PairingCommandBridge * commandBridge;
+@property chip::NodeId deviceID;
+- (void)onPairingComplete:(NSError *)error;
+- (void)onPairingDeleted:(NSError *)error;
+- (void)onCommissioningComplete:(NSError *)error;
+
+@end

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
@@ -1,0 +1,54 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "PairingDelegateBridge.h"
+#import <CHIP/CHIPError_Internal.h>
+
+@interface CHIPToolPairingDelegate ()
+@property (nonatomic, strong) CHIPBasic * cluster;
+@property (nonatomic, strong) ResponseHandler responseHandler;
+@end
+@implementation CHIPToolPairingDelegate
+- (void)onPairingComplete:(NSError *)error
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    NSLog(@"Pairing Complete: %@", error);
+    err = [CHIPError errorToCHIPErrorCode:error];
+    _commandBridge->SetCommandExitStatus(err);
+}
+
+- (void)onPairingDeleted:(NSError *)error
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    NSLog(@"Pairing Deleted: %@", error);
+    err = [CHIPError errorToCHIPErrorCode:error];
+    _commandBridge->SetCommandExitStatus(err);
+}
+
+- (void)onCommissioningComplete:(NSError *)error
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    NSLog(@"Pairing Commissioning Complete: %@", error);
+    err = [CHIPError errorToCHIPErrorCode:error];
+    _commandBridge->SetCommandExitStatus(err);
+}
+
+@end

--- a/examples/chip-tool-darwin/entitlements/chip-tool-darwin.entitlements
+++ b/examples/chip-tool-darwin/entitlements/chip-tool-darwin.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.private.security.container-required</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.appleinternal.chip-tool</string>
+	</array>
+</dict>
+</plist>

--- a/examples/chip-tool-darwin/entitlements/codesign.py
+++ b/examples/chip-tool-darwin/entitlements/codesign.py
@@ -1,0 +1,39 @@
+import argparse
+import subprocess
+import re
+
+
+def find_identity():
+    fail_str = "0 valid identities found"
+    cmd = "/usr/bin/security find-identity -v -p codesigning"
+    find_result = str(subprocess.check_output(cmd.split()))
+    if fail_str in find_result:
+        exit(-1)
+    result = re.search(r'\b[0-9a-fA-F]{40}\b', find_result)
+    return result.group()
+
+
+def codesign(args):
+    identity = find_identity()
+    cmd = "codesign --force -d --sign {identity} --entitlements {entitlement} {target}".format(
+        identity=identity,
+        entitlement=args.entitlements_path,
+        target=args.target_path)
+    print("COMMAND " + cmd)
+    codesign_result = str(subprocess.check_output(cmd.split()))
+    print("Codesign Result: {}".format(codesign_result))
+    with open(args.log_path, "w") as f:
+        f.write(codesign_result)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Codesign the chip-tool-darwin binary')
+    parser.add_argument('--entitlements_path', default='entitlements/chip-tool-darwin.entitlements',
+                        help='Set the entitlements for codesign', required=True)
+    parser.add_argument(
+        '--log_path', help='Output log file destination', required=True)
+    parser.add_argument('--target_path', help='Binary to sign', required=True)
+
+    args = parser.parse_args()
+    codesign(args)

--- a/examples/chip-tool-darwin/main.mm
+++ b/examples/chip-tool-darwin/main.mm
@@ -16,7 +16,13 @@
  *
  */
 
-#import <CHIP/CHIP.h>
-#import <Foundation/Foundation.h>
+#include "commands/common/Commands.h"
 
-int main(int argc, const char * argv[]) { return EXIT_SUCCESS; }
+#include "commands/pairing/Commands.h"
+
+int main(int argc, const char * argv[])
+{
+    Commands commands;
+    registerCommandsPairing(commands);
+    return commands.Run(argc, (char **) argv);
+}

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -274,7 +274,7 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
         break;
     }
 
-    case ArgumentType::Boolean:
+    case ArgumentType::Bool:
     case ArgumentType::Number_uint8: {
         isValidArgument = HandleNullableOptional<uint8_t>(arg, argValue, [&](auto * value) {
             // stringstream treats uint8_t as char, which is not what we want here.

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -62,7 +62,7 @@ enum ArgumentType
     Number_int64,
     Float,
     Double,
-    Boolean,
+    Bool,
     String,
     CharString,
     OctetString,
@@ -132,7 +132,7 @@ public:
     size_t AddArgument(const char * name, CustomArgument * value);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Bool, flags);
     }
     size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, uint8_t flags = 0)
     {

--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -29,8 +29,10 @@ config("darwin_config") {
 static_library("framework") {
   sources = [
     "CHIP.h",
+    "CHIPCluster.mm",
     "CHIPDevice.h",
     "CHIPDevice.mm",
+    "CHIPDeviceConnectionBridge.mm",
     "CHIPDeviceController.h",
     "CHIPDeviceController.mm",
     "CHIPDevicePairingDelegate.h",
@@ -45,6 +47,7 @@ static_library("framework") {
     "CHIPManualSetupPayloadParser.mm",
     "CHIPOnboardingPayloadParser.m",
     "CHIPOperationalCredentialsDelegate.mm",
+    "CHIPP256KeypairBridge.mm",
     "CHIPPersistentStorageDelegate.h",
     "CHIPPersistentStorageDelegateBridge.h",
     "CHIPPersistentStorageDelegateBridge.mm",
@@ -52,6 +55,8 @@ static_library("framework") {
     "CHIPQRCodeSetupPayloadParser.mm",
     "CHIPSetupPayload.h",
     "CHIPSetupPayload.mm",
+    "zap-generated/CHIPAttributeTLVValueDecoder.mm",
+    "zap-generated/CHIPCallbackBridge.mm",
     "zap-generated/CHIPClustersObjc.h",
     "zap-generated/CHIPClustersObjc.mm",
     "zap-generated/CHIPCommandPayloadsObjc.h",


### PR DESCRIPTION
#### Problem
- Add `chip-tool-darwin pairing` commands to exercise CHIP.framework using CLI.

#### Change overview
- Adds Bridge files to support integration of CHIP.framework with C++ chip-tool-utils library.
- Adds code sign script into build since it is required for persistent storage. 
- Adds entitlements

#### Testing
- Compiled
- Paired with qrcode, manualcode, and ethernet.
- Ran unpair command (SDK does not have implemented).

#### Notes
Uses chip-tool-utils for the commands line argument structure. 

