### PR TITLE
Start using responseName for commands now that it's reliable.

### DIFF
--- a/src/app/zap-templates/partials/idl/command_request_response.zapt
+++ b/src/app/zap-templates/partials/idl/command_request_response.zapt
@@ -11,8 +11,8 @@
         {{asUpperCamelCase parent.commandName}}Request
     {{~/first~}}
 {{~/zcl_command_arguments~}}
-): {{#if responseRef~}}
-    {{getResponseCommandName responseRef}}
+): {{#if responseName~}}
+    {{responseName}}
 {{~else~}}
     DefaultSuccess
 {{~/if~}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -118,8 +118,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
 
     using ResponseType =
-    {{~#if responseRef}}
-      Clusters::{{asUpperCamelCase parent.name}}::Commands::{{getResponseCommandName responseRef}}::DecodableType;
+    {{~#if responseName}}
+      Clusters::{{asUpperCamelCase parent.name}}::Commands::{{responseName}}::DecodableType;
     {{else}}
       DataModel::NullObjectType;
     {{/if}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -725,14 +725,6 @@ function getPythonFieldDefault(type, options)
   return _getPythonFieldDefault.call(this, type, options)
 }
 
-async function getResponseCommandName(responseRef, options)
-{
-  let pkgId = await templateUtil.ensureZclPackageId(this);
-
-  const { db, sessionId } = this.global;
-  return queryCommand.selectCommandById(db, responseRef, pkgId).then(response => asUpperCamelCase(response.name));
-}
-
 // Allow-list of enums that we generate as enums, not enum classes.  The goal is
 // to drive this down to 0.
 function isWeaklyTypedEnum(label)
@@ -840,7 +832,6 @@ exports.asMEI                                 = asMEI;
 exports.zapTypeToEncodableClusterObjectType   = zapTypeToEncodableClusterObjectType;
 exports.zapTypeToDecodableClusterObjectType   = zapTypeToDecodableClusterObjectType;
 exports.zapTypeToPythonClusterObjectType      = zapTypeToPythonClusterObjectType;
-exports.getResponseCommandName                = getResponseCommandName;
 exports.isWeaklyTypedEnum                     = isWeaklyTypedEnum;
 exports.getPythonFieldDefault                 = getPythonFieldDefault;
 exports.incrementDepth                        = incrementDepth;


### PR DESCRIPTION
#### Problem
Extra machinery to get the name from the command ref when the name is now available from ZAP directly.

#### Change overview
Remove the machinery.

#### Testing
No changes to the generated code.