### PR TITLE
Incorrect processing in Engine::ScheduleRun()

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -480,9 +480,13 @@ CHIP_ERROR Engine::ScheduleRun()
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
-    ReturnErrorOnFailure(systemLayer->ScheduleWork(Run, this));
     mRunScheduled = true;
-    return CHIP_NO_ERROR;
+    auto err = systemLayer->ScheduleWork(Run, this);
+    if (!::chip::ChipError::IsSuccess(err))
+    {
+        mRunScheduled = false;
+    }
+    return err;
 }
 
 void Engine::Run()


### PR DESCRIPTION
#### Problem
* Fixes #14596 Incorrect processing in Engine::ScheduleRun()

#### Change overview
setup 'mRunScheduled = true' before execute ScheduleWork() to avoid case when scheduled callback has been done before  ScheduleWork() returns
