### PR TITLE
Update openjdk version: apparently alpine has a new openjdk and old v…

### DIFF
--- a/integrations/docker/images/chip-build-zap/Dockerfile
+++ b/integrations/docker/images/chip-build-zap/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.14
 
 RUN apk add --no-cache \
   nodejs=14.18.1-r0 \
-  openjdk11=11.0.12_p7-r0 \
+  openjdk11=11.0.14_p9-r0 \
   npm=7.17.0-r0 \
   python3=3.9.5-r2 \
   pixman-dev=0.40.0-r2 \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.53 Version bump reason: Update ESP-IDF to v4.4 release
+0.5.54 Version bump reason: Openjdk version update for zap image


### PR DESCRIPTION
…ersion is not usable anymore

#### Problem
ZAP image build was failing for docker

#### Change overview
Bump up the openjdk version.

#### Testing
Did a `./build.sh --no-cache`