### PR TITLE
Introduce a Shutdown method to DeviceControllerFactory

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -210,6 +210,11 @@ CHIP_ERROR DeviceControllerFactory::ServiceEvents()
 
 DeviceControllerFactory::~DeviceControllerFactory()
 {
+    Shutdown();
+}
+
+void DeviceControllerFactory::Shutdown()
+{
     if (mSystemState != nullptr)
     {
         mSystemState->Release();

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -90,6 +90,7 @@ public:
     }
 
     CHIP_ERROR Init(FactoryInitParams params);
+    void Shutdown();
     CHIP_ERROR SetupController(SetupParams params, DeviceController & controller);
     CHIP_ERROR SetupCommissioner(SetupParams params, DeviceCommissioner & commissioner);
 


### PR DESCRIPTION


#### Change overview
The new method would be the symmetrical API for DeviceControllerFactory's
already existing `Init()` API.

What is the root of the problem?

The problem we intend to solve is that we'd like to use `Shutdown()` method
to shut down and clean up any memory/functionality enabled by `Init()` as
opposed to waiting for the DeviceControllerFactory destructor, which only
happens once the program shuts down due to the nature of how
DeviceControllerFactory is instantiated.

DeviceControllerFactory can only be instantiated through ::GetInstance(),
this method constructs DeviceControllerFactory only once for the life of
the program (the constructor is a private method). Once the Init() is
invoked, the `mSystemState` is allocated as shown in the following:

```
    mSystemState = chip::Platform::New<DeviceControllerSystemState>(stateParams);
```

However, in DeviceControllerFactory's destructor, which currently is only
invoked once the program shuts down, the deallocation of `mSystemState`
is requested via `chip::Platform::Delete`. This can be problematic since
the application will need to ensure `chip::Platform` memory stays initialized
throughout the memory shutdown.

Adding a shutdown method allows the applications to have symmetry between
the initialization and shutdown sequence related to the
DeviceControllerFactory

#### Problem
What is being fixed?  
Potentially Memory crashes when freeing `mSystemState` when the process shuts down

#### Testing
How was this tested? (at least one bullet point required)
* If new unit tests are not added, why not?

I could use some assistance if there are already existing unit tests that would help with the validation
