### PR TITLE
[OTA] Initalize OTA apps using Linux platform functions

### DIFF
--- a/examples/ota-provider-app/linux/args.gni
+++ b/examples/ota-provider-app/linux/args.gni
@@ -15,3 +15,11 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+
+chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_system_project_config_include = "<SystemProjectConfig.h>"
+
+chip_project_config_include_dirs =
+    [ "${chip_root}/examples/ota-provider-app/linux/include" ]
+chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]

--- a/examples/ota-provider-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/ota-provider-app/linux/include/CHIPProjectAppConfig.h
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// include the CHIPProjectConfig from config/standalone
+#include <CHIPProjectConfig.h>
+
+// Allows app options (ports) to be configured on launch of app
+#define CHIP_DEVICE_ENABLE_PORT_PARAMS 1

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -16,23 +16,16 @@
  *    limitations under the License.
  */
 
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
-
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
 #include <app/clusters/ota-provider/ota-provider.h>
 #include <app/server/Server.h>
 #include <app/util/util.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <json/json.h>
-#include <lib/core/CHIPError.h>
-#include <lib/support/CHIPArgParser.hpp>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <ota-provider-common/BdxOtaSender.h>
 #include <ota-provider-common/DefaultUserConsentProvider.h>
 #include <ota-provider-common/OTAProviderExample.h>
+
+#include "AppMain.h"
 
 #include <fstream>
 #include <iostream>
@@ -61,6 +54,8 @@ constexpr uint16_t kOptionSoftwareVersionStr   = 'S';
 constexpr uint16_t kOptionUserConsentNeeded    = 'c';
 
 static constexpr uint16_t kMaximumDiscriminatorValue = 0xFFF;
+
+OTAProviderExample gOtaProvider;
 
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
 static OTAProviderExample::QueryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUnknown;
@@ -308,85 +303,48 @@ HelpOptions helpOptions("ota-provider-app", "Usage: ota-provider-app [options]",
 
 OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 
-int main(int argc, char * argv[])
+void ApplicationInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    OTAProviderExample otaProvider;
     chip::ota::DefaultUserConsentProvider userConsentProvider;
 
-    if (chip::Platform::MemoryInit() != CHIP_NO_ERROR)
-    {
-        fprintf(stderr, "FAILED to initialize memory\n");
-        return 1;
-    }
-
-    if (chip::DeviceLayer::PlatformMgr().InitChipStack() != CHIP_NO_ERROR)
-    {
-        fprintf(stderr, "FAILED to initialize chip stack\n");
-        return 1;
-    }
-
-    if (!chip::ArgParser::ParseArgs(argv[0], argc, argv, allOptions))
-    {
-        return 1;
-    }
-
-    chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();
-
-    if (gSetupDiscriminator.HasValue())
-    {
-        // Set discriminator to user specified value
-        ChipLogProgress(SoftwareUpdate, "Setting discriminator to: %" PRIu16, gSetupDiscriminator.Value());
-        err = chip::DeviceLayer::ConfigurationMgr().StoreSetupDiscriminator(gSetupDiscriminator.Value());
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(SoftwareUpdate, "Setup discriminator setting failed with code: %" CHIP_ERROR_FORMAT, err.Format());
-            return 1;
-        }
-    }
-
-    chip::Server::GetInstance().Init();
-
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
-
-    BdxOtaSender * bdxOtaSender = otaProvider.GetBdxOtaSender();
-    VerifyOrReturnError(bdxOtaSender != nullptr, 1);
+    BdxOtaSender * bdxOtaSender = gOtaProvider.GetBdxOtaSender();
+    VerifyOrReturn(bdxOtaSender != nullptr);
     err = chip::Server::GetInstance().GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(chip::Protocols::BDX::Id,
                                                                                                         bdxOtaSender);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogDetail(SoftwareUpdate, "RegisterUnsolicitedMessageHandler failed: %s", chip::ErrorStr(err));
-        return 1;
+        return;
     }
 
