### PR TITLE
Stop excluding TestGroupDemo* tests in our CI.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,7 +89,6 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
-                     --target-skip-glob '{TestGroupDemoCommand,TestGroupDemoConfig}' \
                      --chip-tool ./out/linux-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT}/chip-tool \
                      run \
                      --iterations 1 \
@@ -181,7 +180,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT}/chip-tool \
-                     --target-skip-glob '{TestGroupMessaging,TestGroupDemoCommand,TestGroupDemoConfig,TV_*}' \
+                     --target-skip-glob '{TestGroupMessaging,TV_*}' \
                      run \
                      --iterations 1 \
                      --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \


### PR DESCRIPTION
The TestGroupDemo* tests have been moved to the "manual tests" list,
so they get excluded automatically now.  Remove some noise from the CI
description.

Fixes https://github.com/project-chip/connectedhomeip/issues/14753

#### Problem
See above.

#### Change overview
See above.

#### Testing
"Tests" job should still pass.