### PR TITLE
Print Long Manual setup code

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -698,17 +698,7 @@ extern "C" void app_main()
             ->Item("QR Code",
                    [=]() {
                        ESP_LOGI(TAG, "Opening QR code screen");
-                       ESP_LOGI(TAG, "QR CODE Text: '%s'", qrCodeText.c_str());
-                       uint16_t discriminator;
-                       if (ConfigurationMgr().GetSetupDiscriminator(discriminator) == CHIP_NO_ERROR)
-                       {
-                           ESP_LOGI(TAG, "Setup discriminator: %u (0x%x)", discriminator, discriminator);
-                       }
-                       uint32_t setupPINCode;
-                       if (ConfigurationMgr().GetSetupPinCode(setupPINCode) == CHIP_NO_ERROR)
-                       {
-                           ESP_LOGI(TAG, "Setup PIN code: %u (0x%x)", setupPINCode, setupPINCode);
-                       }
+                       PrintOnboardingCodes(chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
                        ScreenManager::PushScreen(chip::Platform::New<QRCodeScreen>(qrCodeText));
                    })
             ->Item("Setup",

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -36,43 +36,15 @@ using namespace ::chip::DeviceLayer;
 
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    std::string qrCode;
-    std::string manualPairingCode;
+    chip::SetupPayload payload;
 
-    if (GetQRCode(qrCode, aRendezvousFlags) == CHIP_NO_ERROR)
+    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    if (err != CHIP_NO_ERROR)
     {
-        chip::Platform::ScopedMemoryBuffer<char> qrCodeBuffer;
-        const size_t qrCodeBufferMaxSize = strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + 3 * qrCode.size() + 1;
-        qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
-
-        ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.c_str());
-        if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
-        {
-            ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:\r\n    %s", qrCodeBuffer.Get());
-        }
-    }
-    else
-    {
-        ChipLogError(AppServer, "Getting QR code failed!");
+        ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
     }
 
-    if (GetManualPairingCode(manualPairingCode, aRendezvousFlags) == CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "Manual pairing code: [%s]", manualPairingCode.c_str());
-    }
-    else
-    {
-        ChipLogError(AppServer, "Getting manual pairing code failed!");
-    }
-
-    if (GetLongManualPairingCode(manualPairingCode, aRendezvousFlags) == CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "Long manual pairing code: [%s]", manualPairingCode.c_str());
-    }
-    else
-    {
-        ChipLogError(AppServer, "Getting long manual pairing code failed!");
-    }
+    PrintOnboardingCodes(payload);
 }
 
 void PrintOnboardingCodes(const chip::SetupPayload & payload)
@@ -105,6 +77,15 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
     else
     {
         ChipLogError(AppServer, "Getting manual pairing code failed!");
+    }
+
+    if (GetLongManualPairingCode(manualPairingCode, payload) == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "Long manual pairing code: [%s]", manualPairingCode.c_str());
+    }
+    else
+    {
+        ChipLogError(AppServer, "Getting long manual pairing code failed!");
     }
 }
 
@@ -167,20 +148,13 @@ CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRe
         return err;
     }
 
-    // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
-    // generating payload
-    err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "Generating QR Code failed: %s", chip::ErrorStr(err));
-        return err;
-    }
-
-    return CHIP_NO_ERROR;
+    return GetQRCode(aQRCode, payload);
 }
 
 CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload)
 {
+    // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
+    // generating payload
     CHIP_ERROR err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
     if (err != CHIP_NO_ERROR)
     {
@@ -215,18 +189,10 @@ CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::Rendezvo
         ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
         return err;
     }
-
-    err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "Generating Manual Pairing Code failed: %s", chip::ErrorStr(err));
-        return err;
-    }
-
-    return CHIP_NO_ERROR;
+    return GetManualPairingCode(aManualPairingCode, payload);
 }
 
-CHIP_ERROR GetLongManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
+CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
 {
     chip::SetupPayload payload;
 
@@ -236,9 +202,15 @@ CHIP_ERROR GetLongManualPairingCode(std::string & aManualPairingCode, chip::Rend
         ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
         return err;
     }
-
+    // TODO: Why is this being set to custom?
     payload.commissioningFlow = chip::CommissioningFlow::kCustom;
-    err                       = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);
+    return GetLongManualPairingCode(aLongManualPairingCode, payload);
+}
+
+CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, const chip::SetupPayload & payload)
+{
+
+    CHIP_ERROR err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aLongManualPairingCode);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(AppServer, "Generating long manual pairing code failed: %s", chip::ErrorStr(err));

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -26,7 +26,8 @@ CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRe
 CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetLongManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 


### PR DESCRIPTION
#### Problem
Long manual code wasn't printed at startup on all clusters app or from QR code screen on M5. Also lots of code duplication.

#### Change overview
- add print of long manual code for the setup payload print function
- removed duplicated code
- change QR code screen on M5 all clusters app to use the util file.

#### Testing
Linux and M5 all clusters app - see prints at start. M5 all clusters app - see print from QR code screen.
