### PR TITLE
Put temporary fix for function pointer casting error in arm gcc

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -372,10 +372,10 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     else
     {
         EmberAfStatus status            = EMBER_ZCL_STATUS_SUCCESS;
-        EmberAfGenericClusterFunction f = emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION);
+        EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback )(emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
         if (f != NULL)
         {
-            status = ((EmberAfClusterPreAttributeChangedCallback) f)(attributePath, attributeType, size, value);
+            status = f(attributePath, attributeType, size, value);
         }
         return status;
     }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -371,8 +371,11 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     }
     else
     {
-        EmberAfStatus status            = EMBER_ZCL_STATUS_SUCCESS;
-        EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback )(emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+        EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+        // Casting and calling a function pointer on the same line results in ignoring the return
+        // of the call on gcc-arm-none-eabi-9-2019-q4-major
+        EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
+            emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
         if (f != NULL)
         {
             status = f(attributePath, attributeType, size, value);


### PR DESCRIPTION
#### Problem
Function pointer cast ignores return value. This seems to be a compiler issue as later arm-gcc versions fix or don't exhibit this error.
This was affecting `write` IM on nrf platform.

#### Change overview
Separate the cast and call of the function.

#### Testing
Tested with chip-tool along with nrf based application.