### PR TITLE
Update TV SDK, minor changes, mostly syncing the xml files per spec.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -380,9 +380,9 @@ server cluster Channel = 1284 {
   struct ChannelInfo {
     INT16U majorNumber = 0;
     INT16U minorNumber = 1;
-    CHAR_STRING<32> name = 2;
-    CHAR_STRING<32> callSign = 3;
-    CHAR_STRING<32> affiliateCallSign = 4;
+    optional CHAR_STRING<32> name = 2;
+    optional CHAR_STRING<32> callSign = 3;
+    optional CHAR_STRING<32> affiliateCallSign = 4;
   }
 
   readonly attribute ChannelInfo channelList[] = 0;
@@ -719,7 +719,7 @@ server cluster ContentLauncher = 1290 {
   struct Parameter {
     ParameterEnum type = 0;
     CHAR_STRING value = 1;
-    AdditionalInfo externalIDList[] = 2;
+    optional AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
@@ -729,17 +729,17 @@ server cluster ContentLauncher = 1290 {
 
   struct BrandingInformation {
     CHAR_STRING providerName = 0;
-    StyleInformation background = 1;
-    StyleInformation logo = 2;
-    StyleInformation progressBar = 3;
-    StyleInformation splash = 4;
-    StyleInformation waterMark = 5;
+    optional StyleInformation background = 1;
+    optional StyleInformation logo = 2;
+    optional StyleInformation progressBar = 3;
+    optional StyleInformation splash = 4;
+    optional StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 0;
-    CHAR_STRING color = 1;
-    Dimension size = 2;
+    optional CHAR_STRING imageUrl = 0;
+    optional CHAR_STRING color = 1;
+    optional Dimension size = 2;
   }
 
   struct Dimension {
@@ -1985,11 +1985,11 @@ server cluster MediaPlayback = 1286 {
   }
 
   readonly attribute PlaybackStateEnum playbackState = 0;
-  readonly attribute epoch_us startTime = 1;
-  readonly attribute int64u duration = 2;
+  readonly attribute nullable epoch_us startTime = 1;
+  readonly attribute nullable int64u duration = 2;
   readonly attribute single playbackSpeed = 4;
-  readonly attribute int64u seekRangeEnd = 5;
-  readonly attribute int64u seekRangeStart = 6;
+  readonly attribute nullable int64u seekRangeEnd = 5;
+  readonly attribute nullable int64u seekRangeStart = 6;
   readonly global attribute int16u clusterRevision = 65533;
 }
 

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -47,7 +47,7 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
 {
     // TODO: Insert code here
     Commands::NavigateTargetResponse::Type response;
-    response.data   = chip::CharSpan::fromCharString("data response");
+    response.data   = chip::Optional<CharSpan>(chip::CharSpan::fromCharString("data response"));
     response.status = chip::app::Clusters::TargetNavigator::StatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -84,7 +84,7 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
             if (jcallSign != NULL)
             {
                 JniUtfString callsign(env, jcallSign);
-                channelInfo.callSign = callsign.charSpan();
+                channelInfo.callSign = Optional<CharSpan>(callsign.charSpan());
             }
 
             jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
@@ -92,7 +92,7 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
             if (jname != NULL)
             {
                 JniUtfString name(env, jname);
-                channelInfo.name = name.charSpan();
+                channelInfo.name = Optional<CharSpan>(name.charSpan());
             }
 
             jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
@@ -100,7 +100,7 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
             if (jaffiliateCallSign != NULL)
             {
                 JniUtfString affiliateCallSign(env, jaffiliateCallSign);
-                channelInfo.affiliateCallSign = affiliateCallSign.charSpan();
+                channelInfo.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
             }
 
             jfieldID majorNumField  = env->GetFieldID(channelClass, "majorNumber", "I");
@@ -154,7 +154,7 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
         if (jlineupName != NULL)
         {
             JniUtfString lineupName(env, jlineupName);
-            lineupInfo.lineupName = lineupName.charSpan();
+            lineupInfo.lineupName = Optional<CharSpan>(lineupName.charSpan());
         }
 
         jfieldID postalCodeFild = env->GetFieldID(channelLineupClazz, "postalCode", "Ljava/lang/String;");
@@ -162,7 +162,7 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
         if (jpostalCode != NULL)
         {
             JniUtfString postalCode(env, jpostalCode);
-            lineupInfo.postalCode = postalCode.charSpan();
+            lineupInfo.postalCode = Optional<CharSpan>(postalCode.charSpan());
         }
 
         jfieldID lineupInfoTypeFild = env->GetFieldID(channelLineupClazz, "lineupInfoTypeEnum", "I");
@@ -200,7 +200,7 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
         if (jcallSign != NULL)
         {
             JniUtfString callsign(env, jcallSign);
-            channelInfo.callSign = callsign.charSpan();
+            channelInfo.callSign = Optional<CharSpan>(callsign.charSpan());
         }
 
         jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
@@ -208,7 +208,7 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
         if (jname != NULL)
         {
             JniUtfString name(env, jname);
-            channelInfo.name = name.charSpan();
+            channelInfo.name = Optional<CharSpan>(name.charSpan());
         }
 
         jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
@@ -216,7 +216,7 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
         if (jaffiliateCallSign != NULL)
         {
             JniUtfString affiliateCallSign(env, jaffiliateCallSign);
-            channelInfo.affiliateCallSign = affiliateCallSign.charSpan();
+            channelInfo.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
         }
 
         jfieldID majorNumField  = env->GetFieldID(channelClass, "majorNumber", "I");
@@ -276,7 +276,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
         if (jcallSign != NULL)
         {
             JniUtfString callsign(env, jcallSign);
-            response.channelMatch.callSign = callsign.charSpan();
+            response.channelMatch.callSign = Optional<CharSpan>(callsign.charSpan());
         }
 
         jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
@@ -284,14 +284,14 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
         if (jname != NULL)
         {
             JniUtfString junitname(env, jname);
-            response.channelMatch.name = junitname.charSpan();
+            response.channelMatch.name = Optional<CharSpan>(junitname.charSpan());
         }
         jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
         jstring jaffiliateCallSign          = static_cast<jstring>(env->GetObjectField(channelObject, getJaffiliateCallSignField));
         if (jaffiliateCallSign != NULL)
         {
             JniUtfString affiliateCallSign(env, jaffiliateCallSign);
-            response.channelMatch.affiliateCallSign = affiliateCallSign.charSpan();
+            response.channelMatch.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
         }
 
         jfieldID majorNumField            = env->GetFieldID(channelClass, "majorNumber", "I");

--- a/examples/tv-app/android/java/ContentLauncherManager.cpp
+++ b/examples/tv-app/android/java/ContentLauncherManager.cpp
@@ -85,7 +85,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
         JniUtfString dataStr(env, jdataStr);
 
         response.status = static_cast<chip::app::Clusters::ContentLauncher::StatusEnum>(status);
-        response.data   = dataStr.charSpan();
+        response.data   = chip::Optional<CharSpan>(dataStr.charSpan());
 
         err = helper.Success(response);
     }
@@ -140,7 +140,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
         JniUtfString dataStr(env, jdataStr);
 
         response.status = static_cast<chip::app::Clusters::ContentLauncher::StatusEnum>(status);
-        response.data   = dataStr.charSpan();
+        response.data   = chip::Optional<CharSpan>(dataStr.charSpan());
 
         err = helper.Success(response);
     }

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -28,6 +28,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;
 
 /** @brief Media PlayBack Cluster Init
@@ -258,7 +259,7 @@ CHIP_ERROR MediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncoder 
 {
     Structs::PlaybackPosition::Type response;
     response.updatedAt = 0;
-    response.position  = 0;
+    response.position  = Nullable<uint64_t>(0);
 
     jobject positionObj;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -283,7 +284,7 @@ CHIP_ERROR MediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncoder 
         jclass inputClass    = env->GetObjectClass(positionObj);
         jfieldID positionId  = env->GetFieldID(inputClass, "position", "J");
         jfieldID updatedAtId = env->GetFieldID(inputClass, "updatedAt", "J");
-        response.position    = static_cast<uint64_t>(env->GetIntField(positionObj, positionId));
+        response.position    = Nullable<uint64_t>(static_cast<uint64_t>(env->GetIntField(positionObj, positionId)));
         response.updatedAt   = static_cast<uint64_t>(env->GetIntField(positionObj, updatedAtId));
     }
 

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -30,9 +30,9 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
         for (int i = 0; i < maximumVectorSize; ++i)
         {
             chip::app::Clusters::Channel::Structs::ChannelInfo::Type channelInfo;
-            channelInfo.affiliateCallSign = chip::CharSpan::fromCharString("exampleASign");
-            channelInfo.callSign          = chip::CharSpan::fromCharString("exampleCSign");
-            channelInfo.name              = chip::CharSpan::fromCharString("exampleName");
+            channelInfo.affiliateCallSign = Optional<CharSpan>(chip::CharSpan::fromCharString("exampleASign"));
+            channelInfo.callSign          = Optional<CharSpan>(chip::CharSpan::fromCharString("exampleCSign"));
+            channelInfo.name              = Optional<CharSpan>(chip::CharSpan::fromCharString("exampleName"));
             channelInfo.majorNumber       = static_cast<uint8_t>(1 + i);
             channelInfo.minorNumber       = static_cast<uint16_t>(2 + i);
 
@@ -47,8 +47,8 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
 {
     chip::app::Clusters::Channel::Structs::LineupInfo::Type lineup;
     lineup.operatorName   = chip::CharSpan::fromCharString("operatorName");
-    lineup.lineupName     = chip::CharSpan::fromCharString("lineupName");
-    lineup.postalCode     = chip::CharSpan::fromCharString("postalCode");
+    lineup.lineupName     = Optional<CharSpan>(chip::CharSpan::fromCharString("lineupName"));
+    lineup.postalCode     = Optional<CharSpan>(chip::CharSpan::fromCharString("postalCode"));
     lineup.lineupInfoType = chip::app::Clusters::Channel::LineupInfoTypeEnum::kMso;
 
     return aEncoder.Encode(lineup);
@@ -57,9 +57,9 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
 CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEncoder)
 {
     chip::app::Clusters::Channel::Structs::ChannelInfo::Type currentChannel;
-    currentChannel.affiliateCallSign = chip::CharSpan::fromCharString("exampleASign");
-    currentChannel.callSign          = chip::CharSpan::fromCharString("exampleCSign");
-    currentChannel.name              = chip::CharSpan::fromCharString("exampleName");
+    currentChannel.affiliateCallSign = Optional<CharSpan>(chip::CharSpan::fromCharString("exampleASign"));
+    currentChannel.callSign          = Optional<CharSpan>(chip::CharSpan::fromCharString("exampleCSign"));
+    currentChannel.name              = Optional<CharSpan>(chip::CharSpan::fromCharString("exampleName"));
     currentChannel.majorNumber       = 1;
     currentChannel.minorNumber       = 0;
 
@@ -71,9 +71,9 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     ChangeChannelResponseType response;
     response.channelMatch.majorNumber       = 1;
     response.channelMatch.minorNumber       = 0;
-    response.channelMatch.name              = chip::CharSpan::fromCharString("name");
-    response.channelMatch.callSign          = chip::CharSpan::fromCharString("callSign");
-    response.channelMatch.affiliateCallSign = chip::CharSpan::fromCharString("affiliateCallSign");
+    response.channelMatch.name              = Optional<CharSpan>(chip::CharSpan::fromCharString("name"));
+    response.channelMatch.callSign          = Optional<CharSpan>(chip::CharSpan::fromCharString("callSign"));
+    response.channelMatch.affiliateCallSign = Optional<CharSpan>(chip::CharSpan::fromCharString("affiliateCallSign"));
     response.errorType                      = chip::app::Clusters::Channel::ErrorTypeEnum::kMultipleMatches;
 
     helper.Success(response);

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -37,7 +37,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
 
     LaunchResponseType response;
     // TODO: Insert code here
-    response.data   = CharSpan::fromCharString("exampleData");
+    response.data   = chip::Optional<CharSpan>(CharSpan::fromCharString("exampleData"));
     response.status = ContentLauncher::StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -52,7 +52,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
 
     // TODO: Insert code here
     LaunchResponseType response;
-    response.data   = CharSpan::fromCharString("exampleData");
+    response.data   = chip::Optional<CharSpan>(CharSpan::fromCharString("exampleData"));
     response.status = ContentLauncher::StatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -18,6 +18,7 @@
 #include "MediaPlaybackManager.h"
 
 using namespace std;
+using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;
 
 PlaybackStateEnum MediaPlaybackManager::HandleGetCurrentState()
@@ -39,7 +40,7 @@ CHIP_ERROR MediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncoder 
 {
     Structs::PlaybackPosition::Type sampledPosition;
     sampledPosition.updatedAt = 0;
-    sampledPosition.position  = 0;
+    sampledPosition.position  = Nullable<uint64_t>(0);
 
     return aEncoder.Encode(sampledPosition);
 }

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -55,14 +55,14 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     NavigateTargetResponseType response;
     if (target == kNoCurrentTarget || target > mTargets.size())
     {
-        response.data   = CharSpan::fromCharString("error");
+        response.data   = chip::Optional<CharSpan>(CharSpan::fromCharString("error"));
         response.status = StatusEnum::kTargetNotFound;
         helper.Success(response);
         return;
     }
     mCurrentTarget = static_cast<uint8_t>(target);
 
-    response.data   = CharSpan::fromCharString("data response");
+    response.data   = chip::Optional<CharSpan>(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -167,7 +167,7 @@ server cluster ApplicationLauncher = 1292 {
 
   struct ApplicationEP {
     Application application = 0;
-    CHAR_STRING endpoint = 1;
+    optional ENDPOINT_NO endpoint = 1;
   }
 
   struct Application {
@@ -176,7 +176,7 @@ server cluster ApplicationLauncher = 1292 {
   }
 
   readonly attribute INT16U applicationLauncherList[] = 0;
-  attribute ApplicationEP applicationLauncherApp = 1;
+  attribute nullable ApplicationEP applicationLauncherApp = 1;
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct HideAppRequestRequest {
@@ -185,7 +185,7 @@ server cluster ApplicationLauncher = 1292 {
 
   request struct LaunchAppRequestRequest {
     Application application = 0;
-    OCTET_STRING data = 1;
+    optional OCTET_STRING data = 1;
   }
 
   request struct StopAppRequestRequest {
@@ -313,21 +313,21 @@ server cluster Channel = 1284 {
   struct ChannelInfo {
     INT16U majorNumber = 0;
     INT16U minorNumber = 1;
-    CHAR_STRING<32> name = 2;
-    CHAR_STRING<32> callSign = 3;
-    CHAR_STRING<32> affiliateCallSign = 4;
+    optional CHAR_STRING<32> name = 2;
+    optional CHAR_STRING<32> callSign = 3;
+    optional CHAR_STRING<32> affiliateCallSign = 4;
   }
 
   struct LineupInfo {
     CHAR_STRING operatorName = 0;
-    CHAR_STRING lineupName = 1;
-    CHAR_STRING postalCode = 2;
+    optional CHAR_STRING lineupName = 1;
+    optional CHAR_STRING postalCode = 2;
     LineupInfoTypeEnum lineupInfoType = 3;
   }
 
   readonly attribute ChannelInfo channelList[] = 0;
-  attribute LineupInfo channelLineup = 1;
-  attribute ChannelInfo currentChannel = 2;
+  readonly attribute nullable LineupInfo channelLineup = 1;
+  readonly attribute nullable ChannelInfo currentChannel = 2;
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct ChangeChannelByNumberRequestRequest {
@@ -398,7 +398,7 @@ server cluster ContentLauncher = 1290 {
   struct Parameter {
     ParameterEnum type = 0;
     CHAR_STRING value = 1;
-    AdditionalInfo externalIDList[] = 2;
+    optional AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
@@ -408,17 +408,17 @@ server cluster ContentLauncher = 1290 {
 
   struct BrandingInformation {
     CHAR_STRING providerName = 0;
-    StyleInformation background = 1;
-    StyleInformation logo = 2;
-    StyleInformation progressBar = 3;
-    StyleInformation splash = 4;
-    StyleInformation waterMark = 5;
+    optional StyleInformation background = 1;
+    optional StyleInformation logo = 2;
+    optional StyleInformation progressBar = 3;
+    optional StyleInformation splash = 4;
+    optional StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 0;
-    CHAR_STRING color = 1;
-    Dimension size = 2;
+    optional CHAR_STRING imageUrl = 0;
+    optional CHAR_STRING color = 1;
+    optional Dimension size = 2;
   }
 
   struct Dimension {
@@ -432,20 +432,20 @@ server cluster ContentLauncher = 1290 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct LaunchContentRequestRequest {
-    BOOLEAN autoPlay = 0;
-    CHAR_STRING data = 1;
-    ContentSearch search[] = 2;
+    ContentSearch search[] = 0;
+    BOOLEAN autoPlay = 1;
+    optional CHAR_STRING data = 2;
   }
 
   request struct LaunchURLRequestRequest {
     CHAR_STRING contentURL = 0;
-    CHAR_STRING displayString = 1;
-    BrandingInformation brandingInformation = 2;
+    optional CHAR_STRING displayString = 1;
+    optional BrandingInformation brandingInformation = 2;
   }
 
   response struct LaunchResponse {
     StatusEnum status = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   command LaunchContentRequest(LaunchContentRequestRequest): LaunchResponse = 0;
@@ -1031,16 +1031,16 @@ server cluster MediaPlayback = 1286 {
 
   struct PlaybackPosition {
     INT64U updatedAt = 0;
-    INT64U position = 1;
+    nullable INT64U position = 1;
   }
 
   readonly attribute PlaybackStateEnum playbackState = 0;
-  readonly attribute epoch_us startTime = 1;
-  readonly attribute int64u duration = 2;
-  attribute PlaybackPosition position = 3;
+  readonly attribute nullable epoch_us startTime = 1;
+  readonly attribute nullable int64u duration = 2;
+  readonly attribute PlaybackPosition position = 3;
   readonly attribute single playbackSpeed = 4;
-  readonly attribute int64u seekRangeEnd = 5;
-  readonly attribute int64u seekRangeStart = 6;
+  readonly attribute nullable int64u seekRangeEnd = 5;
+  readonly attribute nullable int64u seekRangeStart = 6;
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct SeekRequestRequest {
@@ -1668,12 +1668,12 @@ server cluster TargetNavigator = 1285 {
 
   request struct NavigateTargetRequestRequest {
     INT8U target = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   response struct NavigateTargetResponse {
     StatusEnum status = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   command NavigateTargetRequest(NavigateTargetRequestRequest): NavigateTargetResponse = 0;

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -253,8 +253,8 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
         }
         LaunchURLRequest::Type request;
         request.contentURL          = chip::CharSpan::fromCharString(kContentUrl);
-        request.displayString       = chip::CharSpan::fromCharString(kContentDisplayStr);
-        request.brandingInformation = chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type();
+        request.displayString       = Optional<CharSpan>(chip::CharSpan::fromCharString(kContentDisplayStr));
+        request.brandingInformation = Optional<chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type>(chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type());
         cluster.InvokeCommand(request, nullptr, OnContentLauncherSuccessResponse, OnContentLauncherFailureResponse);
     }
 }

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -254,7 +254,8 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
         LaunchURLRequest::Type request;
         request.contentURL          = chip::CharSpan::fromCharString(kContentUrl);
         request.displayString       = Optional<CharSpan>(chip::CharSpan::fromCharString(kContentDisplayStr));
-        request.brandingInformation = Optional<chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type>(chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type());
+        request.brandingInformation = Optional<chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type>(
+            chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type());
         cluster.InvokeCommand(request, nullptr, OnContentLauncherSuccessResponse, OnContentLauncherFailureResponse);
     }
 }

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -168,7 +168,7 @@ client cluster ApplicationLauncher = 1292 {
 
   request struct LaunchAppRequestRequest {
     Application application = 0;
-    OCTET_STRING data = 1;
+    optional OCTET_STRING data = 1;
   }
 
   request struct StopAppRequestRequest {
@@ -332,21 +332,21 @@ client cluster Channel = 1284 {
   struct ChannelInfo {
     INT16U majorNumber = 0;
     INT16U minorNumber = 1;
-    CHAR_STRING<32> name = 2;
-    CHAR_STRING<32> callSign = 3;
-    CHAR_STRING<32> affiliateCallSign = 4;
+    optional CHAR_STRING<32> name = 2;
+    optional CHAR_STRING<32> callSign = 3;
+    optional CHAR_STRING<32> affiliateCallSign = 4;
   }
 
   struct LineupInfo {
     CHAR_STRING operatorName = 0;
-    CHAR_STRING lineupName = 1;
-    CHAR_STRING postalCode = 2;
+    optional CHAR_STRING lineupName = 1;
+    optional CHAR_STRING postalCode = 2;
     LineupInfoTypeEnum lineupInfoType = 3;
   }
 
   readonly attribute ChannelInfo channelList[] = 0;
-  attribute LineupInfo channelLineup = 1;
-  attribute ChannelInfo currentChannel = 2;
+  readonly attribute nullable LineupInfo channelLineup = 1;
+  readonly attribute nullable ChannelInfo currentChannel = 2;
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct ChangeChannelByNumberRequestRequest {
@@ -649,7 +649,7 @@ client cluster ContentLauncher = 1290 {
   struct Parameter {
     ParameterEnum type = 0;
     CHAR_STRING value = 1;
-    AdditionalInfo externalIDList[] = 2;
+    optional AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
@@ -659,17 +659,17 @@ client cluster ContentLauncher = 1290 {
 
   struct BrandingInformation {
     CHAR_STRING providerName = 0;
-    StyleInformation background = 1;
-    StyleInformation logo = 2;
-    StyleInformation progressBar = 3;
-    StyleInformation splash = 4;
-    StyleInformation waterMark = 5;
+    optional StyleInformation background = 1;
+    optional StyleInformation logo = 2;
+    optional StyleInformation progressBar = 3;
+    optional StyleInformation splash = 4;
+    optional StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 0;
-    CHAR_STRING color = 1;
-    Dimension size = 2;
+    optional CHAR_STRING imageUrl = 0;
+    optional CHAR_STRING color = 1;
+    optional Dimension size = 2;
   }
 
   struct Dimension {
@@ -683,15 +683,15 @@ client cluster ContentLauncher = 1290 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct LaunchContentRequestRequest {
-    BOOLEAN autoPlay = 0;
-    CHAR_STRING data = 1;
-    ContentSearch search[] = 2;
+    ContentSearch search[] = 0;
+    BOOLEAN autoPlay = 1;
+    optional CHAR_STRING data = 2;
   }
 
   request struct LaunchURLRequestRequest {
     CHAR_STRING contentURL = 0;
-    CHAR_STRING displayString = 1;
-    BrandingInformation brandingInformation = 2;
+    optional CHAR_STRING displayString = 1;
+    optional BrandingInformation brandingInformation = 2;
   }
 
   command LaunchContentRequest(LaunchContentRequestRequest): LaunchResponse = 0;
@@ -2414,7 +2414,7 @@ client cluster TargetNavigator = 1285 {
 
   request struct NavigateTargetRequestRequest {
     INT8U target = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   command NavigateTargetRequest(NavigateTargetRequestRequest): NavigateTargetResponse = 0;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -114,10 +114,9 @@ CHIP_ERROR Delegate::HandleGetCurrentApp(app::AttributeValueEncoder & aEncoder)
             {
                 ApplicationEPType currentApp;
                 CatalogVendorApp * vendorApp           = app->GetApplicationBasicDelegate()->GetCatalogVendorApp();
-                std::string endpointStr                = std::to_string(app->GetEndpointId());
                 currentApp.application.catalogVendorId = vendorApp->catalogVendorId;
                 currentApp.application.applicationId   = CharSpan(vendorApp->applicationId, strlen(vendorApp->applicationId));
-                currentApp.endpoint                    = CharSpan(endpointStr.c_str(), endpointStr.length());
+                currentApp.endpoint                    = Optional<EndpointId>(app->GetEndpointId());
                 return aEncoder.Encode(currentApp);
             }
         }
@@ -128,7 +127,7 @@ CHIP_ERROR Delegate::HandleGetCurrentApp(app::AttributeValueEncoder & aEncoder)
     ApplicationEPType currentApp;
     currentApp.application.catalogVendorId = 123;
     currentApp.application.applicationId   = CharSpan("applicationId", strlen("applicationId"));
-    currentApp.endpoint                    = CharSpan("endpointId", strlen("endpointId"));
+    currentApp.endpoint                    = Optional<EndpointId>::Missing();
     return aEncoder.Encode(currentApp);
 }
 
@@ -215,12 +214,14 @@ bool emberAfApplicationLauncherClusterLaunchAppRequestCallback(app::CommandHandl
     app::CommandResponseHelper<LauncherResponseType> responder(command, commandPath);
 
     std::string appId(application.applicationId.data(), application.applicationId.size());
-    if (appId.length() == 0)
+
+
+    if (appId.length() == 0 && data.HasValue())
     {
         // chip-tool can't send structs from command line so treat data value as appid if appid is blank
         // TODO: fix this once chip-tool support sending structs from command line
         ChipLogError(Zcl, "ApplicationLauncher blank content id, taking data as appid");
-        appId = std::string((char *) data.data(), data.size());
+        appId = std::string((char *) data.Value().data(), data.Value().size());
     }
     CatalogVendorApp vendorApp(application.catalogVendorId, appId.c_str());
 
@@ -252,7 +253,7 @@ bool emberAfApplicationLauncherClusterLaunchAppRequestCallback(app::CommandHandl
             ContentAppPlatform::GetInstance().SetCurrentApp(app);
 
             ChipLogError(Zcl, "ApplicationLauncher handling launch on ContentApp");
-            app->GetApplicationLauncherDelegate()->HandleLaunchApp(responder, data, application);
+            app->GetApplicationLauncherDelegate()->HandleLaunchApp(responder, data.HasValue() ? data.Value() : ByteSpan(), application);
             return true;
         }
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
@@ -277,7 +278,7 @@ bool emberAfApplicationLauncherClusterLaunchAppRequestCallback(app::CommandHandl
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
         ChipLogError(Zcl, "ApplicationLauncher handling launch");
-        delegate->HandleLaunchApp(responder, data, application);
+        delegate->HandleLaunchApp(responder, data.HasValue() ? data.Value() : ByteSpan(), application);
     }
 
 exit:

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -215,7 +215,6 @@ bool emberAfApplicationLauncherClusterLaunchAppRequestCallback(app::CommandHandl
 
     std::string appId(application.applicationId.data(), application.applicationId.size());
 
-
     if (appId.length() == 0 && data.HasValue())
     {
         // chip-tool can't send structs from command line so treat data value as appid if appid is blank
@@ -253,7 +252,8 @@ bool emberAfApplicationLauncherClusterLaunchAppRequestCallback(app::CommandHandl
             ContentAppPlatform::GetInstance().SetCurrentApp(app);
 
             ChipLogError(Zcl, "ApplicationLauncher handling launch on ContentApp");
-            app->GetApplicationLauncherDelegate()->HandleLaunchApp(responder, data.HasValue() ? data.Value() : ByteSpan(), application);
+            app->GetApplicationLauncherDelegate()->HandleLaunchApp(responder, data.HasValue() ? data.Value() : ByteSpan(),
+                                                                   application);
             return true;
         }
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -242,7 +242,8 @@ bool emberAfContentLauncherClusterLaunchURLRequestCallback(
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
     {
-        delegate->HandleLaunchUrl(responder, contentUrl, displayString.HasValue() ? displayString.Value() : CharSpan(), brandingInformationList);
+        delegate->HandleLaunchUrl(responder, contentUrl, displayString.HasValue() ? displayString.Value() : CharSpan(),
+                                  brandingInformationList);
     }
 
 exit:

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -206,7 +206,7 @@ bool emberAfContentLauncherClusterLaunchContentRequestCallback(
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
     {
-        delegate->HandleLaunchContent(responder, parameterList, autoplay, data);
+        delegate->HandleLaunchContent(responder, parameterList, autoplay, data.HasValue() ? data.Value() : CharSpan());
     }
 
 exit:
@@ -242,7 +242,7 @@ bool emberAfContentLauncherClusterLaunchURLRequestCallback(
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
     {
-        delegate->HandleLaunchUrl(responder, contentUrl, displayString, brandingInformationList);
+        delegate->HandleLaunchUrl(responder, contentUrl, displayString.HasValue() ? displayString.Value() : CharSpan(), brandingInformationList);
     }
 
 exit:

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -182,7 +182,7 @@ bool emberAfTargetNavigatorClusterNavigateTargetRequestCallback(app::CommandHand
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
-        delegate->HandleNavigateTarget(responder, target, data);
+        delegate->HandleNavigateTarget(responder, target, data.HasValue() ? data.Value() : CharSpan());
     }
 
 exit:

--- a/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
@@ -24,14 +24,15 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster provides information about an application running on a TV or media player device which is represented as an endpoint.</description>
-    <attribute side="server" code="0x0000" define="APPLICATION_VENDOR_NAME" type="CHAR_STRING" length="32" writable="false" optional="false">vendor name</attribute>
-    <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">vendor id</attribute>
-    <attribute side="server" code="0x0002" define="APPLICATION_NAME" length="32" type="CHAR_STRING" writable="false" optional="false">application name</attribute>
-    <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">product id</attribute>
-    <attribute side="server" code="0x0004" define="APPLICATION_APP" type="ApplicationBasicApplication" writable="false" optional="false">application app</attribute>
-    <attribute side="server" code="0x0005" define="APPLICATION_STATUS" type="ApplicationStatusEnum" min="0x00" max="0xFF" default="0x01" writable="false" optional="false">application status</attribute>
-    <attribute side="server" code="0x0006" define="APPLICATION_VERSION" type="CHAR_STRING" length="32" writable="false" optional="false">application version</attribute>
-    <attribute side="server" code="0x0007" define="APPLICATION_ALLOWED_VENDOR_LIST" type="ARRAY" entryType="vendor_id" length="32" writable="false" optional="false">allowed vendor list</attribute>
+    <attribute side="server" code="0x0000" define="APPLICATION_VENDOR_NAME"         type="CHAR_STRING"                default=""     length="32"               writable="false" optional="true">vendor name</attribute>
+    <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID"           type="INT16U"                     default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">vendor id</attribute>
+    <attribute side="server" code="0x0002" define="APPLICATION_NAME"                type="CHAR_STRING"                               length="32"               writable="false" optional="false">application name</attribute>
+    <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID"          type="INT16U"                     default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">product id</attribute>
+    <attribute side="server" code="0x0004" define="APPLICATION_APP"                 type="ApplicationBasicApplication"                                         writable="false" optional="false">application app</attribute>
+    <attribute side="server" code="0x0005" define="APPLICATION_STATUS"              type="ApplicationStatusEnum"      default="0x01" min="0x00"   max="0xFF"   writable="false" optional="false">application status</attribute>
+    <attribute side="server" code="0x0006" define="APPLICATION_VERSION"             type="CHAR_STRING"                               length="32"               writable="false" optional="false">application version</attribute>
+    <attribute side="server" code="0x0007" define="APPLICATION_ALLOWED_VENDOR_LIST" type="ARRAY" entryType="vendor_id"               length="32"               writable="false" optional="false">allowed vendor list</attribute>
+
   </cluster>
 
   <struct name="ApplicationBasicApplication">

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -25,23 +25,23 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
 
-    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST" type="ARRAY" entryType="INT16U" length="254" writable="false" optional="false">application launcher list</attribute>
-    <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEP" writable="true" optional="false">application launcher app</attribute>
+    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST"        type="ARRAY" entryType="INT16U" length="254" reportable="true"  writable="false" optional="false">application launcher list</attribute>
+    <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEP"            default="0x0" isNullable="true" writable="true"  optional="true">application launcher app</attribute>
 
     <command source="client" code="0x00" name="LaunchAppRequest" response="LauncherResponse" optional="false">
       <description>Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns a Launch Response.</description>
-      <arg name="application" type="Application"/>
-      <arg name="data"  type="OCTET_STRING"/>
+      <arg name="application" type="Application" reportable="true"/>
+      <arg name="data"  type="OCTET_STRING" optional="true"/>
     </command>
 
     <command source="client" code="0x01" name="StopAppRequest" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.</description>
-      <arg name="application" type="Application"/>
+      <arg name="application" type="Application" reportable="true"/>
     </command>
 
     <command source="client" code="0x02" name="HideAppRequest" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.</description>
-      <arg name="application" type="Application"/>
+      <arg name="application" type="Application" reportable="true"/>
     </command>
 
     <command source="server" code="0x03" name="LauncherResponse" optional="false">
@@ -55,7 +55,7 @@ limitations under the License.
   <struct name="ApplicationEP">
     <cluster code="0x050c"/>
     <item name="application" type="Application"/>
-    <item name="endpoint" type="CHAR_STRING"/>
+    <item name="endpoint" type="ENDPOINT_NO" optional="true"/>
   </struct>
       
   <struct name="Application">

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -25,8 +25,8 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the Output on a media device such as a TV.</description>
-    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST" type="ARRAY" entryType="OutputInfo" length="254" writable="false" optional="false">audio output list</attribute>
-    <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">current audio output</attribute>
+    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST"           type="ARRAY" entryType="OutputInfo" length="254"          writable="false"  optional="false">audio output list</attribute>
+    <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="INT8U" default="0x00"         min="0x00" max="0xFF" writable="false"  optional="true">current audio output</attribute>
 
     <command source="client" code="0x00" name="SelectOutputRequest" optional="false">
       <description>Upon receipt, this SHALL change the output on the media device to the output at a specific index in the Output List.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -25,9 +25,9 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the current Channel on a device.</description>
-    <attribute side="server" code="0x0000" define="CHANNEL_LIST" type="ARRAY" entryType="ChannelInfo" length="254" writable="false" optional="true">channel list</attribute>
-    <attribute side="server" code="0x0001" define="CHANNEL_LINEUP" type="LineupInfo" writable="true" optional="true">channel lineup</attribute>
-    <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfo" writable="true" optional="true">current channel</attribute>
+    <attribute side="server" code="0x0000" define="CHANNEL_LIST"            type="ARRAY" entryType="ChannelInfo" length="254"                    writable="false" optional="true">channel list</attribute>
+    <attribute side="server" code="0x0001" define="CHANNEL_LINEUP"          type="LineupInfo"                    default="0x0" isNullable="true" writable="false" optional="true">channel lineup</attribute>
+    <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfo"                   default="0x0" isNullable="true" writable="false" optional="true">current channel</attribute>
 
     <command source="client" code="0x00" name="ChangeChannelRequest" response="ChangeChannelResponse" optional="false">
       <description>Change the channel on the media player to the channel case-insensitive exact matching the value passed as an argument. </description>
@@ -48,25 +48,25 @@ limitations under the License.
     <command source="server" code="0x01" name="ChangeChannelResponse" optional="false">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
       <arg name="channelMatch" type="ChannelInfo"/>
-      <arg name="errorType" type="ErrorTypeEnum"/>
+      <arg name="errorType"    type="ErrorTypeEnum"/>
     </command>
 
   </cluster>
 
   <struct name="ChannelInfo">
     <cluster code="0x0504"/>
-    <item name="majorNumber" type="INT16U"/>
-    <item name="minorNumber" type="INT16U"/>
-    <item name="name" type="CHAR_STRING" length="32"/>
-    <item name="callSign" type="CHAR_STRING" length="32"/>
-    <item name="affiliateCallSign" type="CHAR_STRING" length="32"/>
+    <item name="majorNumber"       type="INT16U"/>
+    <item name="minorNumber"       type="INT16U"/>
+    <item name="name"              type="CHAR_STRING" optional="true" length="32"/>
+    <item name="callSign"          type="CHAR_STRING" optional="true" length="32"/>
+    <item name="affiliateCallSign" type="CHAR_STRING" optional="true" length="32"/>
   </struct>
 
   <struct name="LineupInfo">
     <cluster code="0x0504"/>
-    <item name="operatorName" type="CHAR_STRING"/>
-    <item name="lineupName" type="CHAR_STRING"/>
-    <item name="postalCode" type="CHAR_STRING"/>
+    <item name="operatorName"   type="CHAR_STRING"/>
+    <item name="lineupName"     type="CHAR_STRING" default="" optional="true"/>
+    <item name="postalCode"     type="CHAR_STRING" default="" optional="true"/>
     <item name="lineupInfoType" type="LineupInfoTypeEnum"/>
   </struct>
 
@@ -84,7 +84,7 @@ limitations under the License.
   <bitmap name="ChannelFeature" type="BITMAP32">
     <cluster code="0x050c"/>
     <field name="ChannelList" mask="0x1"/>
-    <field name="LineupInfo" mask="0x2"/>
+    <field name="LineupInfo"  mask="0x2"/>
   </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -26,27 +26,27 @@ limitations under the License.
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
 
-    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER" type="ARRAY" entryType="CHAR_STRING" length="254" writable="false" optional="false">accept header list</attribute>
-    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="BITMAP32" writable="true" optional="false">supported streaming protocols</attribute>
+    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="ARRAY" entryType="CHAR_STRING" length="254" writable="false" optional="true">accept header list</attribute>
+    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="BITMAP32" default="0"                       writable="true"  optional="true">supported streaming protocols</attribute>
 
     <command source="client" code="0x00" name="LaunchContentRequest" response="LaunchResponse" optional="false">
       <description>Upon receipt, this SHALL launch the specified content with optional search criteria.</description>
-      <arg name="autoPlay" type="BOOLEAN"/>
-      <arg name="data" type="CHAR_STRING"/>
       <arg name="search" type="ContentSearch" array="true"/>
+      <arg name="autoPlay" type="BOOLEAN"/>
+      <arg name="data" type="CHAR_STRING" optional="true"/>
     </command>
 
     <command source="client" code="0x01" name="LaunchURLRequest" response="LaunchResponse" optional="false">
       <description>Upon receipt, this SHALL launch content from the specified URL.</description>
       <arg name="contentURL" type="CHAR_STRING"/>
-      <arg name="displayString" type="CHAR_STRING"/>
-      <arg name="brandingInformation" type="BrandingInformation"/>
+      <arg name="displayString" type="CHAR_STRING" optional="true"/>
+      <arg name="brandingInformation" type="BrandingInformation" optional="true"/>
     </command>
 
     <command source="server" code="0x02" name="LaunchResponse" optional="false" disableDefaultResponse="true">
       <description>This command SHALL be generated in response to LaunchContent command.</description>
       <arg name="status" type="StatusEnum"/>
-      <arg name="data" type="CHAR_STRING"/>
+      <arg name="data" type="CHAR_STRING" optional="true"/>
     </command>
 
   </cluster>
@@ -77,19 +77,19 @@ limitations under the License.
 
   <struct name="StyleInformation">
     <cluster code="0x050a"/>
-    <item name="imageUrl" type="CHAR_STRING"/>
-    <item name="color" type="CHAR_STRING"/>
-    <item name="size" type="Dimension"/>
+    <item name="imageUrl" type="CHAR_STRING" optional="true"/>
+    <item name="color" type="CHAR_STRING" optional="true"/>
+    <item name="size" type="Dimension" optional="true"/>
   </struct>
 
   <struct name="BrandingInformation">
     <cluster code="0x050a"/>
     <item name="providerName" type="CHAR_STRING"/>
-    <item name="background" type="StyleInformation"/>
-    <item name="logo" type="StyleInformation"/>
-    <item name="progressBar" type="StyleInformation"/>
-    <item name="splash" type="StyleInformation"/>
-    <item name="waterMark" type="StyleInformation"/>
+    <item name="background" type="StyleInformation" optional="true"/>
+    <item name="logo" type="StyleInformation" optional="true"/>
+    <item name="progressBar" type="StyleInformation" optional="true"/>
+    <item name="splash" type="StyleInformation" optional="true"/>
+    <item name="waterMark" type="StyleInformation" optional="true"/>
   </struct>
 
 
@@ -121,7 +121,7 @@ limitations under the License.
     <cluster code="0x050a"/>
     <item name="type" type="ParameterEnum"/>
     <item name="value" type="CHAR_STRING"/>
-    <item name="externalIDList" type="AdditionalInfo" array="true"/>
+    <item name="externalIDList" type="AdditionalInfo" array="true" optional="true"/>
   </struct>
 
   <bitmap name="SupportedStreamingProtocol" type="BITMAP32">

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -25,8 +25,8 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the Input Selector on a media device such as a TV.</description>
-    <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST" type="ARRAY" entryType="InputInfo" length="254" writable="false" optional="false">media input list</attribute>
-    <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">current media input</attribute>
+    <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST"          type="ARRAY" entryType="InputInfo" length="254"           writable="false" optional="false">media input list</attribute>
+    <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="INT8U" default="0x00"        min="0x00" max="0xFF"  writable="false" optional="true">current media input</attribute>
 
     <command source="client" code="0x00" name="SelectInputRequest" optional="false">
       <description>Upon receipt, this SHALL change the input on the media device to the input at a specific index in the Input List.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -26,13 +26,13 @@ limitations under the License.
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.</description>
 
-    <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE" type="PlaybackStateEnum" min="0x00" max="0x02" writable="false" default="0x00" optional="true">playback state</attribute>
-    <attribute side="server" code="0x0001" define="MEDIA_PLAYBACK_START_TIME" type="EPOCH_US" min="0x00"  writable="false" default="0xFF" optional="true">start time</attribute>
-    <attribute side="server" code="0x0002" define="MEDIA_PLAYBACK_DURATION" type="INT64U" min="0x00"  writable="false" optional="true">duration</attribute>
-    <attribute side="server" code="0x0003" define="MEDIA_PLAYBACK_PLAYBACK_POSITION" type="PlaybackPosition" writable="true" optional="false">position</attribute>
-    <attribute side="server" code="0x0004" define="MEDIA_PLAYBACK_PLAYBACK_SPEED" type="single" min="0x00"  writable="false" optional="true">playback speed</attribute>
-    <attribute side="server" code="0x0005" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_END" type="INT64U" min="0x00"  writable="false" optional="true">seek range end</attribute>
-    <attribute side="server" code="0x0006" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_START" type="INT64U" min="0x00"  writable="false" optional="true">seek range start</attribute>
+    <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE"                     type="PlaybackStateEnum" min="0x00" max="0x02" default="0x00" writable="false"                    optional="false">playback state</attribute>
+    <attribute side="server" code="0x0001" define="MEDIA_PLAYBACK_START_TIME"                type="EPOCH_US"          min="0x00"            default="0x00" writable="false" isNullable="true"  optional="true">start time</attribute>
+    <attribute side="server" code="0x0002" define="MEDIA_PLAYBACK_DURATION"                  type="INT64U"            min="0x00"            default="0"    writable="false" isNullable="true"  optional="true">duration</attribute>
+    <attribute side="server" code="0x0003" define="MEDIA_PLAYBACK_PLAYBACK_POSITION"         type="PlaybackPosition"                                       writable="false"                    optional="true">position</attribute>
+    <attribute side="server" code="0x0004" define="MEDIA_PLAYBACK_PLAYBACK_SPEED"            type="single"            min="0x00"            default="0"    writable="false"                    optional="true">playback speed</attribute>
+    <attribute side="server" code="0x0005" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_END"   type="INT64U"            min="0x00"                           writable="false" isNullable="true"  optional="true">seek range end</attribute>
+    <attribute side="server" code="0x0006" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_START" type="INT64U"            min="0x00"                           writable="false" isNullable="true"  optional="true">seek range start</attribute>
 
 
     <command source="client" code="0x00" name="PlayRequest" response="PlaybackResponse" optional="false">
@@ -47,37 +47,37 @@ limitations under the License.
       <description>Upon receipt, this SHALL stop media. User experience is context-specific. This will often navigate the user back to the location where media was originally launched.</description>
     </command>
 
-    <command source="client" code="0x03" name="StartOverRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x03" name="StartOverRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Start Over with the current media playback item.</description>
     </command>
 
-    <command source="client" code="0x04" name="PreviousRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x04" name="PreviousRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL cause the handler to be invoked for "Previous". User experience is context-specific. This will often Go back to the previous media playback item.</description>
     </command>
 
-    <command source="client" code="0x05" name="NextRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x05" name="NextRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL cause the handler to be invoked for "Next". User experience is context-specific. This will often Go forward to the next media playback item.</description>
     </command>
 
-    <command source="client" code="0x06" name="RewindRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x06" name="RewindRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Rewind through media. Different Rewind speeds can be used on the TV based upon the number of sequential calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).</description>
     </command>
 
-    <command source="client" code="0x07" name="FastForwardRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x07" name="FastForwardRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Advance through media. Different FF speeds can be used on the TV based upon the number of sequential calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).</description>
     </command>
 
-    <command source="client" code="0x08" name="SkipForwardRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x08" name="SkipForwardRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Skip forward in the media by the given number of seconds, using the data as follows:</description>
       <arg name="deltaPositionMilliseconds" type="INT64U"/>
     </command>
 
-    <command source="client" code="0x09" name="SkipBackwardRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x09" name="SkipBackwardRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:</description>
       <arg name="deltaPositionMilliseconds" type="INT64U"/>
     </command>
 
-    <command source="client" code="0x0B" name="SeekRequest" response="PlaybackResponse" optional="false">
+    <command source="client" code="0x0B" name="SeekRequest" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:</description>
       <arg name="position" type="INT64U"/>
     </command>
@@ -92,7 +92,7 @@ limitations under the License.
   <struct name="PlaybackPosition">
     <cluster code="0x0506"/>
     <item name="updatedAt" type="INT64U"/>
-    <item name="position" type="INT64U"/>    
+    <item name="position" type="INT64U" isNullable="true"/>    
   </struct>
 
   <enum name="PlaybackStateEnum" type="ENUM8">

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -25,19 +25,19 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.</description>
-    <attribute side="server" code="0x0000" define="TARGET_NAVIGATOR_LIST" type="ARRAY" entryType="TargetInfo" length="254" writable="false" optional="false">target navigator list</attribute>
-    <attribute side="server" code="0x0001" define="TARGET_NAVIGATOR_CURRENT_TARGET" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">current navigator target</attribute>
+    <attribute side="server" code="0x0000" define="TARGET_NAVIGATOR_LIST"           type="ARRAY" entryType="TargetInfo"          length="254" writable="false" optional="false">target navigator list</attribute>
+    <attribute side="server" code="0x0001" define="TARGET_NAVIGATOR_CURRENT_TARGET" type="INT8U" default="0"            min="0x00" max="0xFF" writable="false" optional="true">current navigator target</attribute>
 
     <command source="client" code="0x00" name="NavigateTargetRequest" response="NavigateTargetResponse" optional="false">
       <description>Upon receipt, this SHALL navigation the UX to the target identified.</description>
       <arg name="target" type="INT8U"/>
-      <arg name="data" type="CHAR_STRING"/>
+      <arg name="data" type="CHAR_STRING" optional="true"/>
     </command>
 
     <command source="server" code="0x01" name="NavigateTargetResponse" optional="false">
       <description>This command SHALL be generated in response to NavigateTarget commands.</description>
       <arg name="status" type="StatusEnum"/>
-      <arg name="data" type="CHAR_STRING"/>
+      <arg name="data" type="CHAR_STRING" optional="true"/>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/wake-on-lan-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wake-on-lan-cluster.xml
@@ -24,6 +24,6 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.</description>
-    <attribute side="server" code="0x0000" define="WAKE_ON_LAN_MAC_ADDRESS" type="CHAR_STRING" length="32" writable="false" optional="false">wake on lan mac address</attribute>
+    <attribute side="server" code="0x0000" define="WAKE_ON_LAN_MAC_ADDRESS" type="CHAR_STRING" length="32" writable="false" optional="true">wake on lan mac address</attribute>
   </cluster>
 </configurator>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -178,7 +178,7 @@ client cluster ApplicationLauncher = 1292 {
 
   struct ApplicationEP {
     Application application = 0;
-    CHAR_STRING endpoint = 1;
+    optional ENDPOINT_NO endpoint = 1;
   }
 
   struct Application {
@@ -187,7 +187,7 @@ client cluster ApplicationLauncher = 1292 {
   }
 
   readonly attribute INT16U applicationLauncherList[] = 0;
-  attribute ApplicationEP applicationLauncherApp = 1;
+  attribute nullable ApplicationEP applicationLauncherApp = 1;
   readonly global attribute command_id serverGeneratedCommandList[] = 65528;
   readonly global attribute command_id clientGeneratedCommandList[] = 65529;
   readonly global attribute attrib_id attributeList[] = 65531;
@@ -199,7 +199,7 @@ client cluster ApplicationLauncher = 1292 {
 
   request struct LaunchAppRequestRequest {
     Application application = 0;
-    OCTET_STRING data = 1;
+    optional OCTET_STRING data = 1;
   }
 
   request struct StopAppRequestRequest {
@@ -559,21 +559,21 @@ client cluster Channel = 1284 {
   struct ChannelInfo {
     INT16U majorNumber = 0;
     INT16U minorNumber = 1;
-    CHAR_STRING<32> name = 2;
-    CHAR_STRING<32> callSign = 3;
-    CHAR_STRING<32> affiliateCallSign = 4;
+    optional CHAR_STRING<32> name = 2;
+    optional CHAR_STRING<32> callSign = 3;
+    optional CHAR_STRING<32> affiliateCallSign = 4;
   }
 
   struct LineupInfo {
     CHAR_STRING operatorName = 0;
-    CHAR_STRING lineupName = 1;
-    CHAR_STRING postalCode = 2;
+    optional CHAR_STRING lineupName = 1;
+    optional CHAR_STRING postalCode = 2;
     LineupInfoTypeEnum lineupInfoType = 3;
   }
 
   readonly attribute ChannelInfo channelList[] = 0;
-  attribute LineupInfo channelLineup = 1;
-  attribute ChannelInfo currentChannel = 2;
+  readonly attribute nullable LineupInfo channelLineup = 1;
+  readonly attribute nullable ChannelInfo currentChannel = 2;
   readonly global attribute command_id serverGeneratedCommandList[] = 65528;
   readonly global attribute command_id clientGeneratedCommandList[] = 65529;
   readonly global attribute attrib_id attributeList[] = 65531;
@@ -935,7 +935,7 @@ client cluster ContentLauncher = 1290 {
   struct Parameter {
     ParameterEnum type = 0;
     CHAR_STRING value = 1;
-    AdditionalInfo externalIDList[] = 2;
+    optional AdditionalInfo externalIDList[] = 2;
   }
 
   struct AdditionalInfo {
@@ -945,17 +945,17 @@ client cluster ContentLauncher = 1290 {
 
   struct BrandingInformation {
     CHAR_STRING providerName = 0;
-    StyleInformation background = 1;
-    StyleInformation logo = 2;
-    StyleInformation progressBar = 3;
-    StyleInformation splash = 4;
-    StyleInformation waterMark = 5;
+    optional StyleInformation background = 1;
+    optional StyleInformation logo = 2;
+    optional StyleInformation progressBar = 3;
+    optional StyleInformation splash = 4;
+    optional StyleInformation waterMark = 5;
   }
 
   struct StyleInformation {
-    CHAR_STRING imageUrl = 0;
-    CHAR_STRING color = 1;
-    Dimension size = 2;
+    optional CHAR_STRING imageUrl = 0;
+    optional CHAR_STRING color = 1;
+    optional Dimension size = 2;
   }
 
   struct Dimension {
@@ -972,20 +972,20 @@ client cluster ContentLauncher = 1290 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct LaunchContentRequestRequest {
-    BOOLEAN autoPlay = 0;
-    CHAR_STRING data = 1;
-    ContentSearch search[] = 2;
+    ContentSearch search[] = 0;
+    BOOLEAN autoPlay = 1;
+    optional CHAR_STRING data = 2;
   }
 
   request struct LaunchURLRequestRequest {
     CHAR_STRING contentURL = 0;
-    CHAR_STRING displayString = 1;
-    BrandingInformation brandingInformation = 2;
+    optional CHAR_STRING displayString = 1;
+    optional BrandingInformation brandingInformation = 2;
   }
 
   response struct LaunchResponse {
     StatusEnum status = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   command LaunchContentRequest(LaunchContentRequestRequest): LaunchResponse = 0;
@@ -2299,16 +2299,16 @@ client cluster MediaPlayback = 1286 {
 
   struct PlaybackPosition {
     INT64U updatedAt = 0;
-    INT64U position = 1;
+    nullable INT64U position = 1;
   }
 
   readonly attribute PlaybackStateEnum playbackState = 0;
-  readonly attribute epoch_us startTime = 1;
-  readonly attribute int64u duration = 2;
-  attribute PlaybackPosition position = 3;
+  readonly attribute nullable epoch_us startTime = 1;
+  readonly attribute nullable int64u duration = 2;
+  readonly attribute PlaybackPosition position = 3;
   readonly attribute single playbackSpeed = 4;
-  readonly attribute int64u seekRangeEnd = 5;
-  readonly attribute int64u seekRangeStart = 6;
+  readonly attribute nullable int64u seekRangeEnd = 5;
+  readonly attribute nullable int64u seekRangeStart = 6;
   readonly global attribute command_id serverGeneratedCommandList[] = 65528;
   readonly global attribute command_id clientGeneratedCommandList[] = 65529;
   readonly global attribute attrib_id attributeList[] = 65531;
@@ -3226,12 +3226,12 @@ client cluster TargetNavigator = 1285 {
 
   request struct NavigateTargetRequestRequest {
     INT8U target = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   response struct NavigateTargetResponse {
     StatusEnum status = 0;
-    CHAR_STRING data = 1;
+    optional CHAR_STRING data = 1;
   }
 
   command NavigateTargetRequest(NavigateTargetRequestRequest): NavigateTargetResponse = 0;

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -857,56 +857,75 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            jobject value_application;
-            jobject value_application_catalogVendorId;
-            std::string value_application_catalogVendorIdClassName     = "java/lang/Integer";
-            std::string value_application_catalogVendorIdCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
-                value_application_catalogVendorIdClassName.c_str(), value_application_catalogVendorIdCtorSignature.c_str(),
-                cppValue.application.catalogVendorId, value_application_catalogVendorId);
-            jobject value_application_applicationId;
-            value_application_applicationId = env->NewStringUTF(
-                std::string(cppValue.application.applicationId.data(), cppValue.application.applicationId.size()).c_str());
-
-            jclass applicationStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
-                env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplication", applicationStructClass);
-            if (err != CHIP_NO_ERROR)
+            if (cppValue.IsNull())
             {
-                ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplication");
-                return nullptr;
+                value = nullptr;
             }
-            jmethodID applicationStructCtor =
-                env->GetMethodID(applicationStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
-            if (applicationStructCtor == nullptr)
+            else
             {
-                ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplication constructor");
-                return nullptr;
-            }
+                jobject value_application;
+                jobject value_application_catalogVendorId;
+                std::string value_application_catalogVendorIdClassName     = "java/lang/Integer";
+                std::string value_application_catalogVendorIdCtorSignature = "(I)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                    value_application_catalogVendorIdClassName.c_str(), value_application_catalogVendorIdCtorSignature.c_str(),
+                    cppValue.Value().application.catalogVendorId, value_application_catalogVendorId);
+                jobject value_application_applicationId;
+                value_application_applicationId = env->NewStringUTF(std::string(cppValue.Value().application.applicationId.data(),
+                                                                                cppValue.Value().application.applicationId.size())
+                                                                        .c_str());
 
-            value_application = env->NewObject(applicationStructClass, applicationStructCtor, value_application_catalogVendorId,
-                                               value_application_applicationId);
-            jobject value_endpoint;
-            value_endpoint = env->NewStringUTF(std::string(cppValue.endpoint.data(), cppValue.endpoint.size()).c_str());
+                jclass applicationStructClass;
+                err = chip::JniReferences::GetInstance().GetClassRef(
+                    env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplication", applicationStructClass);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplication");
+                    return nullptr;
+                }
+                jmethodID applicationStructCtor =
+                    env->GetMethodID(applicationStructClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
+                if (applicationStructCtor == nullptr)
+                {
+                    ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplication constructor");
+                    return nullptr;
+                }
 
-            jclass applicationEPStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
-                env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationEP", applicationEPStructClass);
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplicationEP");
-                return nullptr;
-            }
-            jmethodID applicationEPStructCtor =
-                env->GetMethodID(applicationEPStructClass, "<init>",
-                                 "(Lchip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplication;Ljava/lang/String;)V");
-            if (applicationEPStructCtor == nullptr)
-            {
-                ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplicationEP constructor");
-                return nullptr;
-            }
+                value_application = env->NewObject(applicationStructClass, applicationStructCtor, value_application_catalogVendorId,
+                                                   value_application_applicationId);
+                jobject value_endpoint;
+                if (!cppValue.Value().endpoint.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, value_endpoint);
+                }
+                else
+                {
+                    std::string value_endpointClassName     = "java/lang/Integer";
+                    std::string value_endpointCtorSignature = "(I)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                        value_endpointClassName.c_str(), value_endpointCtorSignature.c_str(), cppValue.Value().endpoint.Value(),
+                        value_endpoint);
+                }
 
-            value = env->NewObject(applicationEPStructClass, applicationEPStructCtor, value_application, value_endpoint);
+                jclass applicationEPStructClass;
+                err = chip::JniReferences::GetInstance().GetClassRef(
+                    env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationEP", applicationEPStructClass);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "Could not find class ChipStructs$ApplicationLauncherClusterApplicationEP");
+                    return nullptr;
+                }
+                jmethodID applicationEPStructCtor = env->GetMethodID(
+                    applicationEPStructClass, "<init>",
+                    "(Lchip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplication;Ljava/util/Optional;)V");
+                if (applicationEPStructCtor == nullptr)
+                {
+                    ChipLogError(Zcl, "Could not find ChipStructs$ApplicationLauncherClusterApplicationEP constructor");
+                    return nullptr;
+                }
+
+                value = env->NewObject(applicationEPStructClass, applicationEPStructCtor, value_application, value_endpoint);
+            }
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -2647,12 +2666,35 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                newElement_0_minorNumberCtorSignature.c_str(),
                                                                                entry_0.minorNumber, newElement_0_minorNumber);
                 jobject newElement_0_name;
-                newElement_0_name = env->NewStringUTF(std::string(entry_0.name.data(), entry_0.name.size()).c_str());
+                if (!entry_0.name.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_name);
+                }
+                else
+                {
+                    newElement_0_name =
+                        env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+                }
                 jobject newElement_0_callSign;
-                newElement_0_callSign = env->NewStringUTF(std::string(entry_0.callSign.data(), entry_0.callSign.size()).c_str());
+                if (!entry_0.callSign.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_callSign);
+                }
+                else
+                {
+                    newElement_0_callSign =
+                        env->NewStringUTF(std::string(entry_0.callSign.Value().data(), entry_0.callSign.Value().size()).c_str());
+                }
                 jobject newElement_0_affiliateCallSign;
-                newElement_0_affiliateCallSign =
-                    env->NewStringUTF(std::string(entry_0.affiliateCallSign.data(), entry_0.affiliateCallSign.size()).c_str());
+                if (!entry_0.affiliateCallSign.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_affiliateCallSign);
+                }
+                else
+                {
+                    newElement_0_affiliateCallSign = env->NewStringUTF(
+                        std::string(entry_0.affiliateCallSign.Value().data(), entry_0.affiliateCallSign.Value().size()).c_str());
+                }
 
                 jclass channelInfoStructClass;
                 err = chip::JniReferences::GetInstance().GetClassRef(
@@ -2664,7 +2706,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 jmethodID channelInfoStructCtor = env->GetMethodID(
                     channelInfoStructClass, "<init>",
-                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
                 if (channelInfoStructCtor == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfo constructor");
@@ -2687,37 +2729,64 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            jobject value_operatorName;
-            value_operatorName = env->NewStringUTF(std::string(cppValue.operatorName.data(), cppValue.operatorName.size()).c_str());
-            jobject value_lineupName;
-            value_lineupName = env->NewStringUTF(std::string(cppValue.lineupName.data(), cppValue.lineupName.size()).c_str());
-            jobject value_postalCode;
-            value_postalCode = env->NewStringUTF(std::string(cppValue.postalCode.data(), cppValue.postalCode.size()).c_str());
-            jobject value_lineupInfoType;
-            std::string value_lineupInfoTypeClassName     = "java/lang/Integer";
-            std::string value_lineupInfoTypeCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                value_lineupInfoTypeClassName.c_str(), value_lineupInfoTypeCtorSignature.c_str(),
-                static_cast<uint8_t>(cppValue.lineupInfoType), value_lineupInfoType);
-
-            jclass lineupInfoStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs$ChannelClusterLineupInfo",
-                                                                 lineupInfoStructClass);
-            if (err != CHIP_NO_ERROR)
+            if (cppValue.IsNull())
             {
-                ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterLineupInfo");
-                return nullptr;
+                value = nullptr;
             }
-            jmethodID lineupInfoStructCtor = env->GetMethodID(
-                lineupInfoStructClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V");
-            if (lineupInfoStructCtor == nullptr)
+            else
             {
-                ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterLineupInfo constructor");
-                return nullptr;
-            }
+                jobject value_operatorName;
+                value_operatorName = env->NewStringUTF(
+                    std::string(cppValue.Value().operatorName.data(), cppValue.Value().operatorName.size()).c_str());
+                jobject value_lineupName;
+                if (!cppValue.Value().lineupName.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, value_lineupName);
+                }
+                else
+                {
+                    value_lineupName = env->NewStringUTF(
+                        std::string(cppValue.Value().lineupName.Value().data(), cppValue.Value().lineupName.Value().size())
+                            .c_str());
+                }
+                jobject value_postalCode;
+                if (!cppValue.Value().postalCode.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, value_postalCode);
+                }
+                else
+                {
+                    value_postalCode = env->NewStringUTF(
+                        std::string(cppValue.Value().postalCode.Value().data(), cppValue.Value().postalCode.Value().size())
+                            .c_str());
+                }
+                jobject value_lineupInfoType;
+                std::string value_lineupInfoTypeClassName     = "java/lang/Integer";
+                std::string value_lineupInfoTypeCtorSignature = "(I)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
+                    value_lineupInfoTypeClassName.c_str(), value_lineupInfoTypeCtorSignature.c_str(),
+                    static_cast<uint8_t>(cppValue.Value().lineupInfoType), value_lineupInfoType);
 
-            value = env->NewObject(lineupInfoStructClass, lineupInfoStructCtor, value_operatorName, value_lineupName,
-                                   value_postalCode, value_lineupInfoType);
+                jclass lineupInfoStructClass;
+                err = chip::JniReferences::GetInstance().GetClassRef(
+                    env, "chip/devicecontroller/ChipStructs$ChannelClusterLineupInfo", lineupInfoStructClass);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterLineupInfo");
+                    return nullptr;
+                }
+                jmethodID lineupInfoStructCtor =
+                    env->GetMethodID(lineupInfoStructClass, "<init>",
+                                     "(Ljava/lang/String;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/Integer;)V");
+                if (lineupInfoStructCtor == nullptr)
+                {
+                    ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterLineupInfo constructor");
+                    return nullptr;
+                }
+
+                value = env->NewObject(lineupInfoStructClass, lineupInfoStructCtor, value_operatorName, value_lineupName,
+                                       value_postalCode, value_lineupInfoType);
+            }
             return value;
         }
         case Attributes::CurrentChannel::Id: {
@@ -2729,45 +2798,76 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            jobject value_majorNumber;
-            std::string value_majorNumberClassName     = "java/lang/Integer";
-            std::string value_majorNumberCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(value_majorNumberClassName.c_str(),
-                                                                           value_majorNumberCtorSignature.c_str(),
-                                                                           cppValue.majorNumber, value_majorNumber);
-            jobject value_minorNumber;
-            std::string value_minorNumberClassName     = "java/lang/Integer";
-            std::string value_minorNumberCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(value_minorNumberClassName.c_str(),
-                                                                           value_minorNumberCtorSignature.c_str(),
-                                                                           cppValue.minorNumber, value_minorNumber);
-            jobject value_name;
-            value_name = env->NewStringUTF(std::string(cppValue.name.data(), cppValue.name.size()).c_str());
-            jobject value_callSign;
-            value_callSign = env->NewStringUTF(std::string(cppValue.callSign.data(), cppValue.callSign.size()).c_str());
-            jobject value_affiliateCallSign;
-            value_affiliateCallSign =
-                env->NewStringUTF(std::string(cppValue.affiliateCallSign.data(), cppValue.affiliateCallSign.size()).c_str());
-
-            jclass channelInfoStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfo",
-                                                                 channelInfoStructClass);
-            if (err != CHIP_NO_ERROR)
+            if (cppValue.IsNull())
             {
-                ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
-                return nullptr;
+                value = nullptr;
             }
-            jmethodID channelInfoStructCtor =
-                env->GetMethodID(channelInfoStructClass, "<init>",
-                                 "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
-            if (channelInfoStructCtor == nullptr)
+            else
             {
-                ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfo constructor");
-                return nullptr;
-            }
+                jobject value_majorNumber;
+                std::string value_majorNumberClassName     = "java/lang/Integer";
+                std::string value_majorNumberCtorSignature = "(I)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(value_majorNumberClassName.c_str(),
+                                                                               value_majorNumberCtorSignature.c_str(),
+                                                                               cppValue.Value().majorNumber, value_majorNumber);
+                jobject value_minorNumber;
+                std::string value_minorNumberClassName     = "java/lang/Integer";
+                std::string value_minorNumberCtorSignature = "(I)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(value_minorNumberClassName.c_str(),
+                                                                               value_minorNumberCtorSignature.c_str(),
+                                                                               cppValue.Value().minorNumber, value_minorNumber);
+                jobject value_name;
+                if (!cppValue.Value().name.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, value_name);
+                }
+                else
+                {
+                    value_name = env->NewStringUTF(
+                        std::string(cppValue.Value().name.Value().data(), cppValue.Value().name.Value().size()).c_str());
+                }
+                jobject value_callSign;
+                if (!cppValue.Value().callSign.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, value_callSign);
+                }
+                else
+                {
+                    value_callSign = env->NewStringUTF(
+                        std::string(cppValue.Value().callSign.Value().data(), cppValue.Value().callSign.Value().size()).c_str());
+                }
+                jobject value_affiliateCallSign;
+                if (!cppValue.Value().affiliateCallSign.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, value_affiliateCallSign);
+                }
+                else
+                {
+                    value_affiliateCallSign = env->NewStringUTF(std::string(cppValue.Value().affiliateCallSign.Value().data(),
+                                                                            cppValue.Value().affiliateCallSign.Value().size())
+                                                                    .c_str());
+                }
 
-            value = env->NewObject(channelInfoStructClass, channelInfoStructCtor, value_majorNumber, value_minorNumber, value_name,
-                                   value_callSign, value_affiliateCallSign);
+                jclass channelInfoStructClass;
+                err = chip::JniReferences::GetInstance().GetClassRef(
+                    env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfo", channelInfoStructClass);
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
+                    return nullptr;
+                }
+                jmethodID channelInfoStructCtor = env->GetMethodID(
+                    channelInfoStructClass, "<init>",
+                    "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
+                if (channelInfoStructCtor == nullptr)
+                {
+                    ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfo constructor");
+                    return nullptr;
+                }
+
+                value = env->NewObject(channelInfoStructClass, channelInfoStructCtor, value_majorNumber, value_minorNumber,
+                                       value_name, value_callSign, value_affiliateCallSign);
+            }
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -7476,10 +7576,17 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            std::string valueClassName     = "java/lang/Long";
-            std::string valueCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
-                                                                           cppValue, value);
+            if (cppValue.IsNull())
+            {
+                value = nullptr;
+            }
+            else
+            {
+                std::string valueClassName     = "java/lang/Long";
+                std::string valueCtorSignature = "(J)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
+                                                                               cppValue.Value(), value);
+            }
             return value;
         }
         case Attributes::Duration::Id: {
@@ -7491,10 +7598,17 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            std::string valueClassName     = "java/lang/Long";
-            std::string valueCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
-                                                                           cppValue, value);
+            if (cppValue.IsNull())
+            {
+                value = nullptr;
+            }
+            else
+            {
+                std::string valueClassName     = "java/lang/Long";
+                std::string valueCtorSignature = "(J)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
+                                                                               cppValue.Value(), value);
+            }
             return value;
         }
         case Attributes::Position::Id: {
@@ -7512,10 +7626,18 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
                 value_updatedAtClassName.c_str(), value_updatedAtCtorSignature.c_str(), cppValue.updatedAt, value_updatedAt);
             jobject value_position;
-            std::string value_positionClassName     = "java/lang/Long";
-            std::string value_positionCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
-                value_positionClassName.c_str(), value_positionCtorSignature.c_str(), cppValue.position, value_position);
+            if (cppValue.position.IsNull())
+            {
+                value_position = nullptr;
+            }
+            else
+            {
+                std::string value_positionClassName     = "java/lang/Long";
+                std::string value_positionCtorSignature = "(J)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(value_positionClassName.c_str(),
+                                                                               value_positionCtorSignature.c_str(),
+                                                                               cppValue.position.Value(), value_position);
+            }
 
             jclass playbackPositionStructClass;
             err = chip::JniReferences::GetInstance().GetClassRef(
@@ -7560,10 +7682,17 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            std::string valueClassName     = "java/lang/Long";
-            std::string valueCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
-                                                                           cppValue, value);
+            if (cppValue.IsNull())
+            {
+                value = nullptr;
+            }
+            else
+            {
+                std::string valueClassName     = "java/lang/Long";
+                std::string valueCtorSignature = "(J)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
+                                                                               cppValue.Value(), value);
+            }
             return value;
         }
         case Attributes::SeekRangeStart::Id: {
@@ -7575,10 +7704,17 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 return nullptr;
             }
             jobject value;
-            std::string valueClassName     = "java/lang/Long";
-            std::string valueCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
-                                                                           cppValue, value);
+            if (cppValue.IsNull())
+            {
+                value = nullptr;
+            }
+            else
+            {
+                std::string valueClassName     = "java/lang/Long";
+                std::string valueCtorSignature = "(J)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
+                                                                               cppValue.Value(), value);
+            }
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -1514,7 +1514,7 @@ JNI_METHOD(void, ApplicationLauncherCluster, hideAppRequest)
     onFailure.release();
 }
 JNI_METHOD(void, ApplicationLauncherCluster, launchAppRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject application, jbyteArray data, jobject timedInvokeTimeoutMs)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject application, jobject data, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1536,8 +1536,14 @@ JNI_METHOD(void, ApplicationLauncherCluster, launchAppRequest)
     cleanupStrings.push_back(
         chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(application_applicationIdItem_0)));
     request.application.applicationId = cleanupStrings.back()->charSpan();
-    cleanupByteArrays.push_back(chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(data)));
-    request.data = cleanupByteArrays.back()->byteSpan();
+    if (data != nullptr)
+    {
+        jobject optionalValue_0;
+        chip::JniReferences::GetInstance().GetOptionalValue(data, optionalValue_0);
+        auto & definedValue_0 = request.data.Emplace();
+        cleanupByteArrays.push_back(chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(optionalValue_0)));
+        definedValue_0 = cleanupByteArrays.back()->byteSpan();
+    }
 
     std::unique_ptr<CHIPApplicationLauncherClusterLauncherResponseCallback,
                     void (*)(CHIPApplicationLauncherClusterLauncherResponseCallback *)>
@@ -9375,7 +9381,7 @@ JNI_METHOD(jlong, ContentLauncherCluster, initWithDevice)(JNIEnv * env, jobject 
 }
 
 JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject autoPlay, jstring data, jobject search,
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject search, jobject autoPlay, jobject data,
  jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
@@ -9387,10 +9393,6 @@ JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
 
     std::vector<Platform::UniquePtr<JniByteArray>> cleanupByteArrays;
     std::vector<Platform::UniquePtr<JniUtfString>> cleanupStrings;
-    request.autoPlay = static_cast<std::remove_reference_t<decltype(request.autoPlay)>>(
-        chip::JniReferences::GetInstance().BooleanToPrimitive(autoPlay));
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(data)));
-    request.data = cleanupStrings.back()->charSpan();
     {
         using ListType_0       = std::remove_reference_t<decltype(request.search)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -9436,43 +9438,47 @@ JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
                                 chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(element_2_valueItem_3)));
                             listHolder_2->mList[i_2].value = cleanupStrings.back()->charSpan();
                             jobject element_2_externalIDListItem_3;
-                            chip::JniReferences::GetInstance().GetObjectField(element_2, "externalIDList", "Ljava/util/ArrayList;",
+                            chip::JniReferences::GetInstance().GetObjectField(element_2, "externalIDList", "Ljava/util/Optional;",
                                                                               element_2_externalIDListItem_3);
+                            if (element_2_externalIDListItem_3 != nullptr)
                             {
-                                using ListType_4       = std::remove_reference_t<decltype(listHolder_2->mList[i_2].externalIDList)>;
-                                using ListMemberType_4 = ListMemberTypeGetter<ListType_4>::Type;
-                                jint element_2_externalIDListItem_3Size;
-                                chip::JniReferences::GetInstance().GetArrayListSize(element_2_externalIDListItem_3,
-                                                                                    element_2_externalIDListItem_3Size);
-                                if (element_2_externalIDListItem_3Size != 0)
+                                jobject optionalValue_4;
+                                chip::JniReferences::GetInstance().GetOptionalValue(element_2_externalIDListItem_3,
+                                                                                    optionalValue_4);
+                                auto & definedValue_4 = listHolder_2->mList[i_2].externalIDList.Emplace();
                                 {
-                                    auto * listHolder_4 = new ListHolder<ListMemberType_4>(element_2_externalIDListItem_3Size);
-                                    listFreer.add(listHolder_4);
-
-                                    for (size_t i_4 = 0; i_4 < static_cast<size_t>(element_2_externalIDListItem_3Size); ++i_4)
+                                    using ListType_5       = std::remove_reference_t<decltype(definedValue_4)>;
+                                    using ListMemberType_5 = ListMemberTypeGetter<ListType_5>::Type;
+                                    jint optionalValue_4Size;
+                                    chip::JniReferences::GetInstance().GetArrayListSize(optionalValue_4, optionalValue_4Size);
+                                    if (optionalValue_4Size != 0)
                                     {
-                                        jobject element_4;
-                                        chip::JniReferences::GetInstance().GetArrayListItem(element_2_externalIDListItem_3, i_4,
-                                                                                            element_4);
-                                        jobject element_4_nameItem_5;
-                                        chip::JniReferences::GetInstance().GetObjectField(element_4, "name", "Ljava/lang/String;",
-                                                                                          element_4_nameItem_5);
-                                        cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-                                            env, static_cast<jstring>(element_4_nameItem_5)));
-                                        listHolder_4->mList[i_4].name = cleanupStrings.back()->charSpan();
-                                        jobject element_4_valueItem_5;
-                                        chip::JniReferences::GetInstance().GetObjectField(element_4, "value", "Ljava/lang/String;",
-                                                                                          element_4_valueItem_5);
-                                        cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-                                            env, static_cast<jstring>(element_4_valueItem_5)));
-                                        listHolder_4->mList[i_4].value = cleanupStrings.back()->charSpan();
+                                        auto * listHolder_5 = new ListHolder<ListMemberType_5>(optionalValue_4Size);
+                                        listFreer.add(listHolder_5);
+
+                                        for (size_t i_5 = 0; i_5 < static_cast<size_t>(optionalValue_4Size); ++i_5)
+                                        {
+                                            jobject element_5;
+                                            chip::JniReferences::GetInstance().GetArrayListItem(optionalValue_4, i_5, element_5);
+                                            jobject element_5_nameItem_6;
+                                            chip::JniReferences::GetInstance().GetObjectField(
+                                                element_5, "name", "Ljava/lang/String;", element_5_nameItem_6);
+                                            cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
+                                                env, static_cast<jstring>(element_5_nameItem_6)));
+                                            listHolder_5->mList[i_5].name = cleanupStrings.back()->charSpan();
+                                            jobject element_5_valueItem_6;
+                                            chip::JniReferences::GetInstance().GetObjectField(
+                                                element_5, "value", "Ljava/lang/String;", element_5_valueItem_6);
+                                            cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
+                                                env, static_cast<jstring>(element_5_valueItem_6)));
+                                            listHolder_5->mList[i_5].value = cleanupStrings.back()->charSpan();
+                                        }
+                                        definedValue_4 = ListType_5(listHolder_5->mList, optionalValue_4Size);
                                     }
-                                    listHolder_2->mList[i_2].externalIDList =
-                                        ListType_4(listHolder_4->mList, element_2_externalIDListItem_3Size);
-                                }
-                                else
-                                {
-                                    listHolder_2->mList[i_2].externalIDList = ListType_4();
+                                    else
+                                    {
+                                        definedValue_4 = ListType_5();
+                                    }
                                 }
                             }
                         }
@@ -9490,6 +9496,16 @@ JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
         {
             request.search = ListType_0();
         }
+    }
+    request.autoPlay = static_cast<std::remove_reference_t<decltype(request.autoPlay)>>(
+        chip::JniReferences::GetInstance().BooleanToPrimitive(autoPlay));
+    if (data != nullptr)
+    {
+        jobject optionalValue_0;
+        chip::JniReferences::GetInstance().GetOptionalValue(data, optionalValue_0);
+        auto & definedValue_0 = request.data.Emplace();
+        cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_0)));
+        definedValue_0 = cleanupStrings.back()->charSpan();
     }
 
     std::unique_ptr<CHIPContentLauncherClusterLaunchResponseCallback, void (*)(CHIPContentLauncherClusterLaunchResponseCallback *)>
@@ -9530,7 +9546,7 @@ JNI_METHOD(void, ContentLauncherCluster, launchContentRequest)
     onFailure.release();
 }
 JNI_METHOD(void, ContentLauncherCluster, launchURLRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring contentURL, jstring displayString,
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring contentURL, jobject displayString,
  jobject brandingInformation, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
@@ -9544,212 +9560,311 @@ JNI_METHOD(void, ContentLauncherCluster, launchURLRequest)
     std::vector<Platform::UniquePtr<JniUtfString>> cleanupStrings;
     cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(contentURL)));
     request.contentURL = cleanupStrings.back()->charSpan();
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(displayString)));
-    request.displayString = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_providerNameItem_0;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation, "providerName", "Ljava/lang/String;",
-                                                      brandingInformation_providerNameItem_0);
-    cleanupStrings.push_back(
-        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(brandingInformation_providerNameItem_0)));
-    request.brandingInformation.providerName = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_backgroundItem_0;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation, "background",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterStyleInformation;",
-                                                      brandingInformation_backgroundItem_0);
-    jobject brandingInformation_backgroundItem_0_imageUrlItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_backgroundItem_0, "imageUrl", "Ljava/lang/String;",
-                                                      brandingInformation_backgroundItem_0_imageUrlItem_1);
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-        env, static_cast<jstring>(brandingInformation_backgroundItem_0_imageUrlItem_1)));
-    request.brandingInformation.background.imageUrl = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_backgroundItem_0_colorItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_backgroundItem_0, "color", "Ljava/lang/String;",
-                                                      brandingInformation_backgroundItem_0_colorItem_1);
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-        env, static_cast<jstring>(brandingInformation_backgroundItem_0_colorItem_1)));
-    request.brandingInformation.background.color = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_backgroundItem_0_sizeItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_backgroundItem_0, "size",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterDimension;",
-                                                      brandingInformation_backgroundItem_0_sizeItem_1);
-    jobject brandingInformation_backgroundItem_0_sizeItem_1_widthItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_backgroundItem_0_sizeItem_1, "width",
-                                                      "Ljava/lang/Double;",
-                                                      brandingInformation_backgroundItem_0_sizeItem_1_widthItem_2);
-    request.brandingInformation.background.size.width =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.background.size.width)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_backgroundItem_0_sizeItem_1_widthItem_2));
-    jobject brandingInformation_backgroundItem_0_sizeItem_1_heightItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_backgroundItem_0_sizeItem_1, "height",
-                                                      "Ljava/lang/Double;",
-                                                      brandingInformation_backgroundItem_0_sizeItem_1_heightItem_2);
-    request.brandingInformation.background.size.height =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.background.size.height)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_backgroundItem_0_sizeItem_1_heightItem_2));
-    jobject brandingInformation_backgroundItem_0_sizeItem_1_metricItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_backgroundItem_0_sizeItem_1, "metric",
-                                                      "Ljava/lang/Integer;",
-                                                      brandingInformation_backgroundItem_0_sizeItem_1_metricItem_2);
-    request.brandingInformation.background.size.metric =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.background.size.metric)>>(
-            chip::JniReferences::GetInstance().IntegerToPrimitive(brandingInformation_backgroundItem_0_sizeItem_1_metricItem_2));
-    jobject brandingInformation_logoItem_0;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation, "logo",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterStyleInformation;",
-                                                      brandingInformation_logoItem_0);
-    jobject brandingInformation_logoItem_0_imageUrlItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_logoItem_0, "imageUrl", "Ljava/lang/String;",
-                                                      brandingInformation_logoItem_0_imageUrlItem_1);
-    cleanupStrings.push_back(
-        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(brandingInformation_logoItem_0_imageUrlItem_1)));
-    request.brandingInformation.logo.imageUrl = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_logoItem_0_colorItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_logoItem_0, "color", "Ljava/lang/String;",
-                                                      brandingInformation_logoItem_0_colorItem_1);
-    cleanupStrings.push_back(
-        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(brandingInformation_logoItem_0_colorItem_1)));
-    request.brandingInformation.logo.color = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_logoItem_0_sizeItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_logoItem_0, "size",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterDimension;",
-                                                      brandingInformation_logoItem_0_sizeItem_1);
-    jobject brandingInformation_logoItem_0_sizeItem_1_widthItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_logoItem_0_sizeItem_1, "width", "Ljava/lang/Double;",
-                                                      brandingInformation_logoItem_0_sizeItem_1_widthItem_2);
-    request.brandingInformation.logo.size.width =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.logo.size.width)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_logoItem_0_sizeItem_1_widthItem_2));
-    jobject brandingInformation_logoItem_0_sizeItem_1_heightItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_logoItem_0_sizeItem_1, "height", "Ljava/lang/Double;",
-                                                      brandingInformation_logoItem_0_sizeItem_1_heightItem_2);
-    request.brandingInformation.logo.size.height =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.logo.size.height)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_logoItem_0_sizeItem_1_heightItem_2));
-    jobject brandingInformation_logoItem_0_sizeItem_1_metricItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_logoItem_0_sizeItem_1, "metric", "Ljava/lang/Integer;",
-                                                      brandingInformation_logoItem_0_sizeItem_1_metricItem_2);
-    request.brandingInformation.logo.size.metric =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.logo.size.metric)>>(
-            chip::JniReferences::GetInstance().IntegerToPrimitive(brandingInformation_logoItem_0_sizeItem_1_metricItem_2));
-    jobject brandingInformation_progressBarItem_0;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation, "progressBar",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterStyleInformation;",
-                                                      brandingInformation_progressBarItem_0);
-    jobject brandingInformation_progressBarItem_0_imageUrlItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_progressBarItem_0, "imageUrl", "Ljava/lang/String;",
-                                                      brandingInformation_progressBarItem_0_imageUrlItem_1);
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-        env, static_cast<jstring>(brandingInformation_progressBarItem_0_imageUrlItem_1)));
-    request.brandingInformation.progressBar.imageUrl = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_progressBarItem_0_colorItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_progressBarItem_0, "color", "Ljava/lang/String;",
-                                                      brandingInformation_progressBarItem_0_colorItem_1);
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-        env, static_cast<jstring>(brandingInformation_progressBarItem_0_colorItem_1)));
-    request.brandingInformation.progressBar.color = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_progressBarItem_0_sizeItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_progressBarItem_0, "size",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterDimension;",
-                                                      brandingInformation_progressBarItem_0_sizeItem_1);
-    jobject brandingInformation_progressBarItem_0_sizeItem_1_widthItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_progressBarItem_0_sizeItem_1, "width",
-                                                      "Ljava/lang/Double;",
-                                                      brandingInformation_progressBarItem_0_sizeItem_1_widthItem_2);
-    request.brandingInformation.progressBar.size.width =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.progressBar.size.width)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_progressBarItem_0_sizeItem_1_widthItem_2));
-    jobject brandingInformation_progressBarItem_0_sizeItem_1_heightItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_progressBarItem_0_sizeItem_1, "height",
-                                                      "Ljava/lang/Double;",
-                                                      brandingInformation_progressBarItem_0_sizeItem_1_heightItem_2);
-    request.brandingInformation.progressBar.size.height =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.progressBar.size.height)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_progressBarItem_0_sizeItem_1_heightItem_2));
-    jobject brandingInformation_progressBarItem_0_sizeItem_1_metricItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_progressBarItem_0_sizeItem_1, "metric",
-                                                      "Ljava/lang/Integer;",
-                                                      brandingInformation_progressBarItem_0_sizeItem_1_metricItem_2);
-    request.brandingInformation.progressBar.size.metric =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.progressBar.size.metric)>>(
-            chip::JniReferences::GetInstance().IntegerToPrimitive(brandingInformation_progressBarItem_0_sizeItem_1_metricItem_2));
-    jobject brandingInformation_splashItem_0;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation, "splash",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterStyleInformation;",
-                                                      brandingInformation_splashItem_0);
-    jobject brandingInformation_splashItem_0_imageUrlItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_splashItem_0, "imageUrl", "Ljava/lang/String;",
-                                                      brandingInformation_splashItem_0_imageUrlItem_1);
-    cleanupStrings.push_back(
-        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(brandingInformation_splashItem_0_imageUrlItem_1)));
-    request.brandingInformation.splash.imageUrl = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_splashItem_0_colorItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_splashItem_0, "color", "Ljava/lang/String;",
-                                                      brandingInformation_splashItem_0_colorItem_1);
-    cleanupStrings.push_back(
-        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(brandingInformation_splashItem_0_colorItem_1)));
-    request.brandingInformation.splash.color = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_splashItem_0_sizeItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_splashItem_0, "size",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterDimension;",
-                                                      brandingInformation_splashItem_0_sizeItem_1);
-    jobject brandingInformation_splashItem_0_sizeItem_1_widthItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_splashItem_0_sizeItem_1, "width", "Ljava/lang/Double;",
-                                                      brandingInformation_splashItem_0_sizeItem_1_widthItem_2);
-    request.brandingInformation.splash.size.width =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.splash.size.width)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_splashItem_0_sizeItem_1_widthItem_2));
-    jobject brandingInformation_splashItem_0_sizeItem_1_heightItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_splashItem_0_sizeItem_1, "height", "Ljava/lang/Double;",
-                                                      brandingInformation_splashItem_0_sizeItem_1_heightItem_2);
-    request.brandingInformation.splash.size.height =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.splash.size.height)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_splashItem_0_sizeItem_1_heightItem_2));
-    jobject brandingInformation_splashItem_0_sizeItem_1_metricItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_splashItem_0_sizeItem_1, "metric", "Ljava/lang/Integer;",
-                                                      brandingInformation_splashItem_0_sizeItem_1_metricItem_2);
-    request.brandingInformation.splash.size.metric =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.splash.size.metric)>>(
-            chip::JniReferences::GetInstance().IntegerToPrimitive(brandingInformation_splashItem_0_sizeItem_1_metricItem_2));
-    jobject brandingInformation_waterMarkItem_0;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation, "waterMark",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterStyleInformation;",
-                                                      brandingInformation_waterMarkItem_0);
-    jobject brandingInformation_waterMarkItem_0_imageUrlItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_waterMarkItem_0, "imageUrl", "Ljava/lang/String;",
-                                                      brandingInformation_waterMarkItem_0_imageUrlItem_1);
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(
-        env, static_cast<jstring>(brandingInformation_waterMarkItem_0_imageUrlItem_1)));
-    request.brandingInformation.waterMark.imageUrl = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_waterMarkItem_0_colorItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_waterMarkItem_0, "color", "Ljava/lang/String;",
-                                                      brandingInformation_waterMarkItem_0_colorItem_1);
-    cleanupStrings.push_back(
-        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(brandingInformation_waterMarkItem_0_colorItem_1)));
-    request.brandingInformation.waterMark.color = cleanupStrings.back()->charSpan();
-    jobject brandingInformation_waterMarkItem_0_sizeItem_1;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_waterMarkItem_0, "size",
-                                                      "Lchip/devicecontroller/ChipStructs$ContentLauncherClusterDimension;",
-                                                      brandingInformation_waterMarkItem_0_sizeItem_1);
-    jobject brandingInformation_waterMarkItem_0_sizeItem_1_widthItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_waterMarkItem_0_sizeItem_1, "width", "Ljava/lang/Double;",
-                                                      brandingInformation_waterMarkItem_0_sizeItem_1_widthItem_2);
-    request.brandingInformation.waterMark.size.width =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.waterMark.size.width)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_waterMarkItem_0_sizeItem_1_widthItem_2));
-    jobject brandingInformation_waterMarkItem_0_sizeItem_1_heightItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_waterMarkItem_0_sizeItem_1, "height",
-                                                      "Ljava/lang/Double;",
-                                                      brandingInformation_waterMarkItem_0_sizeItem_1_heightItem_2);
-    request.brandingInformation.waterMark.size.height =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.waterMark.size.height)>>(
-            chip::JniReferences::GetInstance().DoubleToPrimitive(brandingInformation_waterMarkItem_0_sizeItem_1_heightItem_2));
-    jobject brandingInformation_waterMarkItem_0_sizeItem_1_metricItem_2;
-    chip::JniReferences::GetInstance().GetObjectField(brandingInformation_waterMarkItem_0_sizeItem_1, "metric",
-                                                      "Ljava/lang/Integer;",
-                                                      brandingInformation_waterMarkItem_0_sizeItem_1_metricItem_2);
-    request.brandingInformation.waterMark.size.metric =
-        static_cast<std::remove_reference_t<decltype(request.brandingInformation.waterMark.size.metric)>>(
-            chip::JniReferences::GetInstance().IntegerToPrimitive(brandingInformation_waterMarkItem_0_sizeItem_1_metricItem_2));
+    if (displayString != nullptr)
+    {
+        jobject optionalValue_0;
+        chip::JniReferences::GetInstance().GetOptionalValue(displayString, optionalValue_0);
+        auto & definedValue_0 = request.displayString.Emplace();
+        cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_0)));
+        definedValue_0 = cleanupStrings.back()->charSpan();
+    }
+    if (brandingInformation != nullptr)
+    {
+        jobject optionalValue_0;
+        chip::JniReferences::GetInstance().GetOptionalValue(brandingInformation, optionalValue_0);
+        auto & definedValue_0 = request.brandingInformation.Emplace();
+        jobject optionalValue_0_providerNameItem_1;
+        chip::JniReferences::GetInstance().GetObjectField(optionalValue_0, "providerName", "Ljava/lang/String;",
+                                                          optionalValue_0_providerNameItem_1);
+        cleanupStrings.push_back(
+            chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_0_providerNameItem_1)));
+        definedValue_0.providerName = cleanupStrings.back()->charSpan();
+        jobject optionalValue_0_backgroundItem_1;
+        chip::JniReferences::GetInstance().GetObjectField(optionalValue_0, "background", "Ljava/util/Optional;",
+                                                          optionalValue_0_backgroundItem_1);
+        if (optionalValue_0_backgroundItem_1 != nullptr)
+        {
+            jobject optionalValue_2;
+            chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_0_backgroundItem_1, optionalValue_2);
+            auto & definedValue_2 = definedValue_0.background.Emplace();
+            jobject optionalValue_2_imageUrlItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "imageUrl", "Ljava/util/Optional;",
+                                                              optionalValue_2_imageUrlItem_3);
+            if (optionalValue_2_imageUrlItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_imageUrlItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_colorItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "color", "Ljava/util/Optional;",
+                                                              optionalValue_2_colorItem_3);
+            if (optionalValue_2_colorItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_colorItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_sizeItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "size", "Ljava/util/Optional;",
+                                                              optionalValue_2_sizeItem_3);
+            if (optionalValue_2_sizeItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_sizeItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                jobject optionalValue_4_widthItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "width", "Ljava/lang/Double;",
+                                                                  optionalValue_4_widthItem_5);
+                definedValue_4.width = static_cast<std::remove_reference_t<decltype(definedValue_4.width)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_widthItem_5));
+                jobject optionalValue_4_heightItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "height", "Ljava/lang/Double;",
+                                                                  optionalValue_4_heightItem_5);
+                definedValue_4.height = static_cast<std::remove_reference_t<decltype(definedValue_4.height)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_heightItem_5));
+                jobject optionalValue_4_metricItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "metric", "Ljava/lang/Integer;",
+                                                                  optionalValue_4_metricItem_5);
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_4_metricItem_5));
+            }
+        }
+        jobject optionalValue_0_logoItem_1;
+        chip::JniReferences::GetInstance().GetObjectField(optionalValue_0, "logo", "Ljava/util/Optional;",
+                                                          optionalValue_0_logoItem_1);
+        if (optionalValue_0_logoItem_1 != nullptr)
+        {
+            jobject optionalValue_2;
+            chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_0_logoItem_1, optionalValue_2);
+            auto & definedValue_2 = definedValue_0.logo.Emplace();
+            jobject optionalValue_2_imageUrlItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "imageUrl", "Ljava/util/Optional;",
+                                                              optionalValue_2_imageUrlItem_3);
+            if (optionalValue_2_imageUrlItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_imageUrlItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_colorItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "color", "Ljava/util/Optional;",
+                                                              optionalValue_2_colorItem_3);
+            if (optionalValue_2_colorItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_colorItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_sizeItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "size", "Ljava/util/Optional;",
+                                                              optionalValue_2_sizeItem_3);
+            if (optionalValue_2_sizeItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_sizeItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                jobject optionalValue_4_widthItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "width", "Ljava/lang/Double;",
+                                                                  optionalValue_4_widthItem_5);
+                definedValue_4.width = static_cast<std::remove_reference_t<decltype(definedValue_4.width)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_widthItem_5));
+                jobject optionalValue_4_heightItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "height", "Ljava/lang/Double;",
+                                                                  optionalValue_4_heightItem_5);
+                definedValue_4.height = static_cast<std::remove_reference_t<decltype(definedValue_4.height)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_heightItem_5));
+                jobject optionalValue_4_metricItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "metric", "Ljava/lang/Integer;",
+                                                                  optionalValue_4_metricItem_5);
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_4_metricItem_5));
+            }
+        }
+        jobject optionalValue_0_progressBarItem_1;
+        chip::JniReferences::GetInstance().GetObjectField(optionalValue_0, "progressBar", "Ljava/util/Optional;",
+                                                          optionalValue_0_progressBarItem_1);
+        if (optionalValue_0_progressBarItem_1 != nullptr)
+        {
+            jobject optionalValue_2;
+            chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_0_progressBarItem_1, optionalValue_2);
+            auto & definedValue_2 = definedValue_0.progressBar.Emplace();
+            jobject optionalValue_2_imageUrlItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "imageUrl", "Ljava/util/Optional;",
+                                                              optionalValue_2_imageUrlItem_3);
+            if (optionalValue_2_imageUrlItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_imageUrlItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_colorItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "color", "Ljava/util/Optional;",
+                                                              optionalValue_2_colorItem_3);
+            if (optionalValue_2_colorItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_colorItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_sizeItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "size", "Ljava/util/Optional;",
+                                                              optionalValue_2_sizeItem_3);
+            if (optionalValue_2_sizeItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_sizeItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                jobject optionalValue_4_widthItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "width", "Ljava/lang/Double;",
+                                                                  optionalValue_4_widthItem_5);
+                definedValue_4.width = static_cast<std::remove_reference_t<decltype(definedValue_4.width)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_widthItem_5));
+                jobject optionalValue_4_heightItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "height", "Ljava/lang/Double;",
+                                                                  optionalValue_4_heightItem_5);
+                definedValue_4.height = static_cast<std::remove_reference_t<decltype(definedValue_4.height)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_heightItem_5));
+                jobject optionalValue_4_metricItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "metric", "Ljava/lang/Integer;",
+                                                                  optionalValue_4_metricItem_5);
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_4_metricItem_5));
+            }
+        }
+        jobject optionalValue_0_splashItem_1;
+        chip::JniReferences::GetInstance().GetObjectField(optionalValue_0, "splash", "Ljava/util/Optional;",
+                                                          optionalValue_0_splashItem_1);
+        if (optionalValue_0_splashItem_1 != nullptr)
+        {
+            jobject optionalValue_2;
+            chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_0_splashItem_1, optionalValue_2);
+            auto & definedValue_2 = definedValue_0.splash.Emplace();
+            jobject optionalValue_2_imageUrlItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "imageUrl", "Ljava/util/Optional;",
+                                                              optionalValue_2_imageUrlItem_3);
+            if (optionalValue_2_imageUrlItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_imageUrlItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_colorItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "color", "Ljava/util/Optional;",
+                                                              optionalValue_2_colorItem_3);
+            if (optionalValue_2_colorItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_colorItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_sizeItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "size", "Ljava/util/Optional;",
+                                                              optionalValue_2_sizeItem_3);
+            if (optionalValue_2_sizeItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_sizeItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                jobject optionalValue_4_widthItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "width", "Ljava/lang/Double;",
+                                                                  optionalValue_4_widthItem_5);
+                definedValue_4.width = static_cast<std::remove_reference_t<decltype(definedValue_4.width)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_widthItem_5));
+                jobject optionalValue_4_heightItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "height", "Ljava/lang/Double;",
+                                                                  optionalValue_4_heightItem_5);
+                definedValue_4.height = static_cast<std::remove_reference_t<decltype(definedValue_4.height)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_heightItem_5));
+                jobject optionalValue_4_metricItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "metric", "Ljava/lang/Integer;",
+                                                                  optionalValue_4_metricItem_5);
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_4_metricItem_5));
+            }
+        }
+        jobject optionalValue_0_waterMarkItem_1;
+        chip::JniReferences::GetInstance().GetObjectField(optionalValue_0, "waterMark", "Ljava/util/Optional;",
+                                                          optionalValue_0_waterMarkItem_1);
+        if (optionalValue_0_waterMarkItem_1 != nullptr)
+        {
+            jobject optionalValue_2;
+            chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_0_waterMarkItem_1, optionalValue_2);
+            auto & definedValue_2 = definedValue_0.waterMark.Emplace();
+            jobject optionalValue_2_imageUrlItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "imageUrl", "Ljava/util/Optional;",
+                                                              optionalValue_2_imageUrlItem_3);
+            if (optionalValue_2_imageUrlItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_imageUrlItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_colorItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "color", "Ljava/util/Optional;",
+                                                              optionalValue_2_colorItem_3);
+            if (optionalValue_2_colorItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_colorItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                cleanupStrings.push_back(
+                    chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_4)));
+                definedValue_4 = cleanupStrings.back()->charSpan();
+            }
+            jobject optionalValue_2_sizeItem_3;
+            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "size", "Ljava/util/Optional;",
+                                                              optionalValue_2_sizeItem_3);
+            if (optionalValue_2_sizeItem_3 != nullptr)
+            {
+                jobject optionalValue_4;
+                chip::JniReferences::GetInstance().GetOptionalValue(optionalValue_2_sizeItem_3, optionalValue_4);
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                jobject optionalValue_4_widthItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "width", "Ljava/lang/Double;",
+                                                                  optionalValue_4_widthItem_5);
+                definedValue_4.width = static_cast<std::remove_reference_t<decltype(definedValue_4.width)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_widthItem_5));
+                jobject optionalValue_4_heightItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "height", "Ljava/lang/Double;",
+                                                                  optionalValue_4_heightItem_5);
+                definedValue_4.height = static_cast<std::remove_reference_t<decltype(definedValue_4.height)>>(
+                    chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_4_heightItem_5));
+                jobject optionalValue_4_metricItem_5;
+                chip::JniReferences::GetInstance().GetObjectField(optionalValue_4, "metric", "Ljava/lang/Integer;",
+                                                                  optionalValue_4_metricItem_5);
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_4_metricItem_5));
+            }
+        }
+    }
 
     std::unique_ptr<CHIPContentLauncherClusterLaunchResponseCallback, void (*)(CHIPContentLauncherClusterLaunchResponseCallback *)>
         onSuccess(Platform::New<CHIPContentLauncherClusterLaunchResponseCallback>(callback),
@@ -19719,8 +19834,9 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeStartTimeAttribute)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)
 {
     chip::DeviceLayer::StackLock lock;
-    std::unique_ptr<CHIPInt64uAttributeCallback, void (*)(CHIPInt64uAttributeCallback *)> onSuccess(
-        Platform::New<CHIPInt64uAttributeCallback>(callback, true), chip::Platform::Delete<CHIPInt64uAttributeCallback>);
+    std::unique_ptr<CHIPMediaPlaybackStartTimeAttributeCallback, void (*)(CHIPMediaPlaybackStartTimeAttributeCallback *)> onSuccess(
+        Platform::New<CHIPMediaPlaybackStartTimeAttributeCallback>(callback, true),
+        chip::Platform::Delete<CHIPMediaPlaybackStartTimeAttributeCallback>);
     VerifyOrReturn(onSuccess.get() != nullptr,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY));
@@ -19744,7 +19860,7 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeStartTimeAttribute)
 
     err = cppCluster->SubscribeAttribute<TypeInfo>(onSuccess->mContext, successFn->mCall, failureFn->mCall,
                                                    static_cast<uint16_t>(minInterval), static_cast<uint16_t>(maxInterval),
-                                                   CHIPInt64uAttributeCallback::OnSubscriptionEstablished);
+                                                   CHIPMediaPlaybackStartTimeAttributeCallback::OnSubscriptionEstablished);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error subscribing to attribute", err));
@@ -19756,8 +19872,9 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeDurationAttribute)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)
 {
     chip::DeviceLayer::StackLock lock;
-    std::unique_ptr<CHIPInt64uAttributeCallback, void (*)(CHIPInt64uAttributeCallback *)> onSuccess(
-        Platform::New<CHIPInt64uAttributeCallback>(callback, true), chip::Platform::Delete<CHIPInt64uAttributeCallback>);
+    std::unique_ptr<CHIPMediaPlaybackDurationAttributeCallback, void (*)(CHIPMediaPlaybackDurationAttributeCallback *)> onSuccess(
+        Platform::New<CHIPMediaPlaybackDurationAttributeCallback>(callback, true),
+        chip::Platform::Delete<CHIPMediaPlaybackDurationAttributeCallback>);
     VerifyOrReturn(onSuccess.get() != nullptr,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY));
@@ -19781,7 +19898,7 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeDurationAttribute)
 
     err = cppCluster->SubscribeAttribute<TypeInfo>(onSuccess->mContext, successFn->mCall, failureFn->mCall,
                                                    static_cast<uint16_t>(minInterval), static_cast<uint16_t>(maxInterval),
-                                                   CHIPInt64uAttributeCallback::OnSubscriptionEstablished);
+                                                   CHIPMediaPlaybackDurationAttributeCallback::OnSubscriptionEstablished);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error subscribing to attribute", err));
@@ -19830,8 +19947,9 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeSeekRangeEndAttribute)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)
 {
     chip::DeviceLayer::StackLock lock;
-    std::unique_ptr<CHIPInt64uAttributeCallback, void (*)(CHIPInt64uAttributeCallback *)> onSuccess(
-        Platform::New<CHIPInt64uAttributeCallback>(callback, true), chip::Platform::Delete<CHIPInt64uAttributeCallback>);
+    std::unique_ptr<CHIPMediaPlaybackSeekRangeEndAttributeCallback, void (*)(CHIPMediaPlaybackSeekRangeEndAttributeCallback *)>
+        onSuccess(Platform::New<CHIPMediaPlaybackSeekRangeEndAttributeCallback>(callback, true),
+                  chip::Platform::Delete<CHIPMediaPlaybackSeekRangeEndAttributeCallback>);
     VerifyOrReturn(onSuccess.get() != nullptr,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY));
@@ -19855,7 +19973,7 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeSeekRangeEndAttribute)
 
     err = cppCluster->SubscribeAttribute<TypeInfo>(onSuccess->mContext, successFn->mCall, failureFn->mCall,
                                                    static_cast<uint16_t>(minInterval), static_cast<uint16_t>(maxInterval),
-                                                   CHIPInt64uAttributeCallback::OnSubscriptionEstablished);
+                                                   CHIPMediaPlaybackSeekRangeEndAttributeCallback::OnSubscriptionEstablished);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error subscribing to attribute", err));
@@ -19867,8 +19985,9 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeSeekRangeStartAttribute)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)
 {
     chip::DeviceLayer::StackLock lock;
-    std::unique_ptr<CHIPInt64uAttributeCallback, void (*)(CHIPInt64uAttributeCallback *)> onSuccess(
-        Platform::New<CHIPInt64uAttributeCallback>(callback, true), chip::Platform::Delete<CHIPInt64uAttributeCallback>);
+    std::unique_ptr<CHIPMediaPlaybackSeekRangeStartAttributeCallback, void (*)(CHIPMediaPlaybackSeekRangeStartAttributeCallback *)>
+        onSuccess(Platform::New<CHIPMediaPlaybackSeekRangeStartAttributeCallback>(callback, true),
+                  chip::Platform::Delete<CHIPMediaPlaybackSeekRangeStartAttributeCallback>);
     VerifyOrReturn(onSuccess.get() != nullptr,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY));
@@ -19892,7 +20011,7 @@ JNI_METHOD(void, MediaPlaybackCluster, subscribeSeekRangeStartAttribute)
 
     err = cppCluster->SubscribeAttribute<TypeInfo>(onSuccess->mContext, successFn->mCall, failureFn->mCall,
                                                    static_cast<uint16_t>(minInterval), static_cast<uint16_t>(maxInterval),
-                                                   CHIPInt64uAttributeCallback::OnSubscriptionEstablished);
+                                                   CHIPMediaPlaybackSeekRangeStartAttributeCallback::OnSubscriptionEstablished);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
                        env, callback, "Error subscribing to attribute", err));
@@ -27842,7 +27961,7 @@ JNI_METHOD(jlong, TargetNavigatorCluster, initWithDevice)(JNIEnv * env, jobject 
 }
 
 JNI_METHOD(void, TargetNavigatorCluster, navigateTargetRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject target, jstring data, jobject timedInvokeTimeoutMs)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject target, jobject data, jobject timedInvokeTimeoutMs)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -27855,8 +27974,14 @@ JNI_METHOD(void, TargetNavigatorCluster, navigateTargetRequest)
     std::vector<Platform::UniquePtr<JniUtfString>> cleanupStrings;
     request.target = static_cast<std::remove_reference_t<decltype(request.target)>>(
         chip::JniReferences::GetInstance().IntegerToPrimitive(target));
-    cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(data)));
-    request.data = cleanupStrings.back()->charSpan();
+    if (data != nullptr)
+    {
+        jobject optionalValue_0;
+        chip::JniReferences::GetInstance().GetOptionalValue(data, optionalValue_0);
+        auto & definedValue_0 = request.data.Emplace();
+        cleanupStrings.push_back(chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_0)));
+        definedValue_0 = cleanupStrings.back()->charSpan();
+    }
 
     std::unique_ptr<CHIPTargetNavigatorClusterNavigateTargetResponseCallback,
                     void (*)(CHIPTargetNavigatorClusterNavigateTargetResponseCallback *)>

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -219,15 +219,37 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
                                                                    channelMatch_minorNumberCtorSignature.c_str(),
                                                                    dataResponse.channelMatch.minorNumber, channelMatch_minorNumber);
     jobject channelMatch_name;
-    channelMatch_name =
-        env->NewStringUTF(std::string(dataResponse.channelMatch.name.data(), dataResponse.channelMatch.name.size()).c_str());
+    if (!dataResponse.channelMatch.name.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, channelMatch_name);
+    }
+    else
+    {
+        channelMatch_name = env->NewStringUTF(
+            std::string(dataResponse.channelMatch.name.Value().data(), dataResponse.channelMatch.name.Value().size()).c_str());
+    }
     jobject channelMatch_callSign;
-    channelMatch_callSign = env->NewStringUTF(
-        std::string(dataResponse.channelMatch.callSign.data(), dataResponse.channelMatch.callSign.size()).c_str());
+    if (!dataResponse.channelMatch.callSign.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, channelMatch_callSign);
+    }
+    else
+    {
+        channelMatch_callSign = env->NewStringUTF(
+            std::string(dataResponse.channelMatch.callSign.Value().data(), dataResponse.channelMatch.callSign.Value().size())
+                .c_str());
+    }
     jobject channelMatch_affiliateCallSign;
-    channelMatch_affiliateCallSign = env->NewStringUTF(
-        std::string(dataResponse.channelMatch.affiliateCallSign.data(), dataResponse.channelMatch.affiliateCallSign.size())
-            .c_str());
+    if (!dataResponse.channelMatch.affiliateCallSign.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, channelMatch_affiliateCallSign);
+    }
+    else
+    {
+        channelMatch_affiliateCallSign = env->NewStringUTF(std::string(dataResponse.channelMatch.affiliateCallSign.Value().data(),
+                                                                       dataResponse.channelMatch.affiliateCallSign.Value().size())
+                                                               .c_str());
+    }
 
     jclass channelInfoStructClass;
     err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfo",
@@ -239,7 +261,7 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
     }
     jmethodID channelInfoStructCtor =
         env->GetMethodID(channelInfoStructClass, "<init>",
-                         "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+                         "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
     if (channelInfoStructCtor == nullptr)
     {
         ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfo constructor");
@@ -304,7 +326,7 @@ void CHIPContentLauncherClusterLaunchResponseCallback::CallbackFn(
     // Java callback is allowed to be null, exit early if this is the case.
     VerifyOrReturn(javaCallbackRef != nullptr);
 
-    err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Integer;Ljava/lang/String;)V",
+    err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Integer;Ljava/util/Optional;)V",
                                                   &javaMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
 
@@ -314,7 +336,14 @@ void CHIPContentLauncherClusterLaunchResponseCallback::CallbackFn(
     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(statusClassName.c_str(), statusCtorSignature.c_str(),
                                                                   static_cast<uint8_t>(dataResponse.status), status);
     jobject data;
-    data = env->NewStringUTF(std::string(dataResponse.data.data(), dataResponse.data.size()).c_str());
+    if (!dataResponse.data.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, data);
+    }
+    else
+    {
+        data = env->NewStringUTF(std::string(dataResponse.data.Value().data(), dataResponse.data.Value().size()).c_str());
+    }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, data);
 }
@@ -3295,7 +3324,7 @@ void CHIPTargetNavigatorClusterNavigateTargetResponseCallback::CallbackFn(
     // Java callback is allowed to be null, exit early if this is the case.
     VerifyOrReturn(javaCallbackRef != nullptr);
 
-    err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Integer;Ljava/lang/String;)V",
+    err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Integer;Ljava/util/Optional;)V",
                                                   &javaMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
 
@@ -3305,7 +3334,14 @@ void CHIPTargetNavigatorClusterNavigateTargetResponseCallback::CallbackFn(
     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(statusClassName.c_str(), statusCtorSignature.c_str(),
                                                                   static_cast<uint8_t>(dataResponse.status), status);
     jobject data;
-    data = env->NewStringUTF(std::string(dataResponse.data.data(), dataResponse.data.size()).c_str());
+    if (!dataResponse.data.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, data);
+    }
+    else
+    {
+        data = env->NewStringUTF(std::string(dataResponse.data.Value().data(), dataResponse.data.Value().size()).c_str());
+    }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, data);
 }

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -4513,12 +4513,34 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
                                                                        newElement_0_minorNumberCtorSignature.c_str(),
                                                                        entry_0.minorNumber, newElement_0_minorNumber);
         jobject newElement_0_name;
-        newElement_0_name = env->NewStringUTF(std::string(entry_0.name.data(), entry_0.name.size()).c_str());
+        if (!entry_0.name.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_name);
+        }
+        else
+        {
+            newElement_0_name = env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+        }
         jobject newElement_0_callSign;
-        newElement_0_callSign = env->NewStringUTF(std::string(entry_0.callSign.data(), entry_0.callSign.size()).c_str());
+        if (!entry_0.callSign.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_callSign);
+        }
+        else
+        {
+            newElement_0_callSign =
+                env->NewStringUTF(std::string(entry_0.callSign.Value().data(), entry_0.callSign.Value().size()).c_str());
+        }
         jobject newElement_0_affiliateCallSign;
-        newElement_0_affiliateCallSign =
-            env->NewStringUTF(std::string(entry_0.affiliateCallSign.data(), entry_0.affiliateCallSign.size()).c_str());
+        if (!entry_0.affiliateCallSign.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_affiliateCallSign);
+        }
+        else
+        {
+            newElement_0_affiliateCallSign = env->NewStringUTF(
+                std::string(entry_0.affiliateCallSign.Value().data(), entry_0.affiliateCallSign.Value().size()).c_str());
+        }
 
         jclass channelInfoStructClass;
         err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfo",
@@ -4528,9 +4550,9 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
             ChipLogError(Zcl, "Could not find class ChipStructs$ChannelClusterChannelInfo");
             return;
         }
-        jmethodID channelInfoStructCtor =
-            env->GetMethodID(channelInfoStructClass, "<init>",
-                             "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        jmethodID channelInfoStructCtor = env->GetMethodID(
+            channelInfoStructClass, "<init>",
+            "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
         if (channelInfoStructCtor == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$ChannelClusterChannelInfo constructor");
@@ -11085,6 +11107,268 @@ void CHIPMediaInputAttributeListAttributeCallback::CallbackFn(void * context,
 
     env->ExceptionClear();
     env->CallVoidMethod(javaCallbackRef, javaMethod, arrayListObj);
+}
+
+CHIPMediaPlaybackStartTimeAttributeCallback::CHIPMediaPlaybackStartTimeAttributeCallback(jobject javaCallback, bool keepAlive) :
+    chip::Callback::Callback<CHIPMediaPlaybackClusterStartTimeAttributeCallbackType>(CallbackFn, this), keepAlive(keepAlive)
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+        return;
+    }
+
+    javaCallbackRef = env->NewGlobalRef(javaCallback);
+    if (javaCallbackRef == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+    }
+}
+
+CHIPMediaPlaybackStartTimeAttributeCallback::~CHIPMediaPlaybackStartTimeAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
+void CHIPMediaPlaybackStartTimeAttributeCallback::CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    jobject javaCallbackRef;
+
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNI env"));
+    std::unique_ptr<CHIPMediaPlaybackStartTimeAttributeCallback, decltype(&maybeDestroy)> cppCallback(
+        reinterpret_cast<CHIPMediaPlaybackStartTimeAttributeCallback *>(context), maybeDestroy);
+
+    // It's valid for javaCallbackRef to be nullptr if the Java code passed in a null callback.
+    javaCallbackRef = cppCallback.get()->javaCallbackRef;
+    VerifyOrReturn(javaCallbackRef != nullptr,
+                   ChipLogProgress(Zcl, "Early return from attribute callback since Java callback is null"));
+
+    jmethodID javaMethod;
+    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Long;)V", &javaMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess() method"));
+
+    jobject javaValue;
+    if (value.IsNull())
+    {
+        javaValue = nullptr;
+    }
+    else
+    {
+        std::string javaValueClassName     = "java/lang/Long";
+        std::string javaValueCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(javaValueClassName.c_str(), javaValueCtorSignature.c_str(),
+                                                                       value.Value(), javaValue);
+    }
+
+    env->CallVoidMethod(javaCallbackRef, javaMethod, javaValue);
+}
+
+CHIPMediaPlaybackDurationAttributeCallback::CHIPMediaPlaybackDurationAttributeCallback(jobject javaCallback, bool keepAlive) :
+    chip::Callback::Callback<CHIPMediaPlaybackClusterDurationAttributeCallbackType>(CallbackFn, this), keepAlive(keepAlive)
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+        return;
+    }
+
+    javaCallbackRef = env->NewGlobalRef(javaCallback);
+    if (javaCallbackRef == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+    }
+}
+
+CHIPMediaPlaybackDurationAttributeCallback::~CHIPMediaPlaybackDurationAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
+void CHIPMediaPlaybackDurationAttributeCallback::CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    jobject javaCallbackRef;
+
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNI env"));
+    std::unique_ptr<CHIPMediaPlaybackDurationAttributeCallback, decltype(&maybeDestroy)> cppCallback(
+        reinterpret_cast<CHIPMediaPlaybackDurationAttributeCallback *>(context), maybeDestroy);
+
+    // It's valid for javaCallbackRef to be nullptr if the Java code passed in a null callback.
+    javaCallbackRef = cppCallback.get()->javaCallbackRef;
+    VerifyOrReturn(javaCallbackRef != nullptr,
+                   ChipLogProgress(Zcl, "Early return from attribute callback since Java callback is null"));
+
+    jmethodID javaMethod;
+    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Long;)V", &javaMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess() method"));
+
+    jobject javaValue;
+    if (value.IsNull())
+    {
+        javaValue = nullptr;
+    }
+    else
+    {
+        std::string javaValueClassName     = "java/lang/Long";
+        std::string javaValueCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(javaValueClassName.c_str(), javaValueCtorSignature.c_str(),
+                                                                       value.Value(), javaValue);
+    }
+
+    env->CallVoidMethod(javaCallbackRef, javaMethod, javaValue);
+}
+
+CHIPMediaPlaybackSeekRangeEndAttributeCallback::CHIPMediaPlaybackSeekRangeEndAttributeCallback(jobject javaCallback,
+                                                                                               bool keepAlive) :
+    chip::Callback::Callback<CHIPMediaPlaybackClusterSeekRangeEndAttributeCallbackType>(CallbackFn, this),
+    keepAlive(keepAlive)
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+        return;
+    }
+
+    javaCallbackRef = env->NewGlobalRef(javaCallback);
+    if (javaCallbackRef == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+    }
+}
+
+CHIPMediaPlaybackSeekRangeEndAttributeCallback::~CHIPMediaPlaybackSeekRangeEndAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
+void CHIPMediaPlaybackSeekRangeEndAttributeCallback::CallbackFn(void * context,
+                                                                const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    jobject javaCallbackRef;
+
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNI env"));
+    std::unique_ptr<CHIPMediaPlaybackSeekRangeEndAttributeCallback, decltype(&maybeDestroy)> cppCallback(
+        reinterpret_cast<CHIPMediaPlaybackSeekRangeEndAttributeCallback *>(context), maybeDestroy);
+
+    // It's valid for javaCallbackRef to be nullptr if the Java code passed in a null callback.
+    javaCallbackRef = cppCallback.get()->javaCallbackRef;
+    VerifyOrReturn(javaCallbackRef != nullptr,
+                   ChipLogProgress(Zcl, "Early return from attribute callback since Java callback is null"));
+
+    jmethodID javaMethod;
+    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Long;)V", &javaMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess() method"));
+
+    jobject javaValue;
+    if (value.IsNull())
+    {
+        javaValue = nullptr;
+    }
+    else
+    {
+        std::string javaValueClassName     = "java/lang/Long";
+        std::string javaValueCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(javaValueClassName.c_str(), javaValueCtorSignature.c_str(),
+                                                                       value.Value(), javaValue);
+    }
+
+    env->CallVoidMethod(javaCallbackRef, javaMethod, javaValue);
+}
+
+CHIPMediaPlaybackSeekRangeStartAttributeCallback::CHIPMediaPlaybackSeekRangeStartAttributeCallback(jobject javaCallback,
+                                                                                                   bool keepAlive) :
+    chip::Callback::Callback<CHIPMediaPlaybackClusterSeekRangeStartAttributeCallbackType>(CallbackFn, this),
+    keepAlive(keepAlive)
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+        return;
+    }
+
+    javaCallbackRef = env->NewGlobalRef(javaCallback);
+    if (javaCallbackRef == nullptr)
+    {
+        ChipLogError(Zcl, "Could not create global reference for Java callback");
+    }
+}
+
+CHIPMediaPlaybackSeekRangeStartAttributeCallback::~CHIPMediaPlaybackSeekRangeStartAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
+void CHIPMediaPlaybackSeekRangeStartAttributeCallback::CallbackFn(void * context,
+                                                                  const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    jobject javaCallbackRef;
+
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNI env"));
+    std::unique_ptr<CHIPMediaPlaybackSeekRangeStartAttributeCallback, decltype(&maybeDestroy)> cppCallback(
+        reinterpret_cast<CHIPMediaPlaybackSeekRangeStartAttributeCallback *>(context), maybeDestroy);
+
+    // It's valid for javaCallbackRef to be nullptr if the Java code passed in a null callback.
+    javaCallbackRef = cppCallback.get()->javaCallbackRef;
+    VerifyOrReturn(javaCallbackRef != nullptr,
+                   ChipLogProgress(Zcl, "Early return from attribute callback since Java callback is null"));
+
+    jmethodID javaMethod;
+    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/Long;)V", &javaMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess() method"));
+
+    jobject javaValue;
+    if (value.IsNull())
+    {
+        javaValue = nullptr;
+    }
+    else
+    {
+        std::string javaValueClassName     = "java/lang/Long";
+        std::string javaValueCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(javaValueClassName.c_str(), javaValueCtorSignature.c_str(),
+                                                                       value.Value(), javaValue);
+    }
+
+    env->CallVoidMethod(javaCallbackRef, javaMethod, javaValue);
 }
 
 CHIPMediaPlaybackServerGeneratedCommandListAttributeCallback::CHIPMediaPlaybackServerGeneratedCommandListAttributeCallback(

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.h
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.h
@@ -4620,6 +4620,126 @@ private:
     bool keepAlive;
 };
 
+class CHIPMediaPlaybackStartTimeAttributeCallback
+    : public chip::Callback::Callback<CHIPMediaPlaybackClusterStartTimeAttributeCallbackType>
+{
+public:
+    CHIPMediaPlaybackStartTimeAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPMediaPlaybackStartTimeAttributeCallback();
+
+    static void maybeDestroy(CHIPMediaPlaybackStartTimeAttributeCallback * callback)
+    {
+        if (!callback->keepAlive)
+        {
+            callback->Cancel();
+            chip::Platform::Delete<CHIPMediaPlaybackStartTimeAttributeCallback>(callback);
+        }
+    }
+
+    static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
+    static void OnSubscriptionEstablished(void * context)
+    {
+        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
+            reinterpret_cast<CHIPMediaPlaybackStartTimeAttributeCallback *>(context)->javaCallbackRef);
+        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
+    };
+
+private:
+    jobject javaCallbackRef;
+    bool keepAlive;
+};
+
+class CHIPMediaPlaybackDurationAttributeCallback
+    : public chip::Callback::Callback<CHIPMediaPlaybackClusterDurationAttributeCallbackType>
+{
+public:
+    CHIPMediaPlaybackDurationAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPMediaPlaybackDurationAttributeCallback();
+
+    static void maybeDestroy(CHIPMediaPlaybackDurationAttributeCallback * callback)
+    {
+        if (!callback->keepAlive)
+        {
+            callback->Cancel();
+            chip::Platform::Delete<CHIPMediaPlaybackDurationAttributeCallback>(callback);
+        }
+    }
+
+    static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
+    static void OnSubscriptionEstablished(void * context)
+    {
+        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
+            reinterpret_cast<CHIPMediaPlaybackDurationAttributeCallback *>(context)->javaCallbackRef);
+        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
+    };
+
+private:
+    jobject javaCallbackRef;
+    bool keepAlive;
+};
+
+class CHIPMediaPlaybackSeekRangeEndAttributeCallback
+    : public chip::Callback::Callback<CHIPMediaPlaybackClusterSeekRangeEndAttributeCallbackType>
+{
+public:
+    CHIPMediaPlaybackSeekRangeEndAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPMediaPlaybackSeekRangeEndAttributeCallback();
+
+    static void maybeDestroy(CHIPMediaPlaybackSeekRangeEndAttributeCallback * callback)
+    {
+        if (!callback->keepAlive)
+        {
+            callback->Cancel();
+            chip::Platform::Delete<CHIPMediaPlaybackSeekRangeEndAttributeCallback>(callback);
+        }
+    }
+
+    static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
+    static void OnSubscriptionEstablished(void * context)
+    {
+        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
+            reinterpret_cast<CHIPMediaPlaybackSeekRangeEndAttributeCallback *>(context)->javaCallbackRef);
+        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
+    };
+
+private:
+    jobject javaCallbackRef;
+    bool keepAlive;
+};
+
+class CHIPMediaPlaybackSeekRangeStartAttributeCallback
+    : public chip::Callback::Callback<CHIPMediaPlaybackClusterSeekRangeStartAttributeCallbackType>
+{
+public:
+    CHIPMediaPlaybackSeekRangeStartAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPMediaPlaybackSeekRangeStartAttributeCallback();
+
+    static void maybeDestroy(CHIPMediaPlaybackSeekRangeStartAttributeCallback * callback)
+    {
+        if (!callback->keepAlive)
+        {
+            callback->Cancel();
+            chip::Platform::Delete<CHIPMediaPlaybackSeekRangeStartAttributeCallback>(callback);
+        }
+    }
+
+    static void CallbackFn(void * context, const chip::app::DataModel::Nullable<uint64_t> & value);
+    static void OnSubscriptionEstablished(void * context)
+    {
+        CHIP_ERROR err = chip::JniReferences::GetInstance().CallSubscriptionEstablished(
+            reinterpret_cast<CHIPMediaPlaybackSeekRangeStartAttributeCallback *>(context)->javaCallbackRef);
+        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error calling onSubscriptionEstablished: %s", ErrorStr(err)));
+    };
+
+private:
+    jobject javaCallbackRef;
+    bool keepAlive;
+};
+
 class CHIPMediaPlaybackServerGeneratedCommandListAttributeCallback
     : public chip::Callback::Callback<CHIPMediaPlaybackClusterServerGeneratedCommandListAttributeCallbackType>
 {

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -932,14 +932,14 @@ public class ChipClusters {
     public void launchAppRequest(
         LauncherResponseCallback callback,
         ChipStructs.ApplicationLauncherClusterApplication application,
-        byte[] data) {
+        Optional<byte[]> data) {
       launchAppRequest(chipClusterPtr, callback, application, data, null);
     }
 
     public void launchAppRequest(
         LauncherResponseCallback callback,
         ChipStructs.ApplicationLauncherClusterApplication application,
-        byte[] data,
+        Optional<byte[]> data,
         int timedInvokeTimeoutMs) {
       launchAppRequest(chipClusterPtr, callback, application, data, timedInvokeTimeoutMs);
     }
@@ -967,7 +967,7 @@ public class ChipClusters {
         long chipClusterPtr,
         LauncherResponseCallback Callback,
         ChipStructs.ApplicationLauncherClusterApplication application,
-        byte[] data,
+        Optional<byte[]> data,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void stopAppRequest(
@@ -5346,26 +5346,26 @@ public class ChipClusters {
 
     public void launchContentRequest(
         LaunchResponseCallback callback,
+        ArrayList<ChipStructs.ContentLauncherClusterContentSearch> search,
         Boolean autoPlay,
-        String data,
-        ArrayList<ChipStructs.ContentLauncherClusterContentSearch> search) {
-      launchContentRequest(chipClusterPtr, callback, autoPlay, data, search, null);
+        Optional<String> data) {
+      launchContentRequest(chipClusterPtr, callback, search, autoPlay, data, null);
     }
 
     public void launchContentRequest(
         LaunchResponseCallback callback,
-        Boolean autoPlay,
-        String data,
         ArrayList<ChipStructs.ContentLauncherClusterContentSearch> search,
+        Boolean autoPlay,
+        Optional<String> data,
         int timedInvokeTimeoutMs) {
-      launchContentRequest(chipClusterPtr, callback, autoPlay, data, search, timedInvokeTimeoutMs);
+      launchContentRequest(chipClusterPtr, callback, search, autoPlay, data, timedInvokeTimeoutMs);
     }
 
     public void launchURLRequest(
         LaunchResponseCallback callback,
         String contentURL,
-        String displayString,
-        ChipStructs.ContentLauncherClusterBrandingInformation brandingInformation) {
+        Optional<String> displayString,
+        Optional<ChipStructs.ContentLauncherClusterBrandingInformation> brandingInformation) {
       launchURLRequest(
           chipClusterPtr, callback, contentURL, displayString, brandingInformation, null);
     }
@@ -5373,8 +5373,8 @@ public class ChipClusters {
     public void launchURLRequest(
         LaunchResponseCallback callback,
         String contentURL,
-        String displayString,
-        ChipStructs.ContentLauncherClusterBrandingInformation brandingInformation,
+        Optional<String> displayString,
+        Optional<ChipStructs.ContentLauncherClusterBrandingInformation> brandingInformation,
         int timedInvokeTimeoutMs) {
       launchURLRequest(
           chipClusterPtr,
@@ -5388,21 +5388,21 @@ public class ChipClusters {
     private native void launchContentRequest(
         long chipClusterPtr,
         LaunchResponseCallback Callback,
-        Boolean autoPlay,
-        String data,
         ArrayList<ChipStructs.ContentLauncherClusterContentSearch> search,
+        Boolean autoPlay,
+        Optional<String> data,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void launchURLRequest(
         long chipClusterPtr,
         LaunchResponseCallback Callback,
         String contentURL,
-        String displayString,
-        ChipStructs.ContentLauncherClusterBrandingInformation brandingInformation,
+        Optional<String> displayString,
+        Optional<ChipStructs.ContentLauncherClusterBrandingInformation> brandingInformation,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface LaunchResponseCallback {
-      void onSuccess(Integer status, String data);
+      void onSuccess(Integer status, Optional<String> data);
 
       void onError(Exception error);
     }
@@ -10720,6 +10720,38 @@ public class ChipClusters {
       void onError(Exception error);
     }
 
+    public interface StartTimeAttributeCallback {
+      void onSuccess(@Nullable Long value);
+
+      void onError(Exception ex);
+
+      default void onSubscriptionEstablished() {}
+    }
+
+    public interface DurationAttributeCallback {
+      void onSuccess(@Nullable Long value);
+
+      void onError(Exception ex);
+
+      default void onSubscriptionEstablished() {}
+    }
+
+    public interface SeekRangeEndAttributeCallback {
+      void onSuccess(@Nullable Long value);
+
+      void onError(Exception ex);
+
+      default void onSubscriptionEstablished() {}
+    }
+
+    public interface SeekRangeStartAttributeCallback {
+      void onSuccess(@Nullable Long value);
+
+      void onError(Exception ex);
+
+      default void onSubscriptionEstablished() {}
+    }
+
     public interface ServerGeneratedCommandListAttributeCallback {
       void onSuccess(List<Long> valueList);
 
@@ -10753,21 +10785,21 @@ public class ChipClusters {
       subscribePlaybackStateAttribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
 
-    public void readStartTimeAttribute(LongAttributeCallback callback) {
+    public void readStartTimeAttribute(StartTimeAttributeCallback callback) {
       readStartTimeAttribute(chipClusterPtr, callback);
     }
 
     public void subscribeStartTimeAttribute(
-        LongAttributeCallback callback, int minInterval, int maxInterval) {
+        StartTimeAttributeCallback callback, int minInterval, int maxInterval) {
       subscribeStartTimeAttribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
 
-    public void readDurationAttribute(LongAttributeCallback callback) {
+    public void readDurationAttribute(DurationAttributeCallback callback) {
       readDurationAttribute(chipClusterPtr, callback);
     }
 
     public void subscribeDurationAttribute(
-        LongAttributeCallback callback, int minInterval, int maxInterval) {
+        DurationAttributeCallback callback, int minInterval, int maxInterval) {
       subscribeDurationAttribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
 
@@ -10780,21 +10812,21 @@ public class ChipClusters {
       subscribePlaybackSpeedAttribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
 
-    public void readSeekRangeEndAttribute(LongAttributeCallback callback) {
+    public void readSeekRangeEndAttribute(SeekRangeEndAttributeCallback callback) {
       readSeekRangeEndAttribute(chipClusterPtr, callback);
     }
 
     public void subscribeSeekRangeEndAttribute(
-        LongAttributeCallback callback, int minInterval, int maxInterval) {
+        SeekRangeEndAttributeCallback callback, int minInterval, int maxInterval) {
       subscribeSeekRangeEndAttribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
 
-    public void readSeekRangeStartAttribute(LongAttributeCallback callback) {
+    public void readSeekRangeStartAttribute(SeekRangeStartAttributeCallback callback) {
       readSeekRangeStartAttribute(chipClusterPtr, callback);
     }
 
     public void subscribeSeekRangeStartAttribute(
-        LongAttributeCallback callback, int minInterval, int maxInterval) {
+        SeekRangeStartAttributeCallback callback, int minInterval, int maxInterval) {
       subscribeSeekRangeStartAttribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
 
@@ -10844,15 +10876,17 @@ public class ChipClusters {
     private native void subscribePlaybackStateAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback, int minInterval, int maxInterval);
 
-    private native void readStartTimeAttribute(long chipClusterPtr, LongAttributeCallback callback);
+    private native void readStartTimeAttribute(
+        long chipClusterPtr, StartTimeAttributeCallback callback);
 
     private native void subscribeStartTimeAttribute(
-        long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
+        long chipClusterPtr, StartTimeAttributeCallback callback, int minInterval, int maxInterval);
 
-    private native void readDurationAttribute(long chipClusterPtr, LongAttributeCallback callback);
+    private native void readDurationAttribute(
+        long chipClusterPtr, DurationAttributeCallback callback);
 
     private native void subscribeDurationAttribute(
-        long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
+        long chipClusterPtr, DurationAttributeCallback callback, int minInterval, int maxInterval);
 
     private native void readPlaybackSpeedAttribute(
         long chipClusterPtr, FloatAttributeCallback callback);
@@ -10861,16 +10895,22 @@ public class ChipClusters {
         long chipClusterPtr, FloatAttributeCallback callback, int minInterval, int maxInterval);
 
     private native void readSeekRangeEndAttribute(
-        long chipClusterPtr, LongAttributeCallback callback);
+        long chipClusterPtr, SeekRangeEndAttributeCallback callback);
 
     private native void subscribeSeekRangeEndAttribute(
-        long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
+        long chipClusterPtr,
+        SeekRangeEndAttributeCallback callback,
+        int minInterval,
+        int maxInterval);
 
     private native void readSeekRangeStartAttribute(
-        long chipClusterPtr, LongAttributeCallback callback);
+        long chipClusterPtr, SeekRangeStartAttributeCallback callback);
 
     private native void subscribeSeekRangeStartAttribute(
-        long chipClusterPtr, LongAttributeCallback callback, int minInterval, int maxInterval);
+        long chipClusterPtr,
+        SeekRangeStartAttributeCallback callback,
+        int minInterval,
+        int maxInterval);
 
     private native void readServerGeneratedCommandListAttribute(
         long chipClusterPtr, ServerGeneratedCommandListAttributeCallback callback);
@@ -14998,14 +15038,14 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void navigateTargetRequest(
-        NavigateTargetResponseCallback callback, Integer target, String data) {
+        NavigateTargetResponseCallback callback, Integer target, Optional<String> data) {
       navigateTargetRequest(chipClusterPtr, callback, target, data, null);
     }
 
     public void navigateTargetRequest(
         NavigateTargetResponseCallback callback,
         Integer target,
-        String data,
+        Optional<String> data,
         int timedInvokeTimeoutMs) {
       navigateTargetRequest(chipClusterPtr, callback, target, data, timedInvokeTimeoutMs);
     }
@@ -15014,11 +15054,11 @@ public class ChipClusters {
         long chipClusterPtr,
         NavigateTargetResponseCallback Callback,
         Integer target,
-        String data,
+        Optional<String> data,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface NavigateTargetResponseCallback {
-      void onSuccess(Integer status, String data);
+      void onSuccess(Integer status, Optional<String> data);
 
       void onError(Exception error);
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
@@ -173,10 +173,10 @@ public class ChipStructs {
 
   public static class ApplicationLauncherClusterApplicationEP {
     public ChipStructs.ApplicationLauncherClusterApplication application;
-    public String endpoint;
+    public Optional<Integer> endpoint;
 
     public ApplicationLauncherClusterApplicationEP(
-        ChipStructs.ApplicationLauncherClusterApplication application, String endpoint) {
+        ChipStructs.ApplicationLauncherClusterApplication application, Optional<Integer> endpoint) {
       this.application = application;
       this.endpoint = endpoint;
     }
@@ -348,16 +348,16 @@ public class ChipStructs {
   public static class ChannelClusterChannelInfo {
     public Integer majorNumber;
     public Integer minorNumber;
-    public String name;
-    public String callSign;
-    public String affiliateCallSign;
+    public Optional<String> name;
+    public Optional<String> callSign;
+    public Optional<String> affiliateCallSign;
 
     public ChannelClusterChannelInfo(
         Integer majorNumber,
         Integer minorNumber,
-        String name,
-        String callSign,
-        String affiliateCallSign) {
+        Optional<String> name,
+        Optional<String> callSign,
+        Optional<String> affiliateCallSign) {
       this.majorNumber = majorNumber;
       this.minorNumber = minorNumber;
       this.name = name;
@@ -391,12 +391,15 @@ public class ChipStructs {
 
   public static class ChannelClusterLineupInfo {
     public String operatorName;
-    public String lineupName;
-    public String postalCode;
+    public Optional<String> lineupName;
+    public Optional<String> postalCode;
     public Integer lineupInfoType;
 
     public ChannelClusterLineupInfo(
-        String operatorName, String lineupName, String postalCode, Integer lineupInfoType) {
+        String operatorName,
+        Optional<String> lineupName,
+        Optional<String> postalCode,
+        Integer lineupInfoType) {
       this.operatorName = operatorName;
       this.lineupName = lineupName;
       this.postalCode = postalCode;
@@ -480,12 +483,12 @@ public class ChipStructs {
   public static class ContentLauncherClusterParameter {
     public Integer type;
     public String value;
-    public ArrayList<ChipStructs.ContentLauncherClusterAdditionalInfo> externalIDList;
+    public Optional<ArrayList<ChipStructs.ContentLauncherClusterAdditionalInfo>> externalIDList;
 
     public ContentLauncherClusterParameter(
         Integer type,
         String value,
-        ArrayList<ChipStructs.ContentLauncherClusterAdditionalInfo> externalIDList) {
+        Optional<ArrayList<ChipStructs.ContentLauncherClusterAdditionalInfo>> externalIDList) {
       this.type = type;
       this.value = value;
       this.externalIDList = externalIDList;
@@ -530,12 +533,14 @@ public class ChipStructs {
   }
 
   public static class ContentLauncherClusterStyleInformation {
-    public String imageUrl;
-    public String color;
-    public ChipStructs.ContentLauncherClusterDimension size;
+    public Optional<String> imageUrl;
+    public Optional<String> color;
+    public Optional<ChipStructs.ContentLauncherClusterDimension> size;
 
     public ContentLauncherClusterStyleInformation(
-        String imageUrl, String color, ChipStructs.ContentLauncherClusterDimension size) {
+        Optional<String> imageUrl,
+        Optional<String> color,
+        Optional<ChipStructs.ContentLauncherClusterDimension> size) {
       this.imageUrl = imageUrl;
       this.color = color;
       this.size = size;
@@ -561,19 +566,19 @@ public class ChipStructs {
 
   public static class ContentLauncherClusterBrandingInformation {
     public String providerName;
-    public ChipStructs.ContentLauncherClusterStyleInformation background;
-    public ChipStructs.ContentLauncherClusterStyleInformation logo;
-    public ChipStructs.ContentLauncherClusterStyleInformation progressBar;
-    public ChipStructs.ContentLauncherClusterStyleInformation splash;
-    public ChipStructs.ContentLauncherClusterStyleInformation waterMark;
+    public Optional<ChipStructs.ContentLauncherClusterStyleInformation> background;
+    public Optional<ChipStructs.ContentLauncherClusterStyleInformation> logo;
+    public Optional<ChipStructs.ContentLauncherClusterStyleInformation> progressBar;
+    public Optional<ChipStructs.ContentLauncherClusterStyleInformation> splash;
+    public Optional<ChipStructs.ContentLauncherClusterStyleInformation> waterMark;
 
     public ContentLauncherClusterBrandingInformation(
         String providerName,
-        ChipStructs.ContentLauncherClusterStyleInformation background,
-        ChipStructs.ContentLauncherClusterStyleInformation logo,
-        ChipStructs.ContentLauncherClusterStyleInformation progressBar,
-        ChipStructs.ContentLauncherClusterStyleInformation splash,
-        ChipStructs.ContentLauncherClusterStyleInformation waterMark) {
+        Optional<ChipStructs.ContentLauncherClusterStyleInformation> background,
+        Optional<ChipStructs.ContentLauncherClusterStyleInformation> logo,
+        Optional<ChipStructs.ContentLauncherClusterStyleInformation> progressBar,
+        Optional<ChipStructs.ContentLauncherClusterStyleInformation> splash,
+        Optional<ChipStructs.ContentLauncherClusterStyleInformation> waterMark) {
       this.providerName = providerName;
       this.background = background;
       this.logo = logo;
@@ -917,9 +922,9 @@ public class ChipStructs {
 
   public static class MediaPlaybackClusterPlaybackPosition {
     public Long updatedAt;
-    public Long position;
+    public @Nullable Long position;
 
-    public MediaPlaybackClusterPlaybackPosition(Long updatedAt, Long position) {
+    public MediaPlaybackClusterPlaybackPosition(Long updatedAt, @Nullable Long position) {
       this.updatedAt = updatedAt;
       this.position = position;
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -1623,11 +1623,11 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(Integer status, String data) {
+    public void onSuccess(Integer status, Optional<String> data) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
       CommandResponseInfo statusResponseValue = new CommandResponseInfo("status", "Integer");
       responseValues.put(statusResponseValue, status);
-      CommandResponseInfo dataResponseValue = new CommandResponseInfo("data", "String");
+      CommandResponseInfo dataResponseValue = new CommandResponseInfo("data", "Optional<String>");
       responseValues.put(dataResponseValue, data);
       callback.onSuccess(responseValues);
     }
@@ -5695,11 +5695,11 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(Integer status, String data) {
+    public void onSuccess(Integer status, Optional<String> data) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
       CommandResponseInfo statusResponseValue = new CommandResponseInfo("status", "Integer");
       responseValues.put(statusResponseValue, status);
-      CommandResponseInfo dataResponseValue = new CommandResponseInfo("data", "String");
+      CommandResponseInfo dataResponseValue = new CommandResponseInfo("data", "Optional<String>");
       responseValues.put(dataResponseValue, data);
       callback.onSuccess(responseValues);
     }
@@ -7644,7 +7644,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> applicationLauncherlaunchAppRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo applicationLauncherlaunchAppRequestdataCommandParameterInfo =
-        new CommandParameterInfo("data", byte[].class);
+        new CommandParameterInfo("data", Optional.class);
     applicationLauncherlaunchAppRequestCommandParams.put(
         "data", applicationLauncherlaunchAppRequestdataCommandParameterInfo);
 
@@ -7656,7 +7656,7 @@ public class ClusterInfoMapping {
                       (ChipClusters.ApplicationLauncherCluster.LauncherResponseCallback) callback,
                       (ChipStructs.ApplicationLauncherClusterApplication)
                           commandArguments.get("application"),
-                      (byte[]) commandArguments.get("data"));
+                      (Optional<byte[]>) commandArguments.get("data"));
             },
             () -> new DelegatedLauncherResponseCallback(),
             applicationLauncherlaunchAppRequestCommandParams);
@@ -8971,7 +8971,7 @@ public class ClusterInfoMapping {
         "autoPlay", contentLauncherlaunchContentRequestautoPlayCommandParameterInfo);
 
     CommandParameterInfo contentLauncherlaunchContentRequestdataCommandParameterInfo =
-        new CommandParameterInfo("data", String.class);
+        new CommandParameterInfo("data", Optional.class);
     contentLauncherlaunchContentRequestCommandParams.put(
         "data", contentLauncherlaunchContentRequestdataCommandParameterInfo);
 
@@ -8981,10 +8981,10 @@ public class ClusterInfoMapping {
               ((ChipClusters.ContentLauncherCluster) cluster)
                   .launchContentRequest(
                       (ChipClusters.ContentLauncherCluster.LaunchResponseCallback) callback,
-                      (Boolean) commandArguments.get("autoPlay"),
-                      (String) commandArguments.get("data"),
                       (ArrayList<ChipStructs.ContentLauncherClusterContentSearch>)
-                          commandArguments.get("search"));
+                          commandArguments.get("search"),
+                      (Boolean) commandArguments.get("autoPlay"),
+                      (Optional<String>) commandArguments.get("data"));
             },
             () -> new DelegatedLaunchResponseCallback(),
             contentLauncherlaunchContentRequestCommandParams);
@@ -8998,7 +8998,7 @@ public class ClusterInfoMapping {
         "contentURL", contentLauncherlaunchURLRequestcontentURLCommandParameterInfo);
 
     CommandParameterInfo contentLauncherlaunchURLRequestdisplayStringCommandParameterInfo =
-        new CommandParameterInfo("displayString", String.class);
+        new CommandParameterInfo("displayString", Optional.class);
     contentLauncherlaunchURLRequestCommandParams.put(
         "displayString", contentLauncherlaunchURLRequestdisplayStringCommandParameterInfo);
 
@@ -9009,8 +9009,8 @@ public class ClusterInfoMapping {
                   .launchURLRequest(
                       (ChipClusters.ContentLauncherCluster.LaunchResponseCallback) callback,
                       (String) commandArguments.get("contentURL"),
-                      (String) commandArguments.get("displayString"),
-                      (ChipStructs.ContentLauncherClusterBrandingInformation)
+                      (Optional<String>) commandArguments.get("displayString"),
+                      (Optional<ChipStructs.ContentLauncherClusterBrandingInformation>)
                           commandArguments.get("brandingInformation"));
             },
             () -> new DelegatedLaunchResponseCallback(),
@@ -11232,7 +11232,7 @@ public class ClusterInfoMapping {
         "target", targetNavigatornavigateTargetRequesttargetCommandParameterInfo);
 
     CommandParameterInfo targetNavigatornavigateTargetRequestdataCommandParameterInfo =
-        new CommandParameterInfo("data", String.class);
+        new CommandParameterInfo("data", Optional.class);
     targetNavigatornavigateTargetRequestCommandParams.put(
         "data", targetNavigatornavigateTargetRequestdataCommandParameterInfo);
 
@@ -11243,7 +11243,7 @@ public class ClusterInfoMapping {
                   .navigateTargetRequest(
                       (ChipClusters.TargetNavigatorCluster.NavigateTargetResponseCallback) callback,
                       (Integer) commandArguments.get("target"),
-                      (String) commandArguments.get("data"));
+                      (Optional<String>) commandArguments.get("data"));
             },
             () -> new DelegatedNavigateTargetResponseCallback(),
             targetNavigatornavigateTargetRequestCommandParams);

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterReadMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterReadMapping.java
@@ -4955,7 +4955,8 @@ public class ClusterReadMapping {
         new InteractionInfo(
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.MediaPlaybackCluster) cluster)
-                  .readStartTimeAttribute((ChipClusters.LongAttributeCallback) callback);
+                  .readStartTimeAttribute(
+                      (ChipClusters.MediaPlaybackCluster.StartTimeAttributeCallback) callback);
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readMediaPlaybackStartTimeCommandParams);
@@ -4967,7 +4968,8 @@ public class ClusterReadMapping {
         new InteractionInfo(
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.MediaPlaybackCluster) cluster)
-                  .readDurationAttribute((ChipClusters.LongAttributeCallback) callback);
+                  .readDurationAttribute(
+                      (ChipClusters.MediaPlaybackCluster.DurationAttributeCallback) callback);
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readMediaPlaybackDurationCommandParams);
@@ -4991,7 +4993,8 @@ public class ClusterReadMapping {
         new InteractionInfo(
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.MediaPlaybackCluster) cluster)
-                  .readSeekRangeEndAttribute((ChipClusters.LongAttributeCallback) callback);
+                  .readSeekRangeEndAttribute(
+                      (ChipClusters.MediaPlaybackCluster.SeekRangeEndAttributeCallback) callback);
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readMediaPlaybackSeekRangeEndCommandParams);
@@ -5003,7 +5006,8 @@ public class ClusterReadMapping {
         new InteractionInfo(
             (cluster, callback, commandArguments) -> {
               ((ChipClusters.MediaPlaybackCluster) cluster)
-                  .readSeekRangeStartAttribute((ChipClusters.LongAttributeCallback) callback);
+                  .readSeekRangeStartAttribute(
+                      (ChipClusters.MediaPlaybackCluster.SeekRangeStartAttributeCallback) callback);
             },
             () -> new ClusterInfoMapping.DelegatedLongAttributeCallback(),
             readMediaPlaybackSeekRangeStartCommandParams);

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -1066,14 +1066,12 @@ class ChipClusters:
                     "attributeId": 0x00000001,
                     "type": "",
                     "reportable": True,
-                    "writable": True,
                 },
                 0x00000002: {
                     "attributeName": "CurrentChannel",
                     "attributeId": 0x00000002,
                     "type": "",
                     "reportable": True,
-                    "writable": True,
                 },
                 0x0000FFF8: {
                     "attributeName": "ServerGeneratedCommandList",
@@ -1671,9 +1669,9 @@ class ChipClusters:
                     "commandId": 0x00000000,
                     "commandName": "LaunchContentRequest",
                     "args": {
+                        "parameterList": "",
                         "autoPlay": "bool",
                         "data": "str",
-                        "parameterList": "",
                     },
                 },
             0x00000001: {
@@ -3357,7 +3355,6 @@ class ChipClusters:
                     "attributeId": 0x00000003,
                     "type": "",
                     "reportable": True,
-                    "writable": True,
                 },
                 0x00000004: {
                     "attributeName": "PlaybackSpeed",

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -31173,7 +31173,7 @@ class WakeOnLan(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields = [
-                ClusterObjectFieldDescriptor(Label="wakeOnLanMacAddress", Tag=0x00000000, Type=str),
+                ClusterObjectFieldDescriptor(Label="wakeOnLanMacAddress", Tag=0x00000000, Type=typing.Optional[str]),
                 ClusterObjectFieldDescriptor(Label="serverGeneratedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="clientGeneratedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -31181,7 +31181,7 @@ class WakeOnLan(Cluster):
                 ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
             ])
 
-    wakeOnLanMacAddress: 'str' = None
+    wakeOnLanMacAddress: 'typing.Optional[str]' = None
     serverGeneratedCommandList: 'typing.List[uint]' = None
     clientGeneratedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -31204,9 +31204,9 @@ class WakeOnLan(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=str)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[str])
 
-            value: 'str' = ""
+            value: 'typing.Optional[str]' = None
 
         @dataclass
         class ServerGeneratedCommandList(ClusterAttributeDescriptor):
@@ -31299,8 +31299,8 @@ class Channel(Cluster):
         return ClusterObjectDescriptor(
             Fields = [
                 ClusterObjectFieldDescriptor(Label="channelList", Tag=0x00000000, Type=typing.Optional[typing.List[Channel.Structs.ChannelInfo]]),
-                ClusterObjectFieldDescriptor(Label="channelLineup", Tag=0x00000001, Type=typing.Optional[Channel.Structs.LineupInfo]),
-                ClusterObjectFieldDescriptor(Label="currentChannel", Tag=0x00000002, Type=typing.Optional[Channel.Structs.ChannelInfo]),
+                ClusterObjectFieldDescriptor(Label="channelLineup", Tag=0x00000001, Type=typing.Union[None, Nullable, Channel.Structs.LineupInfo]),
+                ClusterObjectFieldDescriptor(Label="currentChannel", Tag=0x00000002, Type=typing.Union[None, Nullable, Channel.Structs.ChannelInfo]),
                 ClusterObjectFieldDescriptor(Label="serverGeneratedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="clientGeneratedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -31309,8 +31309,8 @@ class Channel(Cluster):
             ])
 
     channelList: 'typing.Optional[typing.List[Channel.Structs.ChannelInfo]]' = None
-    channelLineup: 'typing.Optional[Channel.Structs.LineupInfo]' = None
-    currentChannel: 'typing.Optional[Channel.Structs.ChannelInfo]' = None
+    channelLineup: 'typing.Union[None, Nullable, Channel.Structs.LineupInfo]' = None
+    currentChannel: 'typing.Union[None, Nullable, Channel.Structs.ChannelInfo]' = None
     serverGeneratedCommandList: 'typing.List[uint]' = None
     clientGeneratedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -31335,16 +31335,16 @@ class Channel(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="majorNumber", Tag=0, Type=uint),
                             ClusterObjectFieldDescriptor(Label="minorNumber", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="callSign", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="affiliateCallSign", Tag=4, Type=str),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=2, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="callSign", Tag=3, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="affiliateCallSign", Tag=4, Type=typing.Optional[str]),
                     ])
 
             majorNumber: 'uint' = 0
             minorNumber: 'uint' = 0
-            name: 'str' = ""
-            callSign: 'str' = ""
-            affiliateCallSign: 'str' = ""
+            name: 'typing.Optional[str]' = None
+            callSign: 'typing.Optional[str]' = None
+            affiliateCallSign: 'typing.Optional[str]' = None
 
         @dataclass
         class LineupInfo(ClusterObject):
@@ -31353,14 +31353,14 @@ class Channel(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="operatorName", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="lineupName", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="postalCode", Tag=2, Type=str),
+                            ClusterObjectFieldDescriptor(Label="lineupName", Tag=1, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="postalCode", Tag=2, Type=typing.Optional[str]),
                             ClusterObjectFieldDescriptor(Label="lineupInfoType", Tag=3, Type=Channel.Enums.LineupInfoTypeEnum),
                     ])
 
             operatorName: 'str' = ""
-            lineupName: 'str' = ""
-            postalCode: 'str' = ""
+            lineupName: 'typing.Optional[str]' = None
+            postalCode: 'typing.Optional[str]' = None
             lineupInfoType: 'Channel.Enums.LineupInfoTypeEnum' = 0
 
 
@@ -31460,9 +31460,9 @@ class Channel(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[Channel.Structs.LineupInfo])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, Channel.Structs.LineupInfo])
 
-            value: 'typing.Optional[Channel.Structs.LineupInfo]' = None
+            value: 'typing.Union[None, Nullable, Channel.Structs.LineupInfo]' = None
 
         @dataclass
         class CurrentChannel(ClusterAttributeDescriptor):
@@ -31476,9 +31476,9 @@ class Channel(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[Channel.Structs.ChannelInfo])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, Channel.Structs.ChannelInfo])
 
-            value: 'typing.Optional[Channel.Structs.ChannelInfo]' = None
+            value: 'typing.Union[None, Nullable, Channel.Structs.ChannelInfo]' = None
 
         @dataclass
         class ServerGeneratedCommandList(ClusterAttributeDescriptor):
@@ -31622,11 +31622,11 @@ class TargetNavigator(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="target", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
             target: 'uint' = 0
-            data: 'str' = ""
+            data: 'typing.Optional[str]' = None
 
         @dataclass
         class NavigateTargetResponse(ClusterCommand):
@@ -31639,11 +31639,11 @@ class TargetNavigator(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=TargetNavigator.Enums.StatusEnum),
-                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
             status: 'TargetNavigator.Enums.StatusEnum' = 0
-            data: 'str' = ""
+            data: 'typing.Optional[str]' = None
 
 
     class Attributes:
@@ -31769,13 +31769,13 @@ class MediaPlayback(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields = [
-                ClusterObjectFieldDescriptor(Label="playbackState", Tag=0x00000000, Type=typing.Optional[MediaPlayback.Enums.PlaybackStateEnum]),
-                ClusterObjectFieldDescriptor(Label="startTime", Tag=0x00000001, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="duration", Tag=0x00000002, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="position", Tag=0x00000003, Type=MediaPlayback.Structs.PlaybackPosition),
+                ClusterObjectFieldDescriptor(Label="playbackState", Tag=0x00000000, Type=MediaPlayback.Enums.PlaybackStateEnum),
+                ClusterObjectFieldDescriptor(Label="startTime", Tag=0x00000001, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="duration", Tag=0x00000002, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="position", Tag=0x00000003, Type=typing.Optional[MediaPlayback.Structs.PlaybackPosition]),
                 ClusterObjectFieldDescriptor(Label="playbackSpeed", Tag=0x00000004, Type=typing.Optional[float]),
-                ClusterObjectFieldDescriptor(Label="seekRangeEnd", Tag=0x00000005, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="seekRangeStart", Tag=0x00000006, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="seekRangeEnd", Tag=0x00000005, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="seekRangeStart", Tag=0x00000006, Type=typing.Union[None, Nullable, uint]),
                 ClusterObjectFieldDescriptor(Label="serverGeneratedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="clientGeneratedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -31783,13 +31783,13 @@ class MediaPlayback(Cluster):
                 ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
             ])
 
-    playbackState: 'typing.Optional[MediaPlayback.Enums.PlaybackStateEnum]' = None
-    startTime: 'typing.Optional[uint]' = None
-    duration: 'typing.Optional[uint]' = None
-    position: 'MediaPlayback.Structs.PlaybackPosition' = None
+    playbackState: 'MediaPlayback.Enums.PlaybackStateEnum' = None
+    startTime: 'typing.Union[None, Nullable, uint]' = None
+    duration: 'typing.Union[None, Nullable, uint]' = None
+    position: 'typing.Optional[MediaPlayback.Structs.PlaybackPosition]' = None
     playbackSpeed: 'typing.Optional[float]' = None
-    seekRangeEnd: 'typing.Optional[uint]' = None
-    seekRangeStart: 'typing.Optional[uint]' = None
+    seekRangeEnd: 'typing.Union[None, Nullable, uint]' = None
+    seekRangeStart: 'typing.Union[None, Nullable, uint]' = None
     serverGeneratedCommandList: 'typing.List[uint]' = None
     clientGeneratedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -31820,11 +31820,11 @@ class MediaPlayback(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="updatedAt", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="position", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="position", Tag=1, Type=typing.Union[Nullable, uint]),
                     ])
 
             updatedAt: 'uint' = 0
-            position: 'uint' = 0
+            position: 'typing.Union[Nullable, uint]' = NullValue
 
 
 
@@ -32007,9 +32007,9 @@ class MediaPlayback(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[MediaPlayback.Enums.PlaybackStateEnum])
+                return ClusterObjectFieldDescriptor(Type=MediaPlayback.Enums.PlaybackStateEnum)
 
-            value: 'typing.Optional[MediaPlayback.Enums.PlaybackStateEnum]' = None
+            value: 'MediaPlayback.Enums.PlaybackStateEnum' = 0
 
         @dataclass
         class StartTime(ClusterAttributeDescriptor):
@@ -32023,9 +32023,9 @@ class MediaPlayback(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Optional[uint]' = None
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class Duration(ClusterAttributeDescriptor):
@@ -32039,9 +32039,9 @@ class MediaPlayback(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Optional[uint]' = None
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class Position(ClusterAttributeDescriptor):
@@ -32055,9 +32055,9 @@ class MediaPlayback(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=MediaPlayback.Structs.PlaybackPosition)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[MediaPlayback.Structs.PlaybackPosition])
 
-            value: 'MediaPlayback.Structs.PlaybackPosition' = field(default_factory=lambda: MediaPlayback.Structs.PlaybackPosition())
+            value: 'typing.Optional[MediaPlayback.Structs.PlaybackPosition]' = None
 
         @dataclass
         class PlaybackSpeed(ClusterAttributeDescriptor):
@@ -32087,9 +32087,9 @@ class MediaPlayback(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Optional[uint]' = None
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class SeekRangeStart(ClusterAttributeDescriptor):
@@ -32103,9 +32103,9 @@ class MediaPlayback(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Optional[uint]' = None
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class ServerGeneratedCommandList(ClusterAttributeDescriptor):
@@ -32786,8 +32786,8 @@ class ContentLauncher(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields = [
-                ClusterObjectFieldDescriptor(Label="acceptHeaderList", Tag=0x00000000, Type=typing.List[str]),
-                ClusterObjectFieldDescriptor(Label="supportedStreamingProtocols", Tag=0x00000001, Type=uint),
+                ClusterObjectFieldDescriptor(Label="acceptHeaderList", Tag=0x00000000, Type=typing.Optional[typing.List[str]]),
+                ClusterObjectFieldDescriptor(Label="supportedStreamingProtocols", Tag=0x00000001, Type=typing.Optional[uint]),
                 ClusterObjectFieldDescriptor(Label="serverGeneratedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="clientGeneratedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -32795,8 +32795,8 @@ class ContentLauncher(Cluster):
                 ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
             ])
 
-    acceptHeaderList: 'typing.List[str]' = None
-    supportedStreamingProtocols: 'uint' = None
+    acceptHeaderList: 'typing.Optional[typing.List[str]]' = None
+    supportedStreamingProtocols: 'typing.Optional[uint]' = None
     serverGeneratedCommandList: 'typing.List[uint]' = None
     clientGeneratedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -32866,12 +32866,12 @@ class ContentLauncher(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="type", Tag=0, Type=ContentLauncher.Enums.ParameterEnum),
                             ClusterObjectFieldDescriptor(Label="value", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="externalIDList", Tag=2, Type=typing.List[ContentLauncher.Structs.AdditionalInfo]),
+                            ClusterObjectFieldDescriptor(Label="externalIDList", Tag=2, Type=typing.Optional[typing.List[ContentLauncher.Structs.AdditionalInfo]]),
                     ])
 
             type: 'ContentLauncher.Enums.ParameterEnum' = 0
             value: 'str' = ""
-            externalIDList: 'typing.List[ContentLauncher.Structs.AdditionalInfo]' = field(default_factory=lambda: [])
+            externalIDList: 'typing.Optional[typing.List[ContentLauncher.Structs.AdditionalInfo]]' = None
 
         @dataclass
         class ContentSearch(ClusterObject):
@@ -32890,14 +32890,14 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="imageUrl", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="color", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="size", Tag=2, Type=ContentLauncher.Structs.Dimension),
+                            ClusterObjectFieldDescriptor(Label="imageUrl", Tag=0, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="color", Tag=1, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="size", Tag=2, Type=typing.Optional[ContentLauncher.Structs.Dimension]),
                     ])
 
-            imageUrl: 'str' = ""
-            color: 'str' = ""
-            size: 'ContentLauncher.Structs.Dimension' = field(default_factory=lambda: ContentLauncher.Structs.Dimension())
+            imageUrl: 'typing.Optional[str]' = None
+            color: 'typing.Optional[str]' = None
+            size: 'typing.Optional[ContentLauncher.Structs.Dimension]' = None
 
         @dataclass
         class BrandingInformation(ClusterObject):
@@ -32906,19 +32906,19 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="providerName", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="background", Tag=1, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="logo", Tag=2, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="progressBar", Tag=3, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="splash", Tag=4, Type=ContentLauncher.Structs.StyleInformation),
-                            ClusterObjectFieldDescriptor(Label="waterMark", Tag=5, Type=ContentLauncher.Structs.StyleInformation),
+                            ClusterObjectFieldDescriptor(Label="background", Tag=1, Type=typing.Optional[ContentLauncher.Structs.StyleInformation]),
+                            ClusterObjectFieldDescriptor(Label="logo", Tag=2, Type=typing.Optional[ContentLauncher.Structs.StyleInformation]),
+                            ClusterObjectFieldDescriptor(Label="progressBar", Tag=3, Type=typing.Optional[ContentLauncher.Structs.StyleInformation]),
+                            ClusterObjectFieldDescriptor(Label="splash", Tag=4, Type=typing.Optional[ContentLauncher.Structs.StyleInformation]),
+                            ClusterObjectFieldDescriptor(Label="waterMark", Tag=5, Type=typing.Optional[ContentLauncher.Structs.StyleInformation]),
                     ])
 
             providerName: 'str' = ""
-            background: 'ContentLauncher.Structs.StyleInformation' = field(default_factory=lambda: ContentLauncher.Structs.StyleInformation())
-            logo: 'ContentLauncher.Structs.StyleInformation' = field(default_factory=lambda: ContentLauncher.Structs.StyleInformation())
-            progressBar: 'ContentLauncher.Structs.StyleInformation' = field(default_factory=lambda: ContentLauncher.Structs.StyleInformation())
-            splash: 'ContentLauncher.Structs.StyleInformation' = field(default_factory=lambda: ContentLauncher.Structs.StyleInformation())
-            waterMark: 'ContentLauncher.Structs.StyleInformation' = field(default_factory=lambda: ContentLauncher.Structs.StyleInformation())
+            background: 'typing.Optional[ContentLauncher.Structs.StyleInformation]' = None
+            logo: 'typing.Optional[ContentLauncher.Structs.StyleInformation]' = None
+            progressBar: 'typing.Optional[ContentLauncher.Structs.StyleInformation]' = None
+            splash: 'typing.Optional[ContentLauncher.Structs.StyleInformation]' = None
+            waterMark: 'typing.Optional[ContentLauncher.Structs.StyleInformation]' = None
 
 
 
@@ -32933,14 +32933,14 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="autoPlay", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="search", Tag=2, Type=typing.List[ContentLauncher.Structs.ContentSearch]),
+                            ClusterObjectFieldDescriptor(Label="search", Tag=0, Type=typing.List[ContentLauncher.Structs.ContentSearch]),
+                            ClusterObjectFieldDescriptor(Label="autoPlay", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=2, Type=typing.Optional[str]),
                     ])
 
-            autoPlay: 'bool' = False
-            data: 'str' = ""
             search: 'typing.List[ContentLauncher.Structs.ContentSearch]' = field(default_factory=lambda: [])
+            autoPlay: 'bool' = False
+            data: 'typing.Optional[str]' = None
 
         @dataclass
         class LaunchURLRequest(ClusterCommand):
@@ -32953,13 +32953,13 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="contentURL", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="displayString", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="brandingInformation", Tag=2, Type=ContentLauncher.Structs.BrandingInformation),
+                            ClusterObjectFieldDescriptor(Label="displayString", Tag=1, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="brandingInformation", Tag=2, Type=typing.Optional[ContentLauncher.Structs.BrandingInformation]),
                     ])
 
             contentURL: 'str' = ""
-            displayString: 'str' = ""
-            brandingInformation: 'ContentLauncher.Structs.BrandingInformation' = field(default_factory=lambda: ContentLauncher.Structs.BrandingInformation())
+            displayString: 'typing.Optional[str]' = None
+            brandingInformation: 'typing.Optional[ContentLauncher.Structs.BrandingInformation]' = None
 
         @dataclass
         class LaunchResponse(ClusterCommand):
@@ -32972,11 +32972,11 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ContentLauncher.Enums.StatusEnum),
-                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
             status: 'ContentLauncher.Enums.StatusEnum' = 0
-            data: 'str' = ""
+            data: 'typing.Optional[str]' = None
 
 
     class Attributes:
@@ -32992,9 +32992,9 @@ class ContentLauncher(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[str])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[str]])
 
-            value: 'typing.List[str]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[str]]' = None
 
         @dataclass
         class SupportedStreamingProtocols(ClusterAttributeDescriptor):
@@ -33008,9 +33008,9 @@ class ContentLauncher(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class ServerGeneratedCommandList(ClusterAttributeDescriptor):
@@ -33305,7 +33305,7 @@ class ApplicationLauncher(Cluster):
         return ClusterObjectDescriptor(
             Fields = [
                 ClusterObjectFieldDescriptor(Label="applicationLauncherList", Tag=0x00000000, Type=typing.List[uint]),
-                ClusterObjectFieldDescriptor(Label="applicationLauncherApp", Tag=0x00000001, Type=ApplicationLauncher.Structs.ApplicationEP),
+                ClusterObjectFieldDescriptor(Label="applicationLauncherApp", Tag=0x00000001, Type=typing.Union[None, Nullable, ApplicationLauncher.Structs.ApplicationEP]),
                 ClusterObjectFieldDescriptor(Label="serverGeneratedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="clientGeneratedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -33314,7 +33314,7 @@ class ApplicationLauncher(Cluster):
             ])
 
     applicationLauncherList: 'typing.List[uint]' = None
-    applicationLauncherApp: 'ApplicationLauncher.Structs.ApplicationEP' = None
+    applicationLauncherApp: 'typing.Union[None, Nullable, ApplicationLauncher.Structs.ApplicationEP]' = None
     serverGeneratedCommandList: 'typing.List[uint]' = None
     clientGeneratedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -33349,11 +33349,11 @@ class ApplicationLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.Application),
-                            ClusterObjectFieldDescriptor(Label="endpoint", Tag=1, Type=str),
+                            ClusterObjectFieldDescriptor(Label="endpoint", Tag=1, Type=typing.Optional[uint]),
                     ])
 
             application: 'ApplicationLauncher.Structs.Application' = field(default_factory=lambda: ApplicationLauncher.Structs.Application())
-            endpoint: 'str' = ""
+            endpoint: 'typing.Optional[uint]' = None
 
 
 
@@ -33369,11 +33369,11 @@ class ApplicationLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="application", Tag=0, Type=ApplicationLauncher.Structs.Application),
-                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=bytes),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[bytes]),
                     ])
 
             application: 'ApplicationLauncher.Structs.Application' = field(default_factory=lambda: ApplicationLauncher.Structs.Application())
-            data: 'bytes' = b""
+            data: 'typing.Optional[bytes]' = None
 
         @dataclass
         class StopAppRequest(ClusterCommand):
@@ -33452,9 +33452,9 @@ class ApplicationLauncher(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=ApplicationLauncher.Structs.ApplicationEP)
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, ApplicationLauncher.Structs.ApplicationEP])
 
-            value: 'ApplicationLauncher.Structs.ApplicationEP' = field(default_factory=lambda: ApplicationLauncher.Structs.ApplicationEP())
+            value: 'typing.Union[None, Nullable, ApplicationLauncher.Structs.ApplicationEP]' = None
 
         @dataclass
         class ServerGeneratedCommandList(ClusterAttributeDescriptor):
@@ -33546,10 +33546,10 @@ class ApplicationBasic(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields = [
-                ClusterObjectFieldDescriptor(Label="vendorName", Tag=0x00000000, Type=str),
-                ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000001, Type=uint),
+                ClusterObjectFieldDescriptor(Label="vendorName", Tag=0x00000000, Type=typing.Optional[str]),
+                ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000001, Type=typing.Optional[uint]),
                 ClusterObjectFieldDescriptor(Label="applicationName", Tag=0x00000002, Type=str),
-                ClusterObjectFieldDescriptor(Label="productId", Tag=0x00000003, Type=uint),
+                ClusterObjectFieldDescriptor(Label="productId", Tag=0x00000003, Type=typing.Optional[uint]),
                 ClusterObjectFieldDescriptor(Label="applicationApp", Tag=0x00000004, Type=ApplicationBasic.Structs.ApplicationBasicApplication),
                 ClusterObjectFieldDescriptor(Label="applicationStatus", Tag=0x00000005, Type=ApplicationBasic.Enums.ApplicationStatusEnum),
                 ClusterObjectFieldDescriptor(Label="applicationVersion", Tag=0x00000006, Type=str),
@@ -33561,10 +33561,10 @@ class ApplicationBasic(Cluster):
                 ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
             ])
 
-    vendorName: 'str' = None
-    vendorId: 'uint' = None
+    vendorName: 'typing.Optional[str]' = None
+    vendorId: 'typing.Optional[uint]' = None
     applicationName: 'str' = None
-    productId: 'uint' = None
+    productId: 'typing.Optional[uint]' = None
     applicationApp: 'ApplicationBasic.Structs.ApplicationBasicApplication' = None
     applicationStatus: 'ApplicationBasic.Enums.ApplicationStatusEnum' = None
     applicationVersion: 'str' = None
@@ -33613,9 +33613,9 @@ class ApplicationBasic(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=str)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[str])
 
-            value: 'str' = ""
+            value: 'typing.Optional[str]' = None
 
         @dataclass
         class VendorId(ClusterAttributeDescriptor):
@@ -33629,9 +33629,9 @@ class ApplicationBasic(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class ApplicationName(ClusterAttributeDescriptor):
@@ -33661,9 +33661,9 @@ class ApplicationBasic(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class ApplicationApp(ClusterAttributeDescriptor):

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -714,16 +714,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            CHIPApplicationLauncherClusterApplicationEP * _Nonnull value;
-            value = [CHIPApplicationLauncherClusterApplicationEP new];
-            value.application = [CHIPApplicationLauncherClusterApplication new];
-            value.application.catalogVendorId = [NSNumber numberWithUnsignedShort:cppValue.application.catalogVendorId];
-            value.application.applicationId = [[NSString alloc] initWithBytes:cppValue.application.applicationId.data()
-                                                                       length:cppValue.application.applicationId.size()
-                                                                     encoding:NSUTF8StringEncoding];
-            value.endpoint = [[NSString alloc] initWithBytes:cppValue.endpoint.data()
-                                                      length:cppValue.endpoint.size()
-                                                    encoding:NSUTF8StringEncoding];
+            CHIPApplicationLauncherClusterApplicationEP * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [CHIPApplicationLauncherClusterApplicationEP new];
+                value.application = [CHIPApplicationLauncherClusterApplication new];
+                value.application.catalogVendorId = [NSNumber numberWithUnsignedShort:cppValue.Value().application.catalogVendorId];
+                value.application.applicationId = [[NSString alloc] initWithBytes:cppValue.Value().application.applicationId.data()
+                                                                           length:cppValue.Value().application.applicationId.size()
+                                                                         encoding:NSUTF8StringEncoding];
+                if (cppValue.Value().endpoint.HasValue()) {
+                    value.endpoint = [NSNumber numberWithUnsignedShort:cppValue.Value().endpoint.Value()];
+                } else {
+                    value.endpoint = nil;
+                }
+            }
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -2239,15 +2245,27 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 newElement_0 = [CHIPChannelClusterChannelInfo new];
                 newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
                 newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.data()
-                                                                 length:entry_0.callSign.size()
+                if (entry_0.name.HasValue()) {
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
+                                                                 length:entry_0.name.Value().size()
                                                                encoding:NSUTF8StringEncoding];
-                newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.data()
-                                                                          length:entry_0.affiliateCallSign.size()
-                                                                        encoding:NSUTF8StringEncoding];
+                } else {
+                    newElement_0.name = nil;
+                }
+                if (entry_0.callSign.HasValue()) {
+                    newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
+                                                                     length:entry_0.callSign.Value().size()
+                                                                   encoding:NSUTF8StringEncoding];
+                } else {
+                    newElement_0.callSign = nil;
+                }
+                if (entry_0.affiliateCallSign.HasValue()) {
+                    newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
+                                                                              length:entry_0.affiliateCallSign.Value().size()
+                                                                            encoding:NSUTF8StringEncoding];
+                } else {
+                    newElement_0.affiliateCallSign = nil;
+                }
                 [array_0 addObject:newElement_0];
             }
             { // Scope for the error so we will know what it's named
@@ -2267,18 +2285,30 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            CHIPChannelClusterLineupInfo * _Nonnull value;
-            value = [CHIPChannelClusterLineupInfo new];
-            value.operatorName = [[NSString alloc] initWithBytes:cppValue.operatorName.data()
-                                                          length:cppValue.operatorName.size()
-                                                        encoding:NSUTF8StringEncoding];
-            value.lineupName = [[NSString alloc] initWithBytes:cppValue.lineupName.data()
-                                                        length:cppValue.lineupName.size()
-                                                      encoding:NSUTF8StringEncoding];
-            value.postalCode = [[NSString alloc] initWithBytes:cppValue.postalCode.data()
-                                                        length:cppValue.postalCode.size()
-                                                      encoding:NSUTF8StringEncoding];
-            value.lineupInfoType = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppValue.lineupInfoType)];
+            CHIPChannelClusterLineupInfo * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [CHIPChannelClusterLineupInfo new];
+                value.operatorName = [[NSString alloc] initWithBytes:cppValue.Value().operatorName.data()
+                                                              length:cppValue.Value().operatorName.size()
+                                                            encoding:NSUTF8StringEncoding];
+                if (cppValue.Value().lineupName.HasValue()) {
+                    value.lineupName = [[NSString alloc] initWithBytes:cppValue.Value().lineupName.Value().data()
+                                                                length:cppValue.Value().lineupName.Value().size()
+                                                              encoding:NSUTF8StringEncoding];
+                } else {
+                    value.lineupName = nil;
+                }
+                if (cppValue.Value().postalCode.HasValue()) {
+                    value.postalCode = [[NSString alloc] initWithBytes:cppValue.Value().postalCode.Value().data()
+                                                                length:cppValue.Value().postalCode.Value().size()
+                                                              encoding:NSUTF8StringEncoding];
+                } else {
+                    value.postalCode = nil;
+                }
+                value.lineupInfoType = [NSNumber numberWithUnsignedChar:chip::to_underlying(cppValue.Value().lineupInfoType)];
+            }
             return value;
         }
         case Attributes::CurrentChannel::Id: {
@@ -2288,19 +2318,35 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            CHIPChannelClusterChannelInfo * _Nonnull value;
-            value = [CHIPChannelClusterChannelInfo new];
-            value.majorNumber = [NSNumber numberWithUnsignedShort:cppValue.majorNumber];
-            value.minorNumber = [NSNumber numberWithUnsignedShort:cppValue.minorNumber];
-            value.name = [[NSString alloc] initWithBytes:cppValue.name.data()
-                                                  length:cppValue.name.size()
-                                                encoding:NSUTF8StringEncoding];
-            value.callSign = [[NSString alloc] initWithBytes:cppValue.callSign.data()
-                                                      length:cppValue.callSign.size()
-                                                    encoding:NSUTF8StringEncoding];
-            value.affiliateCallSign = [[NSString alloc] initWithBytes:cppValue.affiliateCallSign.data()
-                                                               length:cppValue.affiliateCallSign.size()
-                                                             encoding:NSUTF8StringEncoding];
+            CHIPChannelClusterChannelInfo * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [CHIPChannelClusterChannelInfo new];
+                value.majorNumber = [NSNumber numberWithUnsignedShort:cppValue.Value().majorNumber];
+                value.minorNumber = [NSNumber numberWithUnsignedShort:cppValue.Value().minorNumber];
+                if (cppValue.Value().name.HasValue()) {
+                    value.name = [[NSString alloc] initWithBytes:cppValue.Value().name.Value().data()
+                                                          length:cppValue.Value().name.Value().size()
+                                                        encoding:NSUTF8StringEncoding];
+                } else {
+                    value.name = nil;
+                }
+                if (cppValue.Value().callSign.HasValue()) {
+                    value.callSign = [[NSString alloc] initWithBytes:cppValue.Value().callSign.Value().data()
+                                                              length:cppValue.Value().callSign.Value().size()
+                                                            encoding:NSUTF8StringEncoding];
+                } else {
+                    value.callSign = nil;
+                }
+                if (cppValue.Value().affiliateCallSign.HasValue()) {
+                    value.affiliateCallSign = [[NSString alloc] initWithBytes:cppValue.Value().affiliateCallSign.Value().data()
+                                                                       length:cppValue.Value().affiliateCallSign.Value().size()
+                                                                     encoding:NSUTF8StringEncoding];
+                } else {
+                    value.affiliateCallSign = nil;
+                }
+            }
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -6300,8 +6346,12 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            NSNumber * _Nonnull value;
-            value = [NSNumber numberWithUnsignedLongLong:cppValue];
+            NSNumber * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [NSNumber numberWithUnsignedLongLong:cppValue.Value()];
+            }
             return value;
         }
         case Attributes::Duration::Id: {
@@ -6311,8 +6361,12 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            NSNumber * _Nonnull value;
-            value = [NSNumber numberWithUnsignedLongLong:cppValue];
+            NSNumber * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [NSNumber numberWithUnsignedLongLong:cppValue.Value()];
+            }
             return value;
         }
         case Attributes::Position::Id: {
@@ -6325,7 +6379,11 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull value;
             value = [CHIPMediaPlaybackClusterPlaybackPosition new];
             value.updatedAt = [NSNumber numberWithUnsignedLongLong:cppValue.updatedAt];
-            value.position = [NSNumber numberWithUnsignedLongLong:cppValue.position];
+            if (cppValue.position.IsNull()) {
+                value.position = nil;
+            } else {
+                value.position = [NSNumber numberWithUnsignedLongLong:cppValue.position.Value()];
+            }
             return value;
         }
         case Attributes::PlaybackSpeed::Id: {
@@ -6346,8 +6404,12 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            NSNumber * _Nonnull value;
-            value = [NSNumber numberWithUnsignedLongLong:cppValue];
+            NSNumber * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [NSNumber numberWithUnsignedLongLong:cppValue.Value()];
+            }
             return value;
         }
         case Attributes::SeekRangeStart::Id: {
@@ -6357,8 +6419,12 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
             if (*aError != CHIP_NO_ERROR) {
                 return nil;
             }
-            NSNumber * _Nonnull value;
-            value = [NSNumber numberWithUnsignedLongLong:cppValue];
+            NSNumber * _Nullable value;
+            if (cppValue.IsNull()) {
+                value = nil;
+            } else {
+                value = [NSNumber numberWithUnsignedLongLong:cppValue.Value()];
+            }
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -1453,19 +1453,25 @@ void CHIPApplicationLauncherApplicationLauncherListListAttributeCallbackSubscrip
     }
 }
 
-void CHIPApplicationLauncherApplicationLauncherAppStructAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType & value)
+void CHIPApplicationLauncherApplicationLauncherAppStructAttributeCallbackBridge::OnSuccessFn(void * context,
+    const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> & value)
 {
-    CHIPApplicationLauncherClusterApplicationEP * _Nonnull objCValue;
-    objCValue = [CHIPApplicationLauncherClusterApplicationEP new];
-    objCValue.application = [CHIPApplicationLauncherClusterApplication new];
-    objCValue.application.catalogVendorId = [NSNumber numberWithUnsignedShort:value.application.catalogVendorId];
-    objCValue.application.applicationId = [[NSString alloc] initWithBytes:value.application.applicationId.data()
-                                                                   length:value.application.applicationId.size()
-                                                                 encoding:NSUTF8StringEncoding];
-    objCValue.endpoint = [[NSString alloc] initWithBytes:value.endpoint.data()
-                                                  length:value.endpoint.size()
-                                                encoding:NSUTF8StringEncoding];
+    CHIPApplicationLauncherClusterApplicationEP * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [CHIPApplicationLauncherClusterApplicationEP new];
+        objCValue.application = [CHIPApplicationLauncherClusterApplication new];
+        objCValue.application.catalogVendorId = [NSNumber numberWithUnsignedShort:value.Value().application.catalogVendorId];
+        objCValue.application.applicationId = [[NSString alloc] initWithBytes:value.Value().application.applicationId.data()
+                                                                       length:value.Value().application.applicationId.size()
+                                                                     encoding:NSUTF8StringEncoding];
+        if (value.Value().endpoint.HasValue()) {
+            objCValue.endpoint = [NSNumber numberWithUnsignedShort:value.Value().endpoint.Value()];
+        } else {
+            objCValue.endpoint = nil;
+        }
+    }
     DispatchSuccess(context, objCValue);
 };
 
@@ -2752,15 +2758,27 @@ void CHIPChannelChannelListListAttributeCallbackBridge::OnSuccessFn(void * conte
         newElement_0 = [CHIPChannelClusterChannelInfo new];
         newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
         newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.data()
-                                                         length:entry_0.callSign.size()
+        if (entry_0.name.HasValue()) {
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
+                                                         length:entry_0.name.Value().size()
                                                        encoding:NSUTF8StringEncoding];
-        newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.data()
-                                                                  length:entry_0.affiliateCallSign.size()
-                                                                encoding:NSUTF8StringEncoding];
+        } else {
+            newElement_0.name = nil;
+        }
+        if (entry_0.callSign.HasValue()) {
+            newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
+                                                             length:entry_0.callSign.Value().size()
+                                                           encoding:NSUTF8StringEncoding];
+        } else {
+            newElement_0.callSign = nil;
+        }
+        if (entry_0.affiliateCallSign.HasValue()) {
+            newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
+                                                                      length:entry_0.affiliateCallSign.Value().size()
+                                                                    encoding:NSUTF8StringEncoding];
+        } else {
+            newElement_0.affiliateCallSign = nil;
+        }
         [array_0 addObject:newElement_0];
     }
     { // Scope for the error so we will know what it's named
@@ -2791,20 +2809,32 @@ void CHIPChannelChannelListListAttributeCallbackSubscriptionBridge::OnSubscripti
 }
 
 void CHIPChannelChannelLineupStructAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType & value)
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType> & value)
 {
-    CHIPChannelClusterLineupInfo * _Nonnull objCValue;
-    objCValue = [CHIPChannelClusterLineupInfo new];
-    objCValue.operatorName = [[NSString alloc] initWithBytes:value.operatorName.data()
-                                                      length:value.operatorName.size()
-                                                    encoding:NSUTF8StringEncoding];
-    objCValue.lineupName = [[NSString alloc] initWithBytes:value.lineupName.data()
-                                                    length:value.lineupName.size()
-                                                  encoding:NSUTF8StringEncoding];
-    objCValue.postalCode = [[NSString alloc] initWithBytes:value.postalCode.data()
-                                                    length:value.postalCode.size()
-                                                  encoding:NSUTF8StringEncoding];
-    objCValue.lineupInfoType = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.lineupInfoType)];
+    CHIPChannelClusterLineupInfo * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [CHIPChannelClusterLineupInfo new];
+        objCValue.operatorName = [[NSString alloc] initWithBytes:value.Value().operatorName.data()
+                                                          length:value.Value().operatorName.size()
+                                                        encoding:NSUTF8StringEncoding];
+        if (value.Value().lineupName.HasValue()) {
+            objCValue.lineupName = [[NSString alloc] initWithBytes:value.Value().lineupName.Value().data()
+                                                            length:value.Value().lineupName.Value().size()
+                                                          encoding:NSUTF8StringEncoding];
+        } else {
+            objCValue.lineupName = nil;
+        }
+        if (value.Value().postalCode.HasValue()) {
+            objCValue.postalCode = [[NSString alloc] initWithBytes:value.Value().postalCode.Value().data()
+                                                            length:value.Value().postalCode.Value().size()
+                                                          encoding:NSUTF8StringEncoding];
+        } else {
+            objCValue.postalCode = nil;
+        }
+        objCValue.lineupInfoType = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value().lineupInfoType)];
+    }
     DispatchSuccess(context, objCValue);
 };
 
@@ -2825,19 +2855,37 @@ void CHIPChannelChannelLineupStructAttributeCallbackSubscriptionBridge::OnSubscr
 }
 
 void CHIPChannelCurrentChannelStructAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType & value)
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> & value)
 {
-    CHIPChannelClusterChannelInfo * _Nonnull objCValue;
-    objCValue = [CHIPChannelClusterChannelInfo new];
-    objCValue.majorNumber = [NSNumber numberWithUnsignedShort:value.majorNumber];
-    objCValue.minorNumber = [NSNumber numberWithUnsignedShort:value.minorNumber];
-    objCValue.name = [[NSString alloc] initWithBytes:value.name.data() length:value.name.size() encoding:NSUTF8StringEncoding];
-    objCValue.callSign = [[NSString alloc] initWithBytes:value.callSign.data()
-                                                  length:value.callSign.size()
-                                                encoding:NSUTF8StringEncoding];
-    objCValue.affiliateCallSign = [[NSString alloc] initWithBytes:value.affiliateCallSign.data()
-                                                           length:value.affiliateCallSign.size()
-                                                         encoding:NSUTF8StringEncoding];
+    CHIPChannelClusterChannelInfo * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [CHIPChannelClusterChannelInfo new];
+        objCValue.majorNumber = [NSNumber numberWithUnsignedShort:value.Value().majorNumber];
+        objCValue.minorNumber = [NSNumber numberWithUnsignedShort:value.Value().minorNumber];
+        if (value.Value().name.HasValue()) {
+            objCValue.name = [[NSString alloc] initWithBytes:value.Value().name.Value().data()
+                                                      length:value.Value().name.Value().size()
+                                                    encoding:NSUTF8StringEncoding];
+        } else {
+            objCValue.name = nil;
+        }
+        if (value.Value().callSign.HasValue()) {
+            objCValue.callSign = [[NSString alloc] initWithBytes:value.Value().callSign.Value().data()
+                                                          length:value.Value().callSign.Value().size()
+                                                        encoding:NSUTF8StringEncoding];
+        } else {
+            objCValue.callSign = nil;
+        }
+        if (value.Value().affiliateCallSign.HasValue()) {
+            objCValue.affiliateCallSign = [[NSString alloc] initWithBytes:value.Value().affiliateCallSign.Value().data()
+                                                                   length:value.Value().affiliateCallSign.Value().size()
+                                                                 encoding:NSUTF8StringEncoding];
+        } else {
+            objCValue.affiliateCallSign = nil;
+        }
+    }
     DispatchSuccess(context, objCValue);
 };
 
@@ -5940,7 +5988,11 @@ void CHIPMediaPlaybackPositionStructAttributeCallbackBridge::OnSuccessFn(
     CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull objCValue;
     objCValue = [CHIPMediaPlaybackClusterPlaybackPosition new];
     objCValue.updatedAt = [NSNumber numberWithUnsignedLongLong:value.updatedAt];
-    objCValue.position = [NSNumber numberWithUnsignedLongLong:value.position];
+    if (value.position.IsNull()) {
+        objCValue.position = nil;
+    } else {
+        objCValue.position = [NSNumber numberWithUnsignedLongLong:value.position.Value()];
+    }
     DispatchSuccess(context, objCValue);
 };
 
@@ -10043,15 +10095,28 @@ void CHIPChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
         response.channelMatch = [CHIPChannelClusterChannelInfo new];
         response.channelMatch.majorNumber = [NSNumber numberWithUnsignedShort:data.channelMatch.majorNumber];
         response.channelMatch.minorNumber = [NSNumber numberWithUnsignedShort:data.channelMatch.minorNumber];
-        response.channelMatch.name = [[NSString alloc] initWithBytes:data.channelMatch.name.data()
-                                                              length:data.channelMatch.name.size()
-                                                            encoding:NSUTF8StringEncoding];
-        response.channelMatch.callSign = [[NSString alloc] initWithBytes:data.channelMatch.callSign.data()
-                                                                  length:data.channelMatch.callSign.size()
+        if (data.channelMatch.name.HasValue()) {
+            response.channelMatch.name = [[NSString alloc] initWithBytes:data.channelMatch.name.Value().data()
+                                                                  length:data.channelMatch.name.Value().size()
                                                                 encoding:NSUTF8StringEncoding];
-        response.channelMatch.affiliateCallSign = [[NSString alloc] initWithBytes:data.channelMatch.affiliateCallSign.data()
-                                                                           length:data.channelMatch.affiliateCallSign.size()
-                                                                         encoding:NSUTF8StringEncoding];
+        } else {
+            response.channelMatch.name = nil;
+        }
+        if (data.channelMatch.callSign.HasValue()) {
+            response.channelMatch.callSign = [[NSString alloc] initWithBytes:data.channelMatch.callSign.Value().data()
+                                                                      length:data.channelMatch.callSign.Value().size()
+                                                                    encoding:NSUTF8StringEncoding];
+        } else {
+            response.channelMatch.callSign = nil;
+        }
+        if (data.channelMatch.affiliateCallSign.HasValue()) {
+            response.channelMatch.affiliateCallSign =
+                [[NSString alloc] initWithBytes:data.channelMatch.affiliateCallSign.Value().data()
+                                         length:data.channelMatch.affiliateCallSign.Value().size()
+                                       encoding:NSUTF8StringEncoding];
+        } else {
+            response.channelMatch.affiliateCallSign = nil;
+        }
     }
     {
         response.errorType = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.errorType)];
@@ -10067,7 +10132,13 @@ void CHIPContentLauncherClusterLaunchResponseCallbackBridge::OnSuccessFn(
         response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
     }
     {
-        response.data = [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding];
+        if (data.data.HasValue()) {
+            response.data = [[NSString alloc] initWithBytes:data.data.Value().data()
+                                                     length:data.data.Value().size()
+                                                   encoding:NSUTF8StringEncoding];
+        } else {
+            response.data = nil;
+        }
     }
     DispatchSuccess(context, response);
 };
@@ -10930,7 +11001,13 @@ void CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge::OnSuccessFn
         response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
     }
     {
-        response.data = [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding];
+        if (data.data.HasValue()) {
+            response.data = [[NSString alloc] initWithBytes:data.data.Value().data()
+                                                     length:data.data.Value().size()
+                                                   encoding:NSUTF8StringEncoding];
+        } else {
+            response.data = nil;
+        }
     }
     DispatchSuccess(context, response);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -546,11 +546,12 @@ typedef void (*NullableApplianceEventsAndAlertClusterEventIdentificationAttribut
 typedef void (*ApplicationBasicApplicationAppStructAttributeCallback)(
     void *, const chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType &);
 typedef void (*ApplicationLauncherApplicationLauncherAppStructAttributeCallback)(
-    void *, const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType &);
+    void *,
+    const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> &);
 typedef void (*ChannelChannelLineupStructAttributeCallback)(
-    void *, const chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType &);
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType> &);
 typedef void (*ChannelCurrentChannelStructAttributeCallback)(
-    void *, const chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType &);
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> &);
 typedef void (*GeneralCommissioningBasicCommissioningInfoStructAttributeCallback)(
     void *, const chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfo::DecodableType &);
 typedef void (*MediaPlaybackPositionStructAttributeCallback)(
@@ -1787,8 +1788,10 @@ public:
         CHIPCallbackBridge<ApplicationLauncherApplicationLauncherAppStructAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                              keepAlive){};
 
-    static void OnSuccessFn(void * context,
-                            const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType & value);
+    static void OnSuccessFn(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> &
+            value);
 };
 
 class CHIPApplicationLauncherApplicationLauncherAppStructAttributeCallbackSubscriptionBridge
@@ -2731,7 +2734,9 @@ public:
                                                           bool keepAlive = false) :
         CHIPCallbackBridge<ChannelChannelLineupStructAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, const chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType & value);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType> & value);
 };
 
 class CHIPChannelChannelLineupStructAttributeCallbackSubscriptionBridge
@@ -2759,7 +2764,9 @@ public:
                                                            bool keepAlive = false) :
         CHIPCallbackBridge<ChannelCurrentChannelStructAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, const chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType & value);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> & value);
 };
 
 class CHIPChannelCurrentChannelStructAttributeCallbackSubscriptionBridge

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -341,7 +341,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeApplicationLauncherAppWithCompletionHandler:
     (void (^)(CHIPApplicationLauncherClusterApplicationEP * _Nullable value, NSError * _Nullable error))completionHandler;
-- (void)writeAttributeApplicationLauncherAppWithValue:(CHIPApplicationLauncherClusterApplicationEP * _Nonnull)value
+- (void)writeAttributeApplicationLauncherAppWithValue:(CHIPApplicationLauncherClusterApplicationEP * _Nullable)value
                                     completionHandler:(StatusCompletion)completionHandler;
 - (void)
     subscribeAttributeApplicationLauncherAppWithMinInterval:(uint16_t)minInterval
@@ -1146,8 +1146,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeChannelLineupWithCompletionHandler:(void (^)(CHIPChannelClusterLineupInfo * _Nullable value,
                                                             NSError * _Nullable error))completionHandler;
-- (void)writeAttributeChannelLineupWithValue:(CHIPChannelClusterLineupInfo * _Nonnull)value
-                           completionHandler:(StatusCompletion)completionHandler;
 - (void)subscribeAttributeChannelLineupWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
                                subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
@@ -1156,8 +1154,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCurrentChannelWithCompletionHandler:(void (^)(CHIPChannelClusterChannelInfo * _Nullable value,
                                                              NSError * _Nullable error))completionHandler;
-- (void)writeAttributeCurrentChannelWithValue:(CHIPChannelClusterChannelInfo * _Nonnull)value
-                            completionHandler:(StatusCompletion)completionHandler;
 - (void)subscribeAttributeCurrentChannelWithMinInterval:(uint16_t)minInterval
                                             maxInterval:(uint16_t)maxInterval
                                 subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
@@ -3432,8 +3428,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributePositionWithCompletionHandler:(void (^)(CHIPMediaPlaybackClusterPlaybackPosition * _Nullable value,
                                                        NSError * _Nullable error))completionHandler;
-- (void)writeAttributePositionWithValue:(CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull)value
-                      completionHandler:(StatusCompletion)completionHandler;
 - (void)subscribeAttributePositionWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
                           subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -1249,7 +1249,10 @@ using namespace chip::app::Clusters;
     ApplicationLauncher::Commands::LaunchAppRequest::Type request;
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
-    request.data = [self asByteSpan:params.data];
+    if (params.data != nil) {
+        auto & definedValue_0 = request.data.Emplace();
+        definedValue_0 = [self asByteSpan:params.data];
+    }
 
     new CHIPApplicationLauncherClusterLauncherResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -1320,7 +1323,7 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)writeAttributeApplicationLauncherAppWithValue:(CHIPApplicationLauncherClusterApplicationEP * _Nonnull)value
+- (void)writeAttributeApplicationLauncherAppWithValue:(CHIPApplicationLauncherClusterApplicationEP * _Nullable)value
                                     completionHandler:(StatusCompletion)completionHandler
 {
     new CHIPDefaultSuccessCallbackBridge(
@@ -1332,9 +1335,17 @@ using namespace chip::app::Clusters;
             ListFreer listFreer;
             using TypeInfo = ApplicationLauncher::Attributes::ApplicationLauncherApp::TypeInfo;
             TypeInfo::Type cppValue;
-            cppValue.application.catalogVendorId = value.application.catalogVendorId.unsignedShortValue;
-            cppValue.application.applicationId = [self asCharSpan:value.application.applicationId];
-            cppValue.endpoint = [self asCharSpan:value.endpoint];
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0.application.catalogVendorId = value.application.catalogVendorId.unsignedShortValue;
+                nonNullValue_0.application.applicationId = [self asCharSpan:value.application.applicationId];
+                if (value.endpoint != nil) {
+                    auto & definedValue_2 = nonNullValue_0.endpoint.Emplace();
+                    definedValue_2 = value.endpoint.unsignedShortValue;
+                }
+            }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -4500,29 +4511,6 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)writeAttributeChannelLineupWithValue:(CHIPChannelClusterLineupInfo * _Nonnull)value
-                           completionHandler:(StatusCompletion)completionHandler
-{
-    new CHIPDefaultSuccessCallbackBridge(
-        self.callbackQueue,
-        ^(id _Nullable ignored, NSError * _Nullable error) {
-            completionHandler(error);
-        },
-        ^(Cancelable * success, Cancelable * failure) {
-            ListFreer listFreer;
-            using TypeInfo = Channel::Attributes::ChannelLineup::TypeInfo;
-            TypeInfo::Type cppValue;
-            cppValue.operatorName = [self asCharSpan:value.operatorName];
-            cppValue.lineupName = [self asCharSpan:value.lineupName];
-            cppValue.postalCode = [self asCharSpan:value.postalCode];
-            cppValue.lineupInfoType
-                = static_cast<std::remove_reference_t<decltype(cppValue.lineupInfoType)>>(value.lineupInfoType.unsignedCharValue);
-            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
-            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
-        });
-}
-
 - (void)subscribeAttributeChannelLineupWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
                                subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
@@ -4551,29 +4539,6 @@ using namespace chip::app::Clusters;
             auto successFn = Callback<ChannelCurrentChannelStructAttributeCallback>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
-        });
-}
-
-- (void)writeAttributeCurrentChannelWithValue:(CHIPChannelClusterChannelInfo * _Nonnull)value
-                            completionHandler:(StatusCompletion)completionHandler
-{
-    new CHIPDefaultSuccessCallbackBridge(
-        self.callbackQueue,
-        ^(id _Nullable ignored, NSError * _Nullable error) {
-            completionHandler(error);
-        },
-        ^(Cancelable * success, Cancelable * failure) {
-            ListFreer listFreer;
-            using TypeInfo = Channel::Attributes::CurrentChannel::TypeInfo;
-            TypeInfo::Type cppValue;
-            cppValue.majorNumber = value.majorNumber.unsignedShortValue;
-            cppValue.minorNumber = value.minorNumber.unsignedShortValue;
-            cppValue.name = [self asCharSpan:value.name];
-            cppValue.callSign = [self asCharSpan:value.callSign];
-            cppValue.affiliateCallSign = [self asCharSpan:value.affiliateCallSign];
-            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
-            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -7023,8 +6988,6 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ContentLauncher::Commands::LaunchContentRequest::Type request;
-    request.autoPlay = params.autoPlay.boolValue;
-    request.data = [self asCharSpan:params.data];
     {
         using ListType_0 = std::remove_reference_t<decltype(request.search)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -7059,29 +7022,32 @@ using namespace chip::app::Clusters;
                                 = static_cast<std::remove_reference_t<decltype(listHolder_2->mList[i_2].type)>>(
                                     element_2.type.unsignedCharValue);
                             listHolder_2->mList[i_2].value = [self asCharSpan:element_2.value];
-                            {
-                                using ListType_4 = std::remove_reference_t<decltype(listHolder_2->mList[i_2].externalIDList)>;
-                                using ListMemberType_4 = ListMemberTypeGetter<ListType_4>::Type;
-                                if (element_2.externalIDList.count != 0) {
-                                    auto * listHolder_4 = new ListHolder<ListMemberType_4>(element_2.externalIDList.count);
-                                    if (listHolder_4 == nullptr || listHolder_4->mList == nullptr) {
-                                        return;
-                                    }
-                                    listFreer.add(listHolder_4);
-                                    for (size_t i_4 = 0; i_4 < element_2.externalIDList.count; ++i_4) {
-                                        if (![element_2.externalIDList[i_4]
-                                                isKindOfClass:[CHIPContentLauncherClusterAdditionalInfo class]]) {
-                                            // Wrong kind of value.
+                            if (element_2.externalIDList != nil) {
+                                auto & definedValue_4 = listHolder_2->mList[i_2].externalIDList.Emplace();
+                                {
+                                    using ListType_5 = std::remove_reference_t<decltype(definedValue_4)>;
+                                    using ListMemberType_5 = ListMemberTypeGetter<ListType_5>::Type;
+                                    if (element_2.externalIDList.count != 0) {
+                                        auto * listHolder_5 = new ListHolder<ListMemberType_5>(element_2.externalIDList.count);
+                                        if (listHolder_5 == nullptr || listHolder_5->mList == nullptr) {
                                             return;
                                         }
-                                        auto element_4 = (CHIPContentLauncherClusterAdditionalInfo *) element_2.externalIDList[i_4];
-                                        listHolder_4->mList[i_4].name = [self asCharSpan:element_4.name];
-                                        listHolder_4->mList[i_4].value = [self asCharSpan:element_4.value];
+                                        listFreer.add(listHolder_5);
+                                        for (size_t i_5 = 0; i_5 < element_2.externalIDList.count; ++i_5) {
+                                            if (![element_2.externalIDList[i_5]
+                                                    isKindOfClass:[CHIPContentLauncherClusterAdditionalInfo class]]) {
+                                                // Wrong kind of value.
+                                                return;
+                                            }
+                                            auto element_5
+                                                = (CHIPContentLauncherClusterAdditionalInfo *) element_2.externalIDList[i_5];
+                                            listHolder_5->mList[i_5].name = [self asCharSpan:element_5.name];
+                                            listHolder_5->mList[i_5].value = [self asCharSpan:element_5.value];
+                                        }
+                                        definedValue_4 = ListType_5(listHolder_5->mList, element_2.externalIDList.count);
+                                    } else {
+                                        definedValue_4 = ListType_5();
                                     }
-                                    listHolder_2->mList[i_2].externalIDList
-                                        = ListType_4(listHolder_4->mList, element_2.externalIDList.count);
-                                } else {
-                                    listHolder_2->mList[i_2].externalIDList = ListType_4();
                                 }
                             }
                         }
@@ -7095,6 +7061,11 @@ using namespace chip::app::Clusters;
         } else {
             request.search = ListType_0();
         }
+    }
+    request.autoPlay = params.autoPlay.boolValue;
+    if (params.data != nil) {
+        auto & definedValue_0 = request.data.Emplace();
+        definedValue_0 = [self asCharSpan:params.data];
     }
 
     new CHIPContentLauncherClusterLaunchResponseCallbackBridge(
@@ -7112,43 +7083,104 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     ContentLauncher::Commands::LaunchURLRequest::Type request;
     request.contentURL = [self asCharSpan:params.contentURL];
-    request.displayString = [self asCharSpan:params.displayString];
-    request.brandingInformation.providerName = [self asCharSpan:params.brandingInformation.providerName];
-    request.brandingInformation.background.imageUrl = [self asCharSpan:params.brandingInformation.background.imageUrl];
-    request.brandingInformation.background.color = [self asCharSpan:params.brandingInformation.background.color];
-    request.brandingInformation.background.size.width = params.brandingInformation.background.size.width.doubleValue;
-    request.brandingInformation.background.size.height = params.brandingInformation.background.size.height.doubleValue;
-    request.brandingInformation.background.size.metric
-        = static_cast<std::remove_reference_t<decltype(request.brandingInformation.background.size.metric)>>(
-            params.brandingInformation.background.size.metric.unsignedCharValue);
-    request.brandingInformation.logo.imageUrl = [self asCharSpan:params.brandingInformation.logo.imageUrl];
-    request.brandingInformation.logo.color = [self asCharSpan:params.brandingInformation.logo.color];
-    request.brandingInformation.logo.size.width = params.brandingInformation.logo.size.width.doubleValue;
-    request.brandingInformation.logo.size.height = params.brandingInformation.logo.size.height.doubleValue;
-    request.brandingInformation.logo.size.metric
-        = static_cast<std::remove_reference_t<decltype(request.brandingInformation.logo.size.metric)>>(
-            params.brandingInformation.logo.size.metric.unsignedCharValue);
-    request.brandingInformation.progressBar.imageUrl = [self asCharSpan:params.brandingInformation.progressBar.imageUrl];
-    request.brandingInformation.progressBar.color = [self asCharSpan:params.brandingInformation.progressBar.color];
-    request.brandingInformation.progressBar.size.width = params.brandingInformation.progressBar.size.width.doubleValue;
-    request.brandingInformation.progressBar.size.height = params.brandingInformation.progressBar.size.height.doubleValue;
-    request.brandingInformation.progressBar.size.metric
-        = static_cast<std::remove_reference_t<decltype(request.brandingInformation.progressBar.size.metric)>>(
-            params.brandingInformation.progressBar.size.metric.unsignedCharValue);
-    request.brandingInformation.splash.imageUrl = [self asCharSpan:params.brandingInformation.splash.imageUrl];
-    request.brandingInformation.splash.color = [self asCharSpan:params.brandingInformation.splash.color];
-    request.brandingInformation.splash.size.width = params.brandingInformation.splash.size.width.doubleValue;
-    request.brandingInformation.splash.size.height = params.brandingInformation.splash.size.height.doubleValue;
-    request.brandingInformation.splash.size.metric
-        = static_cast<std::remove_reference_t<decltype(request.brandingInformation.splash.size.metric)>>(
-            params.brandingInformation.splash.size.metric.unsignedCharValue);
-    request.brandingInformation.waterMark.imageUrl = [self asCharSpan:params.brandingInformation.waterMark.imageUrl];
-    request.brandingInformation.waterMark.color = [self asCharSpan:params.brandingInformation.waterMark.color];
-    request.brandingInformation.waterMark.size.width = params.brandingInformation.waterMark.size.width.doubleValue;
-    request.brandingInformation.waterMark.size.height = params.brandingInformation.waterMark.size.height.doubleValue;
-    request.brandingInformation.waterMark.size.metric
-        = static_cast<std::remove_reference_t<decltype(request.brandingInformation.waterMark.size.metric)>>(
-            params.brandingInformation.waterMark.size.metric.unsignedCharValue);
+    if (params.displayString != nil) {
+        auto & definedValue_0 = request.displayString.Emplace();
+        definedValue_0 = [self asCharSpan:params.displayString];
+    }
+    if (params.brandingInformation != nil) {
+        auto & definedValue_0 = request.brandingInformation.Emplace();
+        definedValue_0.providerName = [self asCharSpan:params.brandingInformation.providerName];
+        if (params.brandingInformation.background != nil) {
+            auto & definedValue_2 = definedValue_0.background.Emplace();
+            if (params.brandingInformation.background.imageUrl != nil) {
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.background.imageUrl];
+            }
+            if (params.brandingInformation.background.color != nil) {
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.background.color];
+            }
+            if (params.brandingInformation.background.size != nil) {
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                definedValue_4.width = params.brandingInformation.background.size.width.doubleValue;
+                definedValue_4.height = params.brandingInformation.background.size.height.doubleValue;
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    params.brandingInformation.background.size.metric.unsignedCharValue);
+            }
+        }
+        if (params.brandingInformation.logo != nil) {
+            auto & definedValue_2 = definedValue_0.logo.Emplace();
+            if (params.brandingInformation.logo.imageUrl != nil) {
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.logo.imageUrl];
+            }
+            if (params.brandingInformation.logo.color != nil) {
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.logo.color];
+            }
+            if (params.brandingInformation.logo.size != nil) {
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                definedValue_4.width = params.brandingInformation.logo.size.width.doubleValue;
+                definedValue_4.height = params.brandingInformation.logo.size.height.doubleValue;
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    params.brandingInformation.logo.size.metric.unsignedCharValue);
+            }
+        }
+        if (params.brandingInformation.progressBar != nil) {
+            auto & definedValue_2 = definedValue_0.progressBar.Emplace();
+            if (params.brandingInformation.progressBar.imageUrl != nil) {
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.progressBar.imageUrl];
+            }
+            if (params.brandingInformation.progressBar.color != nil) {
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.progressBar.color];
+            }
+            if (params.brandingInformation.progressBar.size != nil) {
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                definedValue_4.width = params.brandingInformation.progressBar.size.width.doubleValue;
+                definedValue_4.height = params.brandingInformation.progressBar.size.height.doubleValue;
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    params.brandingInformation.progressBar.size.metric.unsignedCharValue);
+            }
+        }
+        if (params.brandingInformation.splash != nil) {
+            auto & definedValue_2 = definedValue_0.splash.Emplace();
+            if (params.brandingInformation.splash.imageUrl != nil) {
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.splash.imageUrl];
+            }
+            if (params.brandingInformation.splash.color != nil) {
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.splash.color];
+            }
+            if (params.brandingInformation.splash.size != nil) {
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                definedValue_4.width = params.brandingInformation.splash.size.width.doubleValue;
+                definedValue_4.height = params.brandingInformation.splash.size.height.doubleValue;
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    params.brandingInformation.splash.size.metric.unsignedCharValue);
+            }
+        }
+        if (params.brandingInformation.waterMark != nil) {
+            auto & definedValue_2 = definedValue_0.waterMark.Emplace();
+            if (params.brandingInformation.waterMark.imageUrl != nil) {
+                auto & definedValue_4 = definedValue_2.imageUrl.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.waterMark.imageUrl];
+            }
+            if (params.brandingInformation.waterMark.color != nil) {
+                auto & definedValue_4 = definedValue_2.color.Emplace();
+                definedValue_4 = [self asCharSpan:params.brandingInformation.waterMark.color];
+            }
+            if (params.brandingInformation.waterMark.size != nil) {
+                auto & definedValue_4 = definedValue_2.size.Emplace();
+                definedValue_4.width = params.brandingInformation.waterMark.size.width.doubleValue;
+                definedValue_4.height = params.brandingInformation.waterMark.size.height.doubleValue;
+                definedValue_4.metric = static_cast<std::remove_reference_t<decltype(definedValue_4.metric)>>(
+                    params.brandingInformation.waterMark.size.metric.unsignedCharValue);
+            }
+        }
+    }
 
     new CHIPContentLauncherClusterLaunchResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14059,12 +14091,13 @@ using namespace chip::app::Clusters;
 - (void)readAttributeStartTimeWithCompletionHandler:(void (^)(
                                                         NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
 {
-    new CHIPInt64uAttributeCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
-        using TypeInfo = MediaPlayback::Attributes::StartTime::TypeInfo;
-        auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
-        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-        return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
-    });
+    new CHIPNullableInt64uAttributeCallbackBridge(
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
+            using TypeInfo = MediaPlayback::Attributes::StartTime::TypeInfo;
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
 }
 
 - (void)subscribeAttributeStartTimeWithMinInterval:(uint16_t)minInterval
@@ -14072,14 +14105,14 @@ using namespace chip::app::Clusters;
                            subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                      reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
 {
-    new CHIPInt64uAttributeCallbackSubscriptionBridge(
+    new CHIPNullableInt64uAttributeCallbackSubscriptionBridge(
         self.callbackQueue, reportHandler,
         ^(Cancelable * success, Cancelable * failure) {
             using TypeInfo = MediaPlayback::Attributes::StartTime::TypeInfo;
-            auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.SubscribeAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall,
-                minInterval, maxInterval, CHIPInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
+                minInterval, maxInterval, CHIPNullableInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
         },
         subscriptionEstablishedHandler);
 }
@@ -14087,12 +14120,13 @@ using namespace chip::app::Clusters;
 - (void)readAttributeDurationWithCompletionHandler:(void (^)(
                                                        NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
 {
-    new CHIPInt64uAttributeCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
-        using TypeInfo = MediaPlayback::Attributes::Duration::TypeInfo;
-        auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
-        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-        return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
-    });
+    new CHIPNullableInt64uAttributeCallbackBridge(
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
+            using TypeInfo = MediaPlayback::Attributes::Duration::TypeInfo;
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
 }
 
 - (void)subscribeAttributeDurationWithMinInterval:(uint16_t)minInterval
@@ -14100,14 +14134,14 @@ using namespace chip::app::Clusters;
                           subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                     reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
 {
-    new CHIPInt64uAttributeCallbackSubscriptionBridge(
+    new CHIPNullableInt64uAttributeCallbackSubscriptionBridge(
         self.callbackQueue, reportHandler,
         ^(Cancelable * success, Cancelable * failure) {
             using TypeInfo = MediaPlayback::Attributes::Duration::TypeInfo;
-            auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.SubscribeAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall,
-                minInterval, maxInterval, CHIPInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
+                minInterval, maxInterval, CHIPNullableInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
         },
         subscriptionEstablishedHandler);
 }
@@ -14121,26 +14155,6 @@ using namespace chip::app::Clusters;
             auto successFn = Callback<MediaPlaybackPositionStructAttributeCallback>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
-        });
-}
-
-- (void)writeAttributePositionWithValue:(CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull)value
-                      completionHandler:(StatusCompletion)completionHandler
-{
-    new CHIPDefaultSuccessCallbackBridge(
-        self.callbackQueue,
-        ^(id _Nullable ignored, NSError * _Nullable error) {
-            completionHandler(error);
-        },
-        ^(Cancelable * success, Cancelable * failure) {
-            ListFreer listFreer;
-            using TypeInfo = MediaPlayback::Attributes::Position::TypeInfo;
-            TypeInfo::Type cppValue;
-            cppValue.updatedAt = value.updatedAt.unsignedLongLongValue;
-            cppValue.position = value.position.unsignedLongLongValue;
-            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
-            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -14195,12 +14209,13 @@ using namespace chip::app::Clusters;
 - (void)readAttributeSeekRangeEndWithCompletionHandler:(void (^)(
                                                            NSNumber * _Nullable value, NSError * _Nullable error))completionHandler
 {
-    new CHIPInt64uAttributeCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
-        using TypeInfo = MediaPlayback::Attributes::SeekRangeEnd::TypeInfo;
-        auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
-        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-        return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
-    });
+    new CHIPNullableInt64uAttributeCallbackBridge(
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
+            using TypeInfo = MediaPlayback::Attributes::SeekRangeEnd::TypeInfo;
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
 }
 
 - (void)subscribeAttributeSeekRangeEndWithMinInterval:(uint16_t)minInterval
@@ -14208,14 +14223,14 @@ using namespace chip::app::Clusters;
                               subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEstablishedHandler
                                         reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
 {
-    new CHIPInt64uAttributeCallbackSubscriptionBridge(
+    new CHIPNullableInt64uAttributeCallbackSubscriptionBridge(
         self.callbackQueue, reportHandler,
         ^(Cancelable * success, Cancelable * failure) {
             using TypeInfo = MediaPlayback::Attributes::SeekRangeEnd::TypeInfo;
-            auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.SubscribeAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall,
-                minInterval, maxInterval, CHIPInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
+                minInterval, maxInterval, CHIPNullableInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
         },
         subscriptionEstablishedHandler);
 }
@@ -14223,12 +14238,13 @@ using namespace chip::app::Clusters;
 - (void)readAttributeSeekRangeStartWithCompletionHandler:(void (^)(NSNumber * _Nullable value,
                                                              NSError * _Nullable error))completionHandler
 {
-    new CHIPInt64uAttributeCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
-        using TypeInfo = MediaPlayback::Attributes::SeekRangeStart::TypeInfo;
-        auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
-        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
-        return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
-    });
+    new CHIPNullableInt64uAttributeCallbackBridge(
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
+            using TypeInfo = MediaPlayback::Attributes::SeekRangeStart::TypeInfo;
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.ReadAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
 }
 
 - (void)subscribeAttributeSeekRangeStartWithMinInterval:(uint16_t)minInterval
@@ -14237,14 +14253,14 @@ using namespace chip::app::Clusters;
                                           reportHandler:
                                               (void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler
 {
-    new CHIPInt64uAttributeCallbackSubscriptionBridge(
+    new CHIPNullableInt64uAttributeCallbackSubscriptionBridge(
         self.callbackQueue, reportHandler,
         ^(Cancelable * success, Cancelable * failure) {
             using TypeInfo = MediaPlayback::Attributes::SeekRangeStart::TypeInfo;
-            auto successFn = Callback<Int64uAttributeCallback>::FromCancelable(success);
+            auto successFn = Callback<NullableInt64uAttributeCallback>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.SubscribeAttribute<TypeInfo>(successFn->mContext, successFn->mCall, failureFn->mCall,
-                minInterval, maxInterval, CHIPInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
+                minInterval, maxInterval, CHIPNullableInt64uAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished);
         },
         subscriptionEstablishedHandler);
 }
@@ -19886,7 +19902,10 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     TargetNavigator::Commands::NavigateTargetRequest::Type request;
     request.target = params.target.unsignedCharValue;
-    request.data = [self asCharSpan:params.data];
+    if (params.data != nil) {
+        auto & definedValue_0 = request.data.Emplace();
+        definedValue_0 = [self asCharSpan:params.data];
+    }
 
     new CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -1543,13 +1543,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPTargetNavigatorClusterNavigateTargetRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull target;
-@property (strong, nonatomic) NSString * _Nonnull data;
+@property (strong, nonatomic) NSString * _Nullable data;
 - (instancetype)init;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
-@property (strong, nonatomic) NSString * _Nonnull data;
+@property (strong, nonatomic) NSString * _Nullable data;
 - (instancetype)init;
 @end
 
@@ -1595,22 +1595,22 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface CHIPContentLauncherClusterLaunchContentRequestParams : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull autoPlay;
-@property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSArray * _Nonnull search;
+@property (strong, nonatomic) NSNumber * _Nonnull autoPlay;
+@property (strong, nonatomic) NSString * _Nullable data;
 - (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterLaunchURLRequestParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull contentURL;
-@property (strong, nonatomic) NSString * _Nonnull displayString;
-@property (strong, nonatomic) CHIPContentLauncherClusterBrandingInformation * _Nonnull brandingInformation;
+@property (strong, nonatomic) NSString * _Nullable displayString;
+@property (strong, nonatomic) CHIPContentLauncherClusterBrandingInformation * _Nullable brandingInformation;
 - (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterLaunchResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
-@property (strong, nonatomic) NSString * _Nonnull data;
+@property (strong, nonatomic) NSString * _Nullable data;
 - (instancetype)init;
 @end
 
@@ -1627,7 +1627,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPApplicationLauncherClusterLaunchAppRequestParams : NSObject
 @property (strong, nonatomic) CHIPApplicationLauncherClusterApplication * _Nonnull application;
-@property (strong, nonatomic) NSData * _Nonnull data;
+@property (strong, nonatomic) NSData * _Nullable data;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -3280,7 +3280,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _target = @(0);
 
-        _data = @"";
+        _data = nil;
     }
     return self;
 }
@@ -3293,7 +3293,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _status = @(0);
 
-        _data = @"";
+        _data = nil;
     }
     return self;
 }
@@ -3394,11 +3394,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
+        _search = [NSArray array];
+
         _autoPlay = @(0);
 
-        _data = @"";
-
-        _search = [NSArray array];
+        _data = nil;
     }
     return self;
 }
@@ -3411,9 +3411,9 @@ NS_ASSUME_NONNULL_BEGIN
 
         _contentURL = @"";
 
-        _displayString = @"";
+        _displayString = nil;
 
-        _brandingInformation = [CHIPContentLauncherClusterBrandingInformation new];
+        _brandingInformation = nil;
     }
     return self;
 }
@@ -3426,7 +3426,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _status = @(0);
 
-        _data = @"";
+        _data = nil;
     }
     return self;
 }
@@ -3463,7 +3463,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _application = [CHIPApplicationLauncherClusterApplication new];
 
-        _data = [NSData data];
+        _data = nil;
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -331,16 +331,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPChannelClusterChannelInfo : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
 @property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSString * _Nonnull callSign;
-@property (strong, nonatomic) NSString * _Nonnull affiliateCallSign;
+@property (strong, nonatomic) NSString * _Nullable name;
+@property (strong, nonatomic) NSString * _Nullable callSign;
+@property (strong, nonatomic) NSString * _Nullable affiliateCallSign;
 - (instancetype)init;
 @end
 
 @interface CHIPChannelClusterLineupInfo : NSObject
 @property (strong, nonatomic) NSString * _Nonnull operatorName;
-@property (strong, nonatomic) NSString * _Nonnull lineupName;
-@property (strong, nonatomic) NSString * _Nonnull postalCode;
+@property (strong, nonatomic) NSString * _Nullable lineupName;
+@property (strong, nonatomic) NSString * _Nullable postalCode;
 @property (strong, nonatomic) NSNumber * _Nonnull lineupInfoType;
 - (instancetype)init;
 @end
@@ -353,7 +353,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPMediaPlaybackClusterPlaybackPosition : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull updatedAt;
-@property (strong, nonatomic) NSNumber * _Nonnull position;
+@property (strong, nonatomic) NSNumber * _Nullable position;
 - (instancetype)init;
 @end
 
@@ -381,7 +381,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPContentLauncherClusterParameter : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull type;
 @property (strong, nonatomic) NSString * _Nonnull value;
-@property (strong, nonatomic) NSArray * _Nonnull externalIDList;
+@property (strong, nonatomic) NSArray * _Nullable externalIDList;
 - (instancetype)init;
 @end
 
@@ -391,19 +391,19 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface CHIPContentLauncherClusterStyleInformation : NSObject
-@property (strong, nonatomic) NSString * _Nonnull imageUrl;
-@property (strong, nonatomic) NSString * _Nonnull color;
-@property (strong, nonatomic) CHIPContentLauncherClusterDimension * _Nonnull size;
+@property (strong, nonatomic) NSString * _Nullable imageUrl;
+@property (strong, nonatomic) NSString * _Nullable color;
+@property (strong, nonatomic) CHIPContentLauncherClusterDimension * _Nullable size;
 - (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterBrandingInformation : NSObject
 @property (strong, nonatomic) NSString * _Nonnull providerName;
-@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nonnull background;
-@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nonnull logo;
-@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nonnull progressBar;
-@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nonnull splash;
-@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nonnull waterMark;
+@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nullable background;
+@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nullable logo;
+@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nullable progressBar;
+@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nullable splash;
+@property (strong, nonatomic) CHIPContentLauncherClusterStyleInformation * _Nullable waterMark;
 - (instancetype)init;
 @end
 
@@ -422,7 +422,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPApplicationLauncherClusterApplicationEP : NSObject
 @property (strong, nonatomic) CHIPApplicationLauncherClusterApplication * _Nonnull application;
-@property (strong, nonatomic) NSString * _Nonnull endpoint;
+@property (strong, nonatomic) NSNumber * _Nullable endpoint;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -675,11 +675,11 @@ NS_ASSUME_NONNULL_BEGIN
 
         _minorNumber = @(0);
 
-        _name = @"";
+        _name = nil;
 
-        _callSign = @"";
+        _callSign = nil;
 
-        _affiliateCallSign = @"";
+        _affiliateCallSign = nil;
     }
     return self;
 }
@@ -692,9 +692,9 @@ NS_ASSUME_NONNULL_BEGIN
 
         _operatorName = @"";
 
-        _lineupName = @"";
+        _lineupName = nil;
 
-        _postalCode = @"";
+        _postalCode = nil;
 
         _lineupInfoType = @(0);
     }
@@ -722,7 +722,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _updatedAt = @(0);
 
-        _position = @(0);
+        _position = nil;
     }
     return self;
 }
@@ -782,7 +782,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _value = @"";
 
-        _externalIDList = [NSArray array];
+        _externalIDList = nil;
     }
     return self;
 }
@@ -804,11 +804,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _imageUrl = @"";
+        _imageUrl = nil;
 
-        _color = @"";
+        _color = nil;
 
-        _size = [CHIPContentLauncherClusterDimension new];
+        _size = nil;
     }
     return self;
 }
@@ -821,15 +821,15 @@ NS_ASSUME_NONNULL_BEGIN
 
         _providerName = @"";
 
-        _background = [CHIPContentLauncherClusterStyleInformation new];
+        _background = nil;
 
-        _logo = [CHIPContentLauncherClusterStyleInformation new];
+        _logo = nil;
 
-        _progressBar = [CHIPContentLauncherClusterStyleInformation new];
+        _progressBar = nil;
 
-        _splash = [CHIPContentLauncherClusterStyleInformation new];
+        _splash = nil;
 
-        _waterMark = [CHIPContentLauncherClusterStyleInformation new];
+        _waterMark = nil;
     }
     return self;
 }
@@ -870,7 +870,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _application = [CHIPApplicationLauncherClusterApplication new];
 
-        _endpoint = @"";
+        _endpoint = nil;
     }
     return self;
 }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.h
@@ -283,6 +283,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPTestChannel : CHIPChannel
 
 - (void)writeAttributeChannelListWithValue:(NSArray * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributeChannelLineupWithValue:(CHIPChannelClusterLineupInfo * _Nullable)value
+                           completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributeCurrentChannelWithValue:(CHIPChannelClusterChannelInfo * _Nullable)value
+                            completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeServerGeneratedCommandListWithValue:(NSArray * _Nonnull)value
                                         completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeClientGeneratedCommandListWithValue:(NSArray * _Nonnull)value
@@ -727,11 +731,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPTestMediaPlayback : CHIPMediaPlayback
 
 - (void)writeAttributePlaybackStateWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
-- (void)writeAttributeStartTimeWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
-- (void)writeAttributeDurationWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributeStartTimeWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributeDurationWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributePositionWithValue:(CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull)value
+                      completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributePlaybackSpeedWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
-- (void)writeAttributeSeekRangeEndWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
-- (void)writeAttributeSeekRangeStartWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributeSeekRangeEndWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler;
+- (void)writeAttributeSeekRangeStartWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeServerGeneratedCommandListWithValue:(NSArray * _Nonnull)value
                                         completionHandler:(StatusCompletion)completionHandler;
 - (void)writeAttributeClientGeneratedCommandListWithValue:(NSArray * _Nonnull)value

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -3110,13 +3110,93 @@ using namespace chip::app::Clusters;
                         auto element_0 = (CHIPChannelClusterChannelInfo *) value[i_0];
                         listHolder_0->mList[i_0].majorNumber = element_0.majorNumber.unsignedShortValue;
                         listHolder_0->mList[i_0].minorNumber = element_0.minorNumber.unsignedShortValue;
-                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i_0].callSign = [self asCharSpan:element_0.callSign];
-                        listHolder_0->mList[i_0].affiliateCallSign = [self asCharSpan:element_0.affiliateCallSign];
+                        if (element_0.name != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].name.Emplace();
+                            definedValue_2 = [self asCharSpan:element_0.name];
+                        }
+                        if (element_0.callSign != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].callSign.Emplace();
+                            definedValue_2 = [self asCharSpan:element_0.callSign];
+                        }
+                        if (element_0.affiliateCallSign != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].affiliateCallSign.Emplace();
+                            definedValue_2 = [self asCharSpan:element_0.affiliateCallSign];
+                        }
                     }
                     cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
                     cppValue = ListType_0();
+                }
+            }
+            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
+- (void)writeAttributeChannelLineupWithValue:(CHIPChannelClusterLineupInfo * _Nullable)value
+                           completionHandler:(StatusCompletion)completionHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(
+        self.callbackQueue,
+        ^(id _Nullable ignored, NSError * _Nullable error) {
+            completionHandler(error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            ListFreer listFreer;
+            using TypeInfo = Channel::Attributes::ChannelLineup::TypeInfo;
+            TypeInfo::Type cppValue;
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0.operatorName = [self asCharSpan:value.operatorName];
+                if (value.lineupName != nil) {
+                    auto & definedValue_2 = nonNullValue_0.lineupName.Emplace();
+                    definedValue_2 = [self asCharSpan:value.lineupName];
+                }
+                if (value.postalCode != nil) {
+                    auto & definedValue_2 = nonNullValue_0.postalCode.Emplace();
+                    definedValue_2 = [self asCharSpan:value.postalCode];
+                }
+                nonNullValue_0.lineupInfoType = static_cast<std::remove_reference_t<decltype(nonNullValue_0.lineupInfoType)>>(
+                    value.lineupInfoType.unsignedCharValue);
+            }
+            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
+- (void)writeAttributeCurrentChannelWithValue:(CHIPChannelClusterChannelInfo * _Nullable)value
+                            completionHandler:(StatusCompletion)completionHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(
+        self.callbackQueue,
+        ^(id _Nullable ignored, NSError * _Nullable error) {
+            completionHandler(error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            ListFreer listFreer;
+            using TypeInfo = Channel::Attributes::CurrentChannel::TypeInfo;
+            TypeInfo::Type cppValue;
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0.majorNumber = value.majorNumber.unsignedShortValue;
+                nonNullValue_0.minorNumber = value.minorNumber.unsignedShortValue;
+                if (value.name != nil) {
+                    auto & definedValue_2 = nonNullValue_0.name.Emplace();
+                    definedValue_2 = [self asCharSpan:value.name];
+                }
+                if (value.callSign != nil) {
+                    auto & definedValue_2 = nonNullValue_0.callSign.Emplace();
+                    definedValue_2 = [self asCharSpan:value.callSign];
+                }
+                if (value.affiliateCallSign != nil) {
+                    auto & definedValue_2 = nonNullValue_0.affiliateCallSign.Emplace();
+                    definedValue_2 = [self asCharSpan:value.affiliateCallSign];
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -8705,7 +8785,7 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)writeAttributeStartTimeWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
+- (void)writeAttributeStartTimeWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler
 {
     new CHIPDefaultSuccessCallbackBridge(
         self.callbackQueue,
@@ -8716,14 +8796,19 @@ using namespace chip::app::Clusters;
             ListFreer listFreer;
             using TypeInfo = MediaPlayback::Attributes::StartTime::TypeInfo;
             TypeInfo::Type cppValue;
-            cppValue = value.unsignedLongLongValue;
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0 = value.unsignedLongLongValue;
+            }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)writeAttributeDurationWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
+- (void)writeAttributeDurationWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler
 {
     new CHIPDefaultSuccessCallbackBridge(
         self.callbackQueue,
@@ -8734,7 +8819,37 @@ using namespace chip::app::Clusters;
             ListFreer listFreer;
             using TypeInfo = MediaPlayback::Attributes::Duration::TypeInfo;
             TypeInfo::Type cppValue;
-            cppValue = value.unsignedLongLongValue;
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0 = value.unsignedLongLongValue;
+            }
+            auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
+- (void)writeAttributePositionWithValue:(CHIPMediaPlaybackClusterPlaybackPosition * _Nonnull)value
+                      completionHandler:(StatusCompletion)completionHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(
+        self.callbackQueue,
+        ^(id _Nullable ignored, NSError * _Nullable error) {
+            completionHandler(error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            ListFreer listFreer;
+            using TypeInfo = MediaPlayback::Attributes::Position::TypeInfo;
+            TypeInfo::Type cppValue;
+            cppValue.updatedAt = value.updatedAt.unsignedLongLongValue;
+            if (value.position == nil) {
+                cppValue.position.SetNull();
+            } else {
+                auto & nonNullValue_1 = cppValue.position.SetNonNull();
+                nonNullValue_1 = value.position.unsignedLongLongValue;
+            }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -8759,7 +8874,7 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)writeAttributeSeekRangeEndWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
+- (void)writeAttributeSeekRangeEndWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler
 {
     new CHIPDefaultSuccessCallbackBridge(
         self.callbackQueue,
@@ -8770,14 +8885,19 @@ using namespace chip::app::Clusters;
             ListFreer listFreer;
             using TypeInfo = MediaPlayback::Attributes::SeekRangeEnd::TypeInfo;
             TypeInfo::Type cppValue;
-            cppValue = value.unsignedLongLongValue;
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0 = value.unsignedLongLongValue;
+            }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)writeAttributeSeekRangeStartWithValue:(NSNumber * _Nonnull)value completionHandler:(StatusCompletion)completionHandler
+- (void)writeAttributeSeekRangeStartWithValue:(NSNumber * _Nullable)value completionHandler:(StatusCompletion)completionHandler
 {
     new CHIPDefaultSuccessCallbackBridge(
         self.callbackQueue,
@@ -8788,7 +8908,12 @@ using namespace chip::app::Clusters;
             ListFreer listFreer;
             using TypeInfo = MediaPlayback::Attributes::SeekRangeStart::TypeInfo;
             TypeInfo::Type cppValue;
-            cppValue = value.unsignedLongLongValue;
+            if (value == nil) {
+                cppValue.SetNull();
+            } else {
+                auto & nonNullValue_0 = cppValue.SetNonNull();
+                nonNullValue_0 = value.unsignedLongLongValue;
+            }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -2282,12 +2282,12 @@
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Media Playback (server) */                                                                    \
             { 0x00000000, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* playback state */                                  \
-            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(1495) }, /* start time */   \
-            { 0x00000002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(1503) },   /* duration */     \
-            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(1511) },                            /* playback speed */ \
-            { 0x00000005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(1515) }, /* seek range end */ \
+            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2003) }, /* start time */   \
+            { 0x00000002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2011) },   /* duration */     \
+            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2019) },                            /* playback speed */ \
+            { 0x00000005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2023) }, /* seek range end */ \
             { 0x00000006, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE),                                                       \
