### PR TITLE
Fix github issue #14321 - Thread end device (Requestor) crashes if it cannot reach the Provider

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -86,12 +86,16 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
         return;
     }
 
+    VerifyOrDie(proxy != nullptr);
+
     if (result == nullptr)
     {
         proxy->OnNodeIdResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID);
         proxy->Release();
         return;
     }
+
+    VerifyOrDie(proxy != nullptr);
 
     PeerId peerId;
     error = ExtractIdFromInstanceName(result->mName, &peerId);
@@ -101,6 +105,8 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
         proxy->Release();
         return;
     }
+
+    VerifyOrDie(proxy != nullptr);
 
     ResolvedNodeData nodeData;
     Platform::CopyString(nodeData.mHostName, result->mHostName);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -124,6 +124,9 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
 #endif
     proxy->OnNodeIdResolved(nodeData);
     proxy->Release();
+
+    // Allocated in OnDnsResolveResult(), must be freed here
+    free(result);
 }
 
 static void HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -83,12 +83,15 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
     {
         proxy->OnNodeIdResolutionFailed(PeerId(), error);
         proxy->Release();
+        return;
     }
 
     if (result == nullptr)
     {
         proxy->OnNodeIdResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID);
         proxy->Release();
+        return;
+
     }
 
     PeerId peerId;
@@ -97,6 +100,8 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
     {
         proxy->OnNodeIdResolutionFailed(PeerId(), error);
         proxy->Release();
+        return;
+
     }
 
     ResolvedNodeData nodeData;
@@ -124,9 +129,6 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
 #endif
     proxy->OnNodeIdResolved(nodeData);
     proxy->Release();
-
-    // Allocated in OnDnsResolveResult(), must be freed here
-    free(result);
 }
 
 static void HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -91,7 +91,6 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
         proxy->OnNodeIdResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID);
         proxy->Release();
         return;
-
     }
 
     PeerId peerId;
@@ -101,7 +100,6 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERRO
         proxy->OnNodeIdResolutionFailed(PeerId(), error);
         proxy->Release();
         return;
-
     }
 
     ResolvedNodeData nodeData;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -2317,10 +2317,13 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnDnsResolveResult(otE
 
     error = FromOtDnsResponseToMdnsData(serviceInfo, type, dnsResult->mMdnsService, dnsResult->mServiceTxtEntry);
 
+    VerifyOrExit(error == CHIP_NO_ERROR, );
+
+    DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(dnsResult));
+
 exit:
 
     dnsResult->error = error;
-    DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(dnsResult));
 }
 
 template <class ImplClass>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -2317,13 +2317,11 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnDnsResolveResult(otE
 
     error = FromOtDnsResponseToMdnsData(serviceInfo, type, dnsResult->mMdnsService, dnsResult->mServiceTxtEntry);
 
-    VerifyOrExit(error == CHIP_NO_ERROR, );
-
+exit:
+   
+    dnsResult->error = error;
     DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(dnsResult));
 
-exit:
-
-    dnsResult->error = error;
 }
 
 template <class ImplClass>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -2318,7 +2318,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnDnsResolveResult(otE
     error = FromOtDnsResponseToMdnsData(serviceInfo, type, dnsResult->mMdnsService, dnsResult->mServiceTxtEntry);
 
 exit:
-   
+
     dnsResult->error = error;
     DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(dnsResult));
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -2321,7 +2321,6 @@ exit:
 
     dnsResult->error = error;
     DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(dnsResult));
-
 }
 
 template <class ImplClass>


### PR DESCRIPTION
#### Problem
This fixes Github issue #14321 - Thread end device (Requestor) crashes if it cannot reach the Provider 

When announce-ota-provider is sent with no provider commissioned, a hard fault occurs. 

#### Change  #overview

This change removes the hard fault by omitting the call to ScheduleWork to add DispatchResolve when a provider is not reachable.

#### Testing

This was tested by running the scenario with and without a commissioned provider. 

When the OTA scenario is run with a commissioned provider, announce-ota-provider works as normal.

When the scenario is run without a provider, announce-ota-provider no longer results in a hardfault.