### PR TITLE
Group Data Provider: Security Policy returned by the GroupSessionIter…

### DIFF
--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -31,6 +31,8 @@ namespace Credentials {
 class GroupDataProvider
 {
 public:
+    using SecurityPolicy = app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy;
+
     struct GroupInfo
     {
         static constexpr size_t kGroupNameMax = CHIP_CONFIG_MAX_GROUP_NAME_LENGTH;
@@ -108,6 +110,7 @@ public:
         GroupSession()   = default;
         GroupId group_id = kUndefinedGroupId;
         FabricIndex fabric_index;
+        SecurityPolicy security_policy;
         Crypto::SymmetricKeyContext * key = nullptr;
     };
 
@@ -126,7 +129,6 @@ public:
     struct KeySet
     {
         static constexpr size_t kEpochKeysMax = 3;
-        using SecurityPolicy                  = app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy;
 
         KeySet() = default;
         KeySet(uint16_t id, SecurityPolicy policy_id, uint8_t num_keys) : keyset_id(id), policy(policy_id), num_keys_used(num_keys)

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -717,14 +717,14 @@ struct KeySetData : PersistentData<kPersistentBufferMax>
     chip::KeysetId prev            = 0xffff;
     bool first                     = true;
 
-    uint16_t keyset_id            = 0;
-    KeySet::SecurityPolicy policy = KeySet::SecurityPolicy::kStandard;
-    uint8_t keys_count            = 0;
+    uint16_t keyset_id                       = 0;
+    GroupDataProvider::SecurityPolicy policy = GroupDataProvider::SecurityPolicy::kStandard;
+    uint8_t keys_count                       = 0;
     OperationalKey operational_keys[KeySet::kEpochKeysMax];
 
     KeySetData() = default;
     KeySetData(chip::FabricIndex fabric, chip::KeysetId id) : fabric_index(fabric) { keyset_id = id; }
-    KeySetData(chip::FabricIndex fabric, chip::KeysetId id, KeySet::SecurityPolicy policy_id, uint8_t num_keys) :
+    KeySetData(chip::FabricIndex fabric, chip::KeysetId id, GroupDataProvider::SecurityPolicy policy_id, uint8_t num_keys) :
         fabric_index(fabric), keyset_id(id), policy(policy_id), keys_count(num_keys)
     {}
 
@@ -738,7 +738,7 @@ struct KeySetData : PersistentData<kPersistentBufferMax>
 
     void Clear() override
     {
-        policy     = KeySet::SecurityPolicy::kStandard;
+        policy     = GroupDataProvider::SecurityPolicy::kStandard;
         keys_count = 0;
         memset(operational_keys, 0x00, sizeof(operational_keys));
         next = 0xffff;
@@ -1948,9 +1948,10 @@ bool GroupDataProviderImpl::GroupSessionIteratorImpl::Next(GroupSession & output
         if (key.hash == mSessionId)
         {
             mKeyContext.SetKey(ByteSpan(key.value, sizeof(key.value)), mSessionId);
-            output.fabric_index = fabric.fabric_index;
-            output.group_id     = mapping.group_id;
-            output.key          = &mKeyContext;
+            output.fabric_index    = fabric.fabric_index;
+            output.group_id        = mapping.group_id;
+            output.security_policy = keyset.policy;
+            output.key             = &mKeyContext;
             return true;
         }
     }

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -29,12 +29,13 @@
 #include <utility>
 
 using namespace chip::Credentials;
-using GroupInfo     = GroupDataProvider::GroupInfo;
-using GroupKey      = GroupDataProvider::GroupKey;
-using GroupEndpoint = GroupDataProvider::GroupEndpoint;
-using EpochKey      = GroupDataProvider::EpochKey;
-using KeySet        = GroupDataProvider::KeySet;
-using GroupSession  = GroupDataProvider::GroupSession;
+using GroupInfo      = GroupDataProvider::GroupInfo;
+using GroupKey       = GroupDataProvider::GroupKey;
+using GroupEndpoint  = GroupDataProvider::GroupEndpoint;
+using EpochKey       = GroupDataProvider::EpochKey;
+using KeySet         = GroupDataProvider::KeySet;
+using GroupSession   = GroupDataProvider::GroupSession;
+using SecurityPolicy = GroupDataProvider::SecurityPolicy;
 
 namespace chip {
 namespace app {
@@ -94,10 +95,10 @@ static const GroupKey kGroup3Keyset1(kGroup3, kKeysetId1);
 static const GroupKey kGroup3Keyset2(kGroup3, kKeysetId2);
 static const GroupKey kGroup3Keyset3(kGroup3, kKeysetId3);
 
-static KeySet kKeySet0(kKeysetId0, KeySet::SecurityPolicy::kStandard, 3);
-static KeySet kKeySet1(kKeysetId1, KeySet::SecurityPolicy::kLowLatency, 1);
-static KeySet kKeySet2(kKeysetId2, KeySet::SecurityPolicy::kLowLatency, 2);
-static KeySet kKeySet3(kKeysetId3, KeySet::SecurityPolicy::kStandard, 3);
+static KeySet kKeySet0(kKeysetId0, SecurityPolicy::kStandard, 3);
+static KeySet kKeySet1(kKeysetId1, SecurityPolicy::kLowLatency, 1);
+static KeySet kKeySet2(kKeysetId2, SecurityPolicy::kLowLatency, 2);
+static KeySet kKeySet3(kKeysetId3, SecurityPolicy::kStandard, 3);
 
 uint8_t kZeroKey[EpochKey::kLengthBytes] = { 0 };
 

--- a/src/lib/support/TestGroupData.h
+++ b/src/lib/support/TestGroupData.h
@@ -58,8 +58,8 @@ CHIP_ERROR InitGroupData()
 
     // Key Sets
 
-    chip::Credentials::GroupDataProvider::KeySet keyset1(
-        kKeySet1, chip::Credentials::GroupDataProvider::KeySet::SecurityPolicy::kStandard, 3);
+    chip::Credentials::GroupDataProvider::KeySet keyset1(kKeySet1, chip::Credentials::GroupDataProvider::SecurityPolicy::kStandard,
+                                                         3);
     const chip::Credentials::GroupDataProvider::EpochKey epoch_keys1[] = {
         { 1110000, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
         { 1110001, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
@@ -69,8 +69,8 @@ CHIP_ERROR InitGroupData()
     CHIP_ERROR err = sGroupsProvider.SetKeySet(kFabric1, keyset1);
     ReturnErrorOnFailure(err);
 
-    chip::Credentials::GroupDataProvider::KeySet keyset2(
-        kKeySet2, chip::Credentials::GroupDataProvider::KeySet::SecurityPolicy::kStandard, 3);
+    chip::Credentials::GroupDataProvider::KeySet keyset2(kKeySet2, chip::Credentials::GroupDataProvider::SecurityPolicy::kStandard,
+                                                         3);
     const chip::Credentials::GroupDataProvider::EpochKey epoch_keys2[] = {
         { 2220000, { 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf } },
         { 2220001, { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef } },


### PR DESCRIPTION
#### Problem
Currently the decryption key's security policy is not accessible, and it is required by the implementation of MCSP.

#### Change overview
* Security policy is now exposed by the GroupSessionIterator

#### Testing
Project built successfully.
Group-related tests ran successfully.
