### PR TITLE
Enable Media Struct Atributes on chip tool

### DIFF
--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -176,12 +176,18 @@ client cluster ApplicationLauncher = 1292 {
     kLineupInfo = 0x2;
   }
 
+  struct ApplicationEP {
+    Application application = 0;
+    CHAR_STRING endpoint = 1;
+  }
+
   struct Application {
     INT16U catalogVendorId = 0;
     CHAR_STRING applicationId = 1;
   }
 
   readonly attribute INT16U applicationLauncherList[] = 0;
+  attribute ApplicationEP applicationLauncherApp = 1;
   readonly global attribute command_id serverGeneratedCommandList[] = 65528;
   readonly global attribute command_id clientGeneratedCommandList[] = 65529;
   readonly global attribute attrib_id attributeList[] = 65531;
@@ -567,7 +573,16 @@ client cluster Channel = 1284 {
     CHAR_STRING<32> affiliateCallSign = 4;
   }
 
+  struct LineupInfo {
+    CHAR_STRING operatorName = 0;
+    CHAR_STRING lineupName = 1;
+    CHAR_STRING postalCode = 2;
+    LineupInfoTypeEnum lineupInfoType = 3;
+  }
+
   readonly attribute ChannelInfo channelList[] = 0;
+  attribute LineupInfo channelLineup = 1;
+  attribute ChannelInfo currentChannel = 2;
   readonly global attribute command_id serverGeneratedCommandList[] = 65528;
   readonly global attribute command_id clientGeneratedCommandList[] = 65529;
   readonly global attribute attrib_id attributeList[] = 65531;
@@ -2291,9 +2306,15 @@ client cluster MediaPlayback = 1286 {
     kSeekOutOfRange = 5;
   }
 
+  struct PlaybackPosition {
+    INT64U updatedAt = 0;
+    INT64U position = 1;
+  }
+
   readonly attribute PlaybackStateEnum playbackState = 0;
   readonly attribute epoch_us startTime = 1;
   readonly attribute int64u duration = 2;
+  attribute PlaybackPosition position = 3;
   readonly attribute single playbackSpeed = 4;
   readonly attribute int64u seekRangeEnd = 5;
   readonly attribute int64u seekRangeStart = 6;

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -8015,7 +8015,7 @@
           ],
           "attributes": [
             {
-              "name": "groupKeyMap",
+              "name": "GroupKeyMap",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -8030,7 +8030,7 @@
               "reportableChange": 0
             },
             {
-              "name": "groupTable",
+              "name": "GroupTable",
               "code": 1,
               "mfgCode": null,
               "side": "server",
@@ -8045,7 +8045,7 @@
               "reportableChange": 0
             },
             {
-              "name": "maxGroupsPerFabric",
+              "name": "MaxGroupsPerFabric",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -8060,7 +8060,7 @@
               "reportableChange": 0
             },
             {
-              "name": "maxGroupKeysPerFabric",
+              "name": "MaxGroupKeysPerFabric",
               "code": 3,
               "mfgCode": null,
               "side": "server",
@@ -14085,7 +14085,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "included": 0,
+              "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
@@ -14100,7 +14100,7 @@
               "code": 2,
               "mfgCode": null,
               "side": "server",
-              "included": 0,
+              "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
@@ -14560,7 +14560,7 @@
               "code": 3,
               "mfgCode": null,
               "side": "server",
-              "included": 0,
+              "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
@@ -15624,7 +15624,7 @@
               "code": 1,
               "mfgCode": null,
               "side": "server",
-              "included": 0,
+              "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
@@ -17946,5 +17946,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 22
     }
-  ]
+  ],
+  "log": []
 }

--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -35,7 +35,6 @@ if ({{source}}.IsNull()) {
       ChipLogError(Zcl, "Could not find class ChipStructs${{cluster}}Cluster{{asUpperCamelCase type}}");
       return {{earlyReturn}};
     }
-    chip::JniClass structJniClass({{asLowerCamelCase type}}StructClass);
     jmethodID {{asLowerCamelCase type}}StructCtor = env->GetMethodID({{asLowerCamelCase type}}StructClass, "<init>"
         , "({{#zcl_struct_items_by_struct_name type}}{{asJniSignature type null ../cluster true}}{{/zcl_struct_items_by_struct_name}})V");
     if ({{asLowerCamelCase type}}StructCtor == nullptr) {

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -158,7 +158,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterTarget");
                             return nullptr;
                         }
