### PR TITLE
[BLE] Remove old TODO

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -880,9 +880,6 @@ CHIP_ERROR BLEEndPoint::HandleFragmentConfirmationReceived()
     // Ensure we're in correct state to receive confirmation of non-handshake GATT send.
     VerifyOrExit(IsConnected(mState), err = CHIP_ERROR_INCORRECT_STATE);
 
-    // TODO Packet buffer high water mark optimization: if ack pending, but fragmenter state == complete, free fragmenter's
-    // tx buf before sending ack.
-
     if (mConnStateFlags.Has(ConnectionStateFlag::kStandAloneAckInFlight))
     {
         // If confirmation was received for stand-alone ack, free its tx buffer.


### PR DESCRIPTION
#### Problem

Issue #13939 Optimize Packet buffer usage in CHIPoBLE ACK management

> TODO Packet buffer high water mark optimization: if ack pending,
> but fragmenter state == complete, free fragmenter's tx buf before
> sending ack.

This TODO is seven years old and not worth the risk of implementing
for 1.0.

#### Change overview

Remove the TODO to placate automated scans.
Issue will be left for future consideration.

#### Testing

None; changes comment only.
