### PR TITLE
Use struct mallinfo when __GLIBC__ is defined

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -218,6 +218,9 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
+#ifndef __GLIBC__
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#else
     struct mallinfo mallocInfo = mallinfo();
 
     // Get the current amount of heap memory, in bytes, that are not being utilized
@@ -225,10 +228,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeap
     currentHeapFree = mallocInfo.fordblks;
 
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeapUsed)
 {
+#ifndef __GLIBC__
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#else
     struct mallinfo mallocInfo = mallinfo();
 
     // Get the current amount of heap memory, in bytes, that are being used by
@@ -236,10 +243,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeap
     currentHeapUsed = mallocInfo.uordblks;
 
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
 {
+#ifndef __GLIBC__
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#else
     struct mallinfo mallocInfo = mallinfo();
 
     // The usecase of this function is embedded devices,on which we would need to intercept
@@ -252,6 +263,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     currentHeapHighWatermark = mallocInfo.uordblks;
 
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadMetricsOut)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #9906 Linux build fails with musl libc because struct mallinfo is not available.

#### Change overview
Struct mallinfo is not available with musl libc. Work around the issue
by building source code that uses mallinfo only when __GLIBC__ is
defined.

#### Testing
Manual testing using yocto linux toolchain.