-                        chip::JniClass structJniClass(targetStructClass);
                         jmethodID targetStructCtor =
                             env->GetMethodID(targetStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
                         if (targetStructCtor == nullptr)
@@ -181,7 +180,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlEntry");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(accessControlEntryStructClass);
                 jmethodID accessControlEntryStructCtor = env->GetMethodID(
                     accessControlEntryStructClass, "<init>",
                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
@@ -234,7 +232,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterExtensionEntry");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(extensionEntryStructClass);
                 jmethodID extensionEntryStructCtor =
                     env->GetMethodID(extensionEntryStructClass, "<init>", "(Ljava/lang/Integer;[B)V");
                 if (extensionEntryStructCtor == nullptr)
@@ -667,7 +664,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationBasicClusterApplicationBasicApplication");
                 return nullptr;
             }
-            chip::JniClass structJniClass(applicationBasicApplicationStructClass);
             jmethodID applicationBasicApplicationStructCtor =
                 env->GetMethodID(applicationBasicApplicationStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
             if (applicationBasicApplicationStructCtor == nullptr)
@@ -852,6 +848,67 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
             return value;
         }
+        case Attributes::ApplicationLauncherApp::Id: {
+            using TypeInfo = Attributes::ApplicationLauncherApp::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            jobject value_application;
+            jobject value_application_catalogVendorId;
+            std::string value_application_catalogVendorIdClassName     = "java/lang/Integer";
+            std::string value_application_catalogVendorIdCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                value_application_catalogVendorIdClassName.c_str(), value_application_catalogVendorIdCtorSignature.c_str(),
+                cppValue.application.catalogVendorId, value_application_catalogVendorId);
+            jobject value_application_applicationId;
+            value_application_applicationId = env->NewStringUTF(
+                std::string(cppValue.application.applicationId.data(), cppValue.application.applicationId.size()).c_str());
+
+            jclass applicationStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(
+                env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplication", applicationStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplication");
+                return nullptr;
+            }
+            jmethodID applicationStructCtor =
+                env->GetMethodID(applicationStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
+            if (applicationStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplication constructor");
+                return nullptr;
+            }
+
+            value_application = env->NewObject(applicationStructClass, applicationStructCtor, value_application_catalogVendorId,
+                                               value_application_applicationId);
+            jobject value_endpoint;
+            value_endpoint = env->NewStringUTF(std::string(cppValue.endpoint.data(), cppValue.endpoint.size()).c_str());
+
+            jclass applicationEPStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(
+                env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationEP", applicationEPStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplicationEP");
+                return nullptr;
+            }
+            jmethodID applicationEPStructCtor =
+                env->GetMethodID(applicationEPStructClass, "<init>",
+                                 "(Lchip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplication;Ljava/lang/String;)V");
+            if (applicationEPStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplicationEP constructor");
+                return nullptr;
+            }
+
+            value = env->NewObject(applicationEPStructClass, applicationEPStructCtor, value_application, value_endpoint);
+            return value;
+        }
         case Attributes::ServerGeneratedCommandList::Id: {
             using TypeInfo = Attributes::ServerGeneratedCommandList::TypeInfo;
             TypeInfo::DecodableType cppValue;
@@ -988,7 +1045,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$AudioOutputClusterOutputInfo");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(outputInfoStructClass);
                 jmethodID outputInfoStructCtor = env->GetMethodID(outputInfoStructClass, "<init>",
                                                                   "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V");
                 if (outputInfoStructCtor == nullptr)
@@ -2026,7 +2082,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$BridgedActionsClusterActionStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(actionStructStructClass);
                 jmethodID actionStructStructCtor =
                     env->GetMethodID(actionStructStructClass, "<init>",
                                      "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
@@ -2098,7 +2153,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$BridgedActionsClusterEndpointListStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(endpointListStructStructClass);
                 jmethodID endpointListStructStructCtor =
                     env->GetMethodID(endpointListStructStructClass, "<init>",
                                      "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
@@ -2545,7 +2599,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(channelInfoStructClass);
                 jmethodID channelInfoStructCtor = env->GetMethodID(
                     channelInfoStructClass, "<init>",
                     "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
@@ -2560,6 +2613,98 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                               newElement_0_affiliateCallSign);
                 chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
             }
+            return value;
+        }
+        case Attributes::ChannelLineup::Id: {
+            using TypeInfo = Attributes::ChannelLineup::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            jobject value_operatorName;
+            value_operatorName = env->NewStringUTF(std::string(cppValue.operatorName.data(), cppValue.operatorName.size()).c_str());
+            jobject value_lineupName;
+            value_lineupName = env->NewStringUTF(std::string(cppValue.lineupName.data(), cppValue.lineupName.size()).c_str());
+            jobject value_postalCode;
+            value_postalCode = env->NewStringUTF(std::string(cppValue.postalCode.data(), cppValue.postalCode.size()).c_str());
+            jobject value_lineupInfoType;
+            std::string value_lineupInfoTypeClassName     = "java/lang/Integer";
+            std::string value_lineupInfoTypeCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
+                value_lineupInfoTypeClassName.c_str(), value_lineupInfoTypeCtorSignature.c_str(),
+                static_cast<uint8_t>(cppValue.lineupInfoType), value_lineupInfoType);
+
+            jclass lineupInfoStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs$ChannelClusterLineupInfo",
+                                                                 lineupInfoStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterLineupInfo");
+                return nullptr;
+            }
+            jmethodID lineupInfoStructCtor = env->GetMethodID(
+                lineupInfoStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V");
+            if (lineupInfoStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterLineupInfo constructor");
+                return nullptr;
+            }
+
+            value = env->NewObject(lineupInfoStructClass, lineupInfoStructCtor, value_operatorName, value_lineupName,
+                                   value_postalCode, value_lineupInfoType);
+            return value;
+        }
+        case Attributes::CurrentChannel::Id: {
+            using TypeInfo = Attributes::CurrentChannel::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            jobject value_majorNumber;
+            std::string value_majorNumberClassName     = "java/lang/Integer";
+            std::string value_majorNumberCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(value_majorNumberClassName.c_str(),
+                                                                           value_majorNumberCtorSignature.c_str(),
+                                                                           cppValue.majorNumber, value_majorNumber);
+            jobject value_minorNumber;
+            std::string value_minorNumberClassName     = "java/lang/Integer";
+            std::string value_minorNumberCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(value_minorNumberClassName.c_str(),
+                                                                           value_minorNumberCtorSignature.c_str(),
+                                                                           cppValue.minorNumber, value_minorNumber);
+            jobject value_name;
+            value_name = env->NewStringUTF(std::string(cppValue.name.data(), cppValue.name.size()).c_str());
+            jobject value_callSign;
+            value_callSign = env->NewStringUTF(std::string(cppValue.callSign.data(), cppValue.callSign.size()).c_str());
+            jobject value_affiliateCallSign;
+            value_affiliateCallSign =
+                env->NewStringUTF(std::string(cppValue.affiliateCallSign.data(), cppValue.affiliateCallSign.size()).c_str());
+
+            jclass channelInfoStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfo",
+                                                                 channelInfoStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
+                return nullptr;
+            }
+            jmethodID channelInfoStructCtor =
+                env->GetMethodID(channelInfoStructClass, "<init>",
+                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+            if (channelInfoStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfo constructor");
+                return nullptr;
+            }
+
+            value = env->NewObject(channelInfoStructClass, channelInfoStructCtor, value_majorNumber, value_minorNumber, value_name,
+                                   value_callSign, value_affiliateCallSign);
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -3702,7 +3847,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$DescriptorClusterDeviceType");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(deviceTypeStructClass);
                 jmethodID deviceTypeStructCtor =
                     env->GetMethodID(deviceTypeStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
                 if (deviceTypeStructCtor == nullptr)
@@ -4950,7 +5094,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$FixedLabelClusterLabelStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(labelStructStructClass);
                 jmethodID labelStructStructCtor =
                     env->GetMethodID(labelStructStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
                 if (labelStructStructCtor == nullptr)
@@ -5259,7 +5402,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$GeneralCommissioningClusterBasicCommissioningInfo");
                 return nullptr;
             }
-            chip::JniClass structJniClass(basicCommissioningInfoStructClass);
             jmethodID basicCommissioningInfoStructCtor =
                 env->GetMethodID(basicCommissioningInfoStructClass, "<init>", "(Ljava/lang/Integer;)V");
             if (basicCommissioningInfoStructCtor == nullptr)
@@ -5460,7 +5602,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GeneralDiagnosticsClusterNetworkInterfaceType");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(networkInterfaceTypeStructClass);
                 jmethodID networkInterfaceTypeStructCtor = env->GetMethodID(
                     networkInterfaceTypeStructClass, "<init>",
                     "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/lang/Integer;)V");
@@ -5751,7 +5892,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(groupKeyMapStructStructClass);
                 jmethodID groupKeyMapStructStructCtor = env->GetMethodID(
                     groupKeyMapStructStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
                 if (groupKeyMapStructStructCtor == nullptr)
@@ -5828,7 +5968,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(groupInfoMapStructStructClass);
                 jmethodID groupInfoMapStructStructCtor =
                     env->GetMethodID(groupInfoMapStructStructClass, "<init>",
                                      "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/Optional;)V");
@@ -7109,7 +7248,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$MediaInputClusterInputInfo");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(inputInfoStructClass);
                 jmethodID inputInfoStructCtor =
                     env->GetMethodID(inputInfoStructClass, "<init>",
                                      "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V");
@@ -7280,6 +7418,45 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             std::string valueCtorSignature = "(J)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
                                                                            cppValue, value);
+            return value;
+        }
+        case Attributes::Position::Id: {
+            using TypeInfo = Attributes::Position::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            jobject value_updatedAt;
+            std::string value_updatedAtClassName     = "java/lang/Long";
+            std::string value_updatedAtCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
+                value_updatedAtClassName.c_str(), value_updatedAtCtorSignature.c_str(), cppValue.updatedAt, value_updatedAt);
+            jobject value_position;
+            std::string value_positionClassName     = "java/lang/Long";
+            std::string value_positionCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
+                value_positionClassName.c_str(), value_positionCtorSignature.c_str(), cppValue.position, value_position);
+
+            jclass playbackPositionStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(
+                env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterPlaybackPosition", playbackPositionStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$MediaPlaybackClusterPlaybackPosition");
+                return nullptr;
+            }
+            jmethodID playbackPositionStructCtor =
+                env->GetMethodID(playbackPositionStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
+            if (playbackPositionStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$MediaPlaybackClusterPlaybackPosition constructor");
+                return nullptr;
+            }
+
+            value = env->NewObject(playbackPositionStructClass, playbackPositionStructCtor, value_updatedAt, value_position);
             return value;
         }
         case Attributes::PlaybackSpeed::Id: {
@@ -7477,7 +7654,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ModeSelectClusterModeOptionStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(modeOptionStructStructClass);
                 jmethodID modeOptionStructStructCtor = env->GetMethodID(modeOptionStructStructClass, "<init>",
                                                                         "(Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;)V");
                 if (modeOptionStructStructCtor == nullptr)
@@ -7682,7 +7858,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterNetworkInfo");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(networkInfoStructClass);
                 jmethodID networkInfoStructCtor = env->GetMethodID(networkInfoStructClass, "<init>", "([BLjava/lang/Boolean;)V");
                 if (networkInfoStructCtor == nullptr)
                 {
@@ -7967,7 +8142,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(providerLocationStructClass);
                 jmethodID providerLocationStructCtor = env->GetMethodID(
                     providerLocationStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;)V");
                 if (providerLocationStructCtor == nullptr)
@@ -8587,7 +8761,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterNOCStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(NOCStructStructClass);
                 jmethodID NOCStructStructCtor = env->GetMethodID(NOCStructStructClass, "<init>", "(Ljava/lang/Integer;[B[B)V");
                 if (NOCStructStructCtor == nullptr)
                 {
@@ -8659,7 +8832,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterFabricDescriptor");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(fabricDescriptorStructClass);
                 jmethodID fabricDescriptorStructCtor = env->GetMethodID(
                     fabricDescriptorStructClass, "<init>",
                     "(Ljava/lang/Integer;[BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)V");
@@ -10175,7 +10347,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$SoftwareDiagnosticsClusterThreadMetrics");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(threadMetricsStructClass);
                 jmethodID threadMetricsStructCtor =
                     env->GetMethodID(threadMetricsStructClass, "<init>",
                                      "(Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
@@ -10538,7 +10709,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TargetNavigatorClusterTargetInfo");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(targetInfoStructClass);
                 jmethodID targetInfoStructCtor =
                     env->GetMethodID(targetInfoStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
                 if (targetInfoStructCtor == nullptr)
@@ -11250,7 +11420,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterTestListStructOctet");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(testListStructOctetStructClass);
                 jmethodID testListStructOctetStructCtor =
                     env->GetMethodID(testListStructOctetStructClass, "<init>", "(Ljava/lang/Long;[B)V");
                 if (testListStructOctetStructCtor == nullptr)
@@ -11513,7 +11682,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                         return nullptr;
                     }
-                    chip::JniClass structJniClass(simpleStructStructClass);
                     jmethodID simpleStructStructCtor =
                         env->GetMethodID(simpleStructStructClass, "<init>",
                                          "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -11592,7 +11760,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                         return nullptr;
                     }
-                    chip::JniClass structJniClass(simpleStructStructClass);
                     jmethodID simpleStructStructCtor =
                         env->GetMethodID(simpleStructStructClass, "<init>",
                                          "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -11687,7 +11854,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                             return nullptr;
                         }
-                        chip::JniClass structJniClass(simpleStructStructClass);
                         jmethodID simpleStructStructCtor =
                             env->GetMethodID(simpleStructStructClass, "<init>",
                                              "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/"
@@ -11789,7 +11955,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterNullablesAndOptionalsStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(nullablesAndOptionalsStructStructClass);
                 jmethodID nullablesAndOptionalsStructStructCtor = env->GetMethodID(
                     nullablesAndOptionalsStructStructClass, "<init>",
                     "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/String;Ljava/util/Optional;Ljava/util/"
@@ -11881,7 +12046,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                 return nullptr;
             }
-            chip::JniClass structJniClass(simpleStructStructClass);
             jmethodID simpleStructStructCtor =
                 env->GetMethodID(simpleStructStructClass, "<init>",
                                  "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -12714,7 +12878,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(simpleStructStructClass);
                 jmethodID simpleStructStructCtor =
                     env->GetMethodID(simpleStructStructClass, "<init>",
                                      "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -13586,7 +13749,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTable");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(neighborTableStructClass);
                 jmethodID neighborTableStructCtor =
                     env->GetMethodID(neighborTableStructClass, "<init>",
                                      "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/"
@@ -13691,7 +13853,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterRouteTable");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(routeTableStructClass);
                 jmethodID routeTableStructCtor = env->GetMethodID(
                     routeTableStructClass, "<init>",
                     "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
@@ -14498,7 +14659,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterSecurityPolicy");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(securityPolicyStructClass);
                 jmethodID securityPolicyStructCtor =
                     env->GetMethodID(securityPolicyStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
                 if (securityPolicyStructCtor == nullptr)
@@ -14628,7 +14788,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                  "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterOperationalDatasetComponents");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(operationalDatasetComponentsStructClass);
                 jmethodID operationalDatasetComponentsStructCtor =
                     env->GetMethodID(operationalDatasetComponentsStructClass, "<init>",
                                      "(Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/"
@@ -15022,7 +15181,6 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$UserLabelClusterLabelStruct");
                     return nullptr;
                 }
-                chip::JniClass structJniClass(labelStructStructClass);
                 jmethodID labelStructStructCtor =
                     env->GetMethodID(labelStructStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
                 if (labelStructStructCtor == nullptr)

--- a/src/controller/java/zap-generated/CHIPCallbackTypes.h
+++ b/src/controller/java/zap-generated/CHIPCallbackTypes.h
@@ -93,6 +93,8 @@ typedef void (*CHIPApplicationLauncherClusterLauncherResponseCallbackType)(
 
 typedef void (*CHIPApplicationLauncherClusterApplicationLauncherListAttributeCallbackType)(
     void *, const chip::app::Clusters::ApplicationLauncher::Attributes::ApplicationLauncherList::TypeInfo::DecodableType &);
+typedef void (*CHIPApplicationLauncherClusterApplicationLauncherAppAttributeCallbackType)(
+    void *, chip::app::Clusters::ApplicationLauncher::Attributes::ApplicationLauncherApp::TypeInfo::DecodableArgType);
 typedef void (*CHIPApplicationLauncherClusterServerGeneratedCommandListAttributeCallbackType)(
     void *, const chip::app::Clusters::ApplicationLauncher::Attributes::ServerGeneratedCommandList::TypeInfo::DecodableType &);
 typedef void (*CHIPApplicationLauncherClusterClientGeneratedCommandListAttributeCallbackType)(
@@ -270,6 +272,10 @@ typedef void (*CHIPChannelClusterChangeChannelResponseCallbackType)(
 
 typedef void (*CHIPChannelClusterChannelListAttributeCallbackType)(
     void *, const chip::app::Clusters::Channel::Attributes::ChannelList::TypeInfo::DecodableType &);
+typedef void (*CHIPChannelClusterChannelLineupAttributeCallbackType)(
+    void *, chip::app::Clusters::Channel::Attributes::ChannelLineup::TypeInfo::DecodableArgType);
+typedef void (*CHIPChannelClusterCurrentChannelAttributeCallbackType)(
+    void *, chip::app::Clusters::Channel::Attributes::CurrentChannel::TypeInfo::DecodableArgType);
 typedef void (*CHIPChannelClusterServerGeneratedCommandListAttributeCallbackType)(
     void *, const chip::app::Clusters::Channel::Attributes::ServerGeneratedCommandList::TypeInfo::DecodableType &);
 typedef void (*CHIPChannelClusterClientGeneratedCommandListAttributeCallbackType)(
@@ -799,6 +805,8 @@ typedef void (*CHIPMediaPlaybackClusterStartTimeAttributeCallbackType)(
     void *, chip::app::Clusters::MediaPlayback::Attributes::StartTime::TypeInfo::DecodableArgType);
 typedef void (*CHIPMediaPlaybackClusterDurationAttributeCallbackType)(
     void *, chip::app::Clusters::MediaPlayback::Attributes::Duration::TypeInfo::DecodableArgType);
+typedef void (*CHIPMediaPlaybackClusterPositionAttributeCallbackType)(
+    void *, chip::app::Clusters::MediaPlayback::Attributes::Position::TypeInfo::DecodableArgType);
 typedef void (*CHIPMediaPlaybackClusterPlaybackSpeedAttributeCallbackType)(
     void *, chip::app::Clusters::MediaPlayback::Attributes::PlaybackSpeed::TypeInfo::DecodableArgType);
 typedef void (*CHIPMediaPlaybackClusterSeekRangeEndAttributeCallbackType)(

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -237,7 +237,6 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
         return;
     }
-    chip::JniClass structJniClass(channelInfoStructClass);
     jmethodID channelInfoStructCtor =
         env->GetMethodID(channelInfoStructClass, "<init>",
                          "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
@@ -638,7 +637,6 @@ void CHIPDoorLockClusterGetUserResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$DoorLockClusterDlCredential");
                 return;
             }
-            chip::JniClass structJniClass(dlCredentialStructClass);
             jmethodID dlCredentialStructCtor =
                 env->GetMethodID(dlCredentialStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
             if (dlCredentialStructCtor == nullptr)
@@ -1437,7 +1435,6 @@ void CHIPGroupKeyManagementClusterKeySetReadResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeySetStruct");
         return;
     }
-    chip::JniClass structJniClass(groupKeySetStructStructClass);
     jmethodID groupKeySetStructStructCtor =
         env->GetMethodID(groupKeySetStructStructClass, "<init>",
                          "(Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/Long;[BLjava/lang/Long;[BLjava/lang/Long;)V");
@@ -2158,7 +2155,6 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterWiFiInterfaceScanResult");
                 return;
             }
-            chip::JniClass structJniClass(wiFiInterfaceScanResultStructClass);
             jmethodID wiFiInterfaceScanResultStructCtor =
                 env->GetMethodID(wiFiInterfaceScanResultStructClass, "<init>",
                                  "(Ljava/lang/Integer;[B[BLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
@@ -2240,7 +2236,6 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
                 ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterThreadInterfaceScanResult");
                 return;
             }
-            chip::JniClass structJniClass(threadInterfaceScanResultStructClass);
             jmethodID threadInterfaceScanResultStructCtor =
                 env->GetMethodID(threadInterfaceScanResultStructClass, "<init>",
                                  "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
@@ -3235,7 +3230,6 @@ void CHIPScenesClusterViewSceneResponseCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ScenesClusterSceneExtensionFieldSet");
             return;
         }
-        chip::JniClass structJniClass(sceneExtensionFieldSetStructClass);
         jmethodID sceneExtensionFieldSetStructCtor = env->GetMethodID(sceneExtensionFieldSetStructClass, "<init>",
                                                                       "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;)V");
         if (sceneExtensionFieldSetStructCtor == nullptr)
@@ -3474,7 +3468,6 @@ void CHIPTestClusterClusterSimpleStructResponseCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
         return;
     }
-    chip::JniClass structJniClass(simpleStructStructClass);
     jmethodID simpleStructStructCtor = env->GetMethodID(simpleStructStructClass, "<init>",
                                                         "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/"
                                                         "String;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Double;)V");

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -833,7 +833,6 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
                     ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterTarget");
                     return;
                 }
-                chip::JniClass structJniClass(targetStructClass);
                 jmethodID targetStructCtor =
                     env->GetMethodID(targetStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;)V");
                 if (targetStructCtor == nullptr)
@@ -856,7 +855,6 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterAccessControlEntry");
             return;
         }
-        chip::JniClass structJniClass(accessControlEntryStructClass);
         jmethodID accessControlEntryStructCtor = env->GetMethodID(
             accessControlEntryStructClass, "<init>",
             "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/ArrayList;)V");
@@ -954,7 +952,6 @@ void CHIPAccessControlExtensionAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$AccessControlClusterExtensionEntry");
             return;
         }
-        chip::JniClass structJniClass(extensionEntryStructClass);
         jmethodID extensionEntryStructCtor = env->GetMethodID(extensionEntryStructClass, "<init>", "(Ljava/lang/Integer;[B)V");
         if (extensionEntryStructCtor == nullptr)
         {
@@ -2326,7 +2323,6 @@ void CHIPAudioOutputAudioOutputListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$AudioOutputClusterOutputInfo");
             return;
         }
-        chip::JniClass structJniClass(outputInfoStructClass);
         jmethodID outputInfoStructCtor =
             env->GetMethodID(outputInfoStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V");
         if (outputInfoStructCtor == nullptr)
@@ -3773,7 +3769,6 @@ void CHIPBridgedActionsActionListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$BridgedActionsClusterActionStruct");
             return;
         }
-        chip::JniClass structJniClass(actionStructStructClass);
         jmethodID actionStructStructCtor = env->GetMethodID(
             actionStructStructClass, "<init>",
             "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
@@ -3892,7 +3887,6 @@ void CHIPBridgedActionsEndpointListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$BridgedActionsClusterEndpointListStruct");
             return;
         }
-        chip::JniClass structJniClass(endpointListStructStructClass);
         jmethodID endpointListStructStructCtor =
             env->GetMethodID(endpointListStructStructClass, "<init>",
                              "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/ArrayList;)V");
@@ -4426,7 +4420,6 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
             return;
         }
-        chip::JniClass structJniClass(channelInfoStructClass);
         jmethodID channelInfoStructCtor =
             env->GetMethodID(channelInfoStructClass, "<init>",
                              "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
@@ -5230,7 +5223,6 @@ void CHIPDescriptorDeviceListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$DescriptorClusterDeviceType");
             return;
         }
-        chip::JniClass structJniClass(deviceTypeStructClass);
         jmethodID deviceTypeStructCtor =
             env->GetMethodID(deviceTypeStructClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
         if (deviceTypeStructCtor == nullptr)
@@ -6924,7 +6916,6 @@ void CHIPFixedLabelLabelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$FixedLabelClusterLabelStruct");
             return;
         }
-        chip::JniClass structJniClass(labelStructStructClass);
         jmethodID labelStructStructCtor =
             env->GetMethodID(labelStructStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
         if (labelStructStructCtor == nullptr)
@@ -7685,7 +7676,6 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$GeneralDiagnosticsClusterNetworkInterfaceType");
             return;
         }
-        chip::JniClass structJniClass(networkInterfaceTypeStructClass);
         jmethodID networkInterfaceTypeStructCtor =
             env->GetMethodID(networkInterfaceTypeStructClass, "<init>",
                              "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/lang/Integer;)V");
@@ -8223,7 +8213,6 @@ void CHIPGroupKeyManagementGroupKeyMapAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct");
             return;
         }
-        chip::JniClass structJniClass(groupKeyMapStructStructClass);
         jmethodID groupKeyMapStructStructCtor = env->GetMethodID(groupKeyMapStructStructClass, "<init>",
                                                                  "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
         if (groupKeyMapStructStructCtor == nullptr)
@@ -8348,7 +8337,6 @@ void CHIPGroupKeyManagementGroupTableAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct");
             return;
         }
-        chip::JniClass structJniClass(groupInfoMapStructStructClass);
         jmethodID groupInfoMapStructStructCtor =
             env->GetMethodID(groupInfoMapStructStructClass, "<init>",
                              "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/ArrayList;Ljava/util/Optional;)V");
@@ -10749,7 +10737,6 @@ void CHIPMediaInputMediaInputListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$MediaInputClusterInputInfo");
             return;
         }
-        chip::JniClass structJniClass(inputInfoStructClass);
         jmethodID inputInfoStructCtor = env->GetMethodID(
             inputInfoStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V");
         if (inputInfoStructCtor == nullptr)
@@ -11272,7 +11259,6 @@ void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ModeSelectClusterModeOptionStruct");
             return;
         }
-        chip::JniClass structJniClass(modeOptionStructStructClass);
         jmethodID modeOptionStructStructCtor =
             env->GetMethodID(modeOptionStructStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;)V");
         if (modeOptionStructStructCtor == nullptr)
@@ -11583,7 +11569,6 @@ void CHIPNetworkCommissioningNetworksAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterNetworkInfo");
             return;
         }
-        chip::JniClass structJniClass(networkInfoStructClass);
         jmethodID networkInfoStructCtor = env->GetMethodID(networkInfoStructClass, "<init>", "([BLjava/lang/Boolean;)V");
         if (networkInfoStructCtor == nullptr)
         {
@@ -11906,7 +11891,6 @@ void CHIPOtaSoftwareUpdateRequestorDefaultOtaProvidersAttributeCallback::Callbac
             ChipLogError(Zcl, "Could not find class ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation");
             return;
         }
-        chip::JniClass structJniClass(providerLocationStructClass);
         jmethodID providerLocationStructCtor =
             env->GetMethodID(providerLocationStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Integer;)V");
         if (providerLocationStructCtor == nullptr)
@@ -12796,7 +12780,6 @@ void CHIPOperationalCredentialsNOCsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterNOCStruct");
             return;
         }
-        chip::JniClass structJniClass(NOCStructStructClass);
         jmethodID NOCStructStructCtor = env->GetMethodID(NOCStructStructClass, "<init>", "(Ljava/lang/Integer;[B[B)V");
         if (NOCStructStructCtor == nullptr)
         {
@@ -12914,7 +12897,6 @@ void CHIPOperationalCredentialsFabricsListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$OperationalCredentialsClusterFabricDescriptor");
             return;
         }
-        chip::JniClass structJniClass(fabricDescriptorStructClass);
         jmethodID fabricDescriptorStructCtor =
             env->GetMethodID(fabricDescriptorStructClass, "<init>",
                              "(Ljava/lang/Integer;[BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)V");
@@ -14800,7 +14782,6 @@ void CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$SoftwareDiagnosticsClusterThreadMetrics");
             return;
         }
-        chip::JniClass structJniClass(threadMetricsStructClass);
         jmethodID threadMetricsStructCtor =
             env->GetMethodID(threadMetricsStructClass, "<init>",
                              "(Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
@@ -15323,7 +15304,6 @@ void CHIPTargetNavigatorTargetNavigatorListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$TargetNavigatorClusterTargetInfo");
             return;
         }
-        chip::JniClass structJniClass(targetInfoStructClass);
         jmethodID targetInfoStructCtor =
             env->GetMethodID(targetInfoStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
         if (targetInfoStructCtor == nullptr)
@@ -15845,7 +15825,6 @@ void CHIPTestClusterListStructOctetStringAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterTestListStructOctet");
             return;
         }
-        chip::JniClass structJniClass(testListStructOctetStructClass);
         jmethodID testListStructOctetStructCtor =
             env->GetMethodID(testListStructOctetStructClass, "<init>", "(Ljava/lang/Long;[B)V");
         if (testListStructOctetStructCtor == nullptr)
@@ -16129,7 +16108,6 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                 return;
             }
-            chip::JniClass structJniClass(simpleStructStructClass);
             jmethodID simpleStructStructCtor =
                 env->GetMethodID(simpleStructStructClass, "<init>",
                                  "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -16207,7 +16185,6 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                 return;
             }
-            chip::JniClass structJniClass(simpleStructStructClass);
             jmethodID simpleStructStructCtor =
                 env->GetMethodID(simpleStructStructClass, "<init>",
                                  "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -16299,7 +16276,6 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                     ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterSimpleStruct");
                     return;
                 }
