### PR TITLE
[OTA] Issue#13839 - Adding logging to OTA Provider

### DIFF
--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -78,7 +78,9 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     OTAProviderDelegate * delegate = GetDelegate(endpoint);
 
-    ChipLogDetail(Zcl, "OTA Provider received ApplyUpdateRequest");
+    ChipLogProgress(Zcl, "OTA Provider received ApplyUpdateRequest");
+    ChipLogDetail(Zcl, "  Update Token: %zu", commandData.updateToken.size());
+    ChipLogDetail(Zcl, "  New Version: %" PRIu32, commandData.newVersion);
 
     if (SendStatusIfDelegateNull(endpoint))
     {
@@ -121,7 +123,9 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     OTAProviderDelegate * delegate = GetDelegate(endpoint);
 
-    ChipLogDetail(Zcl, "OTA Provider received NotifyUpdateApplied");
+    ChipLogProgress(Zcl, "OTA Provider received NotifyUpdateApplied");
+    ChipLogDetail(Zcl, "  Update Token: %zu", commandData.updateToken.size());
+    ChipLogDetail(Zcl, "  Software Version: %" PRIu32, commandData.softwareVersion);
 
     if (SendStatusIfDelegateNull(endpoint))
     {


### PR DESCRIPTION
#### Problem
Logging is missing in ApplyUpdateRequest and NotifyUpdateApplied from the OTA Provider app.

Fixes: https://github.com/project-chip/connectedhomeip/issues/13839

#### Change overview
Add logging to ApplyUpdateRequest and NotifyUpdateApplied.

#### Testing

- Manually tested OTA Provider app and ensured additional logs in ApplyUpdateRequest and NotifyUpdateApplied are observed in the terminal.
