### PR TITLE
[TI] enable mtd builds

### DIFF
--- a/examples/lock-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/lock-app/cc13x2x7_26x2x7/chip.syscfg
@@ -138,12 +138,6 @@ TRNG1.$name     = "CONFIG_TRNG_0";
 TRNG2.$name     = "CONFIG_TRNG_1";
 TRNG3.$name     = "CONFIG_TRNG_APP";
 
-/* Thread */
-Thread.deviceType         = "ftd";
-Thread.deviceTypeReadOnly = true;
-/* Thread SysConfig generated sources are not used until the upstream modules
- * can be updated to enable CHIP.
- */
 RTOS.name = "FreeRTOS";
 
 /* BLE */

--- a/examples/persistent-storage/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/persistent-storage/cc13x2x7_26x2x7/chip.syscfg
@@ -136,12 +136,6 @@ TRNG1.$name     = "CONFIG_TRNG_0";
 TRNG2.$name     = "CONFIG_TRNG_1";
 TRNG3.$name     = "CONFIG_TRNG_APP";
 
-/* Thread */
-Thread.deviceType         = "ftd";
-Thread.deviceTypeReadOnly = true;
-/* Thread SysConfig generated sources are not used until the upstream modules
- * can be updated to enable CHIP.
- */
 RTOS.name = "FreeRTOS";
 
 /* BLE */

--- a/examples/platform/cc13x2_26x2/args.gni
+++ b/examples/platform/cc13x2_26x2/args.gni
@@ -16,7 +16,6 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/platform/cc13x2_26x2/args.gni")
 
-chip_openthread_ftd = true
 openthread_config_file = "<OpenThreadConfig.h>"
 openthread_core_config_deps = []
 

--- a/third_party/ti_simplelink_sdk/ti_simplelink_sdk.gni
+++ b/third_party/ti_simplelink_sdk/ti_simplelink_sdk.gni
@@ -20,6 +20,7 @@ import("//build_overrides/openthread.gni")
 import("//build_overrides/pigweed.gni")
 import("//build_overrides/ti_simplelink_sdk.gni")
 
+import("${chip_root}/src/platform/device.gni")
 import("${dir_pw_build}/python.gni")
 import("${freertos_root}/freertos.gni")
 import("${mbedtls_root}/mbedtls.gni")
@@ -230,10 +231,10 @@ template("ti_simplelink_sdk") {
     public_configs = [ ":${sdk_target_name}_config" ]
   }
 
-  if (ti_simplelink_device_family == "cc13x2_26x2") {
-    openthread_example = "cli_mtd"
-  } else if (ti_simplelink_device_family == "cc13x2x7_26x2x7") {
+  if (chip_openthread_ftd) {
     openthread_example = "cli_ftd"
+  } else {
+    openthread_example = "cli_mtd"
   }
 
   config("${sdk_target_name}_openthread_platform_config") {
@@ -290,12 +291,12 @@ template("ti_simplelink_sdk") {
       "${chip_root}/third_party/openthread/repo:openthread_config",
     ]
 
-    if (ti_simplelink_device_family == "cc13x2_26x2") {
-      public_configs +=
-          [ "${chip_root}/third_party/openthread/repo:openthread_mtd_config" ]
-    } else if (ti_simplelink_device_family == "cc13x2x7_26x2x7") {
+    if (chip_openthread_ftd) {
       public_configs +=
           [ "${chip_root}/third_party/openthread/repo:openthread_ftd_config" ]
+    } else {
+      public_configs +=
+          [ "${chip_root}/third_party/openthread/repo:openthread_mtd_config" ]
     }
   }
 


### PR DESCRIPTION
Use the chip option (`chip_openthread_ftd`) for OpenThread ftd/mtd selection on TI platforms.

#### Problem

The selection of a Full Thread Device versus a Minimal Thread device for TI platforms was done on the board level and could not be changed by an application.

#### Change overview

Modified the TI SimpleLink SDK BUILD.gn to use the platform `chip_openthread_ftd` configuration when selecting the OpenThread platform files to build

Removed redundant sysconfig options for Thread config generation.

#### Testing

Build tested with the normal options and adding `--args="chip_openthread_ftd=false"` to ensure building an MTD is possible.
