### PR TITLE
[ota] Parse OTA image header in nRF Connect and Linux platforms

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -47,4 +47,5 @@ config CHIP_OTA_REQUESTOR_BUFFER_SIZE
 # See config/zephyr/Kconfig for full definition
 config CHIP_OTA_IMAGE_BUILD
 	bool
+	default y if CHIP_OTA_REQUESTOR
 	depends on SIGN_IMAGES

--- a/examples/lighting-app/nrfconnect/prj.conf
+++ b/examples/lighting-app/nrfconnect/prj.conf
@@ -37,6 +37,8 @@ CONFIG_MPU_STACK_GUARD=y
 
 # CHIP configuration
 CONFIG_CHIP_PROJECT_CONFIG="main/include/CHIPProjectConfig.h"
+# 20044 == 0x4E4C - "[N]ordic [L]ight"
+CONFIG_CHIP_DEVICE_PRODUCT_ID=20044
 
 # Enable CHIP pairing automatically on application start.
 CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -184,9 +184,7 @@ CHIP_ERROR BDXDownloader::HandleBdxEvent(const chip::bdx::TransferSession::Outpu
     case TransferSession::OutputEventType::kBlockReceived: {
         chip::ByteSpan blockData(outEvent.blockdata.Data, outEvent.blockdata.Length);
         ReturnErrorOnFailure(mImageProcessor->ProcessBlock(blockData));
-        Nullable<uint8_t> percent;
-        mImageProcessor->GetPercentComplete(percent);
-        mStateDelegate->OnUpdateProgressChanged(percent);
+        mStateDelegate->OnUpdateProgressChanged(mImageProcessor->GetPercentComplete());
 
         // TODO: this will cause problems if Finalize() is not guaranteed to do its work after ProcessBlock().
         if (outEvent.blockdata.IsEof)

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -511,8 +511,7 @@ void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_
     // Log the DownloadError event
     OTAImageProcessorInterface * imageProcessor = mBdxDownloader->GetImageProcessorDelegate();
     VerifyOrReturn(imageProcessor != nullptr);
-    Nullable<uint8_t> progressPercent;
-    imageProcessor->GetPercentComplete(progressPercent);
+    Nullable<uint8_t> progressPercent = imageProcessor->GetPercentComplete();
     Nullable<int64_t> platformCode;
     OtaRequestorServerOnDownloadError(mTargetVersion, imageProcessor->GetBytesDownloaded(), progressPercent, platformCode);
 

--- a/src/include/platform/OTAImageProcessor.h
+++ b/src/include/platform/OTAImageProcessor.h
@@ -33,21 +33,6 @@ struct OTAImageProcessorParams
     uint64_t totalFileBytes  = 0;
 };
 
-// TODO: Parse the header when the image is received
-struct OTAImageProcessorHeader
-{
-    uint16_t vendorId;
-    uint16_t productId;
-    uint32_t softwareVersion;
-    CharSpan softwareVersionString;
-    uint64_t payloadSize;
-    uint16_t minApplicableSoftwareVersion;
-    uint16_t maxApplicableSoftwareVersion;
-    CharSpan releaseNotesUrl;
-    uint8_t imageDigestType;
-    ByteSpan imageDigest;
-};
-
 /**
  * @class OTAImageProcessorInterface
  *
@@ -99,16 +84,11 @@ public:
     /**
      * Called to check the current download status of the OTA image download.
      */
-    virtual void GetPercentComplete(app::DataModel::Nullable<uint8_t> & percent)
+    virtual app::DataModel::Nullable<uint8_t> GetPercentComplete()
     {
-        if (mParams.totalFileBytes == 0)
-        {
-            percent.SetNull();
-        }
-        else
-        {
-            percent.SetNonNull(static_cast<uint8_t>((mParams.downloadedBytes * 100) / mParams.totalFileBytes));
-        }
+        return mParams.totalFileBytes > 0
+            ? app::DataModel::Nullable<uint8_t>(static_cast<uint8_t>((mParams.downloadedBytes * 100) / mParams.totalFileBytes))
+            : app::DataModel::Nullable<uint8_t>{};
     }
 
     /**
@@ -118,7 +98,6 @@ public:
 
 protected:
     OTAImageProcessorParams mParams;
-    OTAImageProcessorHeader mHeader;
 };
 
 } // namespace chip

--- a/src/lib/core/OTAImageHeader.h
+++ b/src/lib/core/OTAImageHeader.h
@@ -82,17 +82,20 @@ public:
      * @brief Decode Matter OTA image header
      *
      * The method takes subsequent chunks of the Matter OTA image file and decodes the header when
-     * enough data has been provided.
+     * enough data has been provided. If more image chunks are needed, CHIP_ERROR_BUFFER_TOO_SMALL
+     * error is returned. Other error codes indicate that the header is invalid.
      *
      * @param buffer Byte span containing a subsequent Matter OTA image chunk. When the method
-     *               returns CHIP_NO_ERROR, it contains a remaining part of the chunk, not used
-     *               by the header.
+     *               returns CHIP_NO_ERROR, the byte span is used to return a remaining part
+     *               of the chunk, not used by the header.
      * @param header Structure to store results of the operation. Note that the results must not be
-     *               referenced after the parser is cleared since its string members are not cloned
-     *               by the method.
+     *               referenced after the parser is cleared since string members of the structure
+     *               are only shallow-copied by the method.
      *
      * @retval CHIP_NO_ERROR                        Header has been decoded successfully.
-     * @retval CHIP_ERROR_BUFFER_TOO_SMALL          Provided buffers are insufficient to decode the header.
+     * @retval CHIP_ERROR_BUFFER_TOO_SMALL          Provided buffers are insufficient to decode the
+     *                                              header. A user is expected call the method again
+     *                                              when the next image chunk is available.
      * @retval CHIP_ERROR_INVALID_FILE_IDENTIFIER   Not a Matter OTA image file.
      * @retval Error code                           Encoded header is invalid.
      */

--- a/src/lib/core/OTAImageHeader.h
+++ b/src/lib/core/OTAImageHeader.h
@@ -18,12 +18,14 @@
 #pragma once
 
 #include <lib/core/Optional.h>
+#include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
 
 #include <cstdint>
 
 namespace chip {
 
+/// File signature (aka magic number) of a valid Matter OTA image
 constexpr uint32_t kOTAImageFileIdentifier = 0x1BEEF11E;
 
 enum class OTAImageDigestType : uint8_t
@@ -44,8 +46,6 @@ enum class OTAImageDigestType : uint8_t
 
 struct OTAImageHeader
 {
-    uint64_t mTotalSize;
-    uint32_t mHeaderSize;
     uint16_t mVendorId;
     uint16_t mProductId;
     uint32_t mSoftwareVersion;
@@ -58,6 +58,62 @@ struct OTAImageHeader
     ByteSpan mImageDigest;
 };
 
-CHIP_ERROR DecodeOTAImageHeader(ByteSpan buffer, OTAImageHeader & header);
+class OTAImageHeaderParser
+{
+public:
+    /**
+     * @brief Prepare the parser for accepting Matter OTA image chunks.
+     *
+     * The method can be called many times to reset the parser state.
+     */
+    void Init();
+
+    /**
+     * @brief Clear all resources associated with the parser.
+     */
+    void Clear();
+
+    /**
+     * @brief Returns if the parser is ready to accept subsequent Matter OTA image chunks.
+     */
+    bool IsInitialized() const { return mState != State::kNotInitialized; }
+
+    /**
+     * @brief Decode Matter OTA image header
+     *
+     * The method takes subsequent chunks of the Matter OTA image file and decodes the header when
+     * enough data has been provided.
+     *
+     * @param buffer Byte span containing a subsequent Matter OTA image chunk. When the method
+     *               returns CHIP_NO_ERROR, it contains a remaining part of the chunk, not used
+     *               by the header.
+     * @param header Structure to store results of the operation. Note that the results must not be
+     *               referenced after the parser is cleared since its string members are not cloned
+     *               by the method.
+     *
+     * @retval CHIP_NO_ERROR                        Header has been decoded successfully.
+     * @retval CHIP_ERROR_BUFFER_TOO_SMALL          Provided buffers are insufficient to decode the header.
+     * @retval CHIP_ERROR_INVALID_FILE_IDENTIFIER   Not a Matter OTA image file.
+     * @retval Error code                           Encoded header is invalid.
+     */
+    CHIP_ERROR AccumulateAndDecode(ByteSpan & buffer, OTAImageHeader & header);
+
+private:
+    enum State
+    {
+        kNotInitialized,
+        kInitialized,
+        kTlv
+    };
+
+    void Append(ByteSpan & buffer, uint32_t numBytes);
+    CHIP_ERROR DecodeFixed();
+    CHIP_ERROR DecodeTlv(OTAImageHeader & header);
+
+    State mState;
+    uint32_t mHeaderTlvSize;
+    uint32_t mBufferOffset;
+    Platform::ScopedMemoryBuffer<uint8_t> mBuffer;
+};
 
 } // namespace chip

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -137,7 +137,7 @@ static void HandleProgress(intptr_t context)
         }
         else
         {
-            streamer_printf(streamer_get(), "Update progress: %d %%\r\n", progress);
+            streamer_printf(streamer_get(), "Update progress: %d %%\r\n", progress.Value());
         }
     }
     else

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -96,6 +96,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
         return;
     }
 
