### PR TITLE
Introduce ConcreteClusterPath.

### DIFF
--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/ConcreteClusterPath.h>
 #include <app/util/basic-types.h>
 #include <lib/core/Optional.h>
 
@@ -30,28 +31,34 @@ namespace app {
  * The expanded flag can be set to indicate that a concrete path was expanded from a wildcard
  * or group path.
  */
-struct ConcreteAttributePath
+struct ConcreteAttributePath : public ConcreteClusterPath
 {
-    ConcreteAttributePath() {}
+    ConcreteAttributePath()
+    {
+        // Note: mExpanded is in the superclass, so we can't use a field
+        // initializer.
+        mExpanded = false;
+    }
 
     ConcreteAttributePath(EndpointId aEndpointId, ClusterId aClusterId, AttributeId aAttributeId) :
-        mEndpointId(aEndpointId), mClusterId(aClusterId), mAttributeId(aAttributeId)
-    {}
-
-    bool operator==(const ConcreteAttributePath & other) const
+        ConcreteClusterPath(aEndpointId, aClusterId), mAttributeId(aAttributeId)
     {
-        return (mEndpointId == other.mEndpointId) && (mClusterId == other.mClusterId) && (mAttributeId == other.mAttributeId);
+        // Note: mExpanded is in the supercclass, so we can't use a field
+        // initializer.
+        mExpanded = false;
+    }
+
+    bool operator==(const ConcreteAttributePath & aOther) const
+    {
+        return ConcreteClusterPath::operator==(aOther) && (mAttributeId == aOther.mAttributeId);
     }
 
     bool operator<(const ConcreteAttributePath & path) const
     {
         return (mEndpointId < path.mEndpointId) || ((mEndpointId == path.mEndpointId) && (mClusterId < path.mClusterId)) ||
-            ((mClusterId == path.mClusterId) && (mAttributeId < path.mAttributeId));
+            ((mEndpointId == path.mEndpointId) && (mClusterId == path.mClusterId) && (mAttributeId < path.mAttributeId));
     }
 
-    EndpointId mEndpointId   = 0;
-    bool mExpanded           = false; // NOTE: in between larger members
-    ClusterId mClusterId     = 0;
     AttributeId mAttributeId = 0;
 };
 

--- a/src/app/ConcreteClusterPath.h
+++ b/src/app/ConcreteClusterPath.h
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * A representation of a concrete cluster path.  This identifies a specific
+ * cluster instance.
+ */
+struct ConcreteClusterPath
+{
+    ConcreteClusterPath(EndpointId aEndpointId, ClusterId aClusterId) : mEndpointId(aEndpointId), mClusterId(aClusterId) {}
+
+    ConcreteClusterPath() {}
+
+    ConcreteClusterPath(const ConcreteClusterPath & aOther) = default;
+    ConcreteClusterPath & operator=(const ConcreteClusterPath & aOther) = default;
+
+    bool operator==(const ConcreteClusterPath & aOther) const
+    {
+        return mEndpointId == aOther.mEndpointId && mClusterId == aOther.mClusterId;
+    }
+
+    bool operator!=(const ConcreteClusterPath & aOther) const { return !(*this == aOther); }
+
+    EndpointId mEndpointId = 0;
+    // Note: not all subclasses of ConcreteClusterPath need mExpanded, but due
+    // to alignment requirements it's "free" in the sense of not needing more
+    // memory to put it here.  But we don't initialize it, because that
+    // increases codesize for the non-consumers.
+    bool mExpanded; // NOTE: in between larger members
+    ClusterId mClusterId = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/ConcreteCommandPath.h
+++ b/src/app/ConcreteCommandPath.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include <app/ConcreteClusterPath.h>
 #include <app/util/basic-types.h>
-#include <lib/core/Optional.h>
 
 namespace chip {
 namespace app {
@@ -27,20 +27,20 @@ namespace app {
 /**
  * A representation of a concrete invoke path.
  */
-struct ConcreteCommandPath
+struct ConcreteCommandPath : public ConcreteClusterPath
 {
     ConcreteCommandPath(EndpointId aEndpointId, ClusterId aClusterId, CommandId aCommandId) :
-        mEndpointId(aEndpointId), mClusterId(aClusterId), mCommandId(aCommandId)
+        ConcreteClusterPath(aEndpointId, aClusterId), mCommandId(aCommandId)
     {}
 
-    bool operator==(const ConcreteCommandPath & other) const
+    bool operator==(const ConcreteCommandPath & aOther) const
     {
-        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mCommandId == other.mCommandId;
+        return ConcreteClusterPath::operator==(aOther) && (mCommandId == aOther.mCommandId);
     }
 
-    EndpointId mEndpointId = 0;
-    ClusterId mClusterId   = 0;
-    CommandId mCommandId   = 0;
+    bool operator!=(const ConcreteCommandPath & aOther) const { return !(*this == aOther); }
+
+    CommandId mCommandId = 0;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/ConcreteEventPath.h
+++ b/src/app/ConcreteEventPath.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/ConcreteClusterPath.h>
 #include <app/util/basic-types.h>
 
 namespace chip {
@@ -26,25 +27,25 @@ namespace app {
 /**
  * A representation of a concrete event path.
  */
-struct ConcreteEventPath
+struct ConcreteEventPath : public ConcreteClusterPath
 {
     ConcreteEventPath(EndpointId aEndpointId, ClusterId aClusterId, EventId aEventId) :
-        mEndpointId(aEndpointId), mClusterId(aClusterId), mEventId(aEventId)
+        ConcreteClusterPath(aEndpointId, aClusterId), mEventId(aEventId)
     {}
 
     ConcreteEventPath() {}
 
-    ConcreteEventPath(const ConcreteEventPath & other) = default;
-    ConcreteEventPath & operator=(const ConcreteEventPath & other) = default;
+    ConcreteEventPath(const ConcreteEventPath & aOther) = default;
+    ConcreteEventPath & operator=(const ConcreteEventPath & aOther) = default;
 
-    bool operator==(const ConcreteEventPath & other) const
+    bool operator==(const ConcreteEventPath & aOther) const
     {
-        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mEventId == other.mEventId;
+        return ConcreteClusterPath::operator==(aOther) && (mEventId == aOther.mEventId);
     }
 
-    EndpointId mEndpointId = 0;
-    ClusterId mClusterId   = 0;
-    EventId mEventId       = 0;
+    bool operator!=(const ConcreteEventPath & aOther) const { return !(*this == aOther); }
+
+    EventId mEventId = 0;
 };
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
Will be useful in places where we just need an endpoint+cluster.

Fixes https://github.com/project-chip/connectedhomeip/issues/14820

#### Problem
We end up converting between paths and multiple args representing endpoint + cluster.

#### Change overview
Allow us to just pass paths along as needed.

#### Testing
No behavior changes.