-                chip::JniClass structJniClass(simpleStructStructClass);
                 jmethodID simpleStructStructCtor =
                     env->GetMethodID(simpleStructStructClass, "<init>",
                                      "(Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Integer;[BLjava/lang/String;Ljava/lang/"
@@ -16401,7 +16377,6 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
             ChipLogError(Zcl, "Could not find class ChipStructs$TestClusterClusterNullablesAndOptionalsStruct");
             return;
         }
-        chip::JniClass structJniClass(nullablesAndOptionalsStructStructClass);
         jmethodID nullablesAndOptionalsStructStructCtor =
             env->GetMethodID(nullablesAndOptionalsStructStructClass, "<init>",
                              "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/String;Ljava/util/"
@@ -19283,7 +19258,6 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTable");
             return;
         }
-        chip::JniClass structJniClass(neighborTableStructClass);
         jmethodID neighborTableStructCtor =
             env->GetMethodID(neighborTableStructClass, "<init>",
                              "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/"
@@ -19434,7 +19408,6 @@ void CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterRouteTable");
             return;
         }
-        chip::JniClass structJniClass(routeTableStructClass);
         jmethodID routeTableStructCtor =
             env->GetMethodID(routeTableStructClass, "<init>",
                              "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/"
@@ -19537,7 +19510,6 @@ void CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterSecurityPolicy");
             return;
         }