-              ZAP_LONG_DEFAULTS_INDEX(1523) },                                  /* seek range start */                             \
+              ZAP_LONG_DEFAULTS_INDEX(2031) },                                  /* seek range start */                             \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Media Input (server) */                                                                       \
@@ -3612,7 +3612,7 @@
       .clusterSize = 257, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 197 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 191 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3623,7 +3623,7 @@
       .clusterSize = 2, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 202 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 196 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3634,7 +3634,7 @@
       .clusterSize = 2, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 204 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 198 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3645,7 +3645,7 @@
       .clusterSize = 260, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 206 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 200 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3656,7 +3656,7 @@
       .clusterSize = 257, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 209 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 203 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3667,7 +3667,7 @@
       .clusterSize = 256, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 212 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 206 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3689,7 +3689,7 @@
       .clusterSize = 2, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 214 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 208 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3700,8 +3700,8 @@
       .clusterSize = 3285, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 216 ) ,\
-      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 235 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 210 ) ,\
+      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 229 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: Electrical Measurement (server) */ \
@@ -3722,8 +3722,8 @@
       .clusterSize = 3, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayGroupsServer, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 244 ) ,\
-      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 251 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 238 ) ,\
+      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 245 ) ,\
     },\
   { \
       /* Endpoint: 2, Cluster: On/Off (server) */ \
@@ -3733,7 +3733,7 @@
       .clusterSize = 13, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayOnOffServer, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 256 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 250 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -2281,13 +2281,14 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* ClusterRevision */                          \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Media Playback (server) */                                                                    \
-            { 0x00000000, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },         /* playback state */                          \
-            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2003) }, /* start time */                              \
-            { 0x00000002, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2011) },   /* duration */                                \
-            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2019) },   /* playback speed */                          \
-            { 0x00000005, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2023) },   /* seek range end */                          \
-            { 0x00000006, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2031) },   /* seek range start */                        \
-            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },      /* ClusterRevision */                         \
+            { 0x00000000, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* playback state */                                  \
+            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(1495) }, /* start time */   \
+            { 0x00000002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(1503) },   /* duration */     \
+            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(1511) },                            /* playback speed */ \
+            { 0x00000005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(1515) }, /* seek range end */ \
+            { 0x00000006, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE),                                                       \
+              ZAP_LONG_DEFAULTS_INDEX(1523) },                                  /* seek range start */                             \
+            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Media Input (server) */                                                                       \
             { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2039) }, /* media input list */                         \
