### PR TITLE
Update all_clusters_app README

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -84,7 +84,20 @@ To set IDF target, run set-target with one of the commands.
 
 -   Configuration Options
 
-To choose from the different configuration options, run menuconfig.
+To build the default configuration (`sdkconfig.defaults`) skip to building the
+demo application.
+
+To build a specific configuration (as an example `m5stack`):
+
+          $ rm sdkconfig
+          $ idf.py -D 'SDKCONFIG_DEFAULTS=sdkconfig_m5stack.defaults' build
+
+    Note: If using a specific device configuration, it is highly recommended to
+    start off with one of the defaults and customize on top of that. Certain
+    configurations have different constraints that are customized within the
+    device specific configuration (eg: main app stack size).
+
+To customize the configuration, run menuconfig.
 
           $ idf.py menuconfig
 


### PR DESCRIPTION
The instructions currently customize the device via menuconfig.
This bypasses the various customizations from the device specific
defaults.

Add a section to encourage users to start with the device specific
defaults to avoid running into hard to debug run-time issues.