### PR TITLE
Added FabricId to the Root Cert DN for Android and iOS.

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -72,6 +72,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChainAfterValidation(NodeI
     noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId);
     ChipDN rcac_dn;
     rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId);
+    rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId);
 
     ChipLogProgress(Controller, "Generating NOC");
     chip::Credentials::X509CertRequestParams noc_request = { 1, mNow, mNow + mValidity, noc_dn, rcac_dn };

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -207,6 +207,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
     noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId);
     ChipDN rcac_dn;
     rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId);
+    rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId);
 
     X509CertRequestParams noc_request = { 1, validityStart, validityEnd, noc_dn, rcac_dn };
     ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, pubkey, *mIssuerKey, noc));


### PR DESCRIPTION
#### Problem
Prior #13737 merge the test root certificate included also FabricId.

#### Change overview
To keep consistency with the test environments that were created prior to #13737 this PR adds FabricId attribute to the root certificate DN.

#### Testing
existing tests