### PR TITLE
[chip-tool-darwin] Pass a NSError reference in the pairing module ins…

### DIFF
--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.h
@@ -60,9 +60,9 @@ public:
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(120); }
 
 private:
-    void PairWithCode(NSError * error);
-    void PairWithIPAddress(NSError * error);
-    void Unpair(NSError * error);
+    void PairWithCode(NSError * __autoreleasing * error);
+    void PairWithIPAddress(NSError * __autoreleasing * error);
+    void Unpair(NSError * __autoreleasing * error);
     void SetUpPairingDelegate();
 
     const PairingMode mPairingMode;

--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
@@ -41,37 +41,31 @@ void PairingCommandBridge::SetUpPairingDelegate()
 CHIP_ERROR PairingCommandBridge::RunCommand()
 {
     NSError * error;
-    CHIP_ERROR err = CHIP_NO_ERROR;
     switch (mPairingMode) {
     case PairingMode::None:
-        Unpair(error);
-        err = [CHIPError errorToCHIPErrorCode:error];
-        SetCommandExitStatus(err);
-        return err;
+        Unpair(&error);
+        break;
     case PairingMode::QRCode:
     case PairingMode::ManualCode:
-        PairWithCode(error);
+        PairWithCode(&error);
         break;
     case PairingMode::Ethernet:
-        PairWithIPAddress(error);
+        PairWithIPAddress(&error);
         break;
     }
-    err = [CHIPError errorToCHIPErrorCode:error];
-    if (err != CHIP_NO_ERROR) {
-        ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(err));
-    }
-    return err;
+
+    return [CHIPError errorToCHIPErrorCode:error];
 }
 
-void PairingCommandBridge::PairWithCode(NSError * error)
+void PairingCommandBridge::PairWithCode(NSError * __autoreleasing * error)
 {
     NSString * payload = [NSString stringWithUTF8String:mOnboardingPayload];
 
     SetUpPairingDelegate();
-    [CurrentCommissioner() pairDevice:mNodeId onboardingPayload:payload error:&error];
+    [CurrentCommissioner() pairDevice:mNodeId onboardingPayload:payload error:error];
 }
 
-void PairingCommandBridge::PairWithIPAddress(NSError * error)
+void PairingCommandBridge::PairWithIPAddress(NSError * __autoreleasing * error)
 {
     SetUpPairingDelegate();
     [CurrentCommissioner() pairDevice:mNodeId
@@ -79,11 +73,7 @@ void PairingCommandBridge::PairWithIPAddress(NSError * error)
                                  port:mRemotePort
                         discriminator:mDiscriminator
                          setupPINCode:mSetupPINCode
-                                error:&error];
+                                error:error];
 }
 
-void PairingCommandBridge::Unpair(NSError * error)
-{
-    [CurrentCommissioner() unpairDevice:mNodeId error:&error];
-    NSLog(@"Upairing error: %@", error);
-}
+void PairingCommandBridge::Unpair(NSError * __autoreleasing * error) { [CurrentCommissioner() unpairDevice:mNodeId error:error]; }

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
@@ -20,34 +20,30 @@
 #import <CHIP/CHIPError_Internal.h>
 
 @interface CHIPToolPairingDelegate ()
-@property (nonatomic, strong) CHIPBasic * cluster;
-@property (nonatomic, strong) ResponseHandler responseHandler;
 @end
+
 @implementation CHIPToolPairingDelegate
 - (void)onPairingComplete:(NSError *)error
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+    ChipLogProgress(chipTool, "Pairing Complete: %s", chip::ErrorStr(err));
 
-    NSLog(@"Pairing Complete: %@", error);
-    err = [CHIPError errorToCHIPErrorCode:error];
     _commandBridge->SetCommandExitStatus(err);
 }
 
 - (void)onPairingDeleted:(NSError *)error
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+    ChipLogProgress(chipTool, "Pairing Delete: %s", chip::ErrorStr(err));
 
-    NSLog(@"Pairing Deleted: %@", error);
-    err = [CHIPError errorToCHIPErrorCode:error];
     _commandBridge->SetCommandExitStatus(err);
 }
 
 - (void)onCommissioningComplete:(NSError *)error
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+    ChipLogProgress(chipTool, "Pairing Commissioning Complete: %s", chip::ErrorStr(err));
 
-    NSLog(@"Pairing Commissioning Complete: %@", error);
-    err = [CHIPError errorToCHIPErrorCode:error];
     _commandBridge->SetCommandExitStatus(err);
 }
 


### PR DESCRIPTION
…tead of a copy, and add a few more error checks when starting up the controller

#### Problem

When running `./out/debug/standalone/chip-tool-darwin pairing qrcode 0x12345 this_is_an_invalid_qrcode` there is no error.

#### Change overview
 * Get the error to be pass by reference instead of value
 * Add a few more error checks for the controller startup 
 
#### Testing
Checked locally by fixing the code until `./out/debug/standalone/chip-tool-darwin pairing qrcode 0x12345 this_is_an_invalid_qrcode` returns an error...