### PR TITLE
[EFR32]Remove Thread NVM section in the linker file for WiFi builds

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -260,7 +260,8 @@ efr32_executable("lighting_app") {
   }
   if (use_rs911x || use_wf200) {
     ldflags += [
-      "-Wl,--defsym","-Wl,SILABS_WIFI=1",
+      "-Wl,--defsym",
+      "-Wl,SILABS_WIFI=1",
     ]
   }
 

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -258,6 +258,11 @@ efr32_executable("lighting_app") {
       "-fstack-usage",
     ]
   }
+  if (use_rs911x || use_wf200) {
+    ldflags += [
+      "-Wl,--defsym","-Wl,SILABS_WIFI=1",
+    ]
+  }
 
   output_dir = root_out_dir
 }

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -263,7 +263,8 @@ efr32_executable("lock_app") {
   }
   if (use_rs911x || use_wf200) {
     ldflags += [
-      "-Wl,--defsym","-Wl,SILABS_WIFI=1",
+      "-Wl,--defsym",
+      "-Wl,SILABS_WIFI=1",
     ]
   }
 

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -261,6 +261,11 @@ efr32_executable("lock_app") {
       "-fstack-usage",
     ]
   }
+  if (use_rs911x || use_wf200) {
+    ldflags += [
+      "-Wl,--defsym","-Wl,SILABS_WIFI=1",
+    ]
+  }
 
   output_dir = root_out_dir
 }

--- a/examples/platform/efr32/ldscripts/efr32mg12.ld
+++ b/examples/platform/efr32/ldscripts/efr32mg12.ld
@@ -197,8 +197,8 @@ SECTIONS
     __nvm3_dummy_chip = .;
     KEEP(*(chipNvm3_section));
     . = ALIGN (8192);
-    . += OPENTHREAD_NVM_SIZE;
-    . = ALIGN (8192);
+    . += DEFINED(SILABS_WIFI) ? 0 : OPENTHREAD_NVM_SIZE;
+    . = DEFINED(SILABS_WIFI) ? . : ALIGN (8192);
   } > FLASH
 
   /* Set NVM to end of FLASH */

--- a/examples/platform/efr32/ldscripts/efr32mg24.ld
+++ b/examples/platform/efr32/ldscripts/efr32mg24.ld
@@ -197,8 +197,8 @@ SECTIONS
     __nvm3_dummy_chip = .;
     KEEP(*(chipNvm3_section));
     . = ALIGN (8192);
-    . += OPENTHREAD_NVM_SIZE;
-    . = ALIGN (8192);
+    . += DEFINED(SILABS_WIFI) ? 0 : OPENTHREAD_NVM_SIZE;
+    . = DEFINED(SILABS_WIFI) ? . : ALIGN (8192);
   } > FLASH
 
   /* Set NVM to end of FLASH */

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -220,7 +220,8 @@ efr32_executable("window_app") {
   }
   if (use_rs911x || use_wf200) {
     ldflags += [
-      "-Wl,--defsym","-Wl,SILABS_WIFI=1",
+      "-Wl,--defsym",
+      "-Wl,SILABS_WIFI=1",
     ]
   }
 }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -218,6 +218,11 @@ efr32_executable("window_app") {
       "-fstack-usage",
     ]
   }
+  if (use_rs911x || use_wf200) {
+    ldflags += [
+      "-Wl,--defsym","-Wl,SILABS_WIFI=1",
+    ]
+  }
 }
 
 group("efr32") {


### PR DESCRIPTION
#### Problem
NVM space is allocated for Openthread persistent storage even for WiFi builds

#### Change overview
Add a check in the linker files to prevent the adding of Openthread_NVM space for WiFI builds.

#### Testing
Built a wifi example and validated that the Openthread_NVM used space in the NVM section is gone.