### PR TITLE
Add "response" attributes to all commands with responses in XML.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
@@ -43,7 +43,7 @@ limitations under the License.
         <define>DIAGNOSTIC_LOGS_CLUSTER</define>
         <client tick="false" init="false">true</client>
         <server tick="false" init="false">true</server>
-        <command source="client" code="0x00" name="RetrieveLogsRequest" optional="false" cli="chip logs retrieve">
+        <command source="client" code="0x00" name="RetrieveLogsRequest" response="RetrieveLogsResponse" optional="false" cli="chip logs retrieve">
             <description>Retrieving diagnostic logs from a Node</description>
             <arg name="intent" type="LogsIntent"/>
             <arg name="requestedProtocol" type="LogsTransferProtocol"/>

--- a/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
@@ -43,7 +43,7 @@ limitations under the License.
     <attribute side="server" code="0x01" define="BASICCOMMISSIONINGINFO" type="BasicCommissioningInfo" writable="false" optional="false">BasicCommissioningInfo</attribute>
     <attribute side="server" code="0x02" define="REGULATORYCONFIG" type="ENUM8" writable="false" optional="true">RegulatoryConfig</attribute>
     <attribute side="server" code="0x03" define="LOCATIONCAPABILITY" type="ENUM8" writable="false" optional="true">LocationCapability</attribute>
-    <command source="client" code="0x00" name="ArmFailSafe" optional="false" cli="chip fabric_commissioning armfailsafe">
+    <command source="client" code="0x00" name="ArmFailSafe" response="ArmFailSafeResponse" optional="false" cli="chip fabric_commissioning armfailsafe">
       <description>Arm the persistent fail-safe timer with an expiry time of now + ExpiryLengthSeconds using device clock</description>
       <arg name="expiryLengthSeconds" type="INT16U"/>
       <arg name="breadcrumb" type="INT64U"/>
@@ -54,7 +54,7 @@ limitations under the License.
       <arg name="errorCode" type="CommissioningError"/>
       <arg name="debugText" type="CHAR_STRING"/>
     </command>
-    <command source="client" code="0x02" name="SetRegulatoryConfig" optional="true" cli="chip fabric_commissioning setregulatoryconfig">
+    <command source="client" code="0x02" name="SetRegulatoryConfig" response="SetRegulatoryConfigResponse" optional="true" cli="chip fabric_commissioning setregulatoryconfig">
       <description>Add or update the regulatory configuration</description>
       <arg name="location" type="RegulatoryLocationType"/>
       <arg name="countryCode" type="CHAR_STRING"/>      
@@ -66,7 +66,7 @@ limitations under the License.
       <arg name="errorCode" type="CommissioningError"/>
       <arg name="debugText" type="CHAR_STRING"/>
     </command>
-    <command source="client" code="0x04" name="CommissioningComplete" optional="false" cli="chip fabric_commissioning commissioningcomplete">
+    <command source="client" code="0x04" name="CommissioningComplete" response="CommissioningCompleteResponse" optional="false" cli="chip fabric_commissioning commissioningcomplete">
       <description>Signals the Commissionee that the Commissioner has successfully completed all steps of commissioning</description>
     </command>
     <command source="server" code="0x05" name="CommissioningCompleteResponse" optional="false" cli="chip fabric_commissioning commissioningcompleteresponse">

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -66,7 +66,7 @@ limitations under the License.
       <arg name="groupKeySet" type="GroupKeySet"/>
     </command>
 
-    <command source="client" code="0x01" name="KeySetRead" optional="false" cli="zcl GroupKeyManagement KeySetRead">
+    <command source="client" code="0x01" name="KeySetRead" response="KeySetReadResponse" optional="false" cli="zcl GroupKeyManagement KeySetRead">
       <description>Revoke a Root Key from a Group</description>
       <arg name="groupKeySetID" type="INT16U"/>
     </command>
@@ -83,7 +83,7 @@ limitations under the License.
       <arg name="groupKeySetID" type="INT16U"/>
     </command>
 