+    imageProcessor->mHeaderParser.Init();
     imageProcessor->mOfs.open(imageProcessor->mParams.imageFile.data(),
                               std::ofstream::out | std::ofstream::ate | std::ofstream::app);
     if (!imageProcessor->mOfs.good())
@@ -134,7 +135,8 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     OTARequestorInterface * requestor = chip::GetRequestorInstance();
     if (requestor != nullptr)
     {
-        requestor->NotifyUpdateApplied(imageProcessor->mHeader.softwareVersion);
+        // TODO: Use software version from Configuration Manager
+        requestor->NotifyUpdateApplied(imageProcessor->mSoftwareVersion);
     }
 }
 
@@ -165,17 +167,46 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         return;
     }
 
-    // TODO: Process block header if any
+    ByteSpan block   = imageProcessor->mBlock;
+    CHIP_ERROR error = imageProcessor->ProcessHeader(block);
 
-    if (!imageProcessor->mOfs.write(reinterpret_cast<const char *>(imageProcessor->mBlock.data()),
-                                    static_cast<std::streamsize>(imageProcessor->mBlock.size())))
+    if (error == CHIP_NO_ERROR &&
+        !imageProcessor->mOfs.write(reinterpret_cast<const char *>(block.data()), static_cast<std::streamsize>(block.size())))
     {
-        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+        error = CHIP_ERROR_WRITE_FAILED;
+    }
+
+    if (error != CHIP_NO_ERROR)
+    {
+        imageProcessor->mDownloader->EndDownload(error);
         return;
     }
 
