### PR TITLE
[binding] fix OSX build error

### DIFF
--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -125,7 +125,7 @@ void BindingManager::HandleDeviceConnected(OperationalDeviceProxy * device)
     FabricIndex fabricToRemove = kUndefinedFabricIndex;
     NodeId nodeToRemove        = kUndefinedNodeId;
 
-    for (const PendingNotificationEntry & pendingNotification : mPendingNotificationMap)
+    for (PendingNotificationEntry pendingNotification : mPendingNotificationMap)
     {
         EmberBindingTableEntry entry;
         emberGetBinding(pendingNotification.mBindingEntryId, &entry);


### PR DESCRIPTION
#### Problem

OSX reports build error:

```
../../src/app/clusters/bindings/BindingManager.cpp:128:43: error: loop variable 'pendingNotification' is always a copy because the range of type 'chip::PendingNotificationMap' does not return a reference [-Werror,-Wrange-loop-analysis]
  for (const PendingNotificationEntry & pendingNotification : mPendingNotificationMap)
                     ^
../../src/app/clusters/bindings/BindingManager.cpp:128:10: note: use non-reference type 'chip::PendingNotificationEntry'
  for (const PendingNotificationEntry & pendingNotification : mPendingNotificationMap)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


#### Change overview

Fix the build error.

#### Testing

* CI build
