### PR TITLE
Add OTA support to QPG lock example app

### DIFF
--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR AppTask::StartAppTask()
     sAppTaskHandle = xTaskCreateStatic(AppTaskMain, APP_TASK_NAME, ArraySize(appStack), nullptr, 1, appStack, &appTaskStruct);
     if (sAppTaskHandle == nullptr)
     {
-        return CHIP_NO_ERROR;
+        return CHIP_ERROR_NO_MEMORY;
     }
 
     return CHIP_NO_ERROR;
@@ -365,7 +365,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
 
 void AppTask::CancelTimer()
 {
-    SystemLayer().CancelTimer(TimerEventHandler, this);
+    chip::DeviceLayer::SystemLayer().CancelTimer(TimerEventHandler, this);
     mFunctionTimerActive = false;
 }
 
@@ -373,7 +373,8 @@ void AppTask::StartTimer(uint32_t aTimeoutInMs)
 {
     CHIP_ERROR err;
 
-    err = SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(aTimeoutInMs), TimerEventHandler, this);
+    chip::DeviceLayer::SystemLayer().CancelTimer(TimerEventHandler, this);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(aTimeoutInMs), TimerEventHandler, this);
     SuccessOrExit(err);
 
     mFunctionTimerActive = true;

--- a/examples/lock-app/qpg/BUILD.gn
+++ b/examples/lock-app/qpg/BUILD.gn
@@ -76,7 +76,10 @@ qpg_executable("lock_app") {
     deps += [ "${chip_root}/third_party/openthread/repo:libopenthread-mtd" ]
   }
 
-  include_dirs = [ "include" ]
+  include_dirs = [
+    "include",
+    "${examples_plat_dir}/ota",
+  ]
 
   defines = []
 

--- a/examples/lock-app/qpg/BUILD.gn
+++ b/examples/lock-app/qpg/BUILD.gn
@@ -55,6 +55,7 @@ qpg_executable("lock_app") {
 
   sources = [
     "${examples_plat_dir}/app/main.cpp",
+    "${examples_plat_dir}/ota/ota.cpp",
     "src/AppTask.cpp",
     "src/BoltLockManager.cpp",
     "src/ZclCallbacks.cpp",

--- a/examples/lock-app/qpg/args.gni
+++ b/examples/lock-app/qpg/args.gni
@@ -18,5 +18,9 @@ import("${chip_root}/examples/platform/qpg/args.gni")
 
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
+declare_args() {
+  chip_enable_ota_requestor = true
+}
+
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/lock-app/qpg/include/AppTask.h
+++ b/examples/lock-app/qpg/include/AppTask.h
@@ -71,9 +71,8 @@ private:
     {
         kFunction_NoneSelected   = 0,
         kFunction_SoftwareUpdate = 1,
-        kFunction_Joiner         = 2,
-        kFunction_FactoryReset   = 3,
-        kFunction_StartBleAdv    = 4,
+        kFunction_FactoryReset   = 2,
+        kFunction_StartBleAdv    = 3,
 
         kFunction_Invalid
     } Function;
@@ -81,7 +80,6 @@ private:
     Function_t mFunction;
     bool mFunctionTimerActive;
     bool mSyncClusterToButtonAction;
-    chip::Ble::BLEEndPoint * mBLEEndPoint;
 
     static AppTask sAppTask;
 };

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -328,7 +328,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
 
     // To trigger BLE advertising: press the APP_FUNCTION_BUTTON button briefly (<
     // OTA_START_TRIGGER_TIMEOUT). To trigger software update: press the button
-	// between 1.5sec and 3sec. To initiate factory reset: press the
+    // between 1.5sec and 3sec. To initiate factory reset: press the
     // APP_FUNCTION_BUTTON for FACTORY_RESET_TRIGGER_TIMEOUT +
     // FACTORY_RESET_CANCEL_WINDOW_TIMEOUT All LEDs start blinking after
     // FACTORY_RESET_TRIGGER_TIMEOUT to signal factory reset has been initiated.

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -21,6 +21,7 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "AppTask.h"
+#include "ota.h"
 
 #include <app/server/OnboardingCodesUtil.h>
 
@@ -42,16 +43,12 @@ using namespace chip::Credentials;
 using namespace chip::DeviceLayer;
 
 #include <platform/CHIPDeviceLayer.h>
-#if CHIP_ENABLE_OPENTHREAD
-#include <platform/OpenThread/OpenThreadUtils.h>
-#include <platform/ThreadStackManager.h>
-#include <platform/qpg/ThreadStackManagerImpl.h>
-#define JOINER_START_TRIGGER_TIMEOUT 1500
-#endif
 
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000
 #define FACTORY_RESET_CANCEL_WINDOW_TIMEOUT 3000
-#define APP_TASK_STACK_SIZE (3072)
+#define OTA_START_TRIGGER_TIMEOUT 1500
+
+#define APP_TASK_STACK_SIZE (3 * 1024)
 #define APP_TASK_PRIORITY 2
 #define APP_EVENT_QUEUE_SIZE 10
 
@@ -121,6 +118,9 @@ CHIP_ERROR AppTask::Init()
 
     // Init ZCL Data Model
     chip::Server::GetInstance().Init();
+
+    // Init OTA engine
+    InitializeOTARequestor();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
@@ -253,13 +253,18 @@ void AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
     if (btnIdx == APP_LOCK_BUTTON && btnPressed == true)
     {
         button_event.Handler = LockActionEventHandler;
-        sAppTask.PostEvent(&button_event);
     }
     else if (btnIdx == APP_FUNCTION_BUTTON)
     {
+        // Hand off to Functionality handler - depends on duration of press
         button_event.Handler = FunctionHandler;
-        sAppTask.PostEvent(&button_event);
     }
+    else
+    {
+        return;
+    }
+
+    sAppTask.PostEvent(&button_event);
 }
 
 void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState)