-    <command source="client" code="0x04" name="KeySetReadAllIndices" optional="false" cli="zcl GroupKeyManagement KeySetReadAllIndices">
+    <command source="client" code="0x04" name="KeySetReadAllIndices" response="KeySetReadAllIndicesResponse" optional="false" cli="zcl GroupKeyManagement KeySetReadAllIndices">
       <description>Revoke a Root Key from a Group</description>
       <arg name="groupKeySetIDs" type="INT16U" array="true"/>
     </command>

--- a/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
@@ -59,7 +59,7 @@ limitations under the License.
       </description>
       <arg name="identifyTime" type="INT16U"/>
     </command>
-    <command source="client" code="0x01" name="IdentifyQuery" optional="false">
+    <command source="client" code="0x01" name="IdentifyQuery" response="IdentifyQueryResponse" optional="false">
       <description>
         Command description for IdentifyQuery
       </description>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -63,7 +63,7 @@ limitations under the License.
     <attribute side="server" code="0x0004" define="TRUSTED_ROOTS" type="ARRAY" entryType="OCTET_STRING" length="400" writable="false" optional="false">TrustedRootCertificates</attribute>
     <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="fabric_idx" writable="false" optional="false">CurrentFabricIndex</attribute>
 
-    <command source="client" code="0x00" name="AttestationRequest" optional="false">
+    <command source="client" code="0x00" name="AttestationRequest" response="AttestationResponse" optional="false">
       <description>Sender is requesting attestation information from the receiver.</description>
       <arg name="AttestationNonce" type="OCTET_STRING"/>
     </command>
@@ -74,7 +74,7 @@ limitations under the License.
       <arg name="Signature" type="OCTET_STRING"/>
     </command>
 
-    <command source="client" code="0x02" name="CertificateChainRequest" optional="false">
+    <command source="client" code="0x02" name="CertificateChainRequest" response="CertificateChainResponse" optional="false">
       <description>Sender is requesting a device attestation certificate from the receiver.</description>
       <arg name="CertificateType" type="INT8U"/>
     </command>
@@ -84,7 +84,7 @@ limitations under the License.
       <arg name="Certificate" type="OCTET_STRING"/>
     </command>
 
-    <command source="client" code="0x04" name="OpCSRRequest" optional="false">
+    <command source="client" code="0x04" name="OpCSRRequest" response="OpCSRResponse" optional="false">
       <description>Sender is requesting a certificate signing request (CSR) from the receiver.</description>
       <arg name="CSRNonce" type="OCTET_STRING"/>
     </command>

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -210,7 +210,7 @@ limitations under the License.
       </description>
     </command>
 
-    <command source="client" code="0x02" name="TestSpecific" optional="false">
+    <command source="client" code="0x02" name="TestSpecific" response="TestSpecificResponse" optional="false">
       <description>
         Simple command without any parameters and with a specific response
       </description>
@@ -222,7 +222,7 @@ limitations under the License.
       </description>
     </command>
 
-    <command source="client" code="0x04" name="TestAddArguments" optional="false">
+    <command source="client" code="0x04" name="TestAddArguments" response="TestAddArgumentsResponse" optional="false">
       <description>
         Command that takes two arguments and returns their sum.
       </description>
@@ -230,14 +230,14 @@ limitations under the License.
       <arg name="arg2" type="INT8U"/>
     </command>
 
-    <command source="client" code="0x05" name="TestSimpleArgumentRequest" optional="false">
+    <command source="client" code="0x05" name="TestSimpleArgumentRequest" response="TestSimpleArgumentResponse" optional="false">
       <description>
         Command that takes an argument which is bool
       </description>
       <arg name="arg1" type="BOOLEAN"/>
     </command>
 
-    <command source="client" code="0x06" name="TestStructArrayArgumentRequest" optional="false">
+    <command source="client" code="0x06" name="TestStructArrayArgumentRequest" response="TestStructArrayArgumentResponse" optional="false">
       <description>
         Command that takes various arguments that are arrays, including an array of structs which have a list member.
       </description>
