### PR TITLE
[AddressSanitizer] stack-use-after-scope in src/lib/dnssd/Advertiser_…

### DIFF
--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -679,32 +679,32 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
     AddCommonTxtEntries<CommissionAdvertisingParameters>(params, commonStorage, txtFields, numTxtFields);
 
     // the following sub types only apply to commissionable node advertisements
+    char txtDiscriminator[chip::Dnssd::kKeyLongDiscriminatorMaxLength + 3];
+    char txtCommissioningMode[chip::Dnssd::kKeyCommissioningModeMaxLength + 4];
+    char txtRotatingDeviceId[chip::Dnssd::kKeyRotatingDeviceIdMaxLength + 4];
+    char txtPairingHint[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
+    char txtPairingInstr[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
     {
         // a discriminator always exists
-        char txtDiscriminator[chip::Dnssd::kKeyLongDiscriminatorMaxLength + 3];
         snprintf(txtDiscriminator, sizeof(txtDiscriminator), "D=%d", params.GetLongDiscriminator());
         txtFields[numTxtFields++] = txtDiscriminator;
 
-        char txtCommissioningMode[chip::Dnssd::kKeyCommissioningModeMaxLength + 4];
         snprintf(txtCommissioningMode, sizeof(txtCommissioningMode), "CM=%d", static_cast<int>(params.GetCommissioningMode()));
         txtFields[numTxtFields++] = txtCommissioningMode;
 
-        char txtRotatingDeviceId[chip::Dnssd::kKeyRotatingDeviceIdMaxLength + 4];
         if (params.GetRotatingDeviceId().HasValue())
         {
             snprintf(txtRotatingDeviceId, sizeof(txtRotatingDeviceId), "RI=%s", params.GetRotatingDeviceId().Value());
             txtFields[numTxtFields++] = txtRotatingDeviceId;
         }
 
-        char txtPairingHint[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
         if (params.GetPairingHint().HasValue())
         {
             snprintf(txtPairingHint, sizeof(txtPairingHint), "PH=%d", params.GetPairingHint().Value());
             txtFields[numTxtFields++] = txtPairingHint;
         }
 
-        char txtPairingInstr[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
         if (params.GetPairingInstruction().HasValue())
         {
             snprintf(txtPairingInstr, sizeof(txtPairingInstr), "PI=%s", params.GetPairingInstruction().Value());


### PR DESCRIPTION
…ImplMinimalMdns.cpp

#### Problem

While trying to debug the Tsan issue in #14598 I have found this Asan issue in minimal.

Basically the char array are allocated into a scoped block and a reference to it is passed to `txtFields` which is then used outside of the block.

#### Change overview
 * Move the allocation outside of the block
 
#### Testing
Asan is not complying anymore after this change.