### PR TITLE
ota-provider-app: Adding SoftwareVersionString cli options

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -180,9 +180,16 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
                 newSoftwareVersion = mSoftwareVersion.Value();
             }
 
+            // If software version string is provided using command line then use it.
+            // Otherwise, use default string.
             newSoftwareVersionString = "Example-Image-V0.1";
-            otaFilePath              = mOTAFilePath;
-            queryStatus              = OTAQueryStatus::kUpdateAvailable;
+            if (mSoftwareVersionString)
+            {
+                newSoftwareVersionString = mSoftwareVersionString;
+            }
+
+            otaFilePath = mOTAFilePath;
+            queryStatus = OTAQueryStatus::kUpdateAvailable;
         }
         else if (!mCandidates.empty()) // If list of OTA candidates is supplied instead
         {

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -72,6 +72,7 @@ public:
     void SetDelayedActionTimeSec(uint32_t time) { mDelayedActionTimeSec = time; }
     void SetUserConsentDelegate(chip::ota::UserConsentDelegate * delegate) { mUserConsentDelegate = delegate; }
     void SetSoftwareVersion(uint32_t softwareVersion) { mSoftwareVersion.SetValue(softwareVersion); }
+    void SetSoftwareVersionString(const char * versionString) { mSoftwareVersionString = versionString; }
     void SetUserConsentNeeded(bool needed) { mUserConsentNeeded = needed; }
 
 private:
@@ -91,5 +92,6 @@ private:
                           const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType & commandData,
                           uint32_t targetVersion);
     chip::Optional<uint32_t> mSoftwareVersion;
-    bool mUserConsentNeeded = false;
+    const char * mSoftwareVersionString = nullptr;
+    bool mUserConsentNeeded             = false;
 };


### PR DESCRIPTION
#### Problem
* SoftwareVersionString is not configurable from CLI
* Fixes #14865 

#### Change overview
* Option to configure SoftwareVersionString

#### Testing
Executed provider app as `./chip-ota-provider-app -s 4 -S '4.2' -f /tmp/ota.bin` and provided SoftwareVersionString was included in QueryImageResponse.