### PR TITLE
Make TSan failures in CI fatal.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,7 @@ jobs:
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
+            TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: ubuntu-latest
@@ -124,6 +125,7 @@ jobs:
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
+            TSAN_OPTIONS: "halt_on_error=1"
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: macos-latest

--- a/scripts/tests/chiptest/tsan-linux-suppressions.txt
+++ b/scripts/tests/chiptest/tsan-linux-suppressions.txt
@@ -1,0 +1,10 @@
+# The Linux server app ends up with a data race in libglib.  A race_top
+# suppression does not work, since the actual race is inside a memset, so the
+# thing on top of the stack is memset.  called_from_lib is a narrower
+# suppression than a "race" suppression (which would be "libglib anywhere on the
+# stack", as opposed to "inside a function TSan intercepts, which was called
+# from libglib).
+#
+# See https://github.com/project-chip/connectedhomeip/issues/14710 for
+# addressing this.
+called_from_lib:libglib


### PR DESCRIPTION
Right now warnings are logged and exiting the app would do so with a
failure status, but for the server app we never exit it, so never
discover that warnings happened.

The fix is to just fail on the very first warning.

The suppression added on Linux is to enable us to do this without
immediately failing tests.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Verified that without the suppression the Linux Tests job fails, and with it passes.  Also verified that if I mis-spell "libglib" as "libglig" in the suppression the job fails again.