-        chip::JniClass structJniClass(securityPolicyStructClass);
         jmethodID securityPolicyStructCtor =
             env->GetMethodID(securityPolicyStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
         if (securityPolicyStructCtor == nullptr)
@@ -19701,7 +19673,6 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::
             ChipLogError(Zcl, "Could not find class ChipStructs$ThreadNetworkDiagnosticsClusterOperationalDatasetComponents");
             return;
         }
-        chip::JniClass structJniClass(operationalDatasetComponentsStructClass);
         jmethodID operationalDatasetComponentsStructCtor =
             env->GetMethodID(operationalDatasetComponentsStructClass, "<init>",
                              "(Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/"
@@ -20372,7 +20343,6 @@ void CHIPUserLabelLabelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$UserLabelClusterLabelStruct");
             return;
         }
-        chip::JniClass structJniClass(labelStructStructClass);
         jmethodID labelStructStructCtor =
             env->GetMethodID(labelStructStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
         if (labelStructStructCtor == nullptr)

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -321,6 +321,13 @@ class ChipClusters:
                     "type": "int",
                     "reportable": True,
                 },
+                0x00000001: {
+                    "attributeName": "ApplicationLauncherApp",
+                    "attributeId": 0x00000001,
+                    "type": "",
+                    "reportable": True,
+                    "writable": True,
+                },
                 0x0000FFF8: {
                     "attributeName": "ServerGeneratedCommandList",
                     "attributeId": 0x0000FFF8,
@@ -1067,6 +1074,20 @@ class ChipClusters:
                     "attributeId": 0x00000000,
                     "type": "",
                     "reportable": True,
+                },
+                0x00000001: {
+                    "attributeName": "ChannelLineup",
+                    "attributeId": 0x00000001,
+                    "type": "",
+                    "reportable": True,
+                    "writable": True,
+                },
+                0x00000002: {
+                    "attributeName": "CurrentChannel",
+                    "attributeId": 0x00000002,
+                    "type": "",
+                    "reportable": True,
+                    "writable": True,
                 },
                 0x0000FFF8: {
                     "attributeName": "ServerGeneratedCommandList",
@@ -3344,6 +3365,13 @@ class ChipClusters:
                     "attributeId": 0x00000002,
                     "type": "int",
                     "reportable": True,
+                },
+                0x00000003: {
+                    "attributeName": "Position",
+                    "attributeId": 0x00000003,
+                    "type": "",
+                    "reportable": True,
+                    "writable": True,
                 },
                 0x00000004: {
                     "attributeName": "PlaybackSpeed",

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -707,6 +707,25 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             value = array_0;
             return value;
         }
