### PR TITLE
[ESP32] Automatically build OTA image based on config option

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -29,6 +29,8 @@ if(NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../.. REALPATH)
 endif()
 
+include(${CMAKE_CURRENT_LIST_DIR}/ota-image.cmake)
+
 set(CHIP_REQURIE_COMPONENTS freertos lwip bt mdns mbedtls fatfs app_update console openthread)
 
 if (NOT CMAKE_BUILD_EARLY_EXPANSION)
@@ -245,4 +247,14 @@ add_dependencies(${COMPONENT_LIB} chip_gn)
 if(CONFIG_ENABLE_PW_RPC)
     set(WRAP_FUNCTIONS esp_log_write)
     target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=${WRAP_FUNCTIONS}")
+endif()
+
+# Build Matter OTA image
+if (CONFIG_CHIP_OTA_IMAGE_BUILD)
+    chip_ota_image(chip-ota-image
+        INPUT_FILES ${BUILD_DIR}/${CMAKE_PROJECT_NAME}.bin
+        OUTPUT_FILE ${BUILD_DIR}/${CMAKE_PROJECT_NAME}-ota.bin
+    )
+    # Adding dependecy as app target so that this runs after images are ready
+    add_dependencies(chip-ota-image app)
 endif()

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -287,7 +287,7 @@ menu "CHIP Device Layer"
 
         config DEVICE_SOFTWARE_VERSION
             string "Device Software Version String"
-            default ""
+            default "v1.0"
             help
                 A string identifying the software version running on the device.
 
@@ -765,6 +765,22 @@ menu "CHIP Device Layer"
 
                 When size is set to 0, the debug event buffer and all support
                 for the debug level events are disabled.
+
+    endmenu
+
+    menu "Matter OTA Image"
+
+        config CHIP_OTA_IMAGE_BUILD
+            bool "Generate Matter OTA image"
+            help
+              Enable building OTA (Over-the-air update) image which includes Matter OTA header.
+
+        config CHIP_OTA_IMAGE_EXTRA_ARGS
+            string "OTA image creator extra arguments"
+            depends on CHIP_OTA_IMAGE_BUILD
+            help
+              This option allows one to pass optional arguments to the ota_image_tool.py script,
+              used for building OTA image with Matter OTA header.
 
     endmenu
 

--- a/config/esp32/components/chip/ota-image.cmake
+++ b/config/esp32/components/chip/ota-image.cmake
@@ -1,0 +1,65 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+find_package(Python3 REQUIRED)
+
+#
+# Create CMake target for building Matter OTA (Over-the-air update) image.
+# Required arguments:
+#   INPUT_FILES file1, [file2...] - binary files which Matter OTA image will be composed of
+#   OUTPUT_FILE file - where to store newly created Matter OTA image
+#
+function(chip_ota_image TARGET_NAME)
+    cmake_parse_arguments(ARG "" "OUTPUT_FILE" "INPUT_FILES" ${ARGN})
+
+    if (NOT ARG_INPUT_FILES OR NOT ARG_OUTPUT_FILE)
+        message(FATAL_ERROR "Both INPUT_FILES and OUTPUT_FILE arguments must be specified")
+    endif()
+
+    # Prepare ota_image_tool.py argument list
+    set(OTA_ARGS
+        "--vendor-id"
+        ${CONFIG_DEVICE_VENDOR_ID}
+        "--product-id"
+        ${CONFIG_DEVICE_PRODUCT_ID}
+        "--version"
+        ${CONFIG_DEVICE_SOFTWARE_VERSION_NUMBER}
+        "--version-str"
+        ${CONFIG_DEVICE_SOFTWARE_VERSION}
+        "--digest-algorithm"
+        "sha256"
+    )
+
+    separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CHIP_OTA_IMAGE_EXTRA_ARGS}")
+
+    list(APPEND OTA_ARGS ${OTA_EXTRA_ARGS})
+    list(APPEND OTA_ARGS ${ARG_INPUT_FILES})
+    list(APPEND OTA_ARGS ${ARG_OUTPUT_FILE})
+
+    # Convert the argument list to multi-line string
+    string(REPLACE ";" "\n" OTA_ARGS "${OTA_ARGS}")
+
+    # Pass the argument list via file to avoid hitting Windows command-line length limit
+    file(GENERATE
+        OUTPUT ${BUILD_DIR}/args-ota-image.tmp
+        CONTENT ${OTA_ARGS}
+    )
+
+    add_custom_target(${TARGET_NAME} ALL
+        COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/src/app/ota_image_tool.py create @${BUILD_DIR}/args-ota-image.tmp
+        COMMAND ${CMAKE_COMMAND} -E remove ${BUILD_DIR}/args-ota-image.tmp
+    )
+endfunction()


### PR DESCRIPTION
#### Problem
* Building OTA image during build process is missing

#### Change overview
* Build OTA image during build process which depends on config option

#### Testing
* Tested using all-clusters-app/esp32, OTA image is generated in `build/` directory and `ota_image_tool.py show` shows the correct parameters which were provided using config options.