### PR TITLE
Add ability to keep several IP addresses per PeerAddress

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -92,7 +92,7 @@ void CASESessionManager::OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeDa
     VerifyOrReturn(session != nullptr,
                    ChipLogDetail(Controller, "OnNodeIdResolved was called for a device with no active sessions, ignoring it."));
 
-    LogErrorOnFailure(session->UpdateDeviceData(session->ToPeerAddress(nodeData), nodeData.GetMRPConfig()));
+    LogErrorOnFailure(session->UpdateDeviceData(OperationalDeviceProxy::ToPeerAddress(nodeData), nodeData.GetMRPConfig()));
 }
 
 void CASESessionManager::OnNodeIdResolutionFailed(const PeerId & peer, CHIP_ERROR error)

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -196,7 +196,9 @@ public:
             if (err != CHIP_NO_ERROR)
             {
                 char addr_str[Inet::IPAddress::kMaxStringLength];
-                ChipLogError(Controller, "Could not append IP address %s: %s", addr.ToString(addr_str), err.AsString());
+                addr.ToString(addr_str);
+
+                ChipLogError(Controller, "Could not append IP address %s: %s", addr_str, err.AsString());
             }
         }
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -178,8 +178,6 @@ public:
 
     static Transport::PeerAddress ToPeerAddress(const Dnssd::ResolvedNodeData & nodeData)
     {
-        // TODO: this is copied & pasted in CHIPDeviceController.cpp.
-        //       There should be a single place of implementation for things.
         Transport::PeerAddress address = Transport::PeerAddress(Transport::Type::kUdp);
         address.SetPort(nodeData.mPort);
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -178,19 +178,31 @@ public:
 
     static Transport::PeerAddress ToPeerAddress(const Dnssd::ResolvedNodeData & nodeData)
     {
-        Inet::InterfaceId interfaceId = Inet::InterfaceId::Null();
+        // TODO: this is copied & pasted in CHIPDeviceController.cpp.
+        //       There should be a single place of implementation for things.
+        Transport::PeerAddress address = Transport::PeerAddress(Transport::Type::kUdp);
+        address.SetPort(nodeData.mPort);
 
-        // TODO - Revisit usage of InterfaceID only for addresses that are IPv6 LLA
-        // Only use the DNS-SD resolution's InterfaceID for addresses that are IPv6 LLA.
-        // For all other addresses, we should rely on the device's routing table to route messages sent.
-        // Forcing messages down an InterfaceId might fail. For example, in bridged networks like Thread,
-        // mDNS advertisements are not usually received on the same interface the peer is reachable on.
-        if (nodeData.mAddress[0].IsIPv6LinkLocal())
+        for (unsigned i = 0; i < nodeData.mNumIPs; i++)
         {
-            interfaceId = nodeData.mInterfaceId;
+            const auto addr = nodeData.mAddress[i];
+            // Only use the mDNS resolution's InterfaceID for addresses that are IPv6 LLA.
+            // For all other addresses, we should rely on the device's routing table to route messages sent.
+            // Forcing messages down an InterfaceId might fail. For example, in bridged networks like Thread,
+            // mDNS advertisements are not usually received on the same interface the peer is reachable on.
+            // TODO: Right now, just use addr0, but we should really push all the addresses and interfaces to
+            // the device and allow it to make a proper decision about which addresses are preferred and reachable.
+            CHIP_ERROR err = address.AppendDestination(nodeData.mAddress[i],
+                                                       addr.IsIPv6LinkLocal() ? nodeData.mInterfaceId : Inet::InterfaceId::Null());
+
+            if (err != CHIP_NO_ERROR)
+            {
+                char addr_str[Inet::IPAddress::kMaxStringLength];
+                ChipLogError(Controller, "Could not append IP address %s: %s", addr.ToString(addr_str), err.AsString());
+            }
         }
 
-        return Transport::PeerAddress::UDP(nodeData.mAddress[0], nodeData.mPort, interfaceId);
+        return address;
     }
 
 private:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -639,12 +639,12 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     mUdcTransportMgr = chip::Platform::New<DeviceIPTransportMgr>();
     ReturnErrorOnFailure(mUdcTransportMgr->Init(Transport::UdpListenParameters(mSystemState->UDPEndPointManager())
                                                     .SetAddressType(Inet::IPAddressType::kIPv6)
-                                                    .SetListenPort((uint16_t) (mUdcListenPort))
+                                                    .SetListenPort((uint16_t)(mUdcListenPort))
 #if INET_CONFIG_ENABLE_IPV4
                                                     ,
                                                 Transport::UdpListenParameters(mSystemState->UDPEndPointManager())
                                                     .SetAddressType(Inet::IPAddressType::kIPv4)
-                                                    .SetListenPort((uint16_t) (mUdcListenPort))
+                                                    .SetListenPort((uint16_t)(mUdcListenPort))
 #endif // INET_CONFIG_ENABLE_IPV4
                                                     ));
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -554,32 +554,6 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowInternal()
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-Transport::PeerAddress DeviceController::ToPeerAddress(const chip::Dnssd::ResolvedNodeData & nodeData)
-{
-    Transport::PeerAddress address = Transport::PeerAddress(Transport::Type::kUdp);
-    address.SetPort(nodeData.mPort);
-
-    for (unsigned i = 0; i < nodeData.mNumIPs; i++)
-    {
-        const auto addr = nodeData.mAddress[i];
-        // Only use the mDNS resolution's InterfaceID for addresses that are IPv6 LLA.
-        // For all other addresses, we should rely on the device's routing table to route messages sent.
-        // Forcing messages down an InterfaceId might fail. For example, in bridged networks like Thread,
-        // mDNS advertisements are not usually received on the same interface the peer is reachable on.
-        // TODO: Right now, just use addr0, but we should really push all the addresses and interfaces to
-        // the device and allow it to make a proper decision about which addresses are preferred and reachable.
-        CHIP_ERROR err = address.AppendDestination(nodeData.mAddress[i],
-                                                   addr.IsIPv6LinkLocal() ? nodeData.mInterfaceId : Inet::InterfaceId::Null());
-
-        if (err != CHIP_NO_ERROR)
-        {
-            char addr_str[Inet::IPAddress::kMaxStringLength];
-            ChipLogError(Controller, "Could not append IP address %s: %s", addr.ToString(addr_str), err.AsString());
-        }
-    }
-
-    return address;
-}
 
 void DeviceController::OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData)
 {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -353,8 +353,6 @@ protected:
 
     PersistentStorageDelegate * mStorageDelegate = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    static Transport::PeerAddress ToPeerAddress(const chip::Dnssd::ResolvedNodeData & nodeData);
-
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
     // TODO(cecille): Make this configuarable.
     static constexpr int kMaxCommissionableNodes = 10;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -353,7 +353,7 @@ protected:
 
     PersistentStorageDelegate * mStorageDelegate = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    Transport::PeerAddress ToPeerAddress(const chip::Dnssd::ResolvedNodeData & nodeData) const;
+    static Transport::PeerAddress ToPeerAddress(const chip::Dnssd::ResolvedNodeData & nodeData);
 
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
     // TODO(cecille): Make this configuarable.

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -216,7 +216,7 @@ public:
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }
 