@@ -305,7 +305,7 @@ limitations under the License.
       <arg name="arg1" type="NestedStructList" array="true"/>
     </command>
 
-    <command source="client" code="0x0D" name="TestListInt8UReverseRequest" optional="false">
+    <command source="client" code="0x0D" name="TestListInt8UReverseRequest" response="TestListInt8UReverseResponse" optional="false">
       <description>
         Command that takes an argument which is a list of INT8U and expects a
         response that reverses the list.
@@ -313,7 +313,7 @@ limitations under the License.
       <arg name="arg1" type="INT8U" array="true"/>
     </command>
 
-    <command source="client" code="0x0E" name="TestEnumsRequest" optional="false">
+    <command source="client" code="0x0E" name="TestEnumsRequest" response="TestEnumsResponse" optional="false">
       <description>
         Command that sends a vendor id and an enum.  The server is expected to
         echo them back.

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -86,7 +86,7 @@ limitations under the License.
       <arg name="modeForSequence" type="ModeForSequence"/>
       <arg name="payload" type="INT8U" array="true"/>
     </command>
-    <command source="client" code="0x02" name="GetWeeklySchedule" optional="true">
+    <command source="client" code="0x02" name="GetWeeklySchedule" response="GetWeeklyScheduleResponse" optional="true">
       <description>
         Command description for GetWeeklySchedule
       </description>
@@ -98,7 +98,7 @@ limitations under the License.
         The Clear Weekly Schedule command is used to clear the weekly schedule.
       </description>
     </command>
-    <command source="client" code="0x04" name="GetRelayStatusLog" optional="true">
+    <command source="client" code="0x04" name="GetRelayStatusLog" response="GetRelayStatusLogResponse" optional="true">
       <description>
         The Get Relay Status Log command is used to query the thermostat internal relay status log.
       </description>

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -185,26 +185,26 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
     <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
     <!-- NAME_SUPPORT -->
-    <command source="client" code="0x00" name="AddGroup" optional="false" cli="zcl groups add">
+    <command source="client" code="0x00" name="AddGroup" response="AddGroupResponse" optional="false" cli="zcl groups add">
       <description>
         Command description for AddGroup
       </description>
       <arg name="groupId" type="INT16U"/>
       <arg name="groupName" type="CHAR_STRING"/>
     </command>
-    <command source="client" code="0x01" name="ViewGroup" optional="false" cli="zcl groups view">
+    <command source="client" code="0x01" name="ViewGroup" response="ViewGroupResponse" optional="false" cli="zcl groups view">
       <description>
         Command description for ViewGroup
       </description>
       <arg name="groupId" type="INT16U"/>
     </command>
-    <command source="client" code="0x02" name="GetGroupMembership" cliFunctionName="zclGroupsGetCommand" optional="false" cli="zcl groups get">
+    <command source="client" code="0x02" name="GetGroupMembership" response="GetGroupMembershipResponse" cliFunctionName="zclGroupsGetCommand" optional="false" cli="zcl groups get">
       <description>
         Command description for GetGroupMembership
       </description>
       <arg name="groupList" type="INT16U" array="true"/>
     </command>
-    <command source="client" code="0x03" name="RemoveGroup" optional="false" cli="zcl groups remove">
+    <command source="client" code="0x03" name="RemoveGroup" response="RemoveGroupResponse" optional="false" cli="zcl groups remove">
       <description>
         Command description for RemoveGroup
       </description>
@@ -268,7 +268,7 @@ limitations under the License.
     <attribute side="server" code="0x0004" define="SCENE_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
     <!-- NAME_SUPPORT -->
     <attribute side="server" code="0x0005" define="LAST_CONFIGURED_BY" type="NODE_ID" writable="false" optional="true">last configured by</attribute>
-    <command source="client" code="0x00" name="AddScene" optional="false" cli="zcl scenes add">
+    <command source="client" code="0x00" name="AddScene" response="AddSceneResponse" optional="false" cli="zcl scenes add">
       <description>
         Add a scene to the scene table. Extension field sets are supported, and are inputed as arrays of the form [[cluster ID] [length] [value0...n] ...]
       </description>
