### PR TITLE
Add --KVS option for examples/platform/linux in order to specify wher…

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -123,6 +123,18 @@ int ChipLinuxAppInit(int argc, char ** argv)
     err = Platform::MemoryInit();
     SuccessOrExit(err);
 
+#ifdef CHIP_CONFIG_KVS_PATH
+    if (LinuxDeviceOptions::GetInstance().KVS == nullptr)
+    {
+        err = DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
+    }
+    else
+    {
+        err = DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(LinuxDeviceOptions::GetInstance().KVS);
+    }
+    SuccessOrExit(err);
+#endif
+
     err = DeviceLayer::PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -47,7 +47,8 @@ enum
     kDeviceOption_SecuredCommissionerPort   = 0x100b,
     kDeviceOption_UnsecuredCommissionerPort = 0x100c,
     kDeviceOption_Command                   = 0x100d,
-    kDeviceOption_PICS                      = 0x100e
+    kDeviceOption_PICS                      = 0x100e,
+    kDeviceOption_KVS                       = 0x100f
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -74,6 +75,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "unsecured-commissioner-port", kArgumentRequired, kDeviceOption_UnsecuredCommissionerPort },
     { "command", kArgumentRequired, kDeviceOption_Command },
     { "PICS", kArgumentRequired, kDeviceOption_PICS },
+    { "KVS", kArgumentRequired, kDeviceOption_KVS },
     {}
 };
 
@@ -129,6 +131,9 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --PICS <filepath>\n"
     "       A file containing PICS items.\n"
+    "\n"
+    "  --KVS <filepath>\n"
+    "       A file to store Key Value Store items.\n"
     "\n";
 
 bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
@@ -211,6 +216,10 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_PICS:
         LinuxDeviceOptions::GetInstance().PICS = aValue;
+        break;
+
+    case kDeviceOption_KVS:
+        LinuxDeviceOptions::GetInstance().KVS = aValue;
         break;
 
     default:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -40,6 +40,7 @@ struct LinuxDeviceOptions
     uint32_t unsecuredCommissionerPort = CHIP_UDC_PORT;
     const char * command               = nullptr;
     const char * PICS                  = nullptr;
+    const char * KVS                   = nullptr;
 
     static LinuxDeviceOptions & GetInstance();
 };

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -66,9 +66,6 @@ class App:
 
     def factoryReset(self):
         storage = '/tmp/chip_kvs'
-        if platform.system() == 'Darwin':
-            storage = str(Path.home()) + '/Documents/chip.store'
-
         if os.path.exists(storage):
             os.unlink(storage)
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -113,13 +113,6 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     // handler.
     SetAttributePersistenceProvider(&mAttributePersister);
 
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-    err = DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init("chip.store");
-    SuccessOrExit(err);
-#elif CHIP_DEVICE_LAYER_TARGET_LINUX
-    DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
-#endif
-
     InitDataModelHandler(&mExchangeMgr);
 
     err = mFabrics.Init(&mDeviceStorage);

--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -74,3 +74,7 @@
 // TODO - Fine tune MRP default parameters for Darwin platform
 #define CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL (15000)
 #define CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL (2000_ms32)
+
+#ifndef CHIP_CONFIG_KVS_PATH
+#define CHIP_CONFIG_KVS_PATH "/tmp/chip_kvs"
+#endif // CHIP_CONFIG_KVS_PATH

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -165,7 +165,7 @@ namespace DeviceLayer {
 
                 url = [NSURL URLWithString:[NSString stringWithUTF8String:fileName] relativeToURL:documentsDirectory];
             } else {
-                url = [NSURL URLWithString:[NSString stringWithUTF8String:fileName]];
+                url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:fileName]];
             }
             ReturnErrorCodeIf(url == nullptr, CHIP_ERROR_NO_MEMORY);
 

--- a/src/platform/Linux/KeyValueStoreManagerImpl.h
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.h
@@ -36,7 +36,7 @@ public:
      * @brief
      * Initalize the KVS, must be called before using.
      */
-    void Init(const char * file) { mStorage.Init(file); }
+    CHIP_ERROR Init(const char * file) { return mStorage.Init(file); }
 
     CHIP_ERROR _Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size = nullptr, size_t offset = 0);
     CHIP_ERROR _Delete(const char * key);


### PR DESCRIPTION
…e the kvs store will be created

#### Problem

The Key Value Store for a given application is stored at a fixed path. While on Linux it can be configured with `CHIP_CONFIG_KVS_PATH` it always points to `chip.store` on Mac. That makes it hard to use multiple applications at the same time.

For convenience I have also added a `--KVS` command line option so the user can choose at run-time instead of compile time.

#### Change overview
 * Add `CHIP_CONFIG_KVS_PATH` for darwin too
 * Use `/tmp/chip_kvs` on darwin instead of `chip.store`
 * Add `--KVS` command line option
 
#### Testing
I have locally launch the `all-clusters-app` and I have updated the test runner to only use `/tmp/chip_kvs` instead of `/tmp/chip_kvs` for Linux and `chip.store` for Mac.