### PR TITLE
Implement data model revision attribute for Basic Information Cluster

### DIFF
--- a/src/app/DataModelRevision.h
+++ b/src/app/DataModelRevision.h
@@ -18,12 +18,11 @@
 #pragma once
 
 /**
- * CHIP_DEVICE_INTERACTION_MODEL_REVISION
+ * CHIP_DEVICE_DATA__MODEL_REVISION
  *
- * A monothonic number identifying the interaction model revision.
+ * A monothonic number identifying the revision number of the Data Model against
+ * which the Node is certified.
  */
-#ifndef CHIP_DEVICE_INTERACTION_MODEL_REVISION
-#define CHIP_DEVICE_INTERACTION_MODEL_REVISION 1
+#ifndef CHIP_DEVICE_DATA__MODEL_REVISION
+#define CHIP_DEVICE_DATA__MODEL_REVISION 1
 #endif
-
-constexpr uint8_t kInteractionModelRevisionTag = 0xFF;

--- a/src/app/DataModelRevision.h
+++ b/src/app/DataModelRevision.h
@@ -18,11 +18,11 @@
 #pragma once
 
 /**
- * CHIP_DEVICE_DATA__MODEL_REVISION
+ * CHIP_DEVICE_DATA_MODEL_REVISION
  *
  * A monotonic number identifying the revision number of the Data Model against
  * which the Node is certified.
  */
-#ifndef CHIP_DEVICE_DATA__MODEL_REVISION
-#define CHIP_DEVICE_DATA__MODEL_REVISION 1
+#ifndef CHIP_DEVICE_DATA_MODEL_REVISION
+#define CHIP_DEVICE_DATA_MODEL_REVISION 1
 #endif

--- a/src/app/DataModelRevision.h
+++ b/src/app/DataModelRevision.h
@@ -20,7 +20,7 @@
 /**
  * CHIP_DEVICE_DATA__MODEL_REVISION
  *
- * A monothonic number identifying the revision number of the Data Model against
+ * A monotonic number identifying the revision number of the Data Model against
  * which the Node is certified.
  */
 #ifndef CHIP_DEVICE_DATA__MODEL_REVISION

--- a/src/app/MessageDef/MessageBuilder.cpp
+++ b/src/app/MessageDef/MessageBuilder.cpp
@@ -25,7 +25,7 @@ namespace app {
 CHIP_ERROR MessageBuilder::EncodeInteractionModelRevision()
 {
     ReturnErrorOnFailure(mpWriter->Put(TLV::ContextTag(kInteractionModelRevisionTag),
-                                       static_cast<InteractionModelRevision>(CHIP_DEVICE_CONFIG_INTERACTION_MODEL_REVISION)));
+                                       static_cast<InteractionModelRevision>(CHIP_DEVICE_INTERACTION_MODEL_REVISION)));
     return CHIP_NO_ERROR;
 }
 } // namespace app

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -20,6 +20,7 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/DataModelRevision.h>
 #include <app/EventLogging.h>
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -52,6 +53,7 @@ public:
     CHIP_ERROR Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder) override;
 
 private:
+    CHIP_ERROR ReadDataModelRevision(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadLocation(AttributeValueEncoder & aEncoder);
     CHIP_ERROR WriteLocation(AttributeValueDecoder & aDecoder);
 };
@@ -76,6 +78,10 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
 
     switch (aPath.mAttributeId)
     {
+    case DataModelRevision::Id:
+        status = ReadDataModelRevision(aEncoder);
+        break;
+
     case Location::Id:
         status = ReadLocation(aEncoder);
         break;
@@ -265,6 +271,12 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
     }
 
     return status;
+}
+
+CHIP_ERROR BasicAttrAccess::ReadDataModelRevision(AttributeValueEncoder & aEncoder)
+{
+    uint16_t revision = CHIP_DEVICE_DATA__MODEL_REVISION;
+    return aEncoder.Encode(revision);
 }
 
 CHIP_ERROR BasicAttrAccess::ReadLocation(AttributeValueEncoder & aEncoder)

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -275,7 +275,7 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
 
 CHIP_ERROR BasicAttrAccess::ReadDataModelRevision(AttributeValueEncoder & aEncoder)
 {
-    uint16_t revision = CHIP_DEVICE_DATA__MODEL_REVISION;
+    uint16_t revision = CHIP_DEVICE_DATA_MODEL_REVISION;
     return aEncoder.Encode(revision);
 }
 


### PR DESCRIPTION
#### Problem
* Missing data model revision implementation for Basic Cluster
* Fixes #14618

#### Change overview
* Implement data model revision attribute for Basic Information Cluster
* Rename CHIP_DEVICE_CONFIG_INTERACTION_MODEL_REVISION to CHIP_DEVICE_INTERACTION_MODEL_REVISION since this does not represent a config option

#### Testing
How was this tested? (at least one bullet point required)
```
yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool basic read data-model-revision 12344321 0
..........
[1643844417.655933][827099:827104] CHIP:EM: Removed CHIP MessageCounter:6317359 from RetransTable on exchange 6446i
[1643844417.655951][827099:827104] CHIP:DMG: ReportDataMessage =
[1643844417.655957][827099:827104] CHIP:DMG: {
[1643844417.655962][827099:827104] CHIP:DMG: 	AttributeReportIBs =
[1643844417.655972][827099:827104] CHIP:DMG: 	[
[1643844417.655978][827099:827104] CHIP:DMG: 		AttributeReportIB =
[1643844417.655989][827099:827104] CHIP:DMG: 		{
[1643844417.655995][827099:827104] CHIP:DMG: 			AttributeDataIB =
[1643844417.656005][827099:827104] CHIP:DMG: 			{
[1643844417.656013][827099:827104] CHIP:DMG: 				DataVersion = 0x36710d42,
[1643844417.656019][827099:827104] CHIP:DMG: 				AttributePathIB =
[1643844417.656025][827099:827104] CHIP:DMG: 				{
[1643844417.656031][827099:827104] CHIP:DMG: 					Endpoint = 0x0,
[1643844417.656038][827099:827104] CHIP:DMG: 					Cluster = 0x28,
[1643844417.656044][827099:827104] CHIP:DMG: 					Attribute = 0x0000_0000,
[1643844417.656050][827099:827104] CHIP:DMG: 				}
[1643844417.656057][827099:827104] CHIP:DMG: 					
[1643844417.656066][827099:827104] CHIP:DMG: 					Data = 1, 
[1643844417.656073][827099:827104] CHIP:DMG: 			},
[1643844417.656081][827099:827104] CHIP:DMG: 			
[1643844417.656087][827099:827104] CHIP:DMG: 		},
[1643844417.656093][827099:827104] CHIP:DMG: 		
[1643844417.656098][827099:827104] CHIP:DMG: 	],
[1643844417.656107][827099:827104] CHIP:DMG: 	
[1643844417.656113][827099:827104] CHIP:DMG: 	SuppressResponse = true, 
[1643844417.656119][827099:827104] CHIP:DMG: 	InteractionModelRevision = 1
[1643844417.656124][827099:827104] CHIP:DMG: }
[1643844417.656198][827099:827104] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0028 Attribute 0x0000_0000
[1643844417.656216][827099:827104] CHIP:TOO:   DataModelRevision: 1
```