@@ -278,27 +278,27 @@ limitations under the License.
       <arg name="sceneName" type="CHAR_STRING"/>
       <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
     </command>
-    <command source="client" code="0x01" name="ViewScene" optional="false" cli="zcl scenes view">
+    <command source="client" code="0x01" name="ViewScene" response="ViewSceneResponse" optional="false" cli="zcl scenes view">
       <description>
         Command description for ViewScene
       </description>
       <arg name="groupId" type="INT16U"/>
       <arg name="sceneId" type="INT8U"/>
     </command>
-    <command source="client" code="0x02" name="RemoveScene" optional="false" cli="zcl scenes remove">
+    <command source="client" code="0x02" name="RemoveScene" response="RemoveSceneResponse" optional="false" cli="zcl scenes remove">
       <description>
         Command description for RemoveScene
       </description>
       <arg name="groupId" type="INT16U"/>
       <arg name="sceneId" type="INT8U"/>
     </command>
-    <command source="client" code="0x03" name="RemoveAllScenes" optional="false" cli="zcl scenes rmall">
+    <command source="client" code="0x03" name="RemoveAllScenes" response="RemoveAllScenesResponse" optional="false" cli="zcl scenes rmall">
       <description>
         Command description for RemoveAllScenes
       </description>
       <arg name="groupId" type="INT16U"/>
     </command>
-    <command source="client" code="0x04" name="StoreScene" optional="false" cli="zcl scenes store">
+    <command source="client" code="0x04" name="StoreScene" response="StoreSceneResponse" optional="false" cli="zcl scenes store">
       <description>
         Command description for StoreScene
       </description>
@@ -313,7 +313,7 @@ limitations under the License.
       <arg name="sceneId" type="INT8U"/>
       <arg name="transitionTime" type="INT16U" introducedIn="zcl-7.0-07-5123-07" optional="1"/>
     </command>
-    <command source="client" code="0x06" name="GetSceneMembership" optional="false" cli="zcl scenes get">
+    <command source="client" code="0x06" name="GetSceneMembership" response="GetSceneMembershipResponse" optional="false" cli="zcl scenes get">
       <description>
         Command description for GetSceneMembership
       </description>
@@ -491,7 +491,7 @@ limitations under the License.
         Command description for ResetAllAlarms
       </description>
     </command>
-    <command source="client" code="0x02" name="GetAlarm" optional="true">
+    <command source="client" code="0x02" name="GetAlarm" response="GetAlarmResponse" optional="true">
       <description>
         Command description for GetAlarm
       </description>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -895,12 +895,12 @@ limitations under the License.
       <arg name="enrollResponseCode" type="IasEnrollResponseCode"/>
       <arg name="zoneId" type="INT8U"/>
     </command>
-    <command source="client" code="0x01" name="InitiateNormalOperationMode" optional="true">
+    <command source="client" code="0x01" name="InitiateNormalOperationMode" response="InitiateNormalOperationModeResponse" optional="true">
       <description>
         Used to tell the IAS Zone server to commence normal operation mode
       </description>
     </command>
-    <command source="client" code="0x02" name="InitiateTestMode" optional="true">
+    <command source="client" code="0x02" name="InitiateTestMode" response="InitiateTestModeResponse" optional="true">
       <description>
         Certain IAS Zone servers may have operational configurations that could be configured OTA or locally on the device. This command enables them to be remotely placed into a test mode so that the user or installer may configure their field of view, sensitivity, and other operational parameters.
       </description>
@@ -916,7 +916,7 @@ limitations under the License.
       <arg name="zoneId" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
       <arg name="delay" type="INT16U" introducedIn="ha-1.2-05-3520-29"/>
     </command>
-    <command source="server" code="0x01" name="ZoneEnrollRequest" optional="false" cli="zcl ias-zone enroll">
+    <command source="server" code="0x01" name="ZoneEnrollRequest" response="ZoneEnrollResponse" optional="false" cli="zcl ias-zone enroll">
       <description>
         Command description for zoneEnrollRequest
       </description>