+        case Attributes::ApplicationLauncherApp::Id: {
+            using TypeInfo = Attributes::ApplicationLauncherApp::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR) {
+                return nil;
+            }
+            CHIPApplicationLauncherClusterApplicationEP * _Nonnull value;
+            value = [CHIPApplicationLauncherClusterApplicationEP new];
+            value.application = [CHIPApplicationLauncherClusterApplication new];
+            value.application.catalogVendorId = [NSNumber numberWithUnsignedShort:cppValue.application.catalogVendorId];
+            value.application.applicationId = [[NSString alloc] initWithBytes:cppValue.application.applicationId.data()
+                                                                       length:cppValue.application.applicationId.size()
+                                                                     encoding:NSUTF8StringEncoding];
+            value.endpoint = [[NSString alloc] initWithBytes:cppValue.endpoint.data()
+                                                      length:cppValue.endpoint.size()
+                                                    encoding:NSUTF8StringEncoding];
+            return value;
+        }
         case Attributes::ServerGeneratedCommandList::Id: {
             using TypeInfo = Attributes::ServerGeneratedCommandList::TypeInfo;
             TypeInfo::DecodableType cppValue;
@@ -2209,6 +2228,49 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 }
             }
             value = array_0;
+            return value;
+        }
+        case Attributes::ChannelLineup::Id: {
+            using TypeInfo = Attributes::ChannelLineup::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR) {
+                return nil;
+            }
+            CHIPChannelClusterLineupInfo * _Nonnull value;
+            value = [CHIPChannelClusterLineupInfo new];
+            value.operatorName = [[NSString alloc] initWithBytes:cppValue.operatorName.data()
+                                                          length:cppValue.operatorName.size()
+                                                        encoding:NSUTF8StringEncoding];
+            value.lineupName = [[NSString alloc] initWithBytes:cppValue.lineupName.data()
+                                                        length:cppValue.lineupName.size()
+                                                      encoding:NSUTF8StringEncoding];
+            value.postalCode = [[NSString alloc] initWithBytes:cppValue.postalCode.data()
+                                                        length:cppValue.postalCode.size()
+                                                      encoding:NSUTF8StringEncoding];
+            value.lineupInfoType = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppValue.lineupInfoType)];
+            return value;
+        }
+        case Attributes::CurrentChannel::Id: {
+            using TypeInfo = Attributes::CurrentChannel::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR) {
+                return nil;
+            }
+            CHIPChannelClusterChannelInfo * _Nonnull value;
+            value = [CHIPChannelClusterChannelInfo new];
+            value.majorNumber = [NSNumber numberWithUnsignedShort:cppValue.majorNumber];
+            value.minorNumber = [NSNumber numberWithUnsignedShort:cppValue.minorNumber];
+            value.name = [[NSString alloc] initWithBytes:cppValue.name.data()
+                                                  length:cppValue.name.size()
+                                                encoding:NSUTF8StringEncoding];
+            value.callSign = [[NSString alloc] initWithBytes:cppValue.callSign.data()
+                                                      length:cppValue.callSign.size()
+                                                    encoding:NSUTF8StringEncoding];
+            value.affiliateCallSign = [[NSString alloc] initWithBytes:cppValue.affiliateCallSign.data()
+                                                               length:cppValue.affiliateCallSign.size()
+                                                             encoding:NSUTF8StringEncoding];
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -6211,6 +6273,19 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             }
             NSNumber * _Nonnull value;
             value = [NSNumber numberWithUnsignedLongLong:cppValue];
