### PR TITLE
[nrfconnect] Auto-reboot on firmware update

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -44,6 +44,16 @@ config CHIP_OTA_REQUESTOR_BUFFER_SIZE
 	  Configures size of the buffer used by OTA Requestor when downloading and
 	  writing a new firmware image to flash.
 
+config CHIP_OTA_REQUESTOR_REBOOT_ON_APPLY
+	bool "Auto-reboot when firmware update is applied"
+	default y
+	depends on CHIP_OTA_REQUESTOR
+	imply REBOOT
+	help
+	  When a user consents to apply a firmware update, and the update package is
+	  downloaded, reboot the device automatically to swap the old and the new
+	  firmware images.
+
 # See config/zephyr/Kconfig for full definition
 config CHIP_OTA_IMAGE_BUILD
 	bool

--- a/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
@@ -62,6 +62,11 @@
 #define CHIP_DEVICE_CONFIG_SETTINGS_KEY "mt"
 #endif // CHIP_DEVICE_CONFIG_SETTINGS_KEY
 
+#ifndef CHIP_DEVICE_CONFIG_OTA_REQUESTOR_REBOOT_DELAY_MS
+/// Delay between completing a firmware update download and reboot to apply the update
+#define CHIP_DEVICE_CONFIG_OTA_REQUESTOR_REBOOT_DELAY_MS 1000
+#endif // CHIP_DEVICE_CONFIG_OTA_REQUESTOR_REBOOT_DELAY_MS
+
 // ========== Platform-specific Configuration Overrides =========
 
 #ifndef CHIP_DEVICE_CONFIG_CHIP_TASK_PRIORITY

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -24,6 +24,7 @@
 
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_mcuboot.h>
+#include <sys/reboot.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -56,7 +57,15 @@ CHIP_ERROR OTAImageProcessorImpl::Abort()
 
 CHIP_ERROR OTAImageProcessorImpl::Apply()
 {
-    return System::MapErrorZephyr(dfu_target_done(true));
+    ReturnErrorOnFailure(System::MapErrorZephyr(dfu_target_done(true)));
+
+#ifdef CONFIG_CHIP_OTA_REQUESTOR_REBOOT_ON_APPLY
+    return DeviceLayer::SystemLayer().StartTimer(
+        System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_OTA_REQUESTOR_REBOOT_DELAY_MS),
+        [](System::Layer *, void * /* context */) { sys_reboot(SYS_REBOOT_WARM); }, nullptr /* context */);
+#else
+    return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)


### PR DESCRIPTION
#### Problem
A user must manually reboot the device to apply a software update on nRF Connect platform.

#### Change overview
Automatically reboot the device when a firmware update is applied.

#### Testing
Tested manually on nRF Connect lighting-app.