@@ -942,7 +942,7 @@ limitations under the License.
     <define>IAS_ACE_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <command source="client" code="0x00" name="Arm" optional="false" cli="zcl ias-ace a">
+    <command source="client" code="0x00" name="Arm" response="ArmResponse" optional="false" cli="zcl ias-ace a">
       <description>
         Command description for Arm
       </description>
@@ -950,7 +950,7 @@ limitations under the License.
       <arg name="armDisarmCode" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
       <arg name="zoneId" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
     </command>
-    <command source="client" code="0x01" name="Bypass" optional="false" cli="zcl ias-ace b">
+    <command source="client" code="0x01" name="Bypass" response="BypassResponse" optional="false" cli="zcl ias-ace b">
       <description>
         Command description for Bypass
       </description>
@@ -973,18 +973,18 @@ limitations under the License.
         Command description for Panic
       </description>
     </command>
-    <command source="client" code="0x05" name="GetZoneIdMap" optional="false" cli="zcl ias-ace getzm">
+    <command source="client" code="0x05" name="GetZoneIdMap" response="GetZoneIdMapResponse" optional="false" cli="zcl ias-ace getzm">
       <description>
         Command description for GetZoneIdMap
       </description>
     </command>
-    <command source="client" code="0x06" name="GetZoneInformation" optional="false" cli="zcl ias-ace getzi">
+    <command source="client" code="0x06" name="GetZoneInformation" response="GetZoneInformationResponse" optional="false" cli="zcl ias-ace getzi">
       <description>
         Command description for GetZoneInformation
       </description>
       <arg name="zoneId" type="INT8U"/>
     </command>
-    <command source="client" code="0x07" name="GetPanelStatus" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+    <command source="client" code="0x07" name="GetPanelStatus" response="GetPanelStatusResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30">
       <description>
         Used by the ACE client to request an update to the status of the ACE server
       </description>
@@ -994,7 +994,7 @@ limitations under the License.
         Used by the ACE client to retrieve the bypassed zones
         </description>
     </command>
-    <command source="client" code="0x09" name="GetZoneStatus" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+    <command source="client" code="0x09" name="GetZoneStatus" response="GetZoneStatusResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30">
       <description>
         Used by the ACE client to request an update to the zone status of the ACE server
       </description>
@@ -1162,7 +1162,7 @@ limitations under the License.
       </description>
       <arg name="commandId" type="CommandIdentification"/>
     </command>
-    <command source="client" code="0x01" name="SignalState" optional="false">
+    <command source="client" code="0x01" name="SignalState" response="SignalStateResponse" optional="false">
       <description>
         This basic message is used to retrieve Household Appliances status.
       </description>
@@ -1223,13 +1223,13 @@ limitations under the License.
     <attribute side="server" code="0x0002" define="ENERGY_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" default="0x01" optional="false">energy formatting</attribute>
     <attribute side="server" code="0x0003" define="ENERGY_REMOTE" type="BOOLEAN" min="0x00" max="0x01" writable="false" reportable="true" default="0x00" optional="false">energy remote</attribute>
     <attribute side="server" code="0x0004" define="SCHEDULE_MODE" type="BITMAP8" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="false">schedule mode</attribute>
-    <command source="client" code="0x00" name="PowerProfileRequest" optional="false" cli="zcl power-profile profile">
+    <command source="client" code="0x00" name="PowerProfileRequest" response="PowerProfileResponse" optional="false" cli="zcl power-profile profile">
       <description>
         The PowerProfileRequest Command is generated by a device supporting the client side of the Power Profile cluster in order to request the Power Profile of a server device.
       </description>
       <arg name="powerProfileId" type="INT8U"/>
     </command>
-    <command source="client" code="0x01" name="PowerProfileStateRequest" optional="false" cli="zcl power-profile state">
+    <command source="client" code="0x01" name="PowerProfileStateRequest" response="PowerProfileStateResponse" optional="false" cli="zcl power-profile state">
       <description>
         The PowerProfileStateRequest Command is generated in order to retrieve the identifiers of current Power Profiles.
       </description>