+            return value;
+        }
+        case Attributes::Position::Id: {
+            using TypeInfo = Attributes::Position::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR) {
+                return nil;
+            }
+            CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull value;
+            value = [CHIPMediaPlaybackClusterPlaybackPosition new];
+            value.updatedAt = [NSNumber numberWithUnsignedLongLong:cppValue.updatedAt];
+            value.position = [NSNumber numberWithUnsignedLongLong:cppValue.position];
             return value;
         }
         case Attributes::PlaybackSpeed::Id: {

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -401,6 +401,7 @@ private:
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * ApplicationLauncherList                                           | 0x0000 |
+| * ApplicationLauncherApp                                            | 0x0001 |
 | * ServerGeneratedCommandList                                        | 0xFFF8 |
 | * ClientGeneratedCommandList                                        | 0xFFF9 |
 | * AttributeList                                                     | 0xFFFB |
@@ -483,6 +484,29 @@ public:
 private:
     chip::app::Clusters::ApplicationLauncher::Commands::StopAppRequest::Type mRequest;
     TypedComplexArgument<chip::app::Clusters::ApplicationLauncher::Structs::Application::Type> mComplex_Application;
+};
+
+class WriteApplicationLauncherApplicationLauncherApp : public WriteAttribute
+{
+public:
+    WriteApplicationLauncherApplicationLauncherApp(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("ApplicationLauncherApp", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "application-launcher-app");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteApplicationLauncherApplicationLauncherApp() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x0000050C, 0x00000001, mValue);
+    }
+
+private:
+    chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type mValue;
+    TypedComplexArgument<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type> mComplex;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -1257,6 +1281,8 @@ private:
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * ChannelList                                                       | 0x0000 |
+| * ChannelLineup                                                     | 0x0001 |
+| * CurrentChannel                                                    | 0x0002 |
 | * ServerGeneratedCommandList                                        | 0xFFF8 |
 | * ClientGeneratedCommandList                                        | 0xFFF9 |
 | * AttributeList                                                     | 0xFFFB |
