### PR TITLE
Missing include in the configuration manager.

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <lib/support/BitFlags.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID


### PR DESCRIPTION
#### Problem
Missing include - some of the defines come from that header.

#### Change overview
Adds header to the GenericConfigurationManagerImpl.h

#### Testing
Compiles, can include GenericConfigurationManagerImpl.h without errors
