### PR TITLE
Improve failure detection and reporting in the Tests job.

### DIFF
--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -101,8 +101,8 @@ class Runner:
             for dependency in dependencies:
                 if dependency.poll() is not None:
                     s.kill()
-                    raise Exception("Unexpected return %d for %r",
-                                    dependency.poll(), dependency)
+                    raise Exception("Unexpected return %d for %r" %
+                                    (dependency.poll(), dependency))
 
         code = s.wait()
         if code != 0:

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -212,6 +212,7 @@ def cmd_run(context, iterations, all_clusters_app, tv_app):
                 test_end = time.time()
                 logging.exception('%s - FAILED in %0.2f seconds' %
                                   (test.name, (test_end - test_start)))
+                apps_register.uninit()
                 sys.exit(2)
 
     apps_register.uninit()


### PR DESCRIPTION
* Fix exception formatting when a dependency of our chip-tool process
  has died.

* Detect startup crashes in the server app without having to wait for
  the entire 10-second timeout.

* Call apps_register.uninit() before sys.exit(), because otherwise on
  failure we end up sitting there waiting for an unjoined thread until
  the test job times out.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Put exit(2) calls in main() and in a cluster command in chip-all-clusters-app, and observed the harness behavior.