### PR TITLE
Set valid device types for application endpoints (#13634)

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -7204,9 +7204,9 @@
       ]
     },
     {
-      "name": "MA-rootdevice",
-      "deviceTypeName": "MA-rootdevice",
-      "deviceTypeCode": 22,
+      "name": "MA-onofflight",
+      "deviceTypeName": "MA-onofflight",
+      "deviceTypeCode": 256,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -17119,9 +17119,9 @@
       ]
     },
     {
-      "name": "MA-rootdevice",
-      "deviceTypeName": "MA-rootdevice",
-      "deviceTypeCode": 22,
+      "name": "MA-onofflight",
+      "deviceTypeName": "MA-onofflight",
+      "deviceTypeCode": 256,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -20121,22 +20121,22 @@
       "deviceIdentifier": 22
     },
     {
-      "endpointTypeName": "MA-rootdevice",
+      "endpointTypeName": "MA-onofflight",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "deviceIdentifier": 256
     },
     {
-      "endpointTypeName": "MA-rootdevice",
+      "endpointTypeName": "MA-onofflight",
       "endpointTypeIndex": 2,
       "profileId": 259,
       "endpointId": 2,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "deviceIdentifier": 256
     }
   ]
 }

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.zap
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.zap
@@ -2471,10 +2471,10 @@
       ]
     },
     {
-      "name": "MA-rootdevice",
-      "deviceTypeName": "MA-rootdevice",
+      "name": "MA-tempsensor",
+      "deviceTypeName": "MA-tempsensor",
       "deviceTypeCode": 22,
-      "deviceTypeProfileId": 259,
+      "deviceTypeProfileId": 770,
       "clusters": [
         {
           "name": "Power Configuration",
@@ -3400,13 +3400,13 @@
       "deviceIdentifier": 22
     },
     {
-      "endpointTypeName": "MA-rootdevice",
+      "endpointTypeName": "MA-tempsensor",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "deviceIdentifier": 770
     }
   ]
 }

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
@@ -6536,9 +6536,9 @@
       ]
     },
     {
-      "name": "MA-rootdevice",
-      "deviceTypeName": "MA-rootdevice",
-      "deviceTypeCode": 22,
+      "name": "MA-videoplayer",
+      "deviceTypeName": "MA-videoplayer",
+      "deviceTypeCode": 35,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -13559,9 +13559,9 @@
       ]
     },
     {
-      "name": "Anonymous Endpoint Type",
-      "deviceTypeName": "MA-rootdevice",
-      "deviceTypeCode": 22,
+      "name": "MA-occupancysensor",
+      "deviceTypeName": "MA-occupancysensor",
+      "deviceTypeCode": 263,
       "deviceTypeProfileId": 259,
       "clusters": [
         {
@@ -16486,22 +16486,22 @@
       "deviceIdentifier": 22
     },
     {
-      "endpointTypeName": "MA-rootdevice",
+      "endpointTypeName": "MA-videoplayer",
       "endpointTypeIndex": 1,
       "profileId": 259,
       "endpointId": 1,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "deviceIdentifier": 35
     },
     {
-      "endpointTypeName": "Anonymous Endpoint Type",
+      "endpointTypeName": "MA-occupancysensor",
       "endpointTypeIndex": 2,
       "profileId": 259,
       "endpointId": 2,
       "networkId": 0,
       "endpointVersion": 1,
-      "deviceIdentifier": 22
+      "deviceIdentifier": 263
     }
   ]
 }

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -2747,7 +2747,7 @@
 // Array of device ids
 #define FIXED_DEVICE_IDS                                                                                                           \
     {                                                                                                                              \
-        22, 22, 22                                                                                                                 \
+        22, 256, 256                                                                                                               \
     }
 
 // Array of device versions

--- a/zzz_generated/temperature-measurement-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/temperature-measurement-app/zap-generated/endpoint_config.h
@@ -516,7 +516,7 @@
 // Array of device ids
 #define FIXED_DEVICE_IDS                                                                                                           \
     {                                                                                                                              \
-        22, 22                                                                                                                     \
+        22, 770                                                                                                                    \
     }
 
 // Array of device versions

--- a/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
@@ -1737,7 +1737,7 @@
 // Array of device ids
 #define FIXED_DEVICE_IDS                                                                                                           \
     {                                                                                                                              \
-        22, 22, 22                                                                                                                 \
+        22, 35, 263                                                                                                                \
     }
 
 // Array of device versions


### PR DESCRIPTION
Several samples are using the root node device type for application
endpoints. This prevents proper identification of the device. Add
types to all non-root endpoints in examples/.

all-clusters-app does not correspond well with any single device type.
This sets it to on/off light. It may be useful to reorganize this
sample into additional endpoints each with a coherent device type.

Multiple root nodes is not compliant. From the spec, "Endpoint
Composition" section: There SHALL be only one root node endpoint for the
node.

(cherry picked from commit a3409d620c4437d2ab5aa09b08d76f75f66bb52d)