-    ChipLogDetail(SoftwareUpdate, "using OTA file: %s", gOtaFilepath ? gOtaFilepath : "(none)");
+    ChipLogDetail(SoftwareUpdate, "Using OTA file: %s", gOtaFilepath ? gOtaFilepath : "(none)");
 
     if (gOtaFilepath != nullptr)
     {
-        otaProvider.SetOTAFilePath(gOtaFilepath);
+        gOtaProvider.SetOTAFilePath(gOtaFilepath);
     }
 
-    otaProvider.SetQueryImageBehavior(gQueryImageBehavior);
-    otaProvider.SetDelayedActionTimeSec(gDelayedActionTimeSec);
+    gOtaProvider.SetQueryImageBehavior(gQueryImageBehavior);
+    gOtaProvider.SetDelayedActionTimeSec(gDelayedActionTimeSec);
     if (gSoftwareVersion.HasValue())
     {
-        otaProvider.SetSoftwareVersion(gSoftwareVersion.Value());
+        gOtaProvider.SetSoftwareVersion(gSoftwareVersion.Value());
     }
     if (gSoftwareVersionString)
     {
-        otaProvider.SetSoftwareVersionString(gSoftwareVersionString);
+        gOtaProvider.SetSoftwareVersionString(gSoftwareVersionString);
     }
 
     if (gUserConsentState != chip::ota::UserConsentState::kUnknown)
     {
         userConsentProvider.SetGlobalUserConsentState(gUserConsentState);
-        otaProvider.SetUserConsentDelegate(&userConsentProvider);
+        gOtaProvider.SetUserConsentDelegate(&userConsentProvider);
     }
 
     if (gUserConsentNeeded)
     {
-        otaProvider.SetUserConsentNeeded(true);
+        gOtaProvider.SetUserConsentNeeded(true);
     }
 
     ChipLogDetail(SoftwareUpdate, "Using ImageList file: %s", gOtaImageListFilepath ? gOtaImageListFilepath : "(none)");
@@ -396,12 +354,15 @@ int main(int argc, char * argv[])
         // Parse JSON file and load the ota candidates
         std::vector<OTAProviderExample::DeviceSoftwareVersionModel> candidates;
         ParseJsonFileAndPopulateCandidates(gOtaImageListFilepath, candidates);
-        otaProvider.SetOTACandidates(candidates);
+        gOtaProvider.SetOTACandidates(candidates);
     }
 
-    chip::app::Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, &otaProvider);
+    chip::app::Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, &gOtaProvider);
+}
 
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
-
+int main(int argc, char * argv[])
+{
+    VerifyOrDie(ChipLinuxAppInit(argc, argv, &cmdLineOptions) == 0);
+    ChipLinuxAppMainLoop();
     return 0;
 }

--- a/examples/ota-requestor-app/linux/args.gni
+++ b/examples/ota-requestor-app/linux/args.gni
@@ -16,6 +16,14 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
 
+chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_system_project_config_include = "<SystemProjectConfig.h>"
+
+chip_project_config_include_dirs =
+    [ "${chip_root}/examples/ota-requestor-app/linux/include" ]
+chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+
 declare_args() {
   chip_enable_ota_requestor = true
 }

--- a/examples/ota-requestor-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/ota-requestor-app/linux/include/CHIPProjectAppConfig.h
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// include the CHIPProjectConfig from config/standalone
+#include <CHIPProjectConfig.h>
+
+// Allows app options (ports) to be configured on launch of app
+#define CHIP_DEVICE_ENABLE_PORT_PARAMS 1

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -122,12 +122,6 @@ int ChipLinuxAppInit(int argc, char ** argv, OptionSet * customOptions)
     err = Platform::MemoryInit();
     SuccessOrExit(err);
 
-    err = DeviceLayer::PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
-
-    err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
-    SuccessOrExit(err);
-
     err = ParseArguments(argc, argv, customOptions);
     SuccessOrExit(err);
 
@@ -142,6 +136,19 @@ int ChipLinuxAppInit(int argc, char ** argv, OptionSet * customOptions)
     }
     SuccessOrExit(err);
 #endif
