### PR TITLE
[ota] OTA Image header parsing

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -103,6 +103,8 @@ static_library("core") {
     "DataModelTypes.h",
     "GroupId.h",
     "NodeId.h",
+    "OTAImageHeader.cpp",
+    "OTAImageHeader.h",
     "PasscodeId.h",
     "PeerId.h",
   ]

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2408,6 +2408,15 @@ using CHIP_ERROR = ::chip::ChipError;
 #define CHIP_ERROR_IM_MALFORMED_TIMED_REQUEST_MESSAGE                    CHIP_CORE_ERROR(0xda)
 
 /**
+ * @def CHIP_ERROR_INVALID_FILE_IDENTIFIER
+ *
+ * @brief
+ *   The file identifier, encoded in the first few bytes of a processed file,
+ *   has unexpected value.
+ */
+#define CHIP_ERROR_INVALID_FILE_IDENTIFIER                     CHIP_CORE_ERROR(0xdb)
+
+/**
  *  @}
  */
 

--- a/src/lib/core/OTAImageHeader.cpp
+++ b/src/lib/core/OTAImageHeader.cpp
@@ -1,0 +1,105 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "OTAImageHeader.h"
+
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/BufferReader.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+
+namespace {
+
+enum class Tag : uint8_t
+{
+    kVendorId              = 0,
+    kProductId             = 1,
+    kSoftwareVersion       = 2,
+    kSoftwareVersionString = 3,
+    kPayloadSize           = 4,
+    kMinApplicableVersion  = 5,
+    kMaxApplicableVersion  = 6,
+    kReleaseNotesURL       = 7,
+    kImageDigestType       = 8,
+    kImageDigest           = 9,
+};
+
+} // namespace
+
+CHIP_ERROR DecodeOTAImageHeader(ByteSpan buffer, OTAImageHeader & header)
+{
+    Encoding::LittleEndian::Reader reader(buffer);
+
+    // Parse the fixed part of the header
+    uint32_t fileIdentifier;
+    ReturnErrorOnFailure(reader.Read32(&fileIdentifier).StatusCode());
+    VerifyOrReturnError(fileIdentifier == kOTAImageFileIdentifier, CHIP_ERROR_INVALID_FILE_IDENTIFIER);
+    ReturnErrorOnFailure(reader.Read64(&header.mTotalSize).Read32(&header.mHeaderSize).StatusCode());
+
+    // Parse the TLV elements of the header
+    VerifyOrReturnError(header.mHeaderSize <= reader.Remaining(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    TLV::TLVReader tlvReader;
+    tlvReader.Init(buffer.data() + reader.OctetsRead(), header.mHeaderSize);
+    ReturnErrorOnFailure(tlvReader.Next(TLV::TLVType::kTLVType_Structure, TLV::AnonymousTag()));
+
+    TLV::TLVType outerType;
+    ReturnErrorOnFailure(tlvReader.EnterContainer(outerType));
+
+    ReturnErrorOnFailure(tlvReader.Next(TLV::ContextTag(to_underlying(Tag::kVendorId))));
+    ReturnErrorOnFailure(tlvReader.Get(header.mVendorId));
+    ReturnErrorOnFailure(tlvReader.Next(TLV::ContextTag(to_underlying(Tag::kProductId))));
+    ReturnErrorOnFailure(tlvReader.Get(header.mProductId));
+    ReturnErrorOnFailure(tlvReader.Next(TLV::ContextTag(to_underlying(Tag::kSoftwareVersion))));
+    ReturnErrorOnFailure(tlvReader.Get(header.mSoftwareVersion));
+    ReturnErrorOnFailure(tlvReader.Next(TLV::ContextTag(to_underlying(Tag::kSoftwareVersionString))));
+    ReturnErrorOnFailure(tlvReader.Get(header.mSoftwareVersionString));
+    ReturnErrorOnFailure(tlvReader.Next(TLV::ContextTag(to_underlying(Tag::kPayloadSize))));
+    ReturnErrorOnFailure(tlvReader.Get(header.mPayloadSize));
+    ReturnErrorOnFailure(tlvReader.Next());
+
+    if (tlvReader.GetTag() == TLV::ContextTag(to_underlying(Tag::kMinApplicableVersion)))
+    {
+        ReturnErrorOnFailure(tlvReader.Get(header.mMinApplicableVersion.Emplace()));
+        ReturnErrorOnFailure(tlvReader.Next());
+    }
+
+    if (tlvReader.GetTag() == TLV::ContextTag(to_underlying(Tag::kMaxApplicableVersion)))
+    {
+        ReturnErrorOnFailure(tlvReader.Get(header.mMaxApplicableVersion.Emplace()));
+        ReturnErrorOnFailure(tlvReader.Next());
+    }
+
+    if (tlvReader.GetTag() == TLV::ContextTag(to_underlying(Tag::kReleaseNotesURL)))
+    {
+        ReturnErrorOnFailure(tlvReader.Get(header.mReleaseNotesURL));
+        ReturnErrorOnFailure(tlvReader.Next());
+    }
+
+    VerifyOrReturnError(tlvReader.GetTag() == TLV::ContextTag(to_underlying(Tag::kImageDigestType)),
+                        CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    ReturnErrorOnFailure(tlvReader.Get(header.mImageDigestType));
+    ReturnErrorOnFailure(tlvReader.Next(TLV::ContextTag(to_underlying(Tag::kImageDigest))));
+    ReturnErrorOnFailure(tlvReader.Get(header.mImageDigest));
+
+    ReturnErrorOnFailure(tlvReader.ExitContainer(outerType));
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip

--- a/src/lib/core/OTAImageHeader.h
+++ b/src/lib/core/OTAImageHeader.h
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/Optional.h>
+#include <lib/support/Span.h>
+
+#include <cstdint>
+
+namespace chip {
+
+constexpr uint32_t kOTAImageFileIdentifier = 0x1BEEF11E;
+
+enum class OTAImageDigestType : uint8_t
+{
+    kSha256     = 1,
+    kSha256_128 = 2,
+    kSha256_120 = 3,
+    kSha256_96  = 4,
+    kSha256_64  = 5,
+    kSha256_32  = 6,
+    kSha384     = 7,
+    kSha512     = 8,
+    kSha3_224   = 9,
+    kSha3_256   = 10,
+    kSha3_384   = 11,
+    kSha3_512   = 12,
+};
+
+struct OTAImageHeader
+{
+    uint64_t mTotalSize;
+    uint32_t mHeaderSize;
+    uint16_t mVendorId;
+    uint16_t mProductId;
+    uint32_t mSoftwareVersion;
+    CharSpan mSoftwareVersionString;
+    uint64_t mPayloadSize;
+    Optional<uint32_t> mMinApplicableVersion;
+    Optional<uint32_t> mMaxApplicableVersion;
+    CharSpan mReleaseNotesURL;
+    OTAImageDigestType mImageDigestType;
+    ByteSpan mImageDigest;
+};
+
+CHIP_ERROR DecodeOTAImageHeader(ByteSpan buffer, OTAImageHeader & header);
+
+} // namespace chip

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -25,8 +25,8 @@ chip_test_suite("tests") {
     "TestCHIPCallback.cpp",
     "TestCHIPErrorStr.cpp",
     "TestCHIPTLV.cpp",
-    "TestOptional.cpp",
     "TestOTAImageHeader.cpp",
+    "TestOptional.cpp",
     "TestReferenceCounted.cpp",
   ]
 

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
     "TestCHIPErrorStr.cpp",
     "TestCHIPTLV.cpp",
     "TestOptional.cpp",
+    "TestOTAImageHeader.cpp",
     "TestReferenceCounted.cpp",
   ]
 

--- a/src/lib/core/tests/TestOTAImageHeader.cpp
+++ b/src/lib/core/tests/TestOTAImageHeader.cpp
@@ -1,0 +1,143 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/core/OTAImageHeader.h>
+#include <lib/support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+namespace {
+
+// Magic: 1beef11e
+// Total Size: 110
+// Header Size: 82
+// Header TLV:
+//   [0] Vendor Id: 57005 (0xdead)
+//   [1] Product Id: 48879 (0xbeef)
+//   [2] Version: 4294967295 (0xffffffff)
+//   [3] Version String: 1.0
+//   [4] Payload Size: 12 (0xc)
+//   [5] Min Version: 1 (0x1)
+//   [6] Max Version: 2 (0x2)
+//   [7] Release Notes Url: https://rn
+//   [8] Digest Type: 1 (0x1)
+//   [9] Digest: 813ca5285c28ccee5cab8b10ebda9c908fd6d78ed9dc94cc65ea6cb67a7f13ae
+const uint8_t kOtaImage[] = { 0x1e, 0xf1, 0xee, 0x1b, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x00, 0x00, 0x00,
+                              0x15, 0x25, 0x00, 0xad, 0xde, 0x25, 0x01, 0xef, 0xbe, 0x26, 0x02, 0xff, 0xff, 0xff, 0xff, 0x2c,
+                              0x03, 0x03, 0x31, 0x2e, 0x30, 0x24, 0x04, 0x0c, 0x24, 0x05, 0x01, 0x24, 0x06, 0x02, 0x2c, 0x07,
+                              0x0a, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x72, 0x6e, 0x24, 0x08, 0x01, 0x30, 0x09,
+                              0x20, 0x81, 0x3c, 0xa5, 0x28, 0x5c, 0x28, 0xcc, 0xee, 0x5c, 0xab, 0x8b, 0x10, 0xeb, 0xda, 0x9c,
+                              0x90, 0x8f, 0xd6, 0xd7, 0x8e, 0xd9, 0xdc, 0x94, 0xcc, 0x65, 0xea, 0x6c, 0xb6, 0x7a, 0x7f, 0x13,
+                              0xae, 0x18, 0x74, 0x65, 0x73, 0x74, 0x20, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64 };
+
+// Magic: 1beef11e
+// Total Size: 68
+// Header Size: 52
+// Header TLV:
+//   [0] Vendor Id: 1 (0x1)
+//   [1] Product Id: 1 (0x1)
+//   [2] Version: 1 (0x1)
+//   [3] Version String: 1
+//   [4] Payload Size: 0 (0x0)
+//   [8] Digest Type: 9 (0x9)
+//   [9] Digest: 6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7
+const uint8_t kMinOtaImage[] = { 0x1e, 0xf1, 0xee, 0x1b, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x00,
+                                 0x00, 0x00, 0x15, 0x24, 0x00, 0x01, 0x24, 0x01, 0x01, 0x24, 0x02, 0x01, 0x2c, 0x03,
+                                 0x01, 0x31, 0x24, 0x04, 0x00, 0x24, 0x08, 0x09, 0x30, 0x09, 0x1c, 0x6b, 0x4e, 0x03,
+                                 0x42, 0x36, 0x67, 0xdb, 0xb7, 0x3b, 0x6e, 0x15, 0x45, 0x4f, 0x0e, 0xb1, 0xab, 0xd4,
+                                 0x59, 0x7f, 0x9a, 0x1b, 0x07, 0x8e, 0x3f, 0x5b, 0x5a, 0x6b, 0xc7, 0x18 };
+
+const uint8_t kMinOtaImageWithoutVendor[] = { 0x1e, 0xf1, 0xee, 0x1b, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x31,
+                                              0x00, 0x00, 0x00, 0x15, 0x24, 0x01, 0x01, 0x24, 0x02, 0x01, 0x2c, 0x03, 0x01,
+                                              0x31, 0x24, 0x04, 0x00, 0x24, 0x08, 0x09, 0x30, 0x09, 0x1c, 0x6b, 0x4e, 0x03,
+                                              0x42, 0x36, 0x67, 0xdb, 0xb7, 0x3b, 0x6e, 0x15, 0x45, 0x4f, 0x0e, 0xb1, 0xab,
+                                              0xd4, 0x59, 0x7f, 0x9a, 0x1b, 0x07, 0x8e, 0x3f, 0x5b, 0x5a, 0x6b, 0xc7, 0x18 };
+
+void TestHappyPath(nlTestSuite * inSuite, void * inContext)
+{
+    OTAImageHeader header;
+    NL_TEST_ASSERT(inSuite, DecodeOTAImageHeader(ByteSpan(kOtaImage), header) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, header.mTotalSize == sizeof(kOtaImage));
+    NL_TEST_ASSERT(inSuite, header.mHeaderSize == 82);
+    NL_TEST_ASSERT(inSuite, header.mVendorId == 0xDEAD);
+    NL_TEST_ASSERT(inSuite, header.mProductId == 0xBEEF);
+    NL_TEST_ASSERT(inSuite, header.mSoftwareVersion == 0xFFFFFFFF);
+    NL_TEST_ASSERT(inSuite, header.mSoftwareVersionString.data_equal(CharSpan::fromCharString("1.0")));
+    NL_TEST_ASSERT(inSuite, header.mPayloadSize == strlen("test payload"));
+    NL_TEST_ASSERT(inSuite, header.mMinApplicableVersion.HasValue());
+    NL_TEST_ASSERT(inSuite, header.mMinApplicableVersion.Value() == 1);
+    NL_TEST_ASSERT(inSuite, header.mMaxApplicableVersion.HasValue());
+    NL_TEST_ASSERT(inSuite, header.mMaxApplicableVersion.Value() == 2);
+    NL_TEST_ASSERT(inSuite, header.mReleaseNotesURL.data_equal(CharSpan::fromCharString("https://rn")));
+    NL_TEST_ASSERT(inSuite, header.mImageDigestType == OTAImageDigestType::kSha256);
+    NL_TEST_ASSERT(inSuite, header.mImageDigest.size() == 256 / 8);
+}
+
+void TestEmptyBuffer(nlTestSuite * inSuite, void * inContext)
+{
+    OTAImageHeader header;
+    NL_TEST_ASSERT(inSuite, DecodeOTAImageHeader(ByteSpan(), header) == CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
+void TestInvalidFileIdentifier(nlTestSuite * inSuite, void * inContext)
+{
+    static const uint8_t otaImage[] = { 0x1e, 0xf1, 0xee, 0x1c };
+
+    OTAImageHeader header;
+    NL_TEST_ASSERT(inSuite, DecodeOTAImageHeader(ByteSpan(otaImage), header) == CHIP_ERROR_INVALID_FILE_IDENTIFIER);
+}
+
+void TestTooSmallHeader(nlTestSuite * inSuite, void * inContext)
+{
+    OTAImageHeader header;
+    NL_TEST_ASSERT(inSuite, DecodeOTAImageHeader(ByteSpan(kMinOtaImage), header) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   DecodeOTAImageHeader(ByteSpan(kMinOtaImage, sizeof(kMinOtaImage) - 1), header) == CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
+void TestMissingMandatoryField(nlTestSuite * inSuite, void * inContext)
+{
+    OTAImageHeader header;
+    NL_TEST_ASSERT(inSuite, DecodeOTAImageHeader(ByteSpan(kMinOtaImageWithoutVendor), header) == CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("Test happy path", TestHappyPath),
+    NL_TEST_DEF("Test empty buffer", TestEmptyBuffer),
+    NL_TEST_DEF("Test invalid File Identifier", TestInvalidFileIdentifier),
+    NL_TEST_DEF("Test too small header", TestTooSmallHeader),
+    NL_TEST_DEF("Test missing mandatory field", TestMissingMandatoryField),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestOTAImageHeader(void)
+{
+    nlTestSuite theSuite = { "OTA Image header test", &sTests[0] };
+    nlTestRunner(&theSuite, nullptr);
+
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestOTAImageHeader)


### PR DESCRIPTION
#### Problem
We need a function for parsing OTA image header to be used by both OTA Provider (for example, to verify image integrity) and OTA Requestor (to validate the downloaded and determine the image size to be able to calculate the progress).

#### Change overview
Add a function for parsing OTA image header.

#### Testing
Added unit tests.
