### PR TITLE
Make esp32 temperature measurement app commissionable

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -47,6 +47,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/group-key-mgmt-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning-old"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/route_hook"
                       PRIV_REQUIRES chip QRCode bt)

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -33,8 +33,10 @@
 #include <string>
 #include <vector>
 
+#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <platform/ESP32/NetworkCommissioningDriver.h>
 
 #include <lib/support/ErrorStr.h>
 
@@ -46,6 +48,19 @@ using namespace ::chip::DeviceLayer;
 const char * TAG = "temperature-measurement-app";
 
 static DeviceCallbacks EchoCallbacks;
+
+namespace {
+
+app::Clusters::NetworkCommissioning::Instance
+    sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::ESPWiFiDriver::GetInstance()));
+
+static void InitServer(intptr_t context)
+{
+    chip::Server::GetInstance().Init();
+    sWiFiNetworkCommissioningInstance.Init();
+}
+
+} // namespace
 
 extern "C" void app_main()
 {
@@ -80,7 +95,7 @@ extern "C" void app_main()
         return;
     }
 
-    chip::Server::GetInstance().Init();
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());


### PR DESCRIPTION
#### Problem
DevkitC of temperature measurement app reports being a thread device (does not use the new network config apis)

#### Change overview
Use the new network config API (logic copied from the all-clusters-app for esp32)

#### Testing
Flashed a devkit-c and commissioned. Without this, it fails (says wifi cretendials provided but thread device reported), after the change it passes.
