### PR TITLE
Fix DataModelLogger::LogAttribute for unknown attributes.

### DIFF
--- a/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
@@ -83,13 +83,16 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             }
 {{#last}}
           }
+          break;
         }
 {{/last}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
         default:
-          return CHIP_NO_ERROR;
+          break;
     }
+    ChipLogProgress(chipTool, "  Don't know how to log atribute value");
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data)
@@ -115,13 +118,16 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             }
 {{#last}}
           }
+          break;
         }
 {{/last}}
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
         default:
-          return CHIP_NO_ERROR;
+          break;
     }
+    ChipLogProgress(chipTool, "  Don't know how to log command response data");
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip::TLV::TLVReader * data)
@@ -168,11 +174,14 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             }
 {{#last}}
           }
+          break;
         }
 {{/last}}
 {{/chip_server_cluster_events}}
 {{/chip_client_clusters}}
         default:
-          return CHIP_NO_ERROR;
+          break;
     }
+    ChipLogProgress(chipTool, "  Don't know how to log event data");
+    return CHIP_NO_ERROR;
 }

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -3936,6 +3936,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case AccountLogin::Id: {
         switch (path.mAttributeId)
@@ -3961,6 +3962,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case AdministratorCommissioning::Id: {
         switch (path.mAttributeId)
@@ -4001,6 +4003,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ApplicationBasic::Id: {
         switch (path.mAttributeId)
@@ -4066,6 +4069,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ApplicationLauncher::Id: {
         switch (path.mAttributeId)
@@ -4096,6 +4100,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case AudioOutput::Id: {
         switch (path.mAttributeId)
@@ -4131,6 +4136,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case BarrierControl::Id: {
         switch (path.mAttributeId)
@@ -4176,6 +4182,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Basic::Id: {
         switch (path.mAttributeId)
@@ -4296,6 +4303,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case BinaryInputBasic::Id: {
         switch (path.mAttributeId)
@@ -4336,6 +4344,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Binding::Id: {
         switch (path.mAttributeId)
@@ -4361,6 +4370,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case BooleanState::Id: {
         switch (path.mAttributeId)
@@ -4391,6 +4401,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case BridgedActions::Id: {
         switch (path.mAttributeId)
@@ -4432,6 +4443,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case BridgedDeviceBasic::Id: {
         switch (path.mAttributeId)
@@ -4527,6 +4539,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Channel::Id: {
         switch (path.mAttributeId)
@@ -4557,6 +4570,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ColorControl::Id: {
         switch (path.mAttributeId)
@@ -4842,6 +4856,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ContentLauncher::Id: {
         switch (path.mAttributeId)
@@ -4877,6 +4892,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Descriptor::Id: {
         switch (path.mAttributeId)
@@ -4922,6 +4938,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case DiagnosticLogs::Id: {
         switch (path.mAttributeId)
@@ -4942,6 +4959,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("AttributeList", 1, value);
         }
         }
+        break;
     }
     case DoorLock::Id: {
         switch (path.mAttributeId)
@@ -5072,6 +5090,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ElectricalMeasurement::Id: {
         switch (path.mAttributeId)
@@ -5152,6 +5171,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case EthernetNetworkDiagnostics::Id: {
         switch (path.mAttributeId)
@@ -5227,6 +5247,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case FixedLabel::Id: {
         switch (path.mAttributeId)
@@ -5257,6 +5278,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case FlowMeasurement::Id: {
         switch (path.mAttributeId)
@@ -5302,6 +5324,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case GeneralCommissioning::Id: {
         switch (path.mAttributeId)
@@ -5347,6 +5370,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case GeneralDiagnostics::Id: {
         switch (path.mAttributeId)
@@ -5414,6 +5438,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case GroupKeyManagement::Id: {
         switch (path.mAttributeId)
@@ -5459,6 +5484,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Groups::Id: {
         switch (path.mAttributeId)
@@ -5489,6 +5515,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Identify::Id: {
         switch (path.mAttributeId)
@@ -5524,6 +5551,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case IlluminanceMeasurement::Id: {
         switch (path.mAttributeId)
@@ -5574,6 +5602,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case KeypadInput::Id: {
         switch (path.mAttributeId)
@@ -5599,6 +5628,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case LevelControl::Id: {
         switch (path.mAttributeId)
@@ -5699,6 +5729,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case LocalizationConfiguration::Id: {
         switch (path.mAttributeId)
@@ -5729,6 +5760,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case LowPower::Id: {
         switch (path.mAttributeId)
@@ -5754,6 +5786,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case MediaInput::Id: {
         switch (path.mAttributeId)
@@ -5789,6 +5822,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case MediaPlayback::Id: {
         switch (path.mAttributeId)
@@ -5844,6 +5878,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ModeSelect::Id: {
         switch (path.mAttributeId)
@@ -5894,6 +5929,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case NetworkCommissioning::Id: {
         switch (path.mAttributeId)
@@ -5960,6 +5996,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case OtaSoftwareUpdateProvider::Id: {
         switch (path.mAttributeId)
@@ -5975,6 +6012,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case OtaSoftwareUpdateRequestor::Id: {
         switch (path.mAttributeId)
@@ -6012,6 +6050,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case OccupancySensing::Id: {
         switch (path.mAttributeId)
@@ -6052,6 +6091,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case OnOff::Id: {
         switch (path.mAttributeId)
@@ -6107,6 +6147,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case OnOffSwitchConfiguration::Id: {
         switch (path.mAttributeId)
@@ -6142,6 +6183,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case OperationalCredentials::Id: {
         switch (path.mAttributeId)
@@ -6200,6 +6242,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case PowerSource::Id: {
         switch (path.mAttributeId)
@@ -6275,6 +6318,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case PowerSourceConfiguration::Id: {
         switch (path.mAttributeId)
@@ -6305,6 +6349,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case PressureMeasurement::Id: {
         switch (path.mAttributeId)
@@ -6335,6 +6380,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case PumpConfigurationAndControl::Id: {
         switch (path.mAttributeId)
@@ -6485,6 +6531,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case RelativeHumidityMeasurement::Id: {
         switch (path.mAttributeId)
@@ -6530,6 +6577,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Scenes::Id: {
         switch (path.mAttributeId)
@@ -6580,6 +6628,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case SoftwareDiagnostics::Id: {
         switch (path.mAttributeId)
@@ -6631,6 +6680,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Switch::Id: {
         switch (path.mAttributeId)
@@ -6676,6 +6726,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case TargetNavigator::Id: {
         switch (path.mAttributeId)
@@ -6711,6 +6762,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case TemperatureMeasurement::Id: {
         switch (path.mAttributeId)
@@ -6746,6 +6798,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case TestCluster::Id: {
         switch (path.mAttributeId)
@@ -7174,6 +7227,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case Thermostat::Id: {
         switch (path.mAttributeId)
@@ -7279,6 +7333,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ThermostatUserInterfaceConfiguration::Id: {
         switch (path.mAttributeId)
@@ -7319,6 +7374,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case ThreadNetworkDiagnostics::Id: {
         switch (path.mAttributeId)
@@ -7671,6 +7727,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case TimeFormatLocalization::Id: {
         switch (path.mAttributeId)
@@ -7706,6 +7763,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case UnitLocalization::Id: {
         switch (path.mAttributeId)
@@ -7731,6 +7789,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case UserLabel::Id: {
         switch (path.mAttributeId)
@@ -7756,6 +7815,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case WakeOnLan::Id: {
         switch (path.mAttributeId)
@@ -7786,6 +7846,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case WiFiNetworkDiagnostics::Id: {
         switch (path.mAttributeId)
@@ -7881,6 +7942,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     case WindowCovering::Id: {
         switch (path.mAttributeId)
@@ -8001,10 +8063,13 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("ClusterRevision", 1, value);
         }
         }
+        break;
     }
     default:
-        return CHIP_NO_ERROR;
+        break;
     }
+    ChipLogProgress(chipTool, "  Don't know how to log atribute value");
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data)
@@ -8023,6 +8088,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("GetSetupPINResponse", 1, value);
         }
         }
+        break;
     }
     case ApplicationLauncher::Id: {
         switch (path.mCommandId)
@@ -8033,6 +8099,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("LauncherResponse", 1, value);
         }
         }
+        break;
     }
     case Channel::Id: {
         switch (path.mCommandId)
@@ -8043,6 +8110,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("ChangeChannelResponse", 1, value);
         }
         }
+        break;
     }
     case ContentLauncher::Id: {
         switch (path.mCommandId)
@@ -8053,6 +8121,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("LaunchResponse", 1, value);
         }
         }
+        break;
     }
     case DiagnosticLogs::Id: {
         switch (path.mCommandId)
@@ -8063,6 +8132,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("RetrieveLogsResponse", 1, value);
         }
         }
+        break;
     }
     case DoorLock::Id: {
         switch (path.mCommandId)
@@ -8093,6 +8163,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("SetCredentialResponse", 1, value);
         }
         }
+        break;
     }
     case GeneralCommissioning::Id: {
         switch (path.mCommandId)
@@ -8113,6 +8184,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("SetRegulatoryConfigResponse", 1, value);
         }
         }
+        break;
     }
     case GroupKeyManagement::Id: {
         switch (path.mCommandId)
@@ -8128,6 +8200,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("KeySetReadResponse", 1, value);
         }
         }
+        break;
     }
     case Groups::Id: {
         switch (path.mCommandId)
@@ -8153,6 +8226,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("ViewGroupResponse", 1, value);
         }
         }
+        break;
     }
     case Identify::Id: {
         switch (path.mCommandId)
@@ -8163,6 +8237,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("IdentifyQueryResponse", 1, value);
         }
         }
+        break;
     }
     case KeypadInput::Id: {
         switch (path.mCommandId)
@@ -8173,6 +8248,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("SendKeyResponse", 1, value);
         }
         }
+        break;
     }
     case MediaPlayback::Id: {
         switch (path.mCommandId)
@@ -8183,6 +8259,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("PlaybackResponse", 1, value);
         }
         }
+        break;
     }
     case NetworkCommissioning::Id: {
         switch (path.mCommandId)
@@ -8203,6 +8280,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("ScanNetworksResponse", 1, value);
         }
         }
+        break;
     }
     case OtaSoftwareUpdateProvider::Id: {
         switch (path.mCommandId)
@@ -8218,6 +8296,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("QueryImageResponse", 1, value);
         }
         }
+        break;
     }
     case OperationalCredentials::Id: {
         switch (path.mCommandId)
@@ -8243,6 +8322,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("OpCSRResponse", 1, value);
         }
         }
+        break;
     }
     case Scenes::Id: {
         switch (path.mCommandId)
@@ -8278,6 +8358,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("ViewSceneResponse", 1, value);
         }
         }
+        break;
     }
     case TargetNavigator::Id: {
         switch (path.mCommandId)
@@ -8288,6 +8369,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("NavigateTargetResponse", 1, value);
         }
         }
+        break;
     }
     case TestCluster::Id: {
         switch (path.mCommandId)
@@ -8333,6 +8415,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("TestSpecificResponse", 1, value);
         }
         }
+        break;
     }
     case Thermostat::Id: {
         switch (path.mCommandId)
@@ -8348,10 +8431,13 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
             return DataModelLogger::LogValue("GetWeeklyScheduleResponse", 1, value);
         }
         }
+        break;
     }
     default:
-        return CHIP_NO_ERROR;
+        break;
     }
+    ChipLogProgress(chipTool, "  Don't know how to log command response data");
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip::TLV::TLVReader * data)
@@ -8396,6 +8482,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("AccessControlExtensionChanged", 1, value);
         }
         }
+        break;
     }
     case Basic::Id: {
         switch (header.mPath.mEventId)
@@ -8421,6 +8508,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("ReachableChanged", 1, value);
         }
         }
+        break;
     }
     case BooleanState::Id: {
         switch (header.mPath.mEventId)
@@ -8431,6 +8519,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("StateChange", 1, value);
         }
         }
+        break;
     }
     case BridgedActions::Id: {
         switch (header.mPath.mEventId)
@@ -8446,6 +8535,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("ActionFailed", 1, value);
         }
         }
+        break;
     }
     case BridgedDeviceBasic::Id: {
         switch (header.mPath.mEventId)
@@ -8471,6 +8561,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("ReachableChanged", 1, value);
         }
         }
+        break;
     }
     case DoorLock::Id: {
         switch (header.mPath.mEventId)
@@ -8501,6 +8592,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("LockUserChange", 1, value);
         }
         }
+        break;
     }
     case GeneralDiagnostics::Id: {
         switch (header.mPath.mEventId)
@@ -8526,6 +8618,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("BootReason", 1, value);
         }
         }
