### PR TITLE
Fix write ACL attribute

### DIFF
--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -447,12 +447,14 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(AttributeValueDecoder & aDecoder)
     size_t newCount;
     size_t maxCount;
 
-    AccessControl::EntryIterator it;
-    AccessControl::Entry entry;
-    ReturnErrorOnFailure(GetAccessControl().Entries(it, &accessingFabricIndex));
-    while (it.Next(entry) == CHIP_NO_ERROR)
     {
-        oldCount++;
+        AccessControl::EntryIterator it;
+        AccessControl::Entry entry;
+        ReturnErrorOnFailure(GetAccessControl().Entries(it, &accessingFabricIndex));
+        while (it.Next(entry) == CHIP_NO_ERROR)
+        {
+            oldCount++;
+        }
     }
 
     ReturnErrorOnFailure(GetAccessControl().GetEntryCount(allCount));


### PR DESCRIPTION
#### Problem
PR #13756 altered write ACL function so it has too many outstanding iterators
at a time.

#### Change overview
Scope the added iterator so it doesn't interfere with the other one.

#### Testing
- Wrote ACLs on two fabrics using all-clusters-app with REPL on Linux.