### PR TITLE
[nrfconnect] Fix pigweed/protobuf compiler flags

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -114,13 +114,12 @@ endif()
 
 if (CONFIG_CHIP_PW_RPC)
 
+# Make all targets created below depend on zephyr_interface to inherit MCU-related compilation flags
+link_libraries($<BUILD_INTERFACE:zephyr_interface>)
+
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
-
-# TODO: Remove this temporary fix needed to get RPC builds working.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=cortex-m4 -mthumb" CACHE INTERNAL "")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=cortex-m4 -mthumb" CACHE INTERNAL "")
 
 pw_set_backend(pw_log pw_log_basic)
 pw_set_backend(pw_assert pw_assert_log)
@@ -222,7 +221,5 @@ target_link_options(app
   PUBLIC
     "-T${PIGWEED_ROOT}/pw_tokenizer/pw_tokenizer_linker_sections.ld"
 )
-
-target_link_libraries(pw_build INTERFACE zephyr_interface)
 
 endif(CONFIG_CHIP_PW_RPC)

--- a/examples/lighting-app/nrfconnect/rpc.overlay
+++ b/examples/lighting-app/nrfconnect/rpc.overlay
@@ -26,9 +26,6 @@ CONFIG_CHIP_PW_RPC=y
 CONFIG_STD_CPP14=n
 CONFIG_STD_CPP17=y
 
-# Disable HW floating point, as libprotobuf nano doesn't support building with it
-CONFIG_FPU=n
-
 # Add support for Zephyr console component to use it for Pigweed console purposes
 CONFIG_CONSOLE_SUBSYS=y
 CONFIG_CONSOLE_GETCHAR=y

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -43,6 +43,9 @@ include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
 target_compile_options(app PRIVATE -Werror -Wno-error=maybe-uninitialized)
 
+# Make all targets created below depend on zephyr_interface to inherit MCU-related compilation flags
+link_libraries($<BUILD_INTERFACE:zephyr_interface>)
+
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
 
@@ -85,7 +88,5 @@ target_link_libraries(app PUBLIC
   pw_rpc.nanopb.echo_service
   pw_rpc.server
 )
-
-target_link_libraries(pw_build INTERFACE zephyr_interface)
 
 include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)

--- a/examples/pigweed-app/nrfconnect/README.md
+++ b/examples/pigweed-app/nrfconnect/README.md
@@ -326,7 +326,7 @@ to read more about flashing on the nRF52840 Dongle.
 Run the following command to start an interactive Python shell, where the Echo
 RPC commands can be invoked:
 
-        python -m pw_hdlc.rpc_console --device /dev/ttyACM0 -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/echo.proto -o /tmp/pw_rpc.out
+        python -m pw_hdlc.rpc_console --device /dev/ttyACM0 -b 115200 --proto-globs $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/echo.proto -o /tmp/pw_rpc.out
 
 To send an Echo RPC message, type the following command, where the actual
 message is the text in quotation marks after the `msg=` phrase:

--- a/examples/pigweed-app/nrfconnect/prj.conf
+++ b/examples/pigweed-app/nrfconnect/prj.conf
@@ -30,9 +30,6 @@ CONFIG_CHIP_PW_RPC=y
 CONFIG_STD_CPP14=n
 CONFIG_STD_CPP17=y
 
-# Disable HW floating point, as libprotobuf nano doesn't support building with it
-CONFIG_FPU=n
-
 # Add support for Zephyr console component to use it for Pigweed console purposes
 CONFIG_CONSOLE_SUBSYS=y
 CONFIG_CONSOLE_GETCHAR=y


### PR DESCRIPTION
#### Problem
Enhance the way Zephyr flags are passed to Pigweed and Protobuf components. It happened in the past that some
MCU-related flags were not passed correctly to libprotobuf causing runtime crashes or build failures (e.g. with FPU enabled).

#### Change overview
Make `zephyr_interface` a depdency of all Pigweed-related targets.

#### Testing
Tested nRF Connect pigweed-app and lighting-app using the rpc console.
