### PR TITLE
Use keypair capacity and bytes in example issuer

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -52,10 +52,10 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
     ReturnErrorOnFailure(ASN1ToChipEpochTime(effectiveTime, mNow));
 
     Crypto::P256SerializedKeypair serializedKey;
-    uint16_t keySize = static_cast<uint16_t>(sizeof(serializedKey));
+    uint16_t keySize = static_cast<uint16_t>(serializedKey.Capacity());
 
     PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIssuerKeypairStorage, key,
-                      err = storage.SyncGetKeyValue(key, &serializedKey, keySize));
+                      err = storage.SyncGetKeyValue(key, serializedKey.Bytes(), keySize));
     serializedKey.SetLength(keySize);
 
     if (err != CHIP_NO_ERROR)
@@ -65,10 +65,10 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         ReturnErrorOnFailure(mIssuer.Initialize());
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
 
-        keySize = static_cast<uint16_t>(sizeof(serializedKey));
+        keySize = static_cast<uint16_t>(serializedKey.Capacity());
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIssuerKeypairStorage, key,
-                          ReturnErrorOnFailure(storage.SyncSetKeyValue(key, &serializedKey, keySize)));
+                          ReturnErrorOnFailure(storage.SyncSetKeyValue(key, serializedKey.Bytes(), keySize)));
     }
     else
     {
@@ -76,10 +76,10 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         ReturnErrorOnFailure(mIssuer.Deserialize(serializedKey));
     }
 
-    keySize = static_cast<uint16_t>(sizeof(serializedKey));
+    keySize = static_cast<uint16_t>(serializedKey.Capacity());
 
     PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateIssuerKeypairStorage, key,
-                      err = storage.SyncGetKeyValue(key, &serializedKey, keySize));
+                      err = storage.SyncGetKeyValue(key, serializedKey.Bytes(), keySize));
     serializedKey.SetLength(keySize);
 
     if (err != CHIP_NO_ERROR)
@@ -90,10 +90,10 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         ReturnErrorOnFailure(mIntermediateIssuer.Initialize());
         ReturnErrorOnFailure(mIntermediateIssuer.Serialize(serializedKey));
 
-        keySize = static_cast<uint16_t>(sizeof(serializedKey));
+        keySize = static_cast<uint16_t>(serializedKey.Capacity());
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateIssuerKeypairStorage, key,
-                          ReturnErrorOnFailure(storage.SyncSetKeyValue(key, &serializedKey, keySize)));
+                          ReturnErrorOnFailure(storage.SyncSetKeyValue(key, serializedKey.Bytes(), keySize)));
     }
     else
     {


### PR DESCRIPTION
#### Problem
Example issuer uses `sizeof(serializedKey)` and `&serializedKey` for `P256Keypair` instead of referring to the underlying `bytes` array.

#### Change overview
Use `Capacity()` and `Bytes()` instead

#### Testing
CI, manual verification