@@ -2826,13 +2827,6 @@
   0x00000000 /* PlayRequest */, \
   0x00000001 /* PauseRequest */, \
   0x00000002 /* StopRequest */, \
-  0x00000003 /* StartOverRequest */, \
-  0x00000004 /* PreviousRequest */, \
-  0x00000005 /* NextRequest */, \
-  0x00000006 /* RewindRequest */, \
-  0x00000007 /* FastForwardRequest */, \
-  0x00000008 /* SkipForwardRequest */, \
-  0x00000009 /* SkipBackwardRequest */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Media Input (server) */\
   /*   client_generated */ \
@@ -3618,7 +3612,7 @@
       .clusterSize = 257, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 198 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 197 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3629,7 +3623,7 @@
       .clusterSize = 2, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 203 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 202 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3640,7 +3634,7 @@
       .clusterSize = 2, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 205 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 204 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3651,7 +3645,7 @@
       .clusterSize = 260, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 207 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 206 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3662,7 +3656,7 @@
       .clusterSize = 257, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 210 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 209 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3673,7 +3667,7 @@
       .clusterSize = 256, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 213 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 212 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3695,7 +3689,7 @@
       .clusterSize = 2, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 215 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 214 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \
@@ -3706,8 +3700,8 @@
       .clusterSize = 3285, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 217 ) ,\
