### PR TITLE
Add error mapping for NOT_FOUND on Darwin.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -37,6 +37,7 @@ typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode){
     CHIPErrorCodeUnsupportedAttribute = 0x86,
     CHIPErrorCodeConstraintError      = 0x87,
     CHIPErrorCodeUnsupportedWrite     = 0x88,
+    CHIPErrorCodeNotFound             = 0x8B,
     CHIPErrorCodeInvalidDataType      = 0x8D,
     CHIPErrorCodeUnsupportedCluster   = 0xC3,
 };

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -128,6 +128,10 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
             errorWithDomain:CHIPErrorDomain
                        code:CHIPErrorCodeUnsupportedWrite
                    userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Attempt to write read-only attribute.", nil) }];
+    case EMBER_ZCL_STATUS_NOT_FOUND:
+        return [NSError errorWithDomain:CHIPErrorDomain
+                                   code:CHIPErrorCodeNotFound
+                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Data not found.", nil) }];
     case EMBER_ZCL_STATUS_INVALID_DATA_TYPE:
         return [NSError
             errorWithDomain:CHIPErrorDomain
@@ -207,6 +211,10 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
         return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
     case CHIPErrorCodeUnsupportedWrite:
         return EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
+    case CHIPErrorCodeNotFound:
+        return EMBER_ZCL_STATUS_NOT_FOUND;
+    case CHIPErrorCodeInvalidDataType:
+        return EMBER_ZCL_STATUS_INVALID_DATA_TYPE;
     case CHIPErrorCodeUnsupportedCluster:
         return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
     default:

--- a/src/darwin/Framework/CHIPTests/CHIPErrorTestUtils.mm
+++ b/src/darwin/Framework/CHIPTests/CHIPErrorTestUtils.mm
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
         return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
     case CHIPErrorCodeUnsupportedWrite:
         return EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
+    case CHIPErrorCodeNotFound:
+        return EMBER_ZCL_STATUS_NOT_FOUND;
     case CHIPErrorCodeInvalidDataType:
         return EMBER_ZCL_STATUS_INVALID_DATA_TYPE;
     case CHIPErrorCodeUnsupportedCluster:


### PR DESCRIPTION
#### Problem
NOT_FOUND not mapped to a darwin error correctly, which can cause test failures when it's the expected error.

#### Change overview
Add it to the error mapping bits.

#### Testing
Should be able to use NOT_FOUND in YAML tests now.