### PR TITLE
RPC: Fix NRF RPC build

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -114,6 +114,10 @@ set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
 
+# TODO: Remove this temporary fix needed to get RPC builds working.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=cortex-m4 -mthumb" CACHE INTERNAL "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=cortex-m4 -mthumb" CACHE INTERNAL "")
+
 pw_set_backend(pw_log pw_log_basic)
 pw_set_backend(pw_assert pw_assert_log)
 pw_set_backend(pw_sys_io pw_sys_io.nrfconnect)


### PR DESCRIPTION
#### Problem
RPCs are not currently working on NRF32, this appears to be an issue with the compile time flags not propagating to the Pigweed modules for Zephyr.

#### Change overview
Added the missing flags in the app's cmake, which fixes it for now to unblock testing while I continue to investigate a better solution.
NOTE: This only effects RPC builds, as it's wrapped in `if (CONFIG_CHIP_PW_RPC`.

#### Testing
Built the RPC build and verified with the rpc console