### PR TITLE
Use PasscodeId in NodeId functions

### DIFF
--- a/src/lib/core/NodeId.h
+++ b/src/lib/core/NodeId.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <lib/core/GroupId.h>
+#include <lib/core/PasscodeId.h>
 
 #include <cstdint>
 
@@ -79,12 +80,12 @@ constexpr NodeId NodeIdFromGroupId(GroupId aGroupId)
     return kMinGroupNodeId | aGroupId;
 }
 
-constexpr NodeId NodeIdFromPAKEKeyId(uint16_t aPAKEKeyId)
+constexpr NodeId NodeIdFromPAKEKeyId(PasscodeId aPAKEKeyId)
 {
     return kMinPAKEKeyId | aPAKEKeyId;
 }
 
-constexpr uint16_t PAKEKeyIdFromNodeId(NodeId aNodeId)
+constexpr PasscodeId PAKEKeyIdFromNodeId(NodeId aNodeId)
 {
     return aNodeId & kMaskPAKEKeyId;
 }


### PR DESCRIPTION
#### Problem
Couple functions in NodeId.h still use uint16_t
instead of PasscodeId type.

#### Change overview
Use PasscodeId type instead of uint16_t

Part of issue #14439

#### Testing
Built on Linux
