### PR TITLE
Bulk read all the things

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -133,12 +133,12 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
         // operational network because the provisioning of certificates will trigger the device to start operational advertising.
         if (mNeedsNetworkSetup)
         {
-            if (mParams.GetWiFiCredentials().HasValue() && mDeviceCommissioingInfo.network.wifi != kInvalidEndpointId)
+            if (mParams.GetWiFiCredentials().HasValue() && mDeviceCommissioningInfo.network.wifi != kInvalidEndpointId)
             {
                 return CommissioningStage::kWiFiNetworkSetup;
             }
             else if (mParams.GetThreadOperationalDataset().HasValue() &&
-                     mDeviceCommissioingInfo.network.thread != kInvalidEndpointId)
+                     mDeviceCommissioningInfo.network.thread != kInvalidEndpointId)
             {
                 return CommissioningStage::kThreadNetworkSetup;
             }
@@ -149,8 +149,8 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
                              mParams.GetWiFiCredentials().HasValue() ? "yes" : "no",
                              mParams.GetThreadOperationalDataset().HasValue() ? "yes" : "no");
                 ChipLogError(Controller, "Device supports: wifi (%s) thread(%s)",
-                             mDeviceCommissioingInfo.network.wifi == kInvalidEndpointId ? "no" : "yes",
-                             mDeviceCommissioingInfo.network.thread == kInvalidEndpointId ? "no" : "yes");
+                             mDeviceCommissioningInfo.network.wifi == kInvalidEndpointId ? "no" : "yes",
+                             mDeviceCommissioningInfo.network.thread == kInvalidEndpointId ? "no" : "yes");
                 lastErr = CHIP_ERROR_INVALID_ARGUMENT;
                 return CommissioningStage::kCleanup;
             }
@@ -165,7 +165,7 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
 #endif
         }
     case CommissioningStage::kWiFiNetworkSetup:
-        if (mParams.GetThreadOperationalDataset().HasValue() && mDeviceCommissioingInfo.network.thread != kInvalidEndpointId)
+        if (mParams.GetThreadOperationalDataset().HasValue() && mDeviceCommissioningInfo.network.thread != kInvalidEndpointId)
         {
             return CommissioningStage::kThreadNetworkSetup;
         }
@@ -174,7 +174,7 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
             return CommissioningStage::kWiFiNetworkEnable;
         }
     case CommissioningStage::kThreadNetworkSetup:
-        if (mParams.GetWiFiCredentials().HasValue() && mDeviceCommissioingInfo.network.wifi != kInvalidEndpointId)
+        if (mParams.GetWiFiCredentials().HasValue() && mDeviceCommissioningInfo.network.wifi != kInvalidEndpointId)
         {
             return CommissioningStage::kWiFiNetworkEnable;
         }
@@ -184,7 +184,7 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
         }
 
     case CommissioningStage::kWiFiNetworkEnable:
-        if (mParams.GetThreadOperationalDataset().HasValue() && mDeviceCommissioingInfo.network.thread != kInvalidEndpointId)
+        if (mParams.GetThreadOperationalDataset().HasValue() && mDeviceCommissioningInfo.network.thread != kInvalidEndpointId)
         {
             return CommissioningStage::kThreadNetworkEnable;
         }
@@ -221,10 +221,10 @@ EndpointId AutoCommissioner::GetEndpoint(const CommissioningStage & stage)
     {
     case CommissioningStage::kWiFiNetworkSetup:
     case CommissioningStage::kWiFiNetworkEnable:
-        return mDeviceCommissioingInfo.network.wifi;
+        return mDeviceCommissioningInfo.network.wifi;
     case CommissioningStage::kThreadNetworkSetup:
     case CommissioningStage::kThreadNetworkEnable:
-        return mDeviceCommissioingInfo.network.thread;
+        return mDeviceCommissioningInfo.network.thread;
     default:
         return kRootEndpointId;
     }
