### PR TITLE
Fix reporting in CHIPTool

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -201,16 +201,18 @@
             if (chipDevice) {
                 CHIPTemperatureMeasurement * cluster =
                     [[CHIPTemperatureMeasurement alloc] initWithDevice:chipDevice endpoint:1 queue:dispatch_get_main_queue()];
-                [cluster subscribeAttributeMeasuredValueWithMinInterval:minIntervalSeconds maxInterval:maxIntervalSeconds subscriptionEstablished:^{
+                [cluster subscribeAttributeMeasuredValueWithMinInterval:minIntervalSeconds
+                    maxInterval:maxIntervalSeconds
+                    subscriptionEstablished:^{
 
-                } reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
-                    if (error) {
-                        NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@",
-                              [error description]);
-                        return;
                     }
-                    [self updateTempInUI:value.shortValue];
-                }];
+                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
+                        if (error) {
+                            NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@", [error description]);
+                            return;
+                        }
+                        [self updateTempInUI:value.shortValue];
+                    }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -201,25 +201,16 @@
             if (chipDevice) {
                 CHIPTemperatureMeasurement * cluster =
                     [[CHIPTemperatureMeasurement alloc] initWithDevice:chipDevice endpoint:1 queue:dispatch_get_main_queue()];
-                // TODO - Fix temperature reporting in iOS CHIPTool
-                /*
-                [cluster
-                    subscribeAttributeMeasuredValueWithMinInterval:minIntervalSeconds
-                                                       maxInterval:maxIntervalSeconds
-                                                   responseHandler:^(NSError * error, NSDictionary * values) {
-                                                       if (error == nil)
-                                                           return;
-                                                       NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@",
-                                                           [error description]);
-                                                   }];
+                [cluster subscribeAttributeMeasuredValueWithMinInterval:minIntervalSeconds maxInterval:maxIntervalSeconds subscriptionEstablished:^{
 
-                [cluster reportAttributeMeasuredValueWithResponseHandler:^(NSError * error, NSDictionary * values) {
-                    if (error != nil)
+                } reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
+                    if (error) {
+                        NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@",
+                              [error description]);
                         return;
-                    NSNumber * value = values[@"value"];
+                    }
                     [self updateTempInUI:value.shortValue];
                 }];
-                 */
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }


### PR DESCRIPTION
#### Problem
The temperature sensor screen in CHIPTool is disabled and cannot report changes.
#### Change overview
Fixed it.

#### Testing
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested reporting works with the iOS CHIPTool + M5Stack