### PR TITLE
Trigger StartUp & ShutDown event on all platforms uniformly

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -78,6 +78,7 @@ protected:
 private:
     bool mMsgLayerWasActive;
 
+    static void HandleDeviceRebooted(intptr_t arg);
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -247,22 +247,13 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     mStartTime = System::SystemClock().GetMonotonicTimestamp();
 
-    ScheduleWork(HandleDeviceRebooted, 0);
-
 exit:
     return err;
 }
 
 CHIP_ERROR PlatformManagerImpl::_Shutdown()
 {
-    PlatformManagerDelegate * platformManagerDelegate = PlatformMgr().GetDelegate();
-    uint64_t upTime                                   = 0;
-
-    // The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence.
-    if (platformManagerDelegate != nullptr)
-    {
-        platformManagerDelegate->OnShutDown();
-    }
+    uint64_t upTime = 0;
 
     if (GetDiagnosticDataProvider().GetUpTime(upTime) == CHIP_NO_ERROR)
     {
@@ -387,26 +378,6 @@ PlatformManagerImpl::_GetSupportedCalendarTypes(
     supportedCalendarTypes.add(app::Clusters::TimeFormatLocalization::CalendarType::kTaiwanese);
 
     return CHIP_NO_ERROR;
-}
-
-void PlatformManagerImpl::HandleDeviceRebooted(intptr_t arg)
-{
-    PlatformManagerDelegate * platformManagerDelegate       = PlatformMgr().GetDelegate();
-    GeneralDiagnosticsDelegate * generalDiagnosticsDelegate = GetDiagnosticDataProvider().GetGeneralDiagnosticsDelegate();
-
-    if (generalDiagnosticsDelegate != nullptr)
-    {
-        generalDiagnosticsDelegate->OnDeviceRebooted();
-    }
-
-    // The StartUp event SHALL be emitted by a Node after completing a boot or reboot process
-    if (platformManagerDelegate != nullptr)
-    {
-        uint32_t softwareVersion;
-
-        ReturnOnFailure(ConfigurationMgr().GetSoftwareVersion(softwareVersion));
-        platformManagerDelegate->OnStartUp(softwareVersion);
-    }
 }
 
 void PlatformManagerImpl::HandleGeneralFault(uint32_t EventId)

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -89,7 +89,6 @@ private:
     // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
     // This should be removed or find a better place once we depercate the rendezvous session.
     static void WiFIIPChangeListener();
-    static void HandleDeviceRebooted(intptr_t arg);
 
 #if CHIP_WITH_GIO
     struct GDBusConnectionDeleter

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -125,20 +125,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     k_timer_start(&sOperationalHoursSavingTimer, K_HOURS(CONFIG_CHIP_OPERATIONAL_TIME_SAVE_INTERVAL),
                   K_HOURS(CONFIG_CHIP_OPERATIONAL_TIME_SAVE_INTERVAL));
 
-    ScheduleWork(OnDeviceBoot, 0);
-
 exit:
     return err;
-}
-
-void PlatformManagerImpl::OnDeviceBoot(intptr_t arg)
-{
-    GeneralDiagnosticsDelegate * generalDiagnosticsDelegate = GetDiagnosticDataProvider().GetGeneralDiagnosticsDelegate();
-
-    if (generalDiagnosticsDelegate)
-    {
-        generalDiagnosticsDelegate->OnDeviceRebooted();
-    }
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Zephyr/PlatformManagerImpl.h
+++ b/src/platform/Zephyr/PlatformManagerImpl.h
@@ -56,7 +56,6 @@ private:
 
     static void OperationalHoursSavingTimerEventHandler(k_timer * timer);
     static void UpdateOperationalHours(intptr_t arg);
-    static void OnDeviceBoot(intptr_t arg);
 
     // ===== Members for internal use by the following friends.
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, Startup and ShutDown event are only logged on Linux platform, this is before those event are triggered from the platform layer and only Linux platform has the implementation. Those generic events are not platform specific, we can move the logic to generic platform implementation so that those events are triggered uniformly across platforms. 

* Fixes #14617

#### Change overview
Trigger StartUp & ShutDown event on all platforms uniformly

#### Testing
How was this tested? (at least one bullet point required)
* yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-lighting-app
```
[1643855542.352117][839528:839528] CHIP:ZCL: GeneralDiagnosticsDelegate: OnDeviceRebooted
[1643855542.352125][839528:839528] CHIP:DMG: Endpoint 0, Cluster 0x0000_0033 update version to 965a842d
[1643855542.352138][839528:839528] CHIP:ZCL: PlatformMgrDelegate: OnStartUp
[1643855542.352613][839528:839528] CHIP:EVL: LogEvent event number: 0x00000000000B0000 priority: 2, endpoint id:  0x0 

```
* Shutdown the example app
```
[1643855563.673417][839528:839528] CHIP:ZCL: PlatformMgrDelegate: OnShutDown
[1643855563.673523][839528:839528] CHIP:EVL: LogEvent event number: 0x00000000000B0001 priority: 2, endpoint id:  0x0 cluster id: 0x0000_0028 event id: 0x1 Sys timestamp: 0x00000000373B0AB3
[1643855563.673615][839528:839528] CHIP:DL: Inet Layer shutdown
[1643855563.673643][839528:839528] CHIP:DL: System Layer shutdown
```