@@ -1267,13 +1267,13 @@ limitations under the License.
       <arg name="numOfScheduledPhases" type="INT8U"/>
       <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
     </command>
-    <command source="client" code="0x06" name="PowerProfileScheduleConstraintsRequest" optional="false" cli="zcl power-profile schedule-constraints">
+    <command source="client" code="0x06" name="PowerProfileScheduleConstraintsRequest" response="PowerProfileScheduleConstraintsResponse" optional="false" cli="zcl power-profile schedule-constraints">
       <description>
         The PowerProfileScheduleConstraintsRequest Command is generated by a device supporting the client side of the Power Profile cluster in order to request the constraints -if set- of Power Profile of a client device, in order to set the proper boundaries for the scheduling when calculating the schedules.
       </description>
       <arg name="powerProfileId" type="INT8U"/>
     </command>
-    <command source="client" code="0x07" name="EnergyPhasesScheduleStateRequest" optional="false" cli="zcl power-profile energy-phases-schedule-states">
+    <command source="client" code="0x07" name="EnergyPhasesScheduleStateRequest" response="EnergyPhasesScheduleStateResponse" optional="false" cli="zcl power-profile energy-phases-schedule-states">
       <description>
         The EnergyPhasesScheduleStateRequest  Command is generated by a device supporting the client side of the Power Profile cluster to check the states of the scheduling of a power profile, which is supported in the device implementing the server side of Power Profile cluster.
       </description>
@@ -1313,7 +1313,7 @@ limitations under the License.
       <arg name="powerProfileCount" type="INT8U"/>
       <arg name="powerProfileRecords" type="PowerProfileRecord" array="true"/>
     </command>
-    <command source="server" code="0x03" name="GetPowerProfilePrice" optional="true">
+    <command source="server" code="0x03" name="GetPowerProfilePrice" response="GetPowerProfilePriceResponse" optional="true">
       <description>
         The GetPowerProfilePrice Command is generated by the server (e.g. White goods) in order to retrieve the cost associated to a specific Power profile.
       </description>
@@ -1326,12 +1326,12 @@ limitations under the License.
       <arg name="powerProfileCount" type="INT8U"/>
       <arg name="powerProfileRecords" type="PowerProfileRecord" array="true"/>
     </command>
-    <command source="server" code="0x05" name="GetOverallSchedulePrice" optional="true">
+    <command source="server" code="0x05" name="GetOverallSchedulePrice" response="GetOverallSchedulePriceResponse" optional="true">
       <description>
         The GetOverallSchedulePrice Command is generated by the server (e.g. White goods) in order to retrieve the overall cost associated to all the Power Profiles scheduled by the scheduler (the device supporting the Power Profile cluster client side) for the next 24 hours.
       </description>
     </command>
-    <command source="server" code="0x06" name="EnergyPhasesScheduleRequest" optional="false">
+    <command source="server" code="0x06" name="EnergyPhasesScheduleRequest" response="EnergyPhasesScheduleResponse" optional="false">
       <description>
         The EnergyPhasesScheduleRequest Command is generated by the server (e.g. White goods) in order to retrieve from the scheduler (e.g. Home Gateway) the schedule (if available) associated to the specific Power Profile carried in the payload.
       </description>
@@ -1369,7 +1369,7 @@ limitations under the License.
       <arg name="startAfter" type="INT16U"/>
       <arg name="stopBefore" type="INT16U"/>
     </command>
-    <command source="server" code="0x0B" name="GetPowerProfilePriceExtended" optional="true">
+    <command source="server" code="0x0B" name="GetPowerProfilePriceExtended" response="GetPowerProfilePriceExtendedResponse" optional="true">
       <description>
         The Get Power Profile Price Extended command is generated by the server (e.g., White Goods) in order to retrieve the cost associated to a specific Power profile considering specific conditions described in the option field (e.g., a specific time).
       </description>
