### PR TITLE
[CI] TSAN build on Linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,11 +168,11 @@ jobs:
                   LSAN_OPTIONS: detect_leaks=0
               run: |
                 # for BUILD_TYPE in asan msan tsan ubsan; do
-                  for BUILD_TYPE in asan ubsan; do
+                  for BUILD_TYPE in asan tsan ubsan; do
                       case $BUILD_TYPE in
                           "asan") GN_ARGS='is_clang=true is_asan=true';;
                           "msan") GN_ARGS='is_clang=true is_msan=true';;
-                          "tsan") GN_ARGS='is_clang=true is_tsan=true';;
+                          "tsan") GN_ARGS='is_clang=true is_tsan=true chip_enable_wifi=false';;
                           "ubsan") GN_ARGS='is_clang=true is_ubsan=true';;
                       esac
 


### PR DESCRIPTION
#### Problem

Thread races are bad.

#### Change overview

Add a Linux build with Thread Sanitizer.

This is built with `chip_enable_wifi=false` because builds with WiFi
on Linux enable `CHIP_WITH_GIO`, for which TSAN reports warnings from
the gdbus thread. (It remains to be determined whether these indicate
a genuine problem.)

#### Testing

CI.
