### PR TITLE
Added Serializer and Deserializer to the PASEVerifier Struct

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -513,15 +513,13 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowInternal()
         ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, mCommissioningWindowIteration, salt, randomSetupPIN,
                                                                mSetupPayload.setUpPINCode));
 
-        uint8_t serializedVerifier[2 * kSpake2p_WS_Length];
-        VerifyOrReturnError(sizeof(serializedVerifier) == sizeof(verifier), CHIP_ERROR_INTERNAL);
-
-        memcpy(serializedVerifier, verifier.mW0, kSpake2p_WS_Length);
-        memcpy(&serializedVerifier[kSpake2p_WS_Length], verifier.mL, kSpake2p_WS_Length);
+        chip::PASEVerifierSerialized serializedVerifier;
+        MutableByteSpan serializedVerifierSpan(serializedVerifier);
+        ReturnErrorOnFailure(verifier.Serialize(serializedVerifierSpan));
 
         AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
         request.commissioningTimeout = mCommissioningWindowTimeout;
-        request.PAKEVerifier         = ByteSpan(serializedVerifier);
+        request.PAKEVerifier         = serializedVerifierSpan;
         request.discriminator        = mSetupPayload.discriminator;
         request.iterations           = mCommissioningWindowIteration;
         request.salt                 = salt;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2020-2021 Project CHIP Authors
+ *   Copyright (c) 2020-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -583,6 +583,8 @@ JNI_METHOD(jobject, computePaseVerifier)
     jbyteArray verifierBytes;
     uint32_t passcodeId;
     PASEVerifier verifier;
+    PASEVerifierSerialized serializedVerifier;
+    MutableByteSpan serializedVerifierSpan(serializedVerifier);
     JniByteArray jniSalt(env, salt);
 
     ChipLogProgress(Controller, "computePaseVerifier() called");
@@ -591,11 +593,10 @@ JNI_METHOD(jobject, computePaseVerifier)
     err = wrapper->Controller()->ComputePASEVerifier(iterations, setupPincode, jniSalt.byteSpan(), verifier, passcodeId);
     SuccessOrExit(err);
 
-    uint8_t serializedVerifier[sizeof(verifier.mW0) + sizeof(verifier.mL)];
-    memcpy(serializedVerifier, verifier.mW0, kSpake2p_WS_Length);
-    memcpy(&serializedVerifier[sizeof(verifier.mW0)], verifier.mL, sizeof(verifier.mL));
+    err = verifier.Serialize(serializedVerifierSpan);
+    SuccessOrExit(err);
 
-    err = JniReferences::GetInstance().N2J_ByteArray(env, serializedVerifier, sizeof(serializedVerifier), verifierBytes);
+    err = JniReferences::GetInstance().N2J_ByteArray(env, serializedVerifier, kSpake2pSerializedVerifierSize, verifierBytes);
     SuccessOrExit(err);
 
     err = N2J_PaseVerifierParams(env, setupPincode, static_cast<jlong>(passcodeId), verifierBytes, params);

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -225,8 +225,10 @@ CHIP_ERROR PASESession::ComputePASEVerifier(uint32_t setUpPINCode, uint32_t pbkd
     uint8_t littleEndianSetupPINCode[sizeof(uint32_t)];
     Encoding::LittleEndian::Put32(littleEndianSetupPINCode, setUpPINCode);
 
-    return mPBKDF.pbkdf2_sha256(littleEndianSetupPINCode, sizeof(littleEndianSetupPINCode), salt.data(), salt.size(),
-                                pbkdf2IterCount, sizeof(PASEVerifier), reinterpret_cast<uint8_t *>(&verifier));
+    PASEVerifierSerialized serializedVerifier;
+    ReturnErrorOnFailure(mPBKDF.pbkdf2_sha256(littleEndianSetupPINCode, sizeof(littleEndianSetupPINCode), salt.data(), salt.size(),
+                                              pbkdf2IterCount, sizeof(PASEVerifierSerialized), serializedVerifier));
+    return verifier.Deserialize(ByteSpan(serializedVerifier));
 }
 
 CHIP_ERROR PASESession::GeneratePASEVerifier(PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
@@ -977,6 +979,28 @@ exit:
         mDelegate->OnSessionEstablishmentError(err);
     }
     return err;
+}
+
+CHIP_ERROR PASEVerifier::Serialize(MutableByteSpan & outSerialized)
+{
+    VerifyOrReturnError(outSerialized.size() >= kSpake2pSerializedVerifierSize, CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(&outSerialized.data()[0], mW0, kSpake2p_WS_Length);
+    memcpy(&outSerialized.data()[kSpake2p_WS_Length], mL, kSpake2p_WS_Length);
+
+    outSerialized.reduce_size(kSpake2pSerializedVerifierSize);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PASEVerifier::Deserialize(ByteSpan inSerialized)
+{
+    VerifyOrReturnError(inSerialized.size() >= kSpake2pSerializedVerifierSize, CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(mW0, &inSerialized.data()[0], kSpake2p_WS_Length);
+    memcpy(mL, &inSerialized.data()[kSpake2p_WS_Length], kSpake2p_WS_Length);
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -63,7 +63,8 @@ constexpr uint32_t kSetupPINCodeMaximumValue = 99999998;
 
 using namespace Crypto;
 
-constexpr size_t kSpake2p_WS_Length = kP256_FE_Length + 8;
+constexpr size_t kSpake2p_WS_Length             = kP256_FE_Length + 8;
+constexpr size_t kSpake2pSerializedVerifierSize = kSpake2p_WS_Length * 2;
 
 struct PASESessionSerialized;
 
@@ -76,10 +77,24 @@ struct PASESessionSerializable
     uint16_t mPeerSessionId;
 };
 
+/** @brief Serialized format of the PASE Verifier components.
+ *
+ *  This is used when the Verifier should be presented in a serialized form.
+ *  For example, when it is generated using PBKDF function, when stored in the
+ *  memory or when sent over the wire.
+ *  The serialized format is concatentation of 'W0' and 'L' verifier components
+ *  each exactly 'kSpake2p_WS_Length' bytes of length:
+ *      { PASEVerifier.mW0[kSpake2p_WS_Length], PASEVerifier.mL[kSpake2p_WS_Length] }
+ **/
+typedef uint8_t PASEVerifierSerialized[kSpake2pSerializedVerifierSize];
+
 struct PASEVerifier
 {
     uint8_t mW0[kSpake2p_WS_Length];
     uint8_t mL[kSpake2p_WS_Length];
+
+    CHIP_ERROR Serialize(MutableByteSpan & outSerialized);
+    CHIP_ERROR Deserialize(ByteSpan inSerialized);
 };
 
 class DLL_EXPORT PASESession : public Messaging::ExchangeDelegate, public PairingSession


### PR DESCRIPTION
#### Problem
Need to add serializer and de-serializer to the PASEVerifier struct. This is required to make PASEVerifier storage and generation object layout independent. 

#### Change overview
Added

#### Testing
existing tests