-      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 236 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 216 ) ,\
+      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 235 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: Electrical Measurement (server) */ \
@@ -3728,8 +3722,8 @@
       .clusterSize = 3, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayGroupsServer, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 245 ) ,\
-      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 252 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 244 ) ,\
+      .serverGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 251 ) ,\
     },\
   { \
       /* Endpoint: 2, Cluster: On/Off (server) */ \
@@ -3739,7 +3733,7 @@
       .clusterSize = 13, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayOnOffServer, \
-      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 257 ) ,\
+      .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 256 ) ,\
       .serverGeneratedCommandList = nullptr ,\
     },\
   { \

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -143,7 +143,7 @@ typedef struct _Application
 typedef struct _ApplicationEP
 {
     Application application;
-    chip::CharSpan endpoint;
+    chip::EndpointId endpoint;
 } ApplicationEP;
 
 // Struct for Target

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -30024,24 +30024,27 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::app::Clusters::MediaPlayback:
 
 namespace StartTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
     Traits::StorageType temp;
     uint8_t * readable   = Traits::ToAttributeStoreRepresentation(temp);
     EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
     VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    if (Traits::IsNullValue(temp))
     {
-        return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
+        value.SetNull();
     }
-    *value = Traits::StorageToWorking(temp);
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
     return status;
 }
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
     {
         return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
     }