-    imageProcessor->mParams.downloadedBytes += imageProcessor->mBlock.size();
+    imageProcessor->mParams.downloadedBytes += block.size();
     imageProcessor->mDownloader->FetchNextData();
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
+{
+    if (mHeaderParser.IsInitialized())
+    {
+        OTAImageHeader header;
+        CHIP_ERROR error = mHeaderParser.AccumulateAndDecode(block, header);
+
+        // Needs more data to decode the header
+        ReturnErrorCodeIf(error == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
+        ReturnErrorOnFailure(error);
+
+        // We save the software version to be used in the next NotifyUpdateApplied, but it's a non-standard
+        // behavior of the Linux implementation and the pattern should not be blindly followed by real-life
+        // products. In general, it's up to the implementation to decide which header fields will be
+        // validated or presented to the user.
+        mSoftwareVersion       = header.mSoftwareVersion;
+        mParams.totalFileBytes = header.mPayloadSize;
+        mHeaderParser.Clear();
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR OTAImageProcessorImpl::SetBlock(ByteSpan & block)

--- a/src/platform/Linux/OTAImageProcessorImpl.h
+++ b/src/platform/Linux/OTAImageProcessorImpl.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/clusters/ota-requestor/OTADownloader.h>
+#include <lib/core/OTAImageHeader.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OTAImageProcessor.h>
 
@@ -46,6 +47,8 @@ private:
     static void HandleAbort(intptr_t context);
     static void HandleProcessBlock(intptr_t context);
 
+    CHIP_ERROR ProcessHeader(ByteSpan & block);
+
     /**
      * Called to allocate memory for mBlock if necessary and set it to block
      */
@@ -59,6 +62,8 @@ private:
     std::ofstream mOfs;
     MutableByteSpan mBlock;
     OTADownloader * mDownloader;
+    OTAImageHeaderParser mHeaderParser;
+    uint32_t mSoftwareVersion;
 };
 
 } // namespace chip

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -37,8 +37,10 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
 {
+    mHeaderParser.Init();
     ReturnErrorOnFailure(System::MapErrorZephyr(dfu_target_mcuboot_set_buf(mBuffer, sizeof(mBuffer))));
     ReturnErrorOnFailure(System::MapErrorZephyr(dfu_target_reset()));
+
     return System::MapErrorZephyr(dfu_target_init(DFU_TARGET_IMAGE_TYPE_MCUBOOT, /* size */ 0, nullptr));
 }
 
@@ -61,8 +63,13 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
 {
     VerifyOrReturnError(mDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    // DFU target library buffers data internally, so do not clone the block data.
-    CHIP_ERROR error = System::MapErrorZephyr(dfu_target_write(block.data(), block.size()));
+    CHIP_ERROR error = ProcessHeader(block);
+
+    if (error == CHIP_NO_ERROR)
+    {
+        // DFU target library buffers data internally, so do not clone the block data.
+        error = System::MapErrorZephyr(dfu_target_write(block.data(), block.size()));
+    }
 
     // Report the result back to the downloader asynchronously.
     return DeviceLayer::SystemLayer().ScheduleLambda([this, error, block] {
@@ -76,6 +83,24 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
             mDownloader->EndDownload(error);
         }
     });
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
+{
+    if (mHeaderParser.IsInitialized())
+    {
+        OTAImageHeader header;
+        CHIP_ERROR error = mHeaderParser.AccumulateAndDecode(block, header);
+
+        // Needs more data to decode the header
+        ReturnErrorCodeIf(error == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
+        ReturnErrorOnFailure(error);
+
+        mParams.totalFileBytes = header.mPayloadSize;
+        mHeaderParser.Clear();
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <lib/core/OTAImageHeader.h>
 #include <lib/support/Span.h>
 #include <platform/OTAImageProcessor.h>
 
@@ -41,8 +42,10 @@ public:
 
 private:
     CHIP_ERROR PrepareDownloadImpl();
+    CHIP_ERROR ProcessHeader(ByteSpan & block);
 
     OTADownloader * mDownloader = nullptr;
+    OTAImageHeaderParser mHeaderParser;
     uint8_t mBuffer[kBufferSize];
 };
 


### PR DESCRIPTION
#### Problem
Current OTA image processors don't handle Matter-compliant OTA image header.

#### Change overview
1. Make the OTA image header parser stateful to ease processing small blocks of the image.
2. Use the parser in the image processor for nRF Connect and Linux platforms.
3. Enable OTA image generation for nRF Connect applications, by default.

#### Testing
Enhanced unit tests. Also, tested manually using Linux OTA requestor app and nRF Connect lighting-app (including that the download progress is finally working correctly).

