### PR TITLE
Mark MCSP responses as NOT_IMPLEMENTED

### DIFF
--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -225,6 +225,9 @@ CHIP_ERROR MessageCounterManager::SendMsgCounterSyncResp(Messaging::ExchangeCont
 
     VerifyOrDie(exchangeContext->HasSessionHandle());
 
+    VerifyOrReturnError(exchangeContext->GetSessionHandle()->GetSessionType() == Session::SessionType::kSecure,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+
     // Allocate new buffer.
     msgBuf = MessagePacketBuffer::New(kSyncRespMsgSize);
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_NO_MEMORY);

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -224,7 +224,7 @@ CHIP_ERROR MessageCounterManager::SendMsgCounterSyncResp(Messaging::ExchangeCont
     System::PacketBufferHandle msgBuf;
     VerifyOrDie(exchangeContext->HasSessionHandle());
 
-    VerifyOrReturnError(exchangeContext->GetSessionHandle()->GetSessionType() == Transport::Session::SessionType::kGroupSession,
+    VerifyOrReturnError(exchangeContext->GetSessionHandle()->GetSessionType() == Transport::Session::SessionType::kGroup,
                         CHIP_ERROR_INVALID_ARGUMENT);
 
     // NOTE: not currently implemented. When implementing, the following should be done:

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -222,29 +222,20 @@ CHIP_ERROR MessageCounterManager::SendMsgCounterSyncResp(Messaging::ExchangeCont
                                                          FixedByteSpan<kChallengeSize> challenge)
 {
     System::PacketBufferHandle msgBuf;
-
     VerifyOrDie(exchangeContext->HasSessionHandle());
 
-    VerifyOrReturnError(exchangeContext->GetSessionHandle()->GetSessionType() == Session::SessionType::kSecure,
+    VerifyOrReturnError(exchangeContext->GetSessionHandle()->GetSessionType() == Transport::Session::SessionType::kGroupSession,
                         CHIP_ERROR_INVALID_ARGUMENT);
 
-    // Allocate new buffer.
-    msgBuf = MessagePacketBuffer::New(kSyncRespMsgSize);
-    VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_NO_MEMORY);
+    // NOTE: not currently implemented. When implementing, the following should be done:
+    //    - allocate a new buffer: MessagePacketBuffer::New
+    //    - setup payload and place the local message counter + challange in it
+    //    - exchangeContext->SendMessage(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp, ...)
+    //
+    // You can view the history of this file for a partial implementation that got
+    // removed due to it using non-group sessions.
 
-    {
-        uint8_t * msg = msgBuf->Start();
-        Encoding::LittleEndian::BufferWriter bbuf(msg, kSyncRespMsgSize);
-        bbuf.Put32(
-            exchangeContext->GetSessionHandle()->AsSecureSession()->GetSessionMessageCounter().GetLocalMessageCounter().Value());
-        bbuf.Put(challenge.data(), kChallengeSize);
-        VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_NO_MEMORY);
-    }
-
-    msgBuf->SetDataLength(kSyncRespMsgSize);
-
-    return exchangeContext->SendMessage(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp, std::move(msgBuf),
-                                        Messaging::SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 CHIP_ERROR MessageCounterManager::HandleMsgCounterSyncReq(Messaging::ExchangeContext * exchangeContext,


### PR DESCRIPTION
#### Problem
Potential crash in `AsSecureSession` call.

#### Change overview
Mark MCSP as not implemented. When implementing it should use Group sessions instead of secure sessions.

Fixes #13668

#### Testing
- flashed and commissioned a devkit-c-all-clusters (to ensure this code is not used during regular secure seession support)
- checked out ae05dfc82 and applied these patches on top, no crash