@@ -30051,28 +30054,50 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
     return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
 }
 
+EmberAfStatus SetNull(chip::EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
+}
+
 } // namespace StartTime
 
 namespace Duration {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
     Traits::StorageType temp;
     uint8_t * readable   = Traits::ToAttributeStoreRepresentation(temp);
     EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
     VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    if (Traits::IsNullValue(temp))
     {
-        return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
+        value.SetNull();
     }
-    *value = Traits::StorageToWorking(temp);
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
     return status;
 }
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
     {
         return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
     }
@@ -30080,6 +30105,25 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
     Traits::WorkingToStorage(value, storageValue);
     uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
     return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus SetNull(chip::EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
 }
 
 } // namespace Duration
@@ -30117,24 +30161,27 @@ EmberAfStatus Set(chip::EndpointId endpoint, float value)
 
 namespace SeekRangeEnd {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
     Traits::StorageType temp;
     uint8_t * readable   = Traits::ToAttributeStoreRepresentation(temp);
     EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
     VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    if (Traits::IsNullValue(temp))
     {
-        return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
+        value.SetNull();
     }
-    *value = Traits::StorageToWorking(temp);
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
     return status;
 }
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
     {
         return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
     }
@@ -30142,30 +30189,52 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
     Traits::WorkingToStorage(value, storageValue);
     uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
     return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus SetNull(chip::EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
 }
 
 } // namespace SeekRangeEnd
 
 namespace SeekRangeStart {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
     Traits::StorageType temp;
     uint8_t * readable   = Traits::ToAttributeStoreRepresentation(temp);
     EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, readable, sizeof(temp));
     VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