@@ -1336,6 +1362,52 @@ public:
 
 private:
     chip::app::Clusters::Channel::Commands::SkipChannelRequest::Type mRequest;
+};
+
+class WriteChannelChannelLineup : public WriteAttribute
+{
+public:
+    WriteChannelChannelLineup(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("ChannelLineup", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "channel-lineup");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteChannelChannelLineup() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x00000504, 0x00000001, mValue);
+    }
+
+private:
+    chip::app::Clusters::Channel::Structs::LineupInfo::Type mValue;
+    TypedComplexArgument<chip::app::Clusters::Channel::Structs::LineupInfo::Type> mComplex;
+};
+
+class WriteChannelCurrentChannel : public WriteAttribute
+{
+public:
+    WriteChannelCurrentChannel(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("CurrentChannel", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "current-channel");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteChannelCurrentChannel() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x00000504, 0x00000002, mValue);
+    }
+
+private:
+    chip::app::Clusters::Channel::Structs::ChannelInfo::Type mValue;
+    TypedComplexArgument<chip::app::Clusters::Channel::Structs::ChannelInfo::Type> mComplex;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -4282,6 +4354,7 @@ private:
 | * PlaybackState                                                     | 0x0000 |
 | * StartTime                                                         | 0x0001 |
 | * Duration                                                          | 0x0002 |
+| * Position                                                          | 0x0003 |
 | * PlaybackSpeed                                                     | 0x0004 |
 | * SeekRangeEnd                                                      | 0x0005 |
 | * SeekRangeStart                                                    | 0x0006 |
@@ -4541,6 +4614,29 @@ public:
 
 private:
     chip::app::Clusters::MediaPlayback::Commands::StopRequest::Type mRequest;
