### PR TITLE
Use typesafe network featuremaps instead of re-defining constants

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -66,16 +66,12 @@ public:
                     DeviceLayer::NetworkCommissioning::ThreadScanResponseIterator * networks) override;
 
 private:
-    static constexpr uint32_t kFeatureMapWiFi     = 0b0000'0001;
-    static constexpr uint32_t kFeatureMapThread   = 0b0000'0010;
-    static constexpr uint32_t kFeatureMapEthernet = 0b0000'0100;
-
-    static constexpr uint32_t kFeatureMapWireless = 0b0000'0011;
-
     static void _OnCommissioningComplete(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void OnCommissioningComplete(CHIP_ERROR err);
 
-    const uint32_t mType;
+    using NetworkCommissioningFeature = chip::app::Clusters::NetworkCommissioning::NetworkCommissioningFeature;
+
+    const BitFlags<NetworkCommissioningFeature> mFeatureFlags;
 
     DeviceLayer::NetworkCommissioning::Internal::WirelessDriver * const mpWirelessDriver;
     DeviceLayer::NetworkCommissioning::Internal::BaseDriver * const mpBaseDriver;
@@ -97,24 +93,24 @@ private:
 public:
     Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * apDelegate) :
         CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id),
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mType(kFeatureMapWiFi), mpWirelessDriver(apDelegate),
-        mpBaseDriver(apDelegate)
+        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
+        mFeatureFlags(NetworkCommissioningFeature::kWiFiNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
     {
         mpDriver.Set<DeviceLayer::NetworkCommissioning::WiFiDriver *>(apDelegate);
     }
 
     Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * apDelegate) :
         CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id),
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mType(kFeatureMapThread), mpWirelessDriver(apDelegate),
-        mpBaseDriver(apDelegate)
+        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
+        mFeatureFlags(NetworkCommissioningFeature::kThreadNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
     {
         mpDriver.Set<DeviceLayer::NetworkCommissioning::ThreadDriver *>(apDelegate);
     }
 
     Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::EthernetDriver * apDelegate) :
         CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id),
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mType(kFeatureMapEthernet), mpWirelessDriver(nullptr),
-        mpBaseDriver(apDelegate)
+        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
+        mFeatureFlags(NetworkCommissioningFeature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(apDelegate)
     {}
 
     virtual ~Instance() = default;

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -69,8 +69,6 @@ private:
     static void _OnCommissioningComplete(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void OnCommissioningComplete(CHIP_ERROR err);
 
-    using NetworkCommissioningFeature = chip::app::Clusters::NetworkCommissioning::NetworkCommissioningFeature;
-
     const BitFlags<NetworkCommissioningFeature> mFeatureFlags;
 
     DeviceLayer::NetworkCommissioning::Internal::WirelessDriver * const mpWirelessDriver;


### PR DESCRIPTION
#### Problem
Network commissioning class was re-defining constants for feature maps.

#### Change overview
Switch to using bitflags of expected types, updated logic that relies on 'wifi driver' to use the driver to check not bitflags, use typesafe bitflag comparisons.

#### Testing
Commissioned a ESP32 devkit-c manually after the change (this is a device that reports wifi).