+    if (Traits::IsNullValue(temp))
     {
-        return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
+        value.SetNull();
     }
-    *value = Traits::StorageToWorking(temp);
+    else
+    {
+        value.SetNonNull() = Traits::StorageToWorking(temp);
+    }
     return status;
 }
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
     using Traits = NumericAttributeTraits<uint64_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
+    if (!Traits::CanRepresentValue(/* isNullable = */ true, value))
     {
         return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
     }
@@ -30173,6 +30242,25 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
     Traits::WorkingToStorage(value, storageValue);
     uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
     return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus SetNull(chip::EndpointId endpoint)
+{
+    using Traits = NumericAttributeTraits<uint64_t>;
+    Traits::StorageType value;
+    Traits::SetNull(value);
+    uint8_t * writable = Traits::ToAttributeStoreRepresentation(value);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, writable, ZCL_INT64U_ATTRIBUTE_TYPE);
+}
+
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value)
+{
+    if (value.IsNull())
+    {
+        return SetNull(endpoint);
+    }
+
+    return Set(endpoint, value.Value());
 }
 
 } // namespace SeekRangeStart

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -5276,13 +5276,17 @@ EmberAfStatus Set(chip::EndpointId endpoint, chip::app::Clusters::MediaPlayback:
 } // namespace PlaybackState
 
 namespace StartTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // epoch_us
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value); // epoch_us
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
+EmberAfStatus SetNull(chip::EndpointId endpoint);
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value);
 } // namespace StartTime
 
 namespace Duration {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value); // int64u
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
+EmberAfStatus SetNull(chip::EndpointId endpoint);
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value);
 } // namespace Duration
 
 namespace PlaybackSpeed {
@@ -5291,13 +5295,17 @@ EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace PlaybackSpeed
 
 namespace SeekRangeEnd {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value); // int64u
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
+EmberAfStatus SetNull(chip::EndpointId endpoint);
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value);
 } // namespace SeekRangeEnd
 
 namespace SeekRangeStart {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Get(chip::EndpointId endpoint, DataModel::Nullable<uint64_t> & value); // int64u
 EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
+EmberAfStatus SetNull(chip::EndpointId endpoint);
+EmberAfStatus Set(chip::EndpointId endpoint, const chip::app::DataModel::Nullable<uint64_t> & value);
 } // namespace SeekRangeStart
 
 namespace FeatureMap {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -21624,9 +21624,9 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSearch)), search));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAutoPlay)), autoPlay));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kData)), data));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSearch)), search));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -21642,14 +21642,14 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
