### PR TITLE
Fix compilation on newer clang.

### DIFF
--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -125,7 +125,9 @@ void BindingManager::HandleDeviceConnected(OperationalDeviceProxy * device)
     FabricIndex fabricToRemove = kUndefinedFabricIndex;
     NodeId nodeToRemove        = kUndefinedNodeId;
 
-    for (const PendingNotificationEntry & pendingNotification : mPendingNotificationMap)
+    // Note: not using a const ref here, because the mPendingNotificationMap
+    // iterator returns things by value anyway.
+    for (PendingNotificationEntry pendingNotification : mPendingNotificationMap)
     {
         EmberBindingTableEntry entry;
         emberGetBinding(pendingNotification.mBindingEntryId, &entry);


### PR DESCRIPTION
There's a warning about thinking you are iterating without copying
when you get copied anyway that this code was triggering.

#### Problem
Build broken.

#### Change overview
Fix build.

#### Testing
Compiled on Mac locally.