+
+    err = DeviceLayer::PlatformMgr().InitChipStack();
+    SuccessOrExit(err);
+
+    if (0 != LinuxDeviceOptions::GetInstance().payload.discriminator)
+    {
+        uint16_t discriminator = LinuxDeviceOptions::GetInstance().payload.discriminator;
+        err                    = DeviceLayer::ConfigurationMgr().StoreSetupDiscriminator(discriminator);
+        SuccessOrExit(err);
+    }
+
+    err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
+    SuccessOrExit(err);
 
     ConfigurationMgr().LogDeviceConfig();
 

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -25,7 +25,9 @@
 #include <platform/PlatformManager.h>
 #include <transport/TransportMgr.h>
 
-int ChipLinuxAppInit(int argc, char ** argv);
+#include "Options.h"
+
+int ChipLinuxAppInit(int argc, char ** argv, chip::ArgParser::OptionSet * customOptions = nullptr);
 void ChipLinuxAppMainLoop();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -188,7 +188,6 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         else
         {
             LinuxDeviceOptions::GetInstance().payload.discriminator = value;
-            DeviceLayer::ConfigurationMgr().StoreSetupDiscriminator(value);
         }
         break;
     }
@@ -232,7 +231,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
 OptionSet sDeviceOptions = { HandleOption, sDeviceOptionDefs, "GENERAL OPTIONS", sDeviceOptionHelp };
 
-OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr, nullptr };
+OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr, nullptr, nullptr };
 } // namespace
 
 CHIP_ERROR ParseArguments(int argc, char * argv[], OptionSet * customOptions)

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -22,7 +22,6 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #include <lib/core/CHIPError.h>
-#include <lib/support/CHIPArgParser.hpp>
 
 using namespace chip;
 using namespace chip::ArgParser;
@@ -236,13 +235,21 @@ OptionSet sDeviceOptions = { HandleOption, sDeviceOptionDefs, "GENERAL OPTIONS",
 OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr, nullptr };
 } // namespace
 
-CHIP_ERROR ParseArguments(int argc, char * argv[])
+CHIP_ERROR ParseArguments(int argc, char * argv[], OptionSet * customOptions)
 {
+    // Index 0 is for the general Linux options
+    uint8_t optionSetIndex = 1;
+    if (customOptions != nullptr)
+    {
+        // If there are custom options, include it during arg parsing
+        sLinuxDeviceOptionSets[optionSetIndex++] = customOptions;
+    }
+
     char usage[kAppUsageLength];
     snprintf(usage, kAppUsageLength, "Usage: %s [options]", argv[0]);
 
     HelpOptions helpOptions(argv[0], usage, "1.0");
-    sLinuxDeviceOptionSets[1] = &helpOptions;
+    sLinuxDeviceOptionSets[optionSetIndex] = &helpOptions;
 
     if (!ParseArgs(argv[0], argc, argv, sLinuxDeviceOptionSets))
     {

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -27,6 +27,7 @@
 #include <cstdint>
 
 #include <lib/core/CHIPError.h>
+#include <lib/support/CHIPArgParser.hpp>
 #include <setup_payload/SetupPayload.h>
 
 struct LinuxDeviceOptions
@@ -45,4 +46,4 @@ struct LinuxDeviceOptions
     static LinuxDeviceOptions & GetInstance();
 };
 
-CHIP_ERROR ParseArguments(int argc, char * argv[]);
+CHIP_ERROR ParseArguments(int argc, char * argv[], chip::ArgParser::OptionSet * customOptions = nullptr);


### PR DESCRIPTION
#### Problem
OTA apps can no longer be commissioned after https://github.com/project-chip/connectedhomeip/pull/14832 merged. The PR removed KVS init code from Server which OTA apps relied on.

#### Change overview
- Use the init functions for Linux from AppMain
- Add in an optional param to allow for app-specific custom command line options

#### Testing
Tested that OTA apps can be commissioned again. Also tested that the usual AnnounceOTAProvider command triggers the entire OTA process.