+        case to_underlying(Fields::kSearch):
+            ReturnErrorOnFailure(DataModel::Decode(reader, search));
+            break;
         case to_underlying(Fields::kAutoPlay):
             ReturnErrorOnFailure(DataModel::Decode(reader, autoPlay));
             break;
         case to_underlying(Fields::kData):
             ReturnErrorOnFailure(DataModel::Decode(reader, data));
-            break;
-        case to_underlying(Fields::kSearch):
-            ReturnErrorOnFailure(DataModel::Decode(reader, search));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -33348,9 +33348,9 @@ struct Type
 public:
     uint16_t majorNumber = static_cast<uint16_t>(0);
     uint16_t minorNumber = static_cast<uint16_t>(0);
-    chip::CharSpan name;
-    chip::CharSpan callSign;
-    chip::CharSpan affiliateCallSign;
+    Optional<chip::CharSpan> name;
+    Optional<chip::CharSpan> callSign;
+    Optional<chip::CharSpan> affiliateCallSign;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -33374,8 +33374,8 @@ struct Type
 {
 public:
     chip::CharSpan operatorName;
-    chip::CharSpan lineupName;
-    chip::CharSpan postalCode;
+    Optional<chip::CharSpan> lineupName;
+    Optional<chip::CharSpan> postalCode;
     LineupInfoTypeEnum lineupInfoType = static_cast<LineupInfoTypeEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -33569,9 +33569,10 @@ struct TypeInfo
 namespace ChannelLineup {
 struct TypeInfo
 {
-    using Type             = chip::app::Clusters::Channel::Structs::LineupInfo::Type;
-    using DecodableType    = chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType;
-    using DecodableArgType = const chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType &;
+    using Type          = chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::Type>;
+    using DecodableType = chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType>;
+    using DecodableArgType =
+        const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ChannelLineup::Id; }
@@ -33581,9 +33582,10 @@ struct TypeInfo
 namespace CurrentChannel {
 struct TypeInfo
 {
-    using Type             = chip::app::Clusters::Channel::Structs::ChannelInfo::Type;
-    using DecodableType    = chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType;
-    using DecodableArgType = const chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType &;
+    using Type          = chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::Type>;
+    using DecodableType = chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType>;
+    using DecodableArgType =
+        const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentChannel::Id; }
@@ -33736,7 +33738,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     uint8_t target = static_cast<uint8_t>(0);
-    chip::CharSpan data;
+    Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33752,7 +33754,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     uint8_t target = static_cast<uint8_t>(0);
-    chip::CharSpan data;
+    Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace NavigateTargetRequest
@@ -33771,7 +33773,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     StatusEnum status = static_cast<StatusEnum>(0);
-    chip::CharSpan data;
+    Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33787,7 +33789,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     StatusEnum status = static_cast<StatusEnum>(0);
-    chip::CharSpan data;
+    Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace NavigateTargetResponse
@@ -33933,7 +33935,7 @@ struct Type
 {
 public:
     uint64_t updatedAt = static_cast<uint64_t>(0);
-    uint64_t position  = static_cast<uint64_t>(0);
+    DataModel::Nullable<uint64_t> position;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -34383,9 +34385,9 @@ struct TypeInfo
 namespace StartTime {
 struct TypeInfo
 {
-    using Type             = uint64_t;
-    using DecodableType    = uint64_t;
-    using DecodableArgType = uint64_t;
+    using Type             = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableType    = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableArgType = const chip::app::DataModel::Nullable<uint64_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartTime::Id; }
@@ -34395,9 +34397,9 @@ struct TypeInfo
 namespace Duration {
 struct TypeInfo
 {
-    using Type             = uint64_t;
-    using DecodableType    = uint64_t;
-    using DecodableArgType = uint64_t;
+    using Type             = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableType    = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableArgType = const chip::app::DataModel::Nullable<uint64_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Duration::Id; }
@@ -34431,9 +34433,9 @@ struct TypeInfo
 namespace SeekRangeEnd {
 struct TypeInfo
 {
-    using Type             = uint64_t;
-    using DecodableType    = uint64_t;
-    using DecodableArgType = uint64_t;
+    using Type             = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableType    = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableArgType = const chip::app::DataModel::Nullable<uint64_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SeekRangeEnd::Id; }
@@ -34443,9 +34445,9 @@ struct TypeInfo
 namespace SeekRangeStart {
 struct TypeInfo
 {
-    using Type             = uint64_t;
-    using DecodableType    = uint64_t;
-    using DecodableArgType = uint64_t;
+    using Type             = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableType    = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableArgType = const chip::app::DataModel::Nullable<uint64_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SeekRangeStart::Id; }
@@ -34523,12 +34525,12 @@ struct TypeInfo
 
         Attributes::PlaybackState::TypeInfo::DecodableType playbackState =
             static_cast<chip::app::Clusters::MediaPlayback::PlaybackStateEnum>(0);
-        Attributes::StartTime::TypeInfo::DecodableType startTime = static_cast<uint64_t>(0);
-        Attributes::Duration::TypeInfo::DecodableType duration   = static_cast<uint64_t>(0);
+        Attributes::StartTime::TypeInfo::DecodableType startTime;
+        Attributes::Duration::TypeInfo::DecodableType duration;
         Attributes::Position::TypeInfo::DecodableType position;
-        Attributes::PlaybackSpeed::TypeInfo::DecodableType playbackSpeed   = static_cast<float>(0);
-        Attributes::SeekRangeEnd::TypeInfo::DecodableType seekRangeEnd     = static_cast<uint64_t>(0);
-        Attributes::SeekRangeStart::TypeInfo::DecodableType seekRangeStart = static_cast<uint64_t>(0);
+        Attributes::PlaybackSpeed::TypeInfo::DecodableType playbackSpeed = static_cast<float>(0);
+        Attributes::SeekRangeEnd::TypeInfo::DecodableType seekRangeEnd;
+        Attributes::SeekRangeStart::TypeInfo::DecodableType seekRangeStart;
         Attributes::ServerGeneratedCommandList::TypeInfo::DecodableType serverGeneratedCommandList;
         Attributes::ClientGeneratedCommandList::TypeInfo::DecodableType clientGeneratedCommandList;
         Attributes::AttributeList::TypeInfo::DecodableType attributeList;
@@ -35347,7 +35349,7 @@ struct Type
 public:
     ParameterEnum type = static_cast<ParameterEnum>(0);
     chip::CharSpan value;
-    DataModel::List<const Structs::AdditionalInfo::Type> externalIDList;
+    Optional<DataModel::List<const Structs::AdditionalInfo::Type>> externalIDList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -35359,7 +35361,7 @@ struct DecodableType
 public:
     ParameterEnum type = static_cast<ParameterEnum>(0);
     chip::CharSpan value;
-    DataModel::DecodableList<Structs::AdditionalInfo::DecodableType> externalIDList;
+    Optional<DataModel::DecodableList<Structs::AdditionalInfo::DecodableType>> externalIDList;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 
@@ -35405,9 +35407,9 @@ enum class Fields
 struct Type
 {
 public:
-    chip::CharSpan imageUrl;
-    chip::CharSpan color;
-    Structs::Dimension::Type size;
+    Optional<chip::CharSpan> imageUrl;
+    Optional<chip::CharSpan> color;
+    Optional<Structs::Dimension::Type> size;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -35433,11 +35435,11 @@ struct Type
 {
 public:
     chip::CharSpan providerName;
-    Structs::StyleInformation::Type background;
-    Structs::StyleInformation::Type logo;
-    Structs::StyleInformation::Type progressBar;
-    Structs::StyleInformation::Type splash;
-    Structs::StyleInformation::Type waterMark;
+    Optional<Structs::StyleInformation::Type> background;
+    Optional<Structs::StyleInformation::Type> logo;
+    Optional<Structs::StyleInformation::Type> progressBar;
+    Optional<Structs::StyleInformation::Type> splash;
+    Optional<Structs::StyleInformation::Type> waterMark;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -35474,9 +35476,9 @@ namespace Commands {
 namespace LaunchContentRequest {
 enum class Fields
 {
-    kAutoPlay = 0,
-    kData     = 1,
-    kSearch   = 2,
+    kSearch   = 0,
+    kAutoPlay = 1,
+    kData     = 2,
 };
 
 struct Type
@@ -35486,9 +35488,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchContentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    bool autoPlay = static_cast<bool>(0);
-    chip::CharSpan data;
     DataModel::List<const Structs::ContentSearch::Type> search;
+    bool autoPlay = static_cast<bool>(0);
+    Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -35503,9 +35505,9 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchContentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    bool autoPlay = static_cast<bool>(0);
-    chip::CharSpan data;
     DataModel::DecodableList<Structs::ContentSearch::DecodableType> search;
+    bool autoPlay = static_cast<bool>(0);
+    Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchContentRequest
@@ -35525,8 +35527,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan contentURL;
-    chip::CharSpan displayString;
-    Structs::BrandingInformation::Type brandingInformation;
+    Optional<chip::CharSpan> displayString;
+    Optional<Structs::BrandingInformation::Type> brandingInformation;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -35542,8 +35544,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan contentURL;
-    chip::CharSpan displayString;
-    Structs::BrandingInformation::DecodableType brandingInformation;
+    Optional<chip::CharSpan> displayString;
+    Optional<Structs::BrandingInformation::DecodableType> brandingInformation;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchURLRequest
@@ -35562,7 +35564,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     StatusEnum status = static_cast<StatusEnum>(0);
-    chip::CharSpan data;
+    Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -35578,7 +35580,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     StatusEnum status = static_cast<StatusEnum>(0);
-    chip::CharSpan data;
+    Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchResponse
@@ -35983,7 +35985,7 @@ struct Type
 {
 public:
     Structs::Application::Type application;
-    chip::CharSpan endpoint;
+    Optional<chip::EndpointId> endpoint;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -36037,7 +36039,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     Structs::Application::Type application;
-    chip::ByteSpan data;
+    Optional<chip::ByteSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -36053,7 +36055,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     Structs::Application::DecodableType application;
-    chip::ByteSpan data;
+    Optional<chip::ByteSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchAppRequest
@@ -36175,9 +36177,11 @@ struct TypeInfo
 namespace ApplicationLauncherApp {
 struct TypeInfo
 {
-    using Type             = chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type;
-    using DecodableType    = chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType;
-    using DecodableArgType = const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType &;
+    using Type = chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type>;
+    using DecodableType =
+        chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType>;
+    using DecodableArgType =
+        const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationLauncherApp::Id; }

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -482,8 +482,9 @@ public:
     }
 
 private:
-    chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type mValue;
-    TypedComplexArgument<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type> mComplex;
+    chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type> mValue;
+    TypedComplexArgument<chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::Type>>
+        mComplex;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -1309,52 +1310,6 @@ public:
 
 private:
     chip::app::Clusters::Channel::Commands::SkipChannelRequest::Type mRequest;
-};
-
-class WriteChannelChannelLineup : public WriteAttribute
-{
-public:
-    WriteChannelChannelLineup(CredentialIssuerCommands * credsIssuerConfig) :
-        WriteAttribute("ChannelLineup", credsIssuerConfig), mComplex(&mValue)
-    {
-        AddArgument("attr-name", "channel-lineup");
-        AddArgument("attr-value", &mComplex);
-        WriteAttribute::AddArguments();
-    }
-
-    ~WriteChannelChannelLineup() {}
-
-    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
-    {
-        return WriteAttribute::SendCommand(device, endpointId, 0x00000504, 0x00000001, mValue);
-    }
-
-private:
-    chip::app::Clusters::Channel::Structs::LineupInfo::Type mValue;
-    TypedComplexArgument<chip::app::Clusters::Channel::Structs::LineupInfo::Type> mComplex;
-};
-
-class WriteChannelCurrentChannel : public WriteAttribute
-{
-public:
-    WriteChannelCurrentChannel(CredentialIssuerCommands * credsIssuerConfig) :
-        WriteAttribute("CurrentChannel", credsIssuerConfig), mComplex(&mValue)
-    {
-        AddArgument("attr-name", "current-channel");
-        AddArgument("attr-value", &mComplex);
-        WriteAttribute::AddArguments();
-    }
-
-    ~WriteChannelCurrentChannel() {}
-
-    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
-    {
-        return WriteAttribute::SendCommand(device, endpointId, 0x00000504, 0x00000002, mValue);
-    }
-
-private:
-    chip::app::Clusters::Channel::Structs::ChannelInfo::Type mValue;
-    TypedComplexArgument<chip::app::Clusters::Channel::Structs::ChannelInfo::Type> mComplex;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -2265,9 +2220,9 @@ public:
     ContentLauncherLaunchContentRequest(CredentialIssuerCommands * credsIssuerConfig) :
         ClusterCommand("launch-content-request", credsIssuerConfig), mComplex_Search(&mRequest.search)
     {
+        AddArgument("Search", &mComplex_Search);
         AddArgument("AutoPlay", 0, 1, &mRequest.autoPlay);
         AddArgument("Data", &mRequest.data);
-        AddArgument("Search", &mComplex_Search);
         ClusterCommand::AddArguments();
     }
 
@@ -2308,7 +2263,8 @@ public:
 
 private:
     chip::app::Clusters::ContentLauncher::Commands::LaunchURLRequest::Type mRequest;
-    TypedComplexArgument<chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type> mComplex_BrandingInformation;
+    TypedComplexArgument<chip::Optional<chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type>>
+        mComplex_BrandingInformation;
 };
 
 class WriteContentLauncherSupportedStreamingProtocols : public WriteAttribute
@@ -4561,29 +4517,6 @@ public:
 
 private:
     chip::app::Clusters::MediaPlayback::Commands::StopRequest::Type mRequest;
-};
-
-class WriteMediaPlaybackPosition : public WriteAttribute
-{
-public:
-    WriteMediaPlaybackPosition(CredentialIssuerCommands * credsIssuerConfig) :
-        WriteAttribute("Position", credsIssuerConfig), mComplex(&mValue)
-    {
-        AddArgument("attr-name", "position");
-        AddArgument("attr-value", &mComplex);
-        WriteAttribute::AddArguments();
-    }
-
-    ~WriteMediaPlaybackPosition() {}
-
-    CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId) override
-    {
-        return WriteAttribute::SendCommand(device, endpointId, 0x00000506, 0x00000003, mValue);
-    }
-
-private:
-    chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Type mValue;
-    TypedComplexArgument<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Type> mComplex;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -10044,8 +9977,6 @@ void registerClusterChannel(Commands & commands, CredentialIssuerCommands * cred
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),        //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig),    //
         make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                        //
-        make_unique<WriteChannelChannelLineup>(credsIssuerConfig),                                                 //
-        make_unique<WriteChannelCurrentChannel>(credsIssuerConfig),                                                //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                    //
         make_unique<SubscribeAttribute>(Id, "channel-list", Attributes::ChannelList::Id, credsIssuerConfig),       //
         make_unique<SubscribeAttribute>(Id, "channel-lineup", Attributes::ChannelLineup::Id, credsIssuerConfig),   //
@@ -11300,7 +11231,6 @@ void registerClusterMediaPlayback(Commands & commands, CredentialIssuerCommands 
         make_unique<ReadAttribute>(Id, "attribute-list", Attributes::AttributeList::Id, credsIssuerConfig),         //
         make_unique<ReadAttribute>(Id, "cluster-revision", Attributes::ClusterRevision::Id, credsIssuerConfig),     //
         make_unique<WriteAttribute>(Id, credsIssuerConfig),                                                         //
-        make_unique<WriteMediaPlaybackPosition>(credsIssuerConfig),                                                 //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                     //
         make_unique<SubscribeAttribute>(Id, "playback-state", Attributes::PlaybackState::Id, credsIssuerConfig),    //
         make_unique<SubscribeAttribute>(Id, "start-time", Attributes::StartTime::Id, credsIssuerConfig),            //

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
@@ -191,7 +191,8 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ApplicationEP.application", value.isMember("application")));
+    ReturnErrorOnFailure(
+        ComplexArgumentParser::EnsureMemberExist("ApplicationEP.application", "application", value.isMember("application")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "application");
@@ -328,8 +329,6 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("BrandingInformation.providerName", "providerName",
                                                                   value.isMember("providerName")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("BrandingInformation.providerName", value.isMember("providerName")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "providerName");
@@ -382,8 +381,10 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, chip::app::Clusters:
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.majorNumber", value.isMember("majorNumber")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.minorNumber", value.isMember("minorNumber")));
+    ReturnErrorOnFailure(
+        ComplexArgumentParser::EnsureMemberExist("ChannelInfo.majorNumber", "majorNumber", value.isMember("majorNumber")));
+    ReturnErrorOnFailure(
+        ComplexArgumentParser::EnsureMemberExist("ChannelInfo.minorNumber", "minorNumber", value.isMember("minorNumber")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "majorNumber");
@@ -868,8 +869,10 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, chip::app::Clusters:
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("LineupInfo.operatorName", value.isMember("operatorName")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("LineupInfo.lineupInfoType", value.isMember("lineupInfoType")));
+    ReturnErrorOnFailure(
+        ComplexArgumentParser::EnsureMemberExist("LineupInfo.operatorName", "operatorName", value.isMember("operatorName")));
+    ReturnErrorOnFailure(
+        ComplexArgumentParser::EnsureMemberExist("LineupInfo.lineupInfoType", "lineupInfoType", value.isMember("lineupInfoType")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "operatorName");
@@ -1436,8 +1439,8 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.type", value.isMember("type")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.value", value.isMember("value")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.type", "type", value.isMember("type")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.value", "value", value.isMember("value")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "type");

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
@@ -191,17 +191,17 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("ApplicationEP.application", "application", value.isMember("application")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("ApplicationEP.endpoint", "endpoint", value.isMember("endpoint")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ApplicationEP.application", value.isMember("application")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "application");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.application, value["application"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "endpoint");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.endpoint, value["endpoint"]));
+    if (value.isMember("endpoint"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "endpoint");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.endpoint, value["endpoint"]));
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -329,33 +329,41 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("BrandingInformation.providerName", "providerName",
                                                                   value.isMember("providerName")));
     ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("BrandingInformation.background", "background", value.isMember("background")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("BrandingInformation.logo", "logo", value.isMember("logo")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("BrandingInformation.progressBar", "progressBar", value.isMember("progressBar")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("BrandingInformation.splash", "splash", value.isMember("splash")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("BrandingInformation.waterMark", "waterMark", value.isMember("waterMark")));
+        ComplexArgumentParser::EnsureMemberExist("BrandingInformation.providerName", value.isMember("providerName")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "providerName");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.providerName, value["providerName"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "background");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.background, value["background"]));
+    if (value.isMember("background"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "background");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.background, value["background"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "logo");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.logo, value["logo"]));
+    if (value.isMember("logo"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "logo");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.logo, value["logo"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "progressBar");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.progressBar, value["progressBar"]));
+    if (value.isMember("progressBar"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "progressBar");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.progressBar, value["progressBar"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "splash");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.splash, value["splash"]));
+    if (value.isMember("splash"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "splash");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.splash, value["splash"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "waterMark");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.waterMark, value["waterMark"]));
+    if (value.isMember("waterMark"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "waterMark");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.waterMark, value["waterMark"]));
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -374,14 +382,8 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, chip::app::Clusters:
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("ChannelInfo.majorNumber", "majorNumber", value.isMember("majorNumber")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("ChannelInfo.minorNumber", "minorNumber", value.isMember("minorNumber")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.name", "name", value.isMember("name")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.callSign", "callSign", value.isMember("callSign")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.affiliateCallSign", "affiliateCallSign",
-                                                                  value.isMember("affiliateCallSign")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.majorNumber", value.isMember("majorNumber")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ChannelInfo.minorNumber", value.isMember("minorNumber")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "majorNumber");
@@ -390,14 +392,23 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, chip::app::Clusters:
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "minorNumber");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.minorNumber, value["minorNumber"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "name");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.name, value["name"]));
+    if (value.isMember("name"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "name");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.name, value["name"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "callSign");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.callSign, value["callSign"]));
+    if (value.isMember("callSign"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "callSign");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.callSign, value["callSign"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "affiliateCallSign");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.affiliateCallSign, value["affiliateCallSign"]));
+    if (value.isMember("affiliateCallSign"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "affiliateCallSign");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.affiliateCallSign, value["affiliateCallSign"]));
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -857,24 +868,24 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, chip::app::Clusters:
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("LineupInfo.operatorName", "operatorName", value.isMember("operatorName")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("LineupInfo.lineupName", "lineupName", value.isMember("lineupName")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("LineupInfo.postalCode", "postalCode", value.isMember("postalCode")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("LineupInfo.lineupInfoType", "lineupInfoType", value.isMember("lineupInfoType")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("LineupInfo.operatorName", value.isMember("operatorName")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("LineupInfo.lineupInfoType", value.isMember("lineupInfoType")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "operatorName");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.operatorName, value["operatorName"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "lineupName");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.lineupName, value["lineupName"]));
+    if (value.isMember("lineupName"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "lineupName");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.lineupName, value["lineupName"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "postalCode");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.postalCode, value["postalCode"]));
+    if (value.isMember("postalCode"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "postalCode");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.postalCode, value["postalCode"]));
+    }
 
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "lineupInfoType");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.lineupInfoType, value["lineupInfoType"]));
@@ -1425,10 +1436,8 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.type", "type", value.isMember("type")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.value", "value", value.isMember("value")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("Parameter.externalIDList", "externalIDList", value.isMember("externalIDList")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.type", value.isMember("type")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("Parameter.value", value.isMember("value")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "type");
@@ -1437,8 +1446,11 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "value");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.value, value["value"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "externalIDList");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.externalIDList, value["externalIDList"]));
+    if (value.isMember("externalIDList"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "externalIDList");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.externalIDList, value["externalIDList"]));
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -1808,20 +1820,24 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 {
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("StyleInformation.imageUrl", "imageUrl", value.isMember("imageUrl")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("StyleInformation.color", "color", value.isMember("color")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("StyleInformation.size", "size", value.isMember("size")));
-
     char labelWithMember[kMaxLabelLength];
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "imageUrl");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.imageUrl, value["imageUrl"]));
+    if (value.isMember("imageUrl"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "imageUrl");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.imageUrl, value["imageUrl"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "color");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.color, value["color"]));
+    if (value.isMember("color"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "color");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.color, value["color"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "size");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.size, value["size"]));
+    if (value.isMember("size"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "size");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.size, value["size"]));
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -4122,7 +4122,7 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("application launcher list", 1, value);
         }
         case ApplicationLauncher::Attributes::ApplicationLauncherApp::Id: {
-            chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType value;
+            chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("application launcher app", 1, value);
         }
