### PR TITLE
Set keypair length in example issuer to value length

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -56,9 +56,11 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
 
     PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIssuerKeypairStorage, key,
                       err = storage.SyncGetKeyValue(key, &serializedKey, keySize));
+    serializedKey.SetLength(keySize);
 
     if (err != CHIP_NO_ERROR)
     {
+        ChipLogProgress(Controller, "Couldn't get %s from storage: %s", kOperationalCredentialsIssuerKeypairStorage, ErrorStr(err));
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIssuer.Initialize());
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
@@ -78,9 +80,12 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
 
     PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateIssuerKeypairStorage, key,
                       err = storage.SyncGetKeyValue(key, &serializedKey, keySize));
+    serializedKey.SetLength(keySize);
 
     if (err != CHIP_NO_ERROR)
     {
+        ChipLogProgress(Controller, "Couldn't get %s from storage: %s", kOperationalCredentialsIntermediateIssuerKeypairStorage,
+                        ErrorStr(err));
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIntermediateIssuer.Initialize());
         ReturnErrorOnFailure(mIntermediateIssuer.Serialize(serializedKey));


### PR DESCRIPTION
#### Problem
For `ExampleOperationalCredentialsIssuer`, calls to `Serialize()` occur without setting the length of `serializedKey`, which in the mbedTLS impl defaults to using the [capacity](https://github.com/project-chip/connectedhomeip/blob/1c1eca43fc09cb7fd792657d793e146b0fcb3241/src/crypto/CHIPCryptoPALmbedTLS.cpp#L730).

This is buggy since capacity relies on size_t (architecture-dependent), so a keypair serialized on a 64-bit platform could not be deserialized on a 32-bit platform.

#### Change overview
Set keypair length to the size of the value retrieved from storage, which is `uint16_t`.

#### Testing
Use serialized keypairs on 32-bit and 64-bit platforms.