+};
+
+class WriteMediaPlaybackPosition : public WriteAttribute
+{
+public:
+    WriteMediaPlaybackPosition(CredentialIssuerCommands * credsIssuerConfig) :
+        WriteAttribute("Position", credsIssuerConfig), mComplex(&mValue)
+    {
+        AddArgument("attr-name", "position");
+        AddArgument("attr-value", &mComplex);
+        WriteAttribute::AddArguments();
+    }
+
+    ~WriteMediaPlaybackPosition() {}
+
+    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
+    {
+        return WriteAttribute::SendCommand(device, endpointId, 0x00000506, 0x00000003, mValue);
+    }
+
+private:
+    chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Type mValue;
+    TypedComplexArgument<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Type> mComplex;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -9502,6 +9598,7 @@ void registerClusterApplicationLauncher(Commands & commands, CredentialIssuerCom
         //
         make_unique<ReadAttribute>(Id, credsIssuerConfig),                                                                       //
         make_unique<ReadAttribute>(Id, "application-launcher-list", Attributes::ApplicationLauncherList::Id, credsIssuerConfig), //
+        make_unique<ReadAttribute>(Id, "application-launcher-app", Attributes::ApplicationLauncherApp::Id, credsIssuerConfig),   //
         make_unique<ReadAttribute>(Id, "server-generated-command-list", Attributes::ServerGeneratedCommandList::Id,
                                    credsIssuerConfig), //
         make_unique<ReadAttribute>(Id, "client-generated-command-list", Attributes::ClientGeneratedCommandList::Id,
@@ -9509,8 +9606,11 @@ void registerClusterApplicationLauncher(Commands & commands, CredentialIssuerCom
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),     //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig), //
         make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                     //
+        make_unique<WriteApplicationLauncherApplicationLauncherApp>(credsIssuerConfig),                         //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                 //
         make_unique<SubscribeAttribute>(Id, "application-launcher-list", Attributes::ApplicationLauncherList::Id,
+                                        credsIssuerConfig), //
+        make_unique<SubscribeAttribute>(Id, "application-launcher-app", Attributes::ApplicationLauncherApp::Id,
                                         credsIssuerConfig), //
         make_unique<SubscribeAttribute>(Id, "server-generated-command-list", Attributes::ServerGeneratedCommandList::Id,
                                         credsIssuerConfig), //
@@ -9986,17 +10086,23 @@ void registerClusterChannel(Commands & commands, CredentialIssuerCommands * cred
         //
         // Attributes
         //
-        make_unique<ReadAttribute>(Id, credsIssuerConfig),                                              //
-        make_unique<ReadAttribute>(Id, "channel-list", Attributes::ChannelList::Id, credsIssuerConfig), //
+        make_unique<ReadAttribute>(Id, credsIssuerConfig),                                                    //
+        make_unique<ReadAttribute>(Id, "channel-list", Attributes::ChannelList::Id, credsIssuerConfig),       //
+        make_unique<ReadAttribute>(Id, "channel-lineup", Attributes::ChannelLineup::Id, credsIssuerConfig),   //
+        make_unique<ReadAttribute>(Id, "current-channel", Attributes::CurrentChannel::Id, credsIssuerConfig), //
         make_unique<ReadAttribute>(Id, "server-generated-command-list", Attributes::ServerGeneratedCommandList::Id,
                                    credsIssuerConfig), //
         make_unique<ReadAttribute>(Id, "client-generated-command-list", Attributes::ClientGeneratedCommandList::Id,
-                                   credsIssuerConfig),                                                          //
-        make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),     //
-        make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig), //
-        make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                     //
-        make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                 //
-        make_unique<SubscribeAttribute>(Id, "channel-list", Attributes::ChannelList::Id, credsIssuerConfig),    //
+                                   credsIssuerConfig),                                                             //
+        make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),        //
+        make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig),    //
+        make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                        //
+        make_unique<WriteChannelChannelLineup>(credsIssuerConfig),                                                 //
+        make_unique<WriteChannelCurrentChannel>(credsIssuerConfig),                                                //
+        make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                    //
+        make_unique<SubscribeAttribute>(Id, "channel-list", Attributes::ChannelList::Id, credsIssuerConfig),       //
+        make_unique<SubscribeAttribute>(Id, "channel-lineup", Attributes::ChannelLineup::Id, credsIssuerConfig),   //
+        make_unique<SubscribeAttribute>(Id, "current-channel", Attributes::CurrentChannel::Id, credsIssuerConfig), //
         make_unique<SubscribeAttribute>(Id, "server-generated-command-list", Attributes::ServerGeneratedCommandList::Id,
                                         credsIssuerConfig), //
         make_unique<SubscribeAttribute>(Id, "client-generated-command-list", Attributes::ClientGeneratedCommandList::Id,
@@ -11236,6 +11342,7 @@ void registerClusterMediaPlayback(Commands & commands, CredentialIssuerCommands 
         make_unique<ReadAttribute>(Id, "playback-state", Attributes::PlaybackState::Id, credsIssuerConfig),    //
         make_unique<ReadAttribute>(Id, "start-time", Attributes::StartTime::Id, credsIssuerConfig),            //
         make_unique<ReadAttribute>(Id, "duration", Attributes::Duration::Id, credsIssuerConfig),               //
+        make_unique<ReadAttribute>(Id, "position", Attributes::Position::Id, credsIssuerConfig),               //
         make_unique<ReadAttribute>(Id, "playback-speed", Attributes::PlaybackSpeed::Id, credsIssuerConfig),    //
         make_unique<ReadAttribute>(Id, "seek-range-end", Attributes::SeekRangeEnd::Id, credsIssuerConfig),     //
         make_unique<ReadAttribute>(Id, "seek-range-start", Attributes::SeekRangeStart::Id, credsIssuerConfig), //
@@ -11246,10 +11353,12 @@ void registerClusterMediaPlayback(Commands & commands, CredentialIssuerCommands 
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),         //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig),     //
         make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                         //
+        make_unique<WriteMediaPlaybackPosition>(credsIssuerConfig),                                                 //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                     //
         make_unique<SubscribeAttribute>(Id, "playback-state", Attributes::PlaybackState::Id, credsIssuerConfig),    //
         make_unique<SubscribeAttribute>(Id, "start-time", Attributes::StartTime::Id, credsIssuerConfig),            //
         make_unique<SubscribeAttribute>(Id, "duration", Attributes::Duration::Id, credsIssuerConfig),               //
+        make_unique<SubscribeAttribute>(Id, "position", Attributes::Position::Id, credsIssuerConfig),               //
         make_unique<SubscribeAttribute>(Id, "playback-speed", Attributes::PlaybackSpeed::Id, credsIssuerConfig),    //
         make_unique<SubscribeAttribute>(Id, "seek-range-end", Attributes::SeekRangeEnd::Id, credsIssuerConfig),     //
         make_unique<SubscribeAttribute>(Id, "seek-range-start", Attributes::SeekRangeStart::Id, credsIssuerConfig), //

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -4081,6 +4081,11 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("application launcher list", 1, value);
         }
+        case ApplicationLauncher::Attributes::ApplicationLauncherApp::Id: {
+            chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType value;
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
+            return DataModelLogger::LogValue("application launcher app", 1, value);
+        }
         case ApplicationLauncher::Attributes::ServerGeneratedCommandList::Id: {
             chip::app::DataModel::DecodableList<chip::CommandId> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
@@ -4550,6 +4555,16 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             chip::app::DataModel::DecodableList<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("channel list", 1, value);
+        }
+        case Channel::Attributes::ChannelLineup::Id: {
+            chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType value;
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
+            return DataModelLogger::LogValue("channel lineup", 1, value);
+        }
+        case Channel::Attributes::CurrentChannel::Id: {
+            chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType value;
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
+            return DataModelLogger::LogValue("current channel", 1, value);
         }
         case Channel::Attributes::ServerGeneratedCommandList::Id: {
             chip::app::DataModel::DecodableList<chip::CommandId> value;
@@ -5845,6 +5860,11 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             uint64_t value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("duration", 1, value);
+        }
+        case MediaPlayback::Attributes::Position::Id: {
+            chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType value;
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
+            return DataModelLogger::LogValue("position", 1, value);
         }
         case MediaPlayback::Attributes::PlaybackSpeed::Id: {
             float value;


### PR DESCRIPTION
#### Problem
The list of attributes haven't been enabled on chip tool. Meaning, you were not able to test them on test events.
[ApplicationBasic#ApplicationAttribute](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/ApplicationBasic.adoc#application-attribute)
[ApplicationLauncher#CurrentAppAttribute](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/ApplicationLauncher.adoc#currentapp-attribute)
[ChannelCluster#LineupAttribute](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/Channel.adoc#lineup-attribute)
[ChannelCluster#CurrentChannel](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/Channel.adoc#133-currentchannel-attribute)
[MediaPlaybackCluster#SampledPositionAttribute](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/MediaPlayback.adoc#134-sampledposition-attribute)

#### Issues reported
This PR will resolve these reported issues:
https://github.com/project-chip/connectedhomeip/issues/12204
https://github.com/project-chip/connectedhomeip/issues/14744

#### Important
I've also updated the [zap template file](https://github.com/lazarkov/connectedhomeip/blob/master/src/controller/java/templates/partials/decode_value.zapt) as it caused the Android fail build.

#### Change overview
see above

#### Testing
Run `./scripts/run_in_build_env.sh \  
                  "./scripts/tests/run_test_suite.py \
                     --chip-tool ./out/debug/standalone/chip-tool \
                     run \
                     --iterations 1 \
                     --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                     --tv-app ./out/debug/standalone/chip-tv-app \
                  "`