@@ -1394,7 +1394,7 @@ limitations under the License.
     <attribute side="server" code="0x0004" define="CHECK_IN_INTERVAL_MIN" type="INT32U" writable="false" default="0x00000000" optional="true">check in interval min</attribute>
     <attribute side="server" code="0x0005" define="LONG_POLL_INTERVAL_MIN" type="INT32U" writable="false" default="0x00000000" optional="true">long poll interval min</attribute>
     <attribute side="server" code="0x0006" define="FAST_POLL_TIMEOUT_MAX" type="INT16U" writable="false" default="0x0000" optional="true">fast poll timeout max</attribute>
-    <command source="server" code="0x00" name="CheckIn" optional="false">
+    <command source="server" code="0x00" name="CheckIn" response="CheckInResponse" optional="false">
       <description>
         The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on the server's Check-in Interval attribute.
       </description>
@@ -1476,7 +1476,7 @@ limitations under the License.
     <define>APPLIANCE_EVENTS_AND_ALERT_CLUSTER</define>
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
-    <command source="client" code="0x00" name="GetAlerts" optional="false">
+    <command source="client" code="0x00" name="GetAlerts" response="GetAlertsResponse" optional="false">
       <description>
         This basic message is used to retrieve Household Appliance current alerts.
       </description>
@@ -1547,13 +1547,13 @@ limitations under the License.
       <arg name="logQueueSize" type="INT8U"/>
       <arg name="logIds" type="INT32U" array="true"/>
     </command>
-    <command source="client" code="0x00" name="LogRequest" optional="false">
+    <command source="client" code="0x00" name="LogRequest" response="LogResponse" optional="false">
       <description>
         The Log request command is sent from a device supporting the client side of the Appliance Statistics cluster (e.g., Home Gateway) to retrieve the log from the device supporting the server side (e.g., appliance).
       </description>
       <arg name="logId" type="INT32U"/>
     </command>
-    <command source="client" code="0x01" name="LogQueueRequest" optional="false">
+    <command source="client" code="0x01" name="LogQueueRequest" response="LogQueueResponse" optional="false">
       <description>
         The Log Queue Request command is send from a device supporting the client side of the Appliance Statistics cluster (e.g. Home Gateway) to retrieve the information about the logs inserted in the queue, from the device supporting the server side (e.g. appliance).
       </description>

--- a/src/app/zap-templates/zcl/data-model/silabs/zll.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/zll.xml
@@ -57,7 +57,7 @@ limitations under the License.
     <attribute side="server" code="0x4000" define="SW_BUILD_ID" type="CHAR_STRING" length="16" writable="false" default="" optional="true" introducedIn="zll-1.0-11-0037-10">sw build id</attribute>
   </clusterExtension>
   <clusterExtension code="0x0005">
-    <command source="client" code="0x40" name="EnhancedAddScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eadd">
+    <command source="client" code="0x40" name="EnhancedAddScene" response="EnhancedAddSceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eadd">
       <description>
         Command description for EnhancedAddScene
       </description>
@@ -67,14 +67,14 @@ limitations under the License.
       <arg name="sceneName" type="CHAR_STRING"/>
       <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
     </command>
-    <command source="client" code="0x41" name="EnhancedViewScene" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eview">
+    <command source="client" code="0x41" name="EnhancedViewScene" response="EnhancedViewSceneResponse" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eview">
       <description>
         Command description for EnhancedViewScene
       </description>
       <arg name="groupId" type="INT16U"/>
       <arg name="sceneId" type="INT8U"/>
     </command>
-    <command source="client" code="0x42" name="CopyScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes copy">
+    <command source="client" code="0x42" name="CopyScene" response="CopySceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes copy">
       <description>
         Command description for CopyScene
       </description>


### PR DESCRIPTION
We don't want to rely on name-based heuristics, and can start removing
them after this.

#### Problem
Name-based heuristic hacks used to determine which commands are responses to other commands.

#### Change overview
Just capture this spec-defined information in the XML, using our existing facility for this.

#### Testing
Removed heuristic hack in ZAP and tested that we end up with the same codegen.  That removal will be a separate PR (against ZAP).