### PR TITLE
[ESP32]: PersistentStorageDelegate implementation for ACL

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -45,6 +45,7 @@
 #include <string>
 #include <vector>
 
+#include <access/examples/ExampleAccessControlDelegate.h>
 #include <app-common/zap-generated/att-storage.h>
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
@@ -68,6 +69,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ErrorStr.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/ESP32/ACLPersistentStorage.h>
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 #include <platform/ESP32/OTAImageProcessorImpl.h>
 #include <platform/GenericOTARequestorDriver.h>
@@ -542,6 +544,8 @@ public:
 
 AppCallbacks sCallbacks;
 
+ACLPersistentStorage gACLStorage;
+
 } // namespace
 
 static void InitServer(intptr_t context)
@@ -590,6 +594,9 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
         return;
     }
+
+    Access::Examples::SetAccessControlDelegateStorage(&gACLStorage);
+
 #if CONFIG_ENABLE_PW_RPC
     chip::rpc::Init();
 #endif

--- a/src/platform/ESP32/ACLPersistentStorage.h
+++ b/src/platform/ESP32/ACLPersistentStorage.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <limits>
+#include <platform/ESP32/ESP32Config.h>
+
+class ACLPersistentStorage : public chip::PersistentStorageDelegate
+{
+public:
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    {
+        size_t outSize                                       = 0;
+        chip::DeviceLayer::Internal::ESP32Config::Key getKey = {
+            chip::DeviceLayer::Internal::ESP32Config::kConfigNamespace_ChipConfig, key
+        };
+
+        CHIP_ERROR err =
+            chip::DeviceLayer::Internal::ESP32Config::ReadConfigValueBin(getKey, static_cast<uint8_t *>(buffer), size, outSize);
+        if (err == CHIP_NO_ERROR)
+        {
+            if (outSize > std::numeric_limits<uint16_t>::max())
+            {
+                err = CHIP_ERROR_BUFFER_TOO_SMALL;
+            }
+            else
+            {
+                size = static_cast<uint16_t>(outSize);
+            }
+        }
+        return err;
+    }
+
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    {
+        chip::DeviceLayer::Internal::ESP32Config::Key setKey = {
+            chip::DeviceLayer::Internal::ESP32Config::kConfigNamespace_ChipConfig, key
+        };
+        return chip::DeviceLayer::Internal::ESP32Config::WriteConfigValueBin(setKey, static_cast<const uint8_t *>(value),
+                                                                             static_cast<size_t>(size));
+    }
+
+    CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+    {
+        chip::DeviceLayer::Internal::ESP32Config::Key delKey = {
+            chip::DeviceLayer::Internal::ESP32Config::kConfigNamespace_ChipConfig, key
+        };
+        return chip::DeviceLayer::Internal::ESP32Config::ClearConfigValue(delKey);
+    }
+};

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -21,6 +21,7 @@ assert(chip_device_platform == "esp32")
 static_library("ESP32") {
   sources = [
     "../SingletonConfigurationManager.cpp",
+    "ACLPersistentStorage.h",
     "BLEManagerImpl.h",
     "CHIPDevicePlatformConfig.h",
     "CHIPDevicePlatformEvent.h",


### PR DESCRIPTION
#### Problem
PersistentStorageDelegate implementation for ACL storage is missing for ESP32.
Reference issue: #10251

#### Change overview
Implemented PersistentStorageDelegate for ACL storage. 

#### Testing
Used REPL to write the ACL entries and read back after device reboot. (REF:[Matter repl access control](https://deepnote.com/viewer/github/project-chip/connectedhomeip/blob/master/docs/guides/repl/Matter%20-%20Access%20Control.ipynb))