### PR TITLE
[ESP32] Parse OTA image header

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -789,8 +789,11 @@ menu "CHIP Device Layer"
             string "OTA image creator extra arguments"
             depends on CHIP_OTA_IMAGE_BUILD
             help
-              This option allows one to pass optional arguments to the ota_image_tool.py script,
-              used for building OTA image with Matter OTA header.
+              ota_image_tool.py is used to create the OTA image.
+              Mandatory arguments(Version, VersionString, VID, PID) are picked up from the config options.
+              This option allows us to pass optional arguments(MinApplicableSoftwareVersion, MaxApplicableSoftwareVersion,
+              and ReleaseNotesURL) to the ota_image_tool.py script.
+              eg: "-mi 2 -ma 4 -rn https://github.com/espressif/esp-idf/releases/tag/v4.4"
 
     endmenu
 

--- a/config/esp32/components/chip/ota-image.cmake
+++ b/config/esp32/components/chip/ota-image.cmake
@@ -43,7 +43,7 @@ function(chip_ota_image TARGET_NAME)
         "sha256"
     )
 
-    separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CHIP_OTA_IMAGE_EXTRA_ARGS}")
+    separate_arguments(OTA_EXTRA_ARGS NATIVE_COMMAND "${CONFIG_CHIP_OTA_IMAGE_EXTRA_ARGS}")
 
     list(APPEND OTA_ARGS ${OTA_EXTRA_ARGS})
     list(APPEND OTA_ARGS ${ARG_INPUT_FILES})
@@ -60,6 +60,5 @@ function(chip_ota_image TARGET_NAME)
 
     add_custom_target(${TARGET_NAME} ALL
         COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/src/app/ota_image_tool.py create @${BUILD_DIR}/args-ota-image.tmp
-        COMMAND ${CMAKE_COMMAND} -E remove ${BUILD_DIR}/args-ota-image.tmp
     )
 endfunction()

--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -63,3 +63,18 @@ application of OTA image.
 ```
 ./out/debug/chip-tool pairing onnetwork 12345 20202021
 ```
+
+## Generate OTA image
+
+User can generate the Matter OTA image by simply enabling
+`CONFIG_CHIP_OTA_IMAGE_BUILD` config option. OTA image is generated in `build`
+directory with name `<project name>-ota.bin`. This image then can be used with
+OTA Provider Application.
+
+Please make sure that version number is set to correct value. Use
+`CONFIG_DEVICE_SOFTWARE_VERSION` and `CONFIG_DEVICE_SOFTWARE_VERSION_NUMBER`
+config options for setting software version.
+
+Matter OTA image can also be generated using
+[ota_image_tool.py](https://github.com/project-chip/connectedhomeip/blob/master/src/app/ota_image_tool.py)
+script.

--- a/src/platform/ESP32/OTAImageProcessorImpl.h
+++ b/src/platform/ESP32/OTAImageProcessorImpl.h
@@ -19,6 +19,7 @@
 
 #include "esp_ota_ops.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <lib/core/OTAImageHeader.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OTAImageProcessor.h>
 
@@ -44,11 +45,13 @@ private:
 
     CHIP_ERROR SetBlock(ByteSpan & block);
     CHIP_ERROR ReleaseBlock();
+    CHIP_ERROR ProcessHeader(ByteSpan & block);
 
     OTADownloader * mDownloader = nullptr;
     MutableByteSpan mBlock;
     const esp_partition_t * mOTAUpdatePartition = nullptr;
     esp_ota_handle_t mOTAUpdateHandle;
+    OTAImageHeaderParser mHeaderParser;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
ESP32 OTA image processor do not handle the Matter OTA images.

#### Change overview
* Parse Matter compliant OTA image.
* Also, addressed after merge comment from #14835

#### Testing
Built the OTA image by bumping the software version and provided that images to ota-provider-app/linux app. ESP32 booted with the latest image.