### PR TITLE
[zephyr] Fix Network Commissioning after switching to new API

### DIFF
--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -486,8 +486,7 @@ void OperationalDataset::UnsetPSKc(void)
 
 bool OperationalDataset::IsCommissioned(void) const
 {
-    return Has(ThreadTLV::kNetworkName) && Has(ThreadTLV::kPanId) && Has(ThreadTLV::kMasterKey) && Has(ThreadTLV::kExtendedPanId) &&
-        Has(ThreadTLV::kChannel);
+    return Has(ThreadTLV::kPanId) && Has(ThreadTLV::kMasterKey) && Has(ThreadTLV::kExtendedPanId) && Has(ThreadTLV::kChannel);
 }
 
 const ThreadTLV * OperationalDataset::Locate(uint8_t aType) const

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -61,12 +61,6 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()
-{
-    // Intentionally empty.
-    return CHIP_NO_ERROR;
-}
-
 void ThreadStackManagerImpl::_LockThreadStack()
 {
     openthread_api_mutex_lock(openthread_get_default_context());
@@ -83,9 +77,25 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
     openthread_api_mutex_unlock(openthread_get_default_context());
 }
 
-void ThreadStackManagerImpl::_ProcessThreadActivity()
+void ThreadStackManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 {
-    // Intentionally empty.
+    Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::_OnPlatformEvent(event);
+
+    if (event->Type == DeviceEventType::kThreadStateChange && event->ThreadStateChange.RoleChanged)
+    {
+        const bool isAttached = IsThreadAttached();
+        VerifyOrReturn(isAttached != mIsAttached);
+
+        ChipDeviceEvent attachEvent;
+        attachEvent.Type                            = DeviceEventType::kThreadConnectivityChange;
+        attachEvent.ThreadConnectivityChange.Result = isAttached ? kConnectivity_Established : kConnectivity_Lost;
+
+        CHIP_ERROR error = PlatformMgr().PostEvent(&attachEvent);
+        VerifyOrReturn(error == CHIP_NO_ERROR,
+                       ChipLogError(DeviceLayer, "Failed to post Thread connectivity change: %" CHIP_ERROR_FORMAT, error.Format()));
+
+        mIsAttached = isAttached;
+    }
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -64,14 +64,15 @@ public:
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
-    CHIP_ERROR _StartThreadTask();
+    CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; }
     void _LockThreadStack();
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
     // ===== Methods that override the GenericThreadStackManagerImpl_OpenThread abstract interface.
 
-    void _ProcessThreadActivity();
+    void _ProcessThreadActivity() {}
+    void _OnPlatformEvent(const ChipDeviceEvent * event);
 
     //} // namespace Internal
 
@@ -85,7 +86,7 @@ private:
 
     // ===== Private members for use by this class only.
 
-    ThreadStackManagerImpl() = default;
+    bool mIsAttached = false;
 };
 
 /**


### PR DESCRIPTION
#### Problem
New Network Commissioning cluster code using the generic Thread driver requires that `kThreadConnectivityChange` event
be generated when the device is attached to a Thread network, and that was only implemented for LWIP and Linux platforms.

#### Change overview
Fill the gap for Zephyr.
Also, allow to use operational dataset without the network name as that is not necessary to attach to a network.

#### Testing
Tested that commissioning works again on nRF Connect platform.