@@ -278,21 +283,19 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
         return;
     }
 
-    // If we reached here, the button was held past FACTORY_RESET_TRIGGER_TIMEOUT,
-    // initiate factory reset
+    // If we reached here, the button was held past OTA_START_TRIGGER_TIMEOUT,
+    // initiate OTA update
     if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_StartBleAdv)
     {
-#if CHIP_ENABLE_OPENTHREAD
-        ChipLogProgress(NotSpecified, "Release button now to Start Thread Joiner");
-        ChipLogProgress(NotSpecified, "Hold to trigger Factory Reset");
-        sAppTask.mFunction = kFunction_Joiner;
-        sAppTask.StartTimer(FACTORY_RESET_TRIGGER_TIMEOUT);
+        ChipLogProgress(NotSpecified, "[BTN] Release button now to start Software Updater");
+        ChipLogProgress(NotSpecified, "[BTN] Hold to trigger Factory Reset");
+        sAppTask.mFunction = kFunction_SoftwareUpdate;
+        sAppTask.StartTimer(FACTORY_RESET_TRIGGER_TIMEOUT - OTA_START_TRIGGER_TIMEOUT);
     }
-    else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_Joiner)
+    else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
     {
-#endif
-        ChipLogProgress(NotSpecified, "Factory Reset Triggered. Release button within %ums to cancel.",
-                        FACTORY_RESET_CANCEL_WINDOW_TIMEOUT);
+        ChipLogProgress(NotSpecified, "[BTN] Factory Reset selected. Release within %us to cancel.",
+                        FACTORY_RESET_CANCEL_WINDOW_TIMEOUT / 1000);
 
         // Start timer for FACTORY_RESET_CANCEL_WINDOW_TIMEOUT to allow user to
         // cancel, if required.
@@ -324,7 +327,8 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
     }
 
     // To trigger BLE advertising: press the APP_FUNCTION_BUTTON button briefly (<
-    // FACTORY_RESET_TRIGGER_TIMEOUT) To initiate factory reset: press the
+    // OTA_START_TRIGGER_TIMEOUT). To trigger software update: press the button
+	// between 1.5sec and 3sec. To initiate factory reset: press the
     // APP_FUNCTION_BUTTON for FACTORY_RESET_TRIGGER_TIMEOUT +
     // FACTORY_RESET_CANCEL_WINDOW_TIMEOUT All LEDs start blinking after
     // FACTORY_RESET_TRIGGER_TIMEOUT to signal factory reset has been initiated.
@@ -334,18 +338,18 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
     {
         if (!sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_NoneSelected)
         {
-#if CHIP_ENABLE_OPENTHREAD
-            sAppTask.StartTimer(JOINER_START_TRIGGER_TIMEOUT);
-#else
-            sAppTask.StartTimer(FACTORY_RESET_TRIGGER_TIMEOUT);
-#endif
+            ChipLogProgress(NotSpecified, "[BTN] Hold to select function:");
+            ChipLogProgress(NotSpecified, "[BTN] - Trigger BLE adv (0-1.5s)");
+            ChipLogProgress(NotSpecified, "[BTN] - Trigger OTA (1.5-3s)");
+            ChipLogProgress(NotSpecified, "[BTN] - Factory Reset (>6s)");
 
+            sAppTask.StartTimer(OTA_START_TRIGGER_TIMEOUT);
             sAppTask.mFunction = kFunction_StartBleAdv;
         }
     }
     else
     {
-        // If the button was released before factory reset got initiated, trigger BLE advertising.
+        // If the button was released before 1.5sec, trigger BLE advertising.
         if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_StartBleAdv)
         {
             sAppTask.CancelTimer();
@@ -371,16 +375,16 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
                 }
             }
         }
-#if CHIP_ENABLE_OPENTHREAD
-        else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_Joiner)
+        else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
         {
             sAppTask.CancelTimer();
+
             sAppTask.mFunction = kFunction_NoneSelected;
 
-            CHIP_ERROR error = ThreadStackMgr().JoinerStart();
-            ChipLogProgress(NotSpecified, "Thread joiner triggered: %s", chip::ErrorStr(error));
+            ChipLogProgress(NotSpecified, "[BTN] Triggering OTA Query");
+
+            TriggerOTAQuery();
         }
-#endif
         else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_FactoryReset)
         {
             // Set lock status LED back to show state of lock.
@@ -392,7 +396,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
             // canceled.
             sAppTask.mFunction = kFunction_NoneSelected;
 
-            ChipLogProgress(NotSpecified, "Factory Reset has been Canceled");
+            ChipLogProgress(NotSpecified, "[BTN] Factory Reset has been Canceled");
         }
     }
 }
@@ -484,6 +488,10 @@ void AppTask::PostEvent(const AppEvent * aEvent)
             ChipLogError(NotSpecified, "Failed to post event to app task event queue");
         }
     }
+    else
+    {
+        ChipLogError(NotSpecified, "Event Queue is NULL should never happen");
+    }
 }
 
 void AppTask::DispatchEvent(AppEvent * aEvent)
@@ -498,9 +506,14 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     }
 }
 
+/**
+ * Update cluster status after application level changes
+ */
 void AppTask::UpdateClusterState(void)
 {
     uint8_t newValue = !BoltLockMgr().IsUnlocked();
+
+    ChipLogProgress(NotSpecified, "UpdateClusterState");
 
     // write the new on/off value
     EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,


### PR DESCRIPTION
#### Problem
Adding OTA support to QPG lock app

#### Change overview
This PR contains the necessary additions to enable OTA requestor cluster in the lock example app 

#### Testing
The changes were tested by triggering an OTA update from the QPG6105 platform.