+        break;
     }
     case OtaSoftwareUpdateRequestor::Id: {
         switch (header.mPath.mEventId)
@@ -8546,6 +8639,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("DownloadError", 1, value);
         }
         }
+        break;
     }
     case PumpConfigurationAndControl::Id: {
         switch (header.mPath.mEventId)
@@ -8636,6 +8730,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("TurbineOperation", 1, value);
         }
         }
+        break;
     }
     case SoftwareDiagnostics::Id: {
         switch (header.mPath.mEventId)
@@ -8646,6 +8741,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("SoftwareFault", 1, value);
         }
         }
+        break;
     }
     case Switch::Id: {
         switch (header.mPath.mEventId)
@@ -8686,6 +8782,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("MultiPressComplete", 1, value);
         }
         }
+        break;
     }
     case TestCluster::Id: {
         switch (header.mPath.mEventId)
@@ -8701,6 +8798,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("TestFabricScopedEvent", 1, value);
         }
         }
+        break;
     }
     case ThreadNetworkDiagnostics::Id: {
         switch (header.mPath.mEventId)
@@ -8711,6 +8809,7 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("ConnectionStatus", 1, value);
         }
         }
+        break;
     }
     case WiFiNetworkDiagnostics::Id: {
         switch (header.mPath.mEventId)
@@ -8731,8 +8830,11 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             return DataModelLogger::LogValue("ConnectionStatus", 1, value);
         }
         }
+        break;
     }
     default:
-        return CHIP_NO_ERROR;
+        break;
     }
+    ChipLogProgress(chipTool, "  Don't know how to log event data");
+    return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
LogAttribute was missing break statements in its switches, so trying
to read an attribute that controller-clusters does not have enabled
(e.g. UniqueID from Bridged Device Basic Information) would start
falling through to other clusters and possibly trying to treat it as
another attribute that happens to have the same attribute id (in this
case the Primary1Y attribute from Color Control).

Then TLV decoding would fail due to type mismatch errors, which is not
what we want here.

#### Problem
See above.

#### Change overview
Add breaks as needed.

#### Testing
Verified that trying to do:
```
chip-tool any read-by-id 0x39 0x12 node-id 1 
```
does not fail out anymore.