@@ -4602,12 +4602,12 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("channel list", 1, value);
         }
         case Channel::Attributes::ChannelLineup::Id: {
-            chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType value;
+            chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::LineupInfo::DecodableType> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("channel lineup", 1, value);
         }
         case Channel::Attributes::CurrentChannel::Id: {
-            chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType value;
+            chip::app::DataModel::Nullable<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("current channel", 1, value);
         }
@@ -5897,12 +5897,12 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("playback state", 1, value);
         }
         case MediaPlayback::Attributes::StartTime::Id: {
-            uint64_t value;
+            chip::app::DataModel::Nullable<uint64_t> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("start time", 1, value);
         }
         case MediaPlayback::Attributes::Duration::Id: {
-            uint64_t value;
+            chip::app::DataModel::Nullable<uint64_t> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("duration", 1, value);
         }
@@ -5917,12 +5917,12 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             return DataModelLogger::LogValue("playback speed", 1, value);
         }
         case MediaPlayback::Attributes::SeekRangeEnd::Id: {
-            uint64_t value;
+            chip::app::DataModel::Nullable<uint64_t> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("seek range end", 1, value);
         }
         case MediaPlayback::Attributes::SeekRangeStart::Id: {
-            uint64_t value;
+            chip::app::DataModel::Nullable<uint64_t> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("seek range start", 1, value);
         }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -46679,7 +46679,8 @@ private:
 
         RequestType request;
         request.target = 1;
-        request.data   = chip::Span<const char>("1garbage: not in length on purpose", 1);
+        request.data.Emplace();
+        request.data.Value() = chip::Span<const char>("1garbage: not in length on purpose", 1);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_TargetNavigatorCluster *>(context))->OnSuccessResponse_3(data.status, data.data);
@@ -46699,11 +46700,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_3(chip::app::Clusters::TargetNavigator::StatusEnum status, chip::CharSpan data)
+    void OnSuccessResponse_3(chip::app::Clusters::TargetNavigator::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
-        VerifyOrReturn(CheckValueAsString("data", data, chip::CharSpan("data response", 13)));
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -47092,7 +47094,8 @@ private:
         request.application.catalogVendorId = 123U;
         request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
 
-        request.data = chip::ByteSpan(chip::Uint8::from_const_char("datagarbage: not in length on purpose"), 4);
+        request.data.Emplace();
+        request.data.Value() = chip::ByteSpan(chip::Uint8::from_const_char("datagarbage: not in length on purpose"), 4);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_2(data.status, data.data);
@@ -48055,7 +48058,7 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_2(error);
     }
 
-    static void OnSuccessCallback_2(void * context, uint64_t startTime)
+    static void OnSuccessCallback_2(void * context, const chip::app::DataModel::Nullable<uint64_t> & startTime)
     {
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_2(startTime);
     }
@@ -48065,7 +48068,7 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_3(error);
     }
 
-    static void OnSuccessCallback_3(void * context, uint64_t duration)
+    static void OnSuccessCallback_3(void * context, const chip::app::DataModel::Nullable<uint64_t> & duration)
     {
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_3(duration);
     }
@@ -48085,7 +48088,7 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_5(error);
     }
 
-    static void OnSuccessCallback_5(void * context, uint64_t seekRangeEnd)
+    static void OnSuccessCallback_5(void * context, const chip::app::DataModel::Nullable<uint64_t> & seekRangeEnd)
     {
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_5(seekRangeEnd);
     }
@@ -48095,7 +48098,7 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_6(error);
     }
 
-    static void OnSuccessCallback_6(void * context, uint64_t seekRangeStart)
+    static void OnSuccessCallback_6(void * context, const chip::app::DataModel::Nullable<uint64_t> & seekRangeStart)
     {
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_6(seekRangeStart);
     }
@@ -48151,9 +48154,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_2(uint64_t startTime)
+    void OnSuccessResponse_2(const chip::app::DataModel::Nullable<uint64_t> & startTime)
     {
-        VerifyOrReturn(CheckValue("startTime", startTime, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("startTime", startTime));
+        VerifyOrReturn(CheckValue("startTime.Value()", startTime.Value(), 0ULL));
 
         NextTest();
     }
@@ -48175,9 +48179,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_3(uint64_t duration)
+    void OnSuccessResponse_3(const chip::app::DataModel::Nullable<uint64_t> & duration)
     {
-        VerifyOrReturn(CheckValue("duration", duration, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("duration", duration));
+        VerifyOrReturn(CheckValue("duration.Value()", duration.Value(), 0ULL));
 
         NextTest();
     }
@@ -48223,9 +48228,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_5(uint64_t seekRangeEnd)
+    void OnSuccessResponse_5(const chip::app::DataModel::Nullable<uint64_t> & seekRangeEnd)
     {
-        VerifyOrReturn(CheckValue("seekRangeEnd", seekRangeEnd, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("seekRangeEnd", seekRangeEnd));
+        VerifyOrReturn(CheckValue("seekRangeEnd.Value()", seekRangeEnd.Value(), 0ULL));
 
         NextTest();
     }
@@ -48247,9 +48253,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_6(uint64_t seekRangeStart)
+    void OnSuccessResponse_6(const chip::app::DataModel::Nullable<uint64_t> & seekRangeStart)
     {
-        VerifyOrReturn(CheckValue("seekRangeStart", seekRangeStart, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("seekRangeStart", seekRangeStart));
+        VerifyOrReturn(CheckValue("seekRangeStart.Value()", seekRangeStart.Value(), 0ULL));
 
         NextTest();
     }
@@ -48738,19 +48745,27 @@ private:
             VerifyOrReturn(CheckNextListItemDecodes<decltype(channelList)>("channelList", iter_0, 0));
             VerifyOrReturn(CheckValue("channelList[0].majorNumber", iter_0.GetValue().majorNumber, 1U));
             VerifyOrReturn(CheckValue("channelList[0].minorNumber", iter_0.GetValue().minorNumber, 2U));
-            VerifyOrReturn(CheckValueAsString("channelList[0].name", iter_0.GetValue().name, chip::CharSpan("exampleName", 11)));
-            VerifyOrReturn(
-                CheckValueAsString("channelList[0].callSign", iter_0.GetValue().callSign, chip::CharSpan("exampleCSign", 12)));
-            VerifyOrReturn(CheckValueAsString("channelList[0].affiliateCallSign", iter_0.GetValue().affiliateCallSign,
-                                              chip::CharSpan("exampleASign", 12)));
+            VerifyOrReturn(CheckValuePresent("channelList[0].name", iter_0.GetValue().name));
+            VerifyOrReturn(CheckValueAsString("channelList[0].name.Value()", iter_0.GetValue().name.Value(),
+                                              chip::CharSpan("exampleName", 11)));
+            VerifyOrReturn(CheckValuePresent("channelList[0].callSign", iter_0.GetValue().callSign));
+            VerifyOrReturn(CheckValueAsString("channelList[0].callSign.Value()", iter_0.GetValue().callSign.Value(),
+                                              chip::CharSpan("exampleCSign", 12)));
+            VerifyOrReturn(CheckValuePresent("channelList[0].affiliateCallSign", iter_0.GetValue().affiliateCallSign));
+            VerifyOrReturn(CheckValueAsString("channelList[0].affiliateCallSign.Value()",
+                                              iter_0.GetValue().affiliateCallSign.Value(), chip::CharSpan("exampleASign", 12)));
             VerifyOrReturn(CheckNextListItemDecodes<decltype(channelList)>("channelList", iter_0, 1));
             VerifyOrReturn(CheckValue("channelList[1].majorNumber", iter_0.GetValue().majorNumber, 2U));
             VerifyOrReturn(CheckValue("channelList[1].minorNumber", iter_0.GetValue().minorNumber, 3U));
-            VerifyOrReturn(CheckValueAsString("channelList[1].name", iter_0.GetValue().name, chip::CharSpan("exampleName", 11)));
-            VerifyOrReturn(
-                CheckValueAsString("channelList[1].callSign", iter_0.GetValue().callSign, chip::CharSpan("exampleCSign", 12)));
-            VerifyOrReturn(CheckValueAsString("channelList[1].affiliateCallSign", iter_0.GetValue().affiliateCallSign,
-                                              chip::CharSpan("exampleASign", 12)));
+            VerifyOrReturn(CheckValuePresent("channelList[1].name", iter_0.GetValue().name));
+            VerifyOrReturn(CheckValueAsString("channelList[1].name.Value()", iter_0.GetValue().name.Value(),
+                                              chip::CharSpan("exampleName", 11)));
+            VerifyOrReturn(CheckValuePresent("channelList[1].callSign", iter_0.GetValue().callSign));
+            VerifyOrReturn(CheckValueAsString("channelList[1].callSign.Value()", iter_0.GetValue().callSign.Value(),
+                                              chip::CharSpan("exampleCSign", 12)));
+            VerifyOrReturn(CheckValuePresent("channelList[1].affiliateCallSign", iter_0.GetValue().affiliateCallSign));
+            VerifyOrReturn(CheckValueAsString("channelList[1].affiliateCallSign.Value()",
+                                              iter_0.GetValue().affiliateCallSign.Value(), chip::CharSpan("exampleASign", 12)));
             VerifyOrReturn(CheckNoMoreListItems<decltype(channelList)>("channelList", iter_0, 2));
         }
 
@@ -48788,9 +48803,13 @@ private:
     {
         VerifyOrReturn(CheckValue("channelMatch.majorNumber", channelMatch.majorNumber, 1U));
         VerifyOrReturn(CheckValue("channelMatch.minorNumber", channelMatch.minorNumber, 0U));
-        VerifyOrReturn(CheckValueAsString("channelMatch.name", channelMatch.name, chip::CharSpan("name", 4)));
-        VerifyOrReturn(CheckValueAsString("channelMatch.callSign", channelMatch.callSign, chip::CharSpan("callSign", 8)));
-        VerifyOrReturn(CheckValueAsString("channelMatch.affiliateCallSign", channelMatch.affiliateCallSign,
+        VerifyOrReturn(CheckValuePresent("channelMatch.name", channelMatch.name));
+        VerifyOrReturn(CheckValueAsString("channelMatch.name.Value()", channelMatch.name.Value(), chip::CharSpan("name", 4)));
+        VerifyOrReturn(CheckValuePresent("channelMatch.callSign", channelMatch.callSign));
+        VerifyOrReturn(
+            CheckValueAsString("channelMatch.callSign.Value()", channelMatch.callSign.Value(), chip::CharSpan("callSign", 8)));
+        VerifyOrReturn(CheckValuePresent("channelMatch.affiliateCallSign", channelMatch.affiliateCallSign));
+        VerifyOrReturn(CheckValueAsString("channelMatch.affiliateCallSign.Value()", channelMatch.affiliateCallSign.Value(),
                                           chip::CharSpan("affiliateCallSign", 17)));
 
         VerifyOrReturn(CheckValue("errorType", errorType, 0));
@@ -49136,10 +49155,11 @@ private:
         using RequestType               = chip::app::Clusters::ContentLauncher::Commands::LaunchContentRequest::Type;
 
         RequestType request;
-        request.autoPlay = true;
-        request.data     = chip::Span<const char>("exampleDatagarbage: not in length on purpose", 11);
 
-        request.search = chip::app::DataModel::List<chip::app::Clusters::ContentLauncher::Structs::ContentSearch::Type>();
+        request.search   = chip::app::DataModel::List<chip::app::Clusters::ContentLauncher::Structs::ContentSearch::Type>();
+        request.autoPlay = true;
+        request.data.Emplace();
+        request.data.Value() = chip::Span<const char>("exampleDatagarbage: not in length on purpose", 11);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ContentLauncherCluster *>(context))->OnSuccessResponse_3(data.status, data.data);
@@ -49159,11 +49179,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_3(chip::app::Clusters::ContentLauncher::StatusEnum status, chip::CharSpan data)
+    void OnSuccessResponse_3(chip::app::Clusters::ContentLauncher::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
-        VerifyOrReturn(CheckValueAsString("data", data, chip::CharSpan("exampleData", 11)));
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("exampleData", 11)));
 
         NextTest();
     }
@@ -49174,46 +49195,87 @@ private:
         using RequestType               = chip::app::Clusters::ContentLauncher::Commands::LaunchURLRequest::Type;
 
         RequestType request;
-        request.contentURL    = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
-        request.displayString = chip::Span<const char>("exampleDisplayStringgarbage: not in length on purpose", 20);
+        request.contentURL = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
+        request.displayString.Emplace();
+        request.displayString.Value() = chip::Span<const char>("exampleDisplayStringgarbage: not in length on purpose", 20);
+        request.brandingInformation.Emplace();
 
-        request.brandingInformation.providerName = chip::Span<const char>("exampleNamegarbage: not in length on purpose", 11);
+        request.brandingInformation.Value().providerName =
+            chip::Span<const char>("exampleNamegarbage: not in length on purpose", 11);
+        request.brandingInformation.Value().background.Emplace();
 
-        request.brandingInformation.background.imageUrl = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
-        request.brandingInformation.background.color = chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
-
-        request.brandingInformation.background.size.width  = 0;
-        request.brandingInformation.background.size.height = 0;
-        request.brandingInformation.background.size.metric = static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
-
-        request.brandingInformation.logo.imageUrl = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
-        request.brandingInformation.logo.color    = chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
-
-        request.brandingInformation.logo.size.width  = 0;
-        request.brandingInformation.logo.size.height = 0;
-        request.brandingInformation.logo.size.metric = static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
-
-        request.brandingInformation.progressBar.imageUrl =
+        request.brandingInformation.Value().background.Value().imageUrl.Emplace();
+        request.brandingInformation.Value().background.Value().imageUrl.Value() =
             chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
-        request.brandingInformation.progressBar.color = chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().background.Value().color.Emplace();
+        request.brandingInformation.Value().background.Value().color.Value() =
+            chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().background.Value().size.Emplace();
 
-        request.brandingInformation.progressBar.size.width  = 0;
-        request.brandingInformation.progressBar.size.height = 0;
-        request.brandingInformation.progressBar.size.metric = static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
+        request.brandingInformation.Value().background.Value().size.Value().width  = 0;
+        request.brandingInformation.Value().background.Value().size.Value().height = 0;
+        request.brandingInformation.Value().background.Value().size.Value().metric =
+            static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
 
-        request.brandingInformation.splash.imageUrl = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
-        request.brandingInformation.splash.color    = chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().logo.Emplace();
 
-        request.brandingInformation.splash.size.width  = 0;
-        request.brandingInformation.splash.size.height = 0;
-        request.brandingInformation.splash.size.metric = static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
+        request.brandingInformation.Value().logo.Value().imageUrl.Emplace();
+        request.brandingInformation.Value().logo.Value().imageUrl.Value() =
+            chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
+        request.brandingInformation.Value().logo.Value().color.Emplace();
+        request.brandingInformation.Value().logo.Value().color.Value() =
+            chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().logo.Value().size.Emplace();
 
-        request.brandingInformation.waterMark.imageUrl = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
-        request.brandingInformation.waterMark.color = chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().logo.Value().size.Value().width  = 0;
+        request.brandingInformation.Value().logo.Value().size.Value().height = 0;
+        request.brandingInformation.Value().logo.Value().size.Value().metric =
+            static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
 
-        request.brandingInformation.waterMark.size.width  = 0;
-        request.brandingInformation.waterMark.size.height = 0;
-        request.brandingInformation.waterMark.size.metric = static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
+        request.brandingInformation.Value().progressBar.Emplace();
+
+        request.brandingInformation.Value().progressBar.Value().imageUrl.Emplace();
+        request.brandingInformation.Value().progressBar.Value().imageUrl.Value() =
+            chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
+        request.brandingInformation.Value().progressBar.Value().color.Emplace();
+        request.brandingInformation.Value().progressBar.Value().color.Value() =
+            chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().progressBar.Value().size.Emplace();
+
+        request.brandingInformation.Value().progressBar.Value().size.Value().width  = 0;
+        request.brandingInformation.Value().progressBar.Value().size.Value().height = 0;
+        request.brandingInformation.Value().progressBar.Value().size.Value().metric =
+            static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
+
+        request.brandingInformation.Value().splash.Emplace();
+
+        request.brandingInformation.Value().splash.Value().imageUrl.Emplace();
+        request.brandingInformation.Value().splash.Value().imageUrl.Value() =
+            chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
+        request.brandingInformation.Value().splash.Value().color.Emplace();
+        request.brandingInformation.Value().splash.Value().color.Value() =
+            chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().splash.Value().size.Emplace();
+
+        request.brandingInformation.Value().splash.Value().size.Value().width  = 0;
+        request.brandingInformation.Value().splash.Value().size.Value().height = 0;
+        request.brandingInformation.Value().splash.Value().size.Value().metric =
+            static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
+
+        request.brandingInformation.Value().waterMark.Emplace();
+
+        request.brandingInformation.Value().waterMark.Value().imageUrl.Emplace();
+        request.brandingInformation.Value().waterMark.Value().imageUrl.Value() =
+            chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
+        request.brandingInformation.Value().waterMark.Value().color.Emplace();
+        request.brandingInformation.Value().waterMark.Value().color.Value() =
+            chip::Span<const char>("exampleColorgarbage: not in length on purpose", 12);
+        request.brandingInformation.Value().waterMark.Value().size.Emplace();
+
+        request.brandingInformation.Value().waterMark.Value().size.Value().width  = 0;
+        request.brandingInformation.Value().waterMark.Value().size.Value().height = 0;
+        request.brandingInformation.Value().waterMark.Value().size.Value().metric =
+            static_cast<chip::app::Clusters::ContentLauncher::MetricTypeEnum>(0);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ContentLauncherCluster *>(context))->OnSuccessResponse_4(data.status, data.data);
@@ -49233,11 +49295,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_4(chip::app::Clusters::ContentLauncher::StatusEnum status, chip::CharSpan data)
+    void OnSuccessResponse_4(chip::app::Clusters::ContentLauncher::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
-        VerifyOrReturn(CheckValueAsString("data", data, chip::CharSpan("exampleData", 11)));
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("exampleData", 11)));
 
         NextTest();
     }

--- a/zzz_generated/tv-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-app/zap-generated/endpoint_config.h
@@ -1301,10 +1301,10 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Channel (server) */                                                                           \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1129) }, /* channel list */                             \
-            { 0x00000001, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(875) }, /* channel list */                              \
+            { 0x00000001, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                \
               ZAP_EMPTY_DEFAULT() }, /* channel lineup */                                                                          \
-            { 0x00000002, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                \
+            { 0x00000002, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                \
               ZAP_EMPTY_DEFAULT() },                                            /* current channel */                              \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
@@ -1331,8 +1331,9 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Application Launcher (server) */                                                              \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2149) }, /* application launcher list */                \
-            { 0x00000001, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1895) }, /* application launcher list */                \
+            { 0x00000001, ZAP_TYPE(STRUCT), 0,                                                                                     \
+              ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                  \
               ZAP_EMPTY_DEFAULT() },                                            /* application launcher app */                     \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
@@ -1386,15 +1387,15 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* ClusterRevision */  \
                                                                                                                                    \
             /* Endpoint: 3, Cluster: Media Playback (server) */                                                                    \
-            { 0x00000000, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },         /* playback state */                          \
-            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2661) }, /* start time */                              \
-            { 0x00000002, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2669) },   /* duration */                                \
-            { 0x00000003, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                \
-              ZAP_EMPTY_DEFAULT() },                                               /* position */                                  \
-            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2677) }, /* playback speed */                            \
-            { 0x00000005, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2681) }, /* seek range end */                            \
-            { 0x00000006, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(2689) }, /* seek range start */                          \
-            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* ClusterRevision */                           \
+            { 0x00000000, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* playback state */                                  \
+            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2407) }, /* start time */   \
+            { 0x00000002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2415) },   /* duration */     \
+            { 0x00000003, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() },     /* position */     \
+            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2423) },                            /* playback speed */ \
+            { 0x00000005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2427) }, /* seek range end */ \
+            { 0x00000006, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE),                                                       \
+              ZAP_LONG_DEFAULTS_INDEX(2435) },                                  /* seek range start */                             \
+            { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 3, Cluster: Content Launcher (server) */                                                                  \
             { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2697) }, /* accept header list */                       \

--- a/zzz_generated/tv-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-app/zap-generated/endpoint_config.h
@@ -1301,7 +1301,7 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Channel (server) */                                                                           \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(875) }, /* channel list */                              \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1129) }, /* channel list */                             \
             { 0x00000001, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                \
               ZAP_EMPTY_DEFAULT() }, /* channel lineup */                                                                          \
             { 0x00000002, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                \
@@ -1331,7 +1331,7 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Application Launcher (server) */                                                              \
-            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1895) }, /* application launcher list */                \
+            { 0x00000000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2149) }, /* application launcher list */                \
             { 0x00000001, ZAP_TYPE(STRUCT), 0,                                                                                     \
               ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                  \
               ZAP_EMPTY_DEFAULT() },                                            /* application launcher app */                     \
@@ -1388,13 +1388,13 @@
                                                                                                                                    \
             /* Endpoint: 3, Cluster: Media Playback (server) */                                                                    \
             { 0x00000000, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* playback state */                                  \
-            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2407) }, /* start time */   \
-            { 0x00000002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2415) },   /* duration */     \
+            { 0x00000001, ZAP_TYPE(EPOCH_US), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2661) }, /* start time */   \
+            { 0x00000002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2669) },   /* duration */     \
             { 0x00000003, ZAP_TYPE(STRUCT), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() },     /* position */     \
-            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2423) },                            /* playback speed */ \
-            { 0x00000005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2427) }, /* seek range end */ \
+            { 0x00000004, ZAP_TYPE(SINGLE), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2677) },                            /* playback speed */ \
+            { 0x00000005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_LONG_DEFAULTS_INDEX(2681) }, /* seek range end */ \
             { 0x00000006, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(NULLABLE),                                                       \
-              ZAP_LONG_DEFAULTS_INDEX(2435) },                                  /* seek range start */                             \
+              ZAP_LONG_DEFAULTS_INDEX(2689) },                                  /* seek range start */                             \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                              \
                                                                                                                                    \
             /* Endpoint: 3, Cluster: Content Launcher (server) */                                                                  \


### PR DESCRIPTION
#### Problem
- Media Playback commands should be optional as per spec. (https://github.com/project-chip/connectedhomeip/pull/13195#discussion_r773542618)
- Target Navigator command should be optional as per spec. (https://github.com/project-chip/connectedhomeip/pull/13195#discussion_r773544026)
- Target Navigator argument should be optional as per spec. (https://github.com/project-chip/connectedhomeip/pull/13195#discussion_r773543881)
- Application Launcher, Data Type Application.Endpoint should be endpoint-no as per spec. (https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/media/ApplicationLauncher.adoc#application-3)
- ApplicationLauncher read of currentApp attribute does not allow for null
- Other spec attributes and arguments sync, declaring them optional, or nullable.


#### Issues reported
This PR will resolve these reported issues:
https://github.com/project-chip/connectedhomeip/issues/13214
https://github.com/project-chip/connectedhomeip/issues/13606

#### Change overview
see above

#### Testing
Run `./scripts/run_in_build_env.sh \  
                  "./scripts/tests/run_test_suite.py \
                     --chip-tool ./out/debug/standalone/chip-tool \
                     run \
                     --iterations 1 \
                     --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                     --tv-app ./out/debug/standalone/chip-tv-app \
                  "`