### PR TITLE
[Ameba] Add NetWorkCommissioningInstInit to fix pairing failure

### DIFF
--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -30,9 +30,12 @@
 #include <support/CHIPMem.h>
 
 #include <app/clusters/identify-server/identify-server.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <lib/support/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/NetworkCommissioningDriver.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
@@ -50,6 +53,16 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+namespace {
+app::Clusters::NetworkCommissioning::Instance
+    sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
+} // namespace
+
+void NetWorkCommissioningInstInit()
+{
+    sWiFiNetworkCommissioningInstance.Init();
+}
 
 #ifdef CONFIG_PLATFORM_8721D
 #define STATUS_LED_GPIO_NUM PB_5
@@ -147,31 +160,34 @@ static Identify gIdentify1 = {
 
 extern "C" void ChipTest(void)
 {
-    printf("In ChipTest()\r\n");
+    ChipLogProgress(DeviceLayer, "Lighting App Demo!");
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    printf("initPrefr\n");
     initPref();
 
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
-    err                           = deviceMgr.Init(&EchoCallbacks);
 
+    err = deviceMgr.Init(&EchoCallbacks);
     if (err != CHIP_NO_ERROR)
     {
-        printf("DeviceManagerInit() - ERROR!\r\n");
+        ChipLogError(DeviceLayer, "DeviceManagerInit() - ERROR!\r\n");
     }
     else
     {
-        printf("DeviceManagerInit() - OK\r\n");
+        ChipLogProgress(DeviceLayer, "DeviceManagerInit() - OK\r\n");
     }
 
     chip::Server::GetInstance().Init();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    NetWorkCommissioningInstInit();
 
-    // QR code will be used with CHIP Tool
-    PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+    if (RTW_SUCCESS != wifi_is_connected_to_ap())
+    {
+        // QR code will be used with CHIP Tool
+        PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+    }
 
     statusLED1.Init(STATUS_LED_GPIO_NUM);
 

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -21,11 +21,14 @@
 #include "DeviceCallbacks.h"
 #include "chip_porting.h"
 
+#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+
 #include <lib/support/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
 
@@ -61,6 +64,16 @@ using namespace ::chip;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
+
+namespace {
+app::Clusters::NetworkCommissioning::Instance
+    sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
+} // namespace
+
+void NetWorkCommissioningInstInit()
+{
+    sWiFiNetworkCommissioningInstance.Init();
+}
 
 static DeviceCallbacks EchoCallbacks;
 
@@ -130,6 +143,7 @@ extern "C" void ChipTest(void)
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    NetWorkCommissioningInstInit();
 
     InitOTARequestor();
 


### PR DESCRIPTION
#### Problem
* Fix pairing error on lighting-app and ota-requestor-app

#### Change overview
* Add NetWorkCommissioningInstInit to the chipinterface for both application 
 
#### Testing
Tested on lighting-app and ota-requestor-app
