### PR TITLE
Added common module that defines weak methods that can be overriden b…

### DIFF
--- a/examples/common/datt-config/BUILD.gn
+++ b/examples/common/datt-config/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("datt-weak-config") {
+  include_dirs = [ "." ]
+}
+
+source_set("datt-weak") {
+  sources = [
+    "DattConfig.cpp",
+    "DattConfig.h",
+  ]
+
+  deps = [ "${chip_root}/src/credentials" ]
+
+  public_configs = [ ":datt-weak-config" ]
+}

--- a/examples/common/datt-config/DattConfig.cpp
+++ b/examples/common/datt-config/DattConfig.cpp
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <DattConfig.h>
+
+__attribute__((weak)) const chip::Credentials::AttestationTrustStore * GetAttestationTrustStore()
+{
+    return chip::Credentials::GetTestAttestationTrustStore();
+}
+
+__attribute__((weak)) chip::Credentials::DeviceAttestationCredentialsProvider * GetAttestationCredentialsProvider()
+{
+    return chip::Credentials::Examples::GetExampleDACProvider();
+}

--- a/examples/common/datt-config/DattConfig.h
+++ b/examples/common/datt-config/DattConfig.h
@@ -1,0 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/DeviceAttestationVerifier.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+
+__attribute__((weak)) const chip::Credentials::AttestationTrustStore * GetAttestationTrustStore();
+
+__attribute__((weak)) chip::Credentials::DeviceAttestationCredentialsProvider * GetAttestationCredentialsProvider();

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -33,7 +33,7 @@ config("includes") {
   ]
 }
 
-executable("chip-lighting-app") {
+static_library("chip-lighting-app-utils") {
   sources = [
     "LightingManager.cpp",
     "include/CHIPProjectAppConfig.h",
@@ -81,6 +81,12 @@ executable("chip-lighting-app") {
     # -Wconversion, remove check for RPC build only.
     cflags = [ "-Wconversion" ]
   }
+
+  output_dir = root_out_dir
+}
+
+executable("chip-lighting-app") {
+  deps = [ ":chip-lighting-app-utils" ]
 
   output_dir = root_out_dir
 }

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -25,10 +25,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/NodeId.h>
 
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <DattConfig.h>
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ScopedBuffer.h>
@@ -257,7 +254,7 @@ CHIP_ERROR InitCommissioner()
 
     // Initialize device attestation verifier
     // TODO: Replace testingRootStore with a AttestationTrustStore that has the necessary official PAA roots available
-    const Credentials::AttestationTrustStore * testingRootStore = Credentials::GetTestAttestationTrustStore();
+    const Credentials::AttestationTrustStore * testingRootStore = GetAttestationTrustStore();
     SetDeviceAttestationVerifier(GetDefaultDACVerifier(testingRootStore));
 
     Platform::ScopedMemoryBuffer<uint8_t> noc;
@@ -519,7 +516,7 @@ void ChipLinuxAppMainLoop()
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
     // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    SetDeviceAttestationCredentialsProvider(GetAttestationCredentialsProvider());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     InitCommissioner();

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -43,6 +43,8 @@ source_set("app-main") {
     defines += [ "ENABLE_CHIP_SHELL" ]
   }
 
+  deps = [ "${chip_root}/examples/common/datt-config:datt-weak" ]
+
   public_deps = [
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib",


### PR DESCRIPTION
#### Problem
* Example lighting-app example does not allow external/third-party vendors to override default Device Attestation Provider and Verifier.

#### Change Overview
* Added common module that defines weak methods that can be overridden by vendor apps - that return the default Attestation Trust Stores and Example DAC Provider.
* Updated Linux lighting-app example to generate a static library.
* Updated main Linux app platform code to use the newly added weak methods to fetch the Attestation Trust Store and DAC Provider.

#### Testing
* Matter Unit Tests
* Tested Commissioning flow (chip-tool vs lighting-app)