-    void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
+    void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetSingleIPAddress(deviceAddr); }
 
     PASESession & GetPairing() { return mPairing; }
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -324,7 +324,7 @@ ChipError::StorageType pychip_DeviceController_ConnectIP(chip::Controller::Devic
     VerifyOrReturnError(chip::Inet::IPAddress::FromString(peerAddrStr, peerAddr), CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
 
     // TODO: IP rendezvous should use TCP connection.
-    addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr);
+    addr.SetTransportType(chip::Transport::Type::kUdp).SetSingleIPAddress(peerAddr);
     params.SetPeerAddress(addr).SetDiscriminator(0);
 
     devCtrl->ReleaseOperationalDevice(nodeid);

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -380,7 +380,7 @@ ChipError::StorageType pychip_DeviceController_EstablishPASESessionIP(chip::Cont
     chip::Transport::PeerAddress addr;
     RendezvousParameters params = chip::RendezvousParameters().SetSetupPINCode(setupPINCode);
     VerifyOrReturnError(chip::Inet::IPAddress::FromString(peerAddrStr, peerAddr), CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr);
+    addr.SetTransportType(chip::Transport::Type::kUdp).SetSingleIPAddress(peerAddr);
     params.SetPeerAddress(addr).SetDiscriminator(0);
     return devCtrl->EstablishPASEConnection(nodeid, params).AsInteger();
 }

--- a/src/transport/raw/BUILD.gn
+++ b/src/transport/raw/BUILD.gn
@@ -22,6 +22,7 @@ static_library("raw") {
     "Base.h",
     "MessageHeader.cpp",
     "MessageHeader.h",
+    "PeerAddress.cpp",
     "PeerAddress.h",
     "TCP.cpp",
     "TCP.h",

--- a/src/transport/raw/PeerAddress.cpp
+++ b/src/transport/raw/PeerAddress.cpp
@@ -30,8 +30,7 @@ namespace {
 ///
 /// Examples:
 ///    NONE:123                      // when addresses are empty
-///    NONE%eth0:5040                // addresses are empty but interface is set to something
-///    10.20.30.40:5040              // exactly one IP address in the address list, interface is empty
+///    10.20.30.40:5040              // exactly one IP address in the destination list with null interface
 ///    10.0.0.10%wlan0:123 (+3 more) // 4 input addresses in the list
 /// <ip>%<iface>:port
 void AddIpInfo(StringBuilderBase & dest, uint16_t port, Span<const PeerAddress::IPDestination> destinations)

--- a/src/transport/raw/PeerAddress.cpp
+++ b/src/transport/raw/PeerAddress.cpp
@@ -1,0 +1,119 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "PeerAddress.h"
+
+#include <lib/support/StringBuilder.h>
+
+namespace chip {
+namespace Transport {
+
+namespace {
+
+/// Formats IP addresses into a format suitable for PeerAddress::ToString
+/// Specifically it will add the first IP address, interface used and port
+/// and a marker if more than one IP address is contained in the input list
+///
+/// Examples:
+///    NONE:123                      // when addresses are empty
+///    NONE%eth0:5040                // addresses are empty but interface is set to something
+///    10.20.30.40:5040              // exactly one IP address in the address list, interface is empty
+///    10.0.0.10%wlan0:123 (+3 more) // 4 input addresses in the list
+/// <ip>%<iface>:port
+void AddIpInfo(StringBuilderBase & dest, const char * interface, uint16_t port, Span<const Inet::IPAddress> addresses)
+{
+    if (addresses.empty())
+    {
+        dest.Add("NONE:");
+    }
+    else
+    {
+        // First address information.
+        //
+        // In time, peer addresses should have an 'active address' to determine  which IP is
+        // used to communicate with peers, in which case the output here should be the current
+        // active address rather than just the first in the list.
+        dest.Add(":");
+        char ip_addr[Inet::IPAddress::kMaxStringLength];
+        auto first = addresses.begin();
+        first->ToString(ip_addr);
+        if (first->IsIPv6())
+        {
+            dest.Add("[");
+        }
+        dest.Add(ip_addr);
+        dest.Add(interface);
+        if (first->IsIPv6())
+        {
+            dest.Add("]");
+        }
+        dest.Add(":");
+        dest.Add(port);
+    }
+
+    if (addresses.size() > 1)
+    {
+        dest.Add(" (+");
+        dest.Add(static_cast<int>(addresses.size() - 1));
+        dest.Add(" more)");
+    }
+}
+
+} // namespace
+
+void PeerAddress::ToString(char * buf, size_t bufSize) const
+{
+
+    char interface[Inet::InterfaceId::kMaxIfNameLength + 1] = {}; // +1 to prepend '%'
+    if (mInterface.IsPresent())
+    {
+        interface[0]   = '%';
+        interface[1]   = 0;
+        CHIP_ERROR err = mInterface.GetInterfaceName(interface + 1, sizeof(interface) - 1);
+        if (err != CHIP_NO_ERROR)
+        {
+            Platform::CopyString(interface, sizeof(interface), "%(err)");
+        }
+    }
+
+    StringBuilderBase out(buf, bufSize);
+
+    switch (mTransportType)
+    {
+    case Type::kUndefined:
+        out.Add("UNDEFINED");
+        break;
+    case Type::kUdp:
+        out.Add("UDP:");
+        AddIpInfo(out, interface, mPort, Span<const Inet::IPAddress>(mIPAddresses, mNumValidIPAddresses));
+        break;
+    case Type::kTcp:
+        out.Add("TCP:");
+        AddIpInfo(out, interface, mPort, Span<const Inet::IPAddress>(mIPAddresses, mNumValidIPAddresses));
+        break;
+    case Type::kBle:
+        // Note that BLE does not currently use any specific address.
+        out.Add("BLE");
+        break;
+    default:
+        out.Add("ERROR");
+        break;
+    }
+}
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/raw/PeerAddress.cpp
+++ b/src/transport/raw/PeerAddress.cpp
@@ -104,11 +104,11 @@ void PeerAddress::ToString(char * buf, size_t bufSize) const
         out.Add("UNDEFINED");
         break;
     case Type::kUdp:
-        out.Add("UDP:");
+        out.Add("UDP");
         AddIpInfo(out, mPort, Span<const IPDestination>(mDestinations, mNumValidDestinations));
         break;
     case Type::kTcp:
-        out.Add("TCP:");
+        out.Add("TCP");
         AddIpInfo(out, mPort, Span<const IPDestination>(mDestinations, mNumValidDestinations));
         break;
     case Type::kBle:

--- a/src/transport/raw/PeerAddress.cpp
+++ b/src/transport/raw/PeerAddress.cpp
@@ -37,7 +37,7 @@ void AddIpInfo(StringBuilderBase & dest, uint16_t port, Span<const PeerAddress::
 {
     if (destinations.empty())
     {
-        dest.Add("NONE:");
+        dest.Add(":NONE:");
     }
     else
     {
@@ -80,8 +80,8 @@ void AddIpInfo(StringBuilderBase & dest, uint16_t port, Span<const PeerAddress::
             dest.Add("]");
         }
         dest.Add(":");
-        dest.Add(port);
     }
+    dest.Add(port);
 
     if (destinations.size() > 1)
     {

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -192,8 +192,8 @@ public:
             return false;
         }
 
-        // NOTE: we do NOT try to oder IP addresses here, we check that the valid
-        // IP addresses are identical only.
+        // NOTE: we do NOT try to order/treat as a set all destinations here.
+        // Check that the valid destinations are identical only, including order.
         for (unsigned i = 0; i < mNumValidDestinations; i++)
         {
             if (mDestinations[i] != other.mDestinations[i])

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -85,7 +85,7 @@ public:
 
     // When using DNSSD, a peer may be discovered at multiple addresses.
     // This controls how many addresses can be kept.
-    static constexpr unsigned kMaxPeerDestinations = 5;
+    static constexpr unsigned kMaxPeerDestinations = 3;
 
     PeerAddress() : mTransportType(Type::kUndefined) {}
     PeerAddress(const Inet::IPAddress & addr, Type type) : mTransportType(type)

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -118,7 +118,7 @@ public:
     /// addresses
     CHIP_ERROR AppendDestination(const Inet::IPAddress & addr, const Inet::InterfaceId & interface)
     {
-        if (mNumValidDestinations < kMaxPeerDestinations)
+        if (mNumValidDestinations >= kMaxPeerDestinations)
         {
             return CHIP_ERROR_NO_MEMORY;
         }

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -118,7 +118,7 @@ public:
     /// addresses
     CHIP_ERROR AppendDestination(const Inet::IPAddress & addr, const Inet::InterfaceId & interface)
     {
-        if (mNumValidDestinations + 1 >= kMaxPeerDestinations)
+        if (mNumValidDestinations < kMaxPeerDestinations)
         {
             return CHIP_ERROR_NO_MEMORY;
         }

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -165,19 +165,6 @@ public:
         return *this;
     }
 
-    /// DEPRECATED: Setting this has several drawbacks:
-    ///   - IP address is not set (pair of IP + interface is not maintained as
-    ///     always a pair)
-    ///   - Nodes are generally expected to support multiple IP addresses when
-    ///     discovered using DNSSD.
-    PeerAddress & SetSingleInterface(Inet::InterfaceId interface)
-    {
-        // NOTE: mDestinations[0].ipAddress is NOT changed in any way
-        mDestinations[0].interface = interface;
-        mNumValidDestinations      = 1;
-        return *this;
-    }
-
     bool IsInitialized() const { return mTransportType != Type::kUndefined; }
 
     bool IsMulticast()

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -120,6 +120,22 @@ void TestToString(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+void TestAppendDestinationLimit(nlTestSuite * inSuite, void * inContext)
+{
+    IPAddress ip;
+    IPAddress::FromString("::1", ip);
+
+    PeerAddress udp = PeerAddress(Transport::Type::kUdp);
+    udp.SetPort(123);
+
+    for (unsigned i = 0; i < PeerAddress::kMaxPeerDestinations; i++)
+    {
+        NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == udp.AppendDestination(ip, InterfaceId::Null()));
+    }
+
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR != udp.AppendDestination(ip, InterfaceId::Null()));
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -129,6 +145,7 @@ const nlTest sTests[] =
 {
     NL_TEST_DEF("PeerAddress Multicast", TestPeerAddressMulticast),
     NL_TEST_DEF("ToString", TestToString),
+    NL_TEST_DEF("AppendDestination", TestAppendDestinationLimit),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -106,11 +106,9 @@ void TestToString(nlTestSuite * inSuite, void * inContext)
         udp.AppendDestination(ip, InterfaceId::Null());
         IPAddress::FromString("1223::3456:789a", ip);
         udp.AppendDestination(ip, InterfaceId::Null());
-        IPAddress::FromString("1223::3456:989a", ip);
-        udp.AppendDestination(ip, InterfaceId::Null());
 
         udp.ToString(buff);
-        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[::1]:5840 (+2 more)"));
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[::1]:5840 (+1 more)"));
     }
 
     {

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -79,6 +79,18 @@ void TestToString(nlTestSuite * inSuite, void * inContext)
     }
 
     {
+        IPAddress::FromString("::1", ip);
+        PeerAddress::TCP(ip, 1122).ToString(buff);
+
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "TCP:[::1]:1122"));
+    }
+
+    {
+        PeerAddress::BLE().ToString(buff);
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "BLE"));
+    }
+
+    {
         IPAddress::FromString("1223::3456:789a", ip);
         PeerAddress::UDP(ip, 8080).ToString(buff);
 

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -112,6 +112,14 @@ void TestToString(nlTestSuite * inSuite, void * inContext)
         udp.ToString(buff);
         NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[::1]:5840 (+2 more)"));
     }
+
+    {
+
+        PeerAddress udp = PeerAddress(Transport::Type::kUdp);
+        udp.SetPort(5840);
+        udp.ToString(buff);
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:NONE:5840"));
+    }
 }
 
 /**

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -37,16 +37,21 @@
 
 #include <nlunit-test.h>
 
+namespace {
+
 using namespace chip;
+using chip::Inet::InterfaceId;
+using chip::Inet::IPAddress;
+using chip::Transport::PeerAddress;
 
 /**
  *  Test correct identification of IPv6 multicast addresses.
  */
 void TestPeerAddressMulticast(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr chip::FabricId fabric   = 0xa1a2a4a8b1b2b4b8;
-    constexpr chip::GroupId group     = 0xe10f;
-    chip::Transport::PeerAddress addr = chip::Transport::PeerAddress::Multicast(fabric, group);
+    constexpr chip::FabricId fabric = 0xa1a2a4a8b1b2b4b8;
+    constexpr chip::GroupId group   = 0xe10f;
+    PeerAddress addr                = PeerAddress::Multicast(fabric, group);
     NL_TEST_ASSERT(inSuite, chip::Transport::Type::kUdp == addr.GetTransportType());
     NL_TEST_ASSERT(inSuite, addr.IsMulticast());
 
@@ -62,17 +67,55 @@ void TestPeerAddressMulticast(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !memcmp(expected, result, NL_INET_IPV6_ADDR_LEN_IN_BYTES));
 }
 
+void TestToString(nlTestSuite * inSuite, void * inContext)
+{
+    char buff[PeerAddress::kMaxToStringSize];
+    IPAddress ip;
+    {
+        IPAddress::FromString("::1", ip);
+        PeerAddress::UDP(ip, 1122).ToString(buff);
+
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[::1]:1122"));
+    }
+
+    {
+        IPAddress::FromString("1223::3456:789a", ip);
+        PeerAddress::UDP(ip, 8080).ToString(buff);
+
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[1223::3456:789a]:8080"));
+    }
+
+    {
+
+        PeerAddress udp = PeerAddress(Transport::Type::kUdp);
+        udp.SetPort(5840);
+
+        IPAddress::FromString("::1", ip);
+        udp.AppendDestination(ip, InterfaceId::Null());
+        IPAddress::FromString("1223::3456:789a", ip);
+        udp.AppendDestination(ip, InterfaceId::Null());
+        IPAddress::FromString("1223::3456:989a", ip);
+        udp.AppendDestination(ip, InterfaceId::Null());
+
+        udp.ToString(buff);
+        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[::1]:5840 (+2 more)"));
+    }
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
 
 // clang-format off
-static const nlTest sTests[] =
+const nlTest sTests[] =
 {
     NL_TEST_DEF("PeerAddress Multicast", TestPeerAddressMulticast),
+    NL_TEST_DEF("ToString", TestToString),
     NL_TEST_SENTINEL()
 };
 // clang-format on
+
+} // namespace
 
 int TestPeerAddress(void)
 {


### PR DESCRIPTION
#### Problem
DNSSD discovery will discover potentially more than one IP address, yet existing code always chosses the first one to connect to.

#### Change overview
Makes PeerAddress able to keep more 'valid destinations' for sending packets. Intent is in the future to be able to try multiple addresses when sending: if one path times out, instead of giving up we will be able to move to the next possible address.

This change only adds ability to keep track of addresess and marks one instance of 'SetAddress' which seems wrong (does not set interface) to be replaced in the future.

#### Testing
Built and commissioned an all-cluster-app (used devkitc + linux chiptool).