@@ -308,10 +308,10 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
         switch (report.stageCompleted)
         {
         case CommissioningStage::kReadCommissioningInfo:
-            mDeviceCommissioingInfo = report.Get<ReadCommissioningInfo>();
-            if (!mParams.GetFailsafeTimerSeconds().HasValue() && mDeviceCommissioingInfo.general.recommendedFailsafe > 0)
+            mDeviceCommissioningInfo = report.Get<ReadCommissioningInfo>();
+            if (!mParams.GetFailsafeTimerSeconds().HasValue() && mDeviceCommissioningInfo.general.recommendedFailsafe > 0)
             {
-                mParams.SetFailsafeTimerSeconds(mDeviceCommissioingInfo.general.recommendedFailsafe);
+                mParams.SetFailsafeTimerSeconds(mDeviceCommissioningInfo.general.recommendedFailsafe);
             }
             break;
         case CommissioningStage::kSendPAICertificateRequest:
@@ -354,7 +354,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             mCommissioneeDeviceProxy = nullptr;
             mOperationalDeviceProxy  = nullptr;
             mParams                  = CommissioningParameters();
-            mDeviceCommissioingInfo  = ReadCommissioningInfo();
+            mDeviceCommissioningInfo = ReadCommissioningInfo();
             return CHIP_NO_ERROR;
         default:
             break;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -309,6 +309,10 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
         {
         case CommissioningStage::kReadCommissioningInfo:
             mDeviceCommissioingInfo = report.Get<ReadCommissioningInfo>();
+            if (!mParams.GetFailsafeTimerSeconds().HasValue() && mDeviceCommissioingInfo.general.recommendedFailsafe > 0)
+            {
+                mParams.SetFailsafeTimerSeconds(mDeviceCommissioingInfo.general.recommendedFailsafe);
+            }
             break;
         case CommissioningStage::kSendPAICertificateRequest:
             SetPAI(report.Get<RequestedCertificate>().certificate);

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -63,7 +63,7 @@ private:
     uint8_t mThreadOperationalDataset[CommissioningParameters::kMaxThreadDatasetLen];
 
     bool mNeedsNetworkSetup = false;
-    ReadCommissioningInfo mDeviceCommissioingInfo;
+    ReadCommissioningInfo mDeviceCommissioningInfo;
 
     // TODO: Why were the nonces statically allocated, but the certs dynamically allocated?
     uint8_t * mDAC   = nullptr;

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -57,16 +57,13 @@ private:
     OperationalDeviceProxy * mOperationalDeviceProxy                 = nullptr;
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate = nullptr;
     CommissioningParameters mParams                                  = CommissioningParameters();
-    VendorId mVendorId;
-    uint16_t mProductId;
-    uint32_t mSoftwareVersion;
     // Memory space for the commisisoning parameters that come in as ByteSpans - the caller is not guaranteed to retain this memory
     uint8_t mSsid[CommissioningParameters::kMaxSsidLen];
     uint8_t mCredentials[CommissioningParameters::kMaxCredentialsLen];
     uint8_t mThreadOperationalDataset[CommissioningParameters::kMaxThreadDatasetLen];
 
     bool mNeedsNetworkSetup = false;
-    NetworkClusters mNetworkEndpoints;
+    ReadCommissioningInfo mDeviceCommissioingInfo;
 
     // TODO: Why were the nonces statically allocated, but the certs dynamically allocated?
     uint8_t * mDAC   = nullptr;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1556,43 +1556,59 @@ void DeviceCommissioner::SetupCluster(ClusterBase & base, DeviceProxy * proxy, E
     base.SetCommandTimeout(timeout);
 }
 
-void BasicVendorCallback(void * context, VendorId vendorId)
-{
-    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    CommissioningDelegate::CommissioningReport report;
-    report.Set<BasicVendor>(vendorId);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
-}
-
-void BasicProductCallback(void * context, uint16_t productId)
-{
-    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    CommissioningDelegate::CommissioningReport report;
-    report.Set<BasicProduct>(productId);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
-}
-
-void BasicSoftwareCallback(void * context, uint32_t softwareVersion)
-{
-    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    CommissioningDelegate::CommissioningReport report;
-    report.Set<BasicSoftware>(softwareVersion);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
-}
-
-void AttributeReadFailure(void * context, CHIP_ERROR status)
-{
-    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    commissioner->CommissioningStageComplete(status);
-}
-
 // AttributeCache::Callback impl
 void DeviceCommissioner::OnDone()
 {
-    NetworkClusters clusters;
+    CHIP_ERROR err;
+    CHIP_ERROR return_err = CHIP_NO_ERROR;
+    ReadCommissioningInfo info;
 
-    CHIP_ERROR err = mAttributeCache->ForEachAttribute(
-        app::Clusters::NetworkCommissioning::Id, [this, &clusters](const app::ConcreteAttributePath & path) {
+    // Using ForEachAttribute because this attribute can be queried on any endpoint.
+    err = mAttributeCache->ForEachAttribute(
+        app::Clusters::GeneralCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
+            if (path.mAttributeId != app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::Id)
+            {
+                return CHIP_NO_ERROR;
+            }
+            TLV::TLVReader reader;
+            ReturnErrorOnFailure(this->mAttributeCache->Get(path, reader));
+            app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
+            ReturnErrorOnFailure(app::DataModel::Decode(reader, basicInfo));
+            info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
+            return CHIP_NO_ERROR;
+        });
+
+    // Try to parse as much as we can here before returning, even if this is an error.
+    return_err = err == CHIP_NO_ERROR ? return_err : err;
+
+    err = mAttributeCache->ForEachAttribute(app::Clusters::Basic::Id, [this, &info](const app::ConcreteAttributePath & path) {
+        TLV::TLVReader reader;
+        if (path.mAttributeId != app::Clusters::Basic::Attributes::VendorID::Id &&
+            path.mAttributeId != app::Clusters::Basic::Attributes::ProductID::Id &&
+            path.mAttributeId != app::Clusters::Basic::Attributes::SoftwareVersion::Id)
+        {
+            // Continue on
+            return CHIP_NO_ERROR;
+        }
+
+        ReturnErrorOnFailure(this->mAttributeCache->Get(path, reader));
+        switch (path.mAttributeId)
+        {
+        case app::Clusters::Basic::Attributes::VendorID::Id:
+            return app::DataModel::Decode(reader, info.basic.vendorId);
+        case app::Clusters::Basic::Attributes::ProductID::Id:
+            return app::DataModel::Decode(reader, info.basic.productId);
+        case app::Clusters::Basic::Attributes::SoftwareVersion::Id:
+            return app::DataModel::Decode(reader, info.basic.softwareVersion);
+        default:
+            return CHIP_NO_ERROR;
+        }
+    });
+    // Try to parse as much as we can here before returning, even if this is an error.
+    return_err = err == CHIP_NO_ERROR ? return_err : err;
+
+    err = mAttributeCache->ForEachAttribute(
+        app::Clusters::NetworkCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
             if (path.mAttributeId != app::Clusters::NetworkCommissioning::Attributes::FeatureMap::Id)
             {
                 return CHIP_NO_ERROR;
@@ -1605,43 +1621,44 @@ void DeviceCommissioner::OnDone()
                 {
                     if (features.Has(app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kWiFiNetworkInterface))
                     {
-                        clusters.wifi = path.mEndpointId;
+                        info.network.wifi = path.mEndpointId;
                     }
                     else if (features.Has(
                                  app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kThreadNetworkInterface))
                     {
-                        clusters.thread = path.mEndpointId;
+                        info.network.thread = path.mEndpointId;
                     }
                     else if (features.Has(
                                  app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kEthernetNetworkInterface))
                     {
-                        clusters.eth = path.mEndpointId;
+                        info.network.eth = path.mEndpointId;
                     }
                     else
                     {
                         // TODO: Gross workaround for the empty feature map on all clusters. Remove.
-                        if (clusters.thread == kInvalidEndpointId)
+                        if (info.network.thread == kInvalidEndpointId)
                         {
-                            clusters.thread = path.mEndpointId;
+                            info.network.thread = path.mEndpointId;
                         }
-                        if (clusters.wifi == kInvalidEndpointId)
+                        if (info.network.wifi == kInvalidEndpointId)
                         {
-                            clusters.wifi = path.mEndpointId;
+                            info.network.wifi = path.mEndpointId;
                         }
                     }
                 }
             }
             return CHIP_NO_ERROR;
         });
+    return_err = err == CHIP_NO_ERROR ? return_err : err;
 
-    if (err != CHIP_NO_ERROR)
+    if (return_err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Error parsing Network commissioning features");
+        ChipLogError(Controller, "Error parsing commissioning information");
     }
     mAttributeCache = nullptr;
     mReadClient     = nullptr;
     CommissioningDelegate::CommissioningReport report;
-    report.Set<NetworkClusters>(clusters);
+    report.Set<ReadCommissioningInfo>(info);
     CommissioningStageComplete(err, report);
 }
 void DeviceCommissioner::OnArmFailSafe(void * context,
@@ -1707,30 +1724,6 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
 
     switch (step)
     {
-    case CommissioningStage::kReadVendorId: {
-        ChipLogProgress(Controller, "Reading vendor ID");
-        BasicCluster basic;
-        SetupCluster(basic, proxy, endpoint, timeout);
-        basic.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorID::TypeInfo>(this, BasicVendorCallback,
-                                                                                        AttributeReadFailure);
-    }
-    break;
-    case CommissioningStage::kReadProductId: {
-        ChipLogProgress(Controller, "Reading product ID");
-        BasicCluster basic;
-        SetupCluster(basic, proxy, endpoint, timeout);
-        basic.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductID::TypeInfo>(this, BasicProductCallback,
-                                                                                         AttributeReadFailure);
-    }
-    break;
-    case CommissioningStage::kReadSoftwareVersion: {
-        ChipLogProgress(Controller, "Reading software version");
-        BasicCluster basic;
-        SetupCluster(basic, proxy, endpoint, timeout);
-        basic.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersion::TypeInfo>(this, BasicSoftwareCallback,
-                                                                                               AttributeReadFailure);
-    }
-    break;
     case CommissioningStage::kArmFailsafe: {
         ChipLogProgress(Controller, "Arming failsafe");
         // TODO: should get the endpoint information from the descriptor cluster.
@@ -1741,14 +1734,23 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         SendCommand<GeneralCommissioningCluster>(proxy, request, OnArmFailSafe, OnBasicFailure, endpoint, timeout);
     }
     break;
-    case CommissioningStage::kGetNetworkTechnology: {
-        ChipLogProgress(Controller, "Sending request for network cluster feature map");
+    case CommissioningStage::kReadCommissioningInfo: {
+        ChipLogProgress(Controller, "Sending request for commissioning information");
         app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
         app::ReadPrepareParams readParams(proxy->GetSecureSession().Value());
-        app::AttributePathParams readPath(app::Clusters::NetworkCommissioning::Id,
-                                          app::Clusters::NetworkCommissioning::Attributes::FeatureMap::Id);
-        readParams.mpAttributePathParamsList    = &readPath;
-        readParams.mAttributePathParamsListSize = 1;
+
+        app::AttributePathParams readPaths[3];
+        // Read all the feature maps for all the networking clusters on any endpoint to determine what is supported
+        readPaths[0] = app::AttributePathParams(app::Clusters::NetworkCommissioning::Id,
+                                                app::Clusters::NetworkCommissioning::Attributes::FeatureMap::Id);
+        // Get the basic commissioning info from the general commissioning cluster on this endpoint (recommended failsafe time)
+        readPaths[1] = app::AttributePathParams(endpoint, app::Clusters::GeneralCommissioning::Id,
+                                                app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::Id);
+        // Read all the attributes from the basic info cluster (includes vendor id / product id / software version)
+        readPaths[2] = app::AttributePathParams(endpoint, app::Clusters::Basic::Id);
+
+        readParams.mpAttributePathParamsList    = readPaths;
+        readParams.mAttributePathParamsListSize = 3;
         if (timeout.HasValue())
         {
             readParams.mTimeout = timeout.Value();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1571,7 +1571,9 @@ void DeviceCommissioner::OnDone()
                 return CHIP_NO_ERROR;
             }
             app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
-            ReturnErrorOnFailure(this->mAttributeCache->Get(path, basicInfo));
+            ReturnErrorOnFailure(
+                this->mAttributeCache->Get<app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo>(
+                    path, basicInfo));
             info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
             return CHIP_NO_ERROR;
         });
@@ -1580,7 +1582,6 @@ void DeviceCommissioner::OnDone()
     return_err = err == CHIP_NO_ERROR ? return_err : err;
 
     err = mAttributeCache->ForEachAttribute(app::Clusters::Basic::Id, [this, &info](const app::ConcreteAttributePath & path) {
-        TLV::TLVReader reader;
         if (path.mAttributeId != app::Clusters::Basic::Attributes::VendorID::Id &&
             path.mAttributeId != app::Clusters::Basic::Attributes::ProductID::Id &&
             path.mAttributeId != app::Clusters::Basic::Attributes::SoftwareVersion::Id)
@@ -1589,15 +1590,15 @@ void DeviceCommissioner::OnDone()
             return CHIP_NO_ERROR;
         }
 
-        ReturnErrorOnFailure(this->mAttributeCache->Get(path, reader));
         switch (path.mAttributeId)
         {
         case app::Clusters::Basic::Attributes::VendorID::Id:
-            return this->mAttributeCache->Get(path, info.basic.vendorId);
+            return this->mAttributeCache->Get<app::Clusters::Basic::Attributes::VendorID::TypeInfo>(path, info.basic.vendorId);
         case app::Clusters::Basic::Attributes::ProductID::Id:
-            return app::DataModel::Decode(reader, info.basic.productId);
+            return this->mAttributeCache->Get<app::Clusters::Basic::Attributes::ProductID::TypeInfo>(path, info.basic.productId);
         case app::Clusters::Basic::Attributes::SoftwareVersion::Id:
-            return app::DataModel::Decode(reader, info.basic.softwareVersion);
+            return this->mAttributeCache->Get<app::Clusters::Basic::Attributes::SoftwareVersion::TypeInfo>(
+                path, info.basic.softwareVersion);
         default:
             return CHIP_NO_ERROR;
         }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1657,7 +1657,7 @@ void DeviceCommissioner::OnDone()
     mReadClient     = nullptr;
     CommissioningDelegate::CommissioningReport report;
     report.Set<ReadCommissioningInfo>(info);
-    CommissioningStageComplete(err, report);
+    CommissioningStageComplete(return_err, report);
 }
 void DeviceCommissioner::OnArmFailSafe(void * context,
                                        const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data)
@@ -1736,18 +1736,22 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
         app::ReadPrepareParams readParams(proxy->GetSecureSession().Value());
 
-        app::AttributePathParams readPaths[3];
+        app::AttributePathParams readPaths[5];
         // Read all the feature maps for all the networking clusters on any endpoint to determine what is supported
         readPaths[0] = app::AttributePathParams(app::Clusters::NetworkCommissioning::Id,
                                                 app::Clusters::NetworkCommissioning::Attributes::FeatureMap::Id);
         // Get the basic commissioning info from the general commissioning cluster on this endpoint (recommended failsafe time)
         readPaths[1] = app::AttributePathParams(endpoint, app::Clusters::GeneralCommissioning::Id,
                                                 app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::Id);
-        // Read all the attributes from the basic info cluster (includes vendor id / product id / software version)
-        readPaths[2] = app::AttributePathParams(endpoint, app::Clusters::Basic::Id);
+        // Read attributes from the basic info cluster (vendor id / product id / software version)
+        readPaths[2] = app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::VendorID::Id);
+        readPaths[3] =
+            app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::ProductID::Id);
+        readPaths[4] =
+            app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::SoftwareVersion::Id);
 
         readParams.mpAttributePathParamsList    = readPaths;
-        readParams.mAttributePathParamsListSize = 3;
+        readParams.mAttributePathParamsListSize = 5;
         if (timeout.HasValue())
         {
             readParams.mTimeout = timeout.Value();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1725,12 +1725,11 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     switch (step)
     {
     case CommissioningStage::kArmFailsafe: {
-        ChipLogProgress(Controller, "Arming failsafe");
-        // TODO: should get the endpoint information from the descriptor cluster.
         GeneralCommissioning::Commands::ArmFailSafe::Type request;
-        request.expiryLengthSeconds = params.GetFailsafeTimerSeconds();
+        request.expiryLengthSeconds = params.GetFailsafeTimerSeconds().ValueOr(params.kDefaultFailsafeTimeout);
         request.breadcrumb          = breadcrumb;
         request.timeoutMs           = kCommandTimeoutMs;
+        ChipLogProgress(Controller, "Arming failsafe (%u seconds)", request.expiryLengthSeconds);
         SendCommand<GeneralCommissioningCluster>(proxy, request, OnArmFailSafe, OnBasicFailure, endpoint, timeout);
     }
     break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1570,10 +1570,8 @@ void DeviceCommissioner::OnDone()
             {
                 return CHIP_NO_ERROR;
             }
-            TLV::TLVReader reader;
-            ReturnErrorOnFailure(this->mAttributeCache->Get(path, reader));
             app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
-            ReturnErrorOnFailure(app::DataModel::Decode(reader, basicInfo));
+            ReturnErrorOnFailure(this->mAttributeCache->Get(path, basicInfo));
             info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
             return CHIP_NO_ERROR;
         });

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1726,7 +1726,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     {
     case CommissioningStage::kArmFailsafe: {
         GeneralCommissioning::Commands::ArmFailSafe::Type request;
-        request.expiryLengthSeconds = params.GetFailsafeTimerSeconds().ValueOr(params.kDefaultFailsafeTimeout);
+        request.expiryLengthSeconds = params.GetFailsafeTimerSeconds().ValueOr(kDefaultFailsafeTimeout);
         request.breadcrumb          = breadcrumb;
         request.timeoutMs           = kCommandTimeoutMs;
         ChipLogProgress(Controller, "Arming failsafe (%u seconds)", request.expiryLengthSeconds);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1593,7 +1593,7 @@ void DeviceCommissioner::OnDone()
         switch (path.mAttributeId)
         {
         case app::Clusters::Basic::Attributes::VendorID::Id:
-            return app::DataModel::Decode(reader, info.basic.vendorId);
+            return this->mAttributeCache->Get(path, info.basic.vendorId);
         case app::Clusters::Basic::Attributes::ProductID::Id:
             return app::DataModel::Decode(reader, info.basic.productId);
         case app::Clusters::Basic::Attributes::SoftwareVersion::Id:

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -67,16 +67,15 @@ struct NOCChainGenerationParameters
     ByteSpan nocsrElements;
     ByteSpan signature;
 };
-struct NOCerts
-{
-};
+
+constexpr uint16_t kDefaultFailsafeTimeout = 60;
 class CommissioningParameters
 {
 public:
-    static constexpr size_t kMaxThreadDatasetLen      = 254;
-    static constexpr size_t kMaxSsidLen               = 32;
-    static constexpr size_t kMaxCredentialsLen        = 64;
-    static constexpr uint16_t kDefaultFailsafeTimeout = 60;
+    static constexpr size_t kMaxThreadDatasetLen = 254;
+    static constexpr size_t kMaxSsidLen          = 32;
+    static constexpr size_t kMaxCredentialsLen   = 64;
+
     const Optional<uint16_t> GetFailsafeTimerSeconds() const { return mFailsafeTimerSeconds; }
     const Optional<ByteSpan> GetCSRNonce() const { return mCSRNonce; }
     const Optional<ByteSpan> GetAttestationNonce() const { return mAttestationNonce; }

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -30,10 +30,7 @@ enum CommissioningStage : uint8_t
 {
     kError,
     kSecurePairing,
-    kReadVendorId,
-    kReadProductId,
-    kReadSoftwareVersion,
-    kGetNetworkTechnology,
+    kReadCommissioningInfo,
     kArmFailsafe,
     // kConfigTime,  // NOT YET IMPLEMENTED
     // kConfigTimeZone,  // NOT YET IMPLEMENTED
@@ -239,37 +236,36 @@ struct OperationalNodeFoundData
     OperationalDeviceProxy * operationalProxy;
 };
 
-struct BasicVendor
-{
-    BasicVendor(VendorId id) : vendorId(id) {}
-    VendorId vendorId;
-};
-
-struct BasicProduct
-{
-    BasicProduct(uint16_t id) : productId(id) {}
-    uint16_t productId;
-};
-
-struct BasicSoftware
-{
-    BasicSoftware(uint32_t version) : softwareVersion(version) {}
-    uint32_t softwareVersion;
-};
-
 struct NetworkClusters
 {
     EndpointId wifi   = kInvalidEndpointId;
     EndpointId thread = kInvalidEndpointId;
     EndpointId eth    = kInvalidEndpointId;
 };
+struct BasicClusterInfo
+{
+    VendorId vendorId        = VendorId::Common;
+    uint16_t productId       = 0;
+    uint32_t softwareVersion = 0;
+};
+struct GeneralCommissioningInfo
+{
+    uint16_t recommendedFailsafe = 0;
+};
+
+struct ReadCommissioningInfo
+{
+    NetworkClusters network;
+    BasicClusterInfo basic;
+    GeneralCommissioningInfo general;
+};
 
 class CommissioningDelegate
 {
 public:
     virtual ~CommissioningDelegate(){};
-    struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, NocChain, OperationalNodeFoundData, BasicVendor,
-                                         BasicProduct, BasicSoftware, NetworkClusters>
+    struct CommissioningReport
+        : Variant<RequestedCertificate, AttestationResponse, NocChain, OperationalNodeFoundData, ReadCommissioningInfo>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -73,10 +73,11 @@ struct NOCerts
 class CommissioningParameters
 {
 public:
-    static constexpr size_t kMaxThreadDatasetLen = 254;
-    static constexpr size_t kMaxSsidLen          = 32;
-    static constexpr size_t kMaxCredentialsLen   = 64;
-    uint16_t GetFailsafeTimerSeconds() const { return mFailsafeTimerSeconds; }
+    static constexpr size_t kMaxThreadDatasetLen      = 254;
+    static constexpr size_t kMaxSsidLen               = 32;
+    static constexpr size_t kMaxCredentialsLen        = 64;
+    static constexpr uint16_t kDefaultFailsafeTimeout = 60;
+    const Optional<uint16_t> GetFailsafeTimerSeconds() const { return mFailsafeTimerSeconds; }
     const Optional<ByteSpan> GetCSRNonce() const { return mCSRNonce; }
     const Optional<ByteSpan> GetAttestationNonce() const { return mAttestationNonce; }
     const Optional<WiFiCredentials> GetWiFiCredentials() const { return mWiFiCreds; }
@@ -98,7 +99,7 @@ public:
 
     CommissioningParameters & SetFailsafeTimerSeconds(uint16_t seconds)
     {
-        mFailsafeTimerSeconds = seconds;
+        mFailsafeTimerSeconds.SetValue(seconds);
         return *this;
     }
 
@@ -185,7 +186,7 @@ public:
     void SetCompletionStatus(CHIP_ERROR err) { completionStatus = err; }
 
 private:
-    uint16_t mFailsafeTimerSeconds = 60;
+    Optional<uint16_t> mFailsafeTimerSeconds;
     Optional<ByteSpan> mCSRNonce;         ///< CSR Nonce passed by the commissioner
     Optional<ByteSpan> mAttestationNonce; ///< Attestation Nonce passed by the commissioner
     Optional<WiFiCredentials> mWiFiCreds;


### PR DESCRIPTION
#### Problem
Given that we're already bulk reading the network feature maps, we may as well just piggy back all the other attribute reads in there as well because it's fewer interactions. Also now that https://github.com/project-chip/connectedhomeip/pull/14671 has landed, we can use the general commissioning cluster attributes. 

#### Change overview
- change basic cluster reads to use wild card reads in the same read transaction as the network feature maps
- add read of the general commissioning cluster attributes to get the recommended failsafe

#### Testing
Commissioned BLE (M5) and on network (lightning app). Confirmed recommended failsafe comes from the device.
