### PR TITLE
Allow Darwin framework errors to represend all IM errors.

### DIFF
--- a/src/app/data-model/Decode.h
+++ b/src/app/data-model/Decode.h
@@ -24,6 +24,7 @@
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/core/Optional.h>
+#include <protocols/interaction_model/Constants.h>
 
 namespace chip {
 namespace app {
@@ -161,7 +162,7 @@ CHIP_ERROR Decode(TLV::TLVReader & reader, Nullable<X> & x)
     ReturnErrorOnFailure(Decode(reader, x.SetNonNull()));
     if (!x.HasValidValue())
     {
-        return CHIP_ERROR_IM_CONSTRAINT_ERROR;
+        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -21,6 +21,7 @@
 #include <app/data-model/Nullable.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/core/Optional.h>
+#include <protocols/interaction_model/Constants.h>
 
 #include <type_traits>
 
@@ -123,7 +124,7 @@ CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, const Nullable<X> & x)
 #if !CONFIG_IM_BUILD_FOR_UNIT_TEST
     if (!x.HasValidValue())
     {
-        return CHIP_ERROR_IM_CONSTRAINT_ERROR;
+        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
     }
 #endif // !CONFIG_IM_BUILD_FOR_UNIT_TEST
     return Encode(writer, tag, x.Value());

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -106,7 +106,7 @@ private:
     void OnSubscriptionEstablished(uint64_t aSubscriptionId) override;
 
     void ReportError(CHIP_ERROR err);
-    void ReportError(EmberAfStatus status);
+    void ReportError(const StatusIB & status);
     void ReportError(NSError * _Nullable err);
 
 private:
@@ -223,7 +223,7 @@ void SubscriptionCallback::OnAttributeData(
     }
 
     if (aStatus.mStatus != Status::Success) {
-        ReportError(ToEmberAfStatus(aStatus.mStatus));
+        ReportError(aStatus);
         return;
     }
 
@@ -274,7 +274,7 @@ void SubscriptionCallback::OnSubscriptionEstablished(uint64_t aSubscriptionId)
 
 void SubscriptionCallback::ReportError(CHIP_ERROR err) { ReportError([CHIPError errorForCHIPErrorCode:err]); }
 
-void SubscriptionCallback::ReportError(EmberAfStatus status) { ReportError([CHIPError errorForZCLErrorCode:status]); }
+void SubscriptionCallback::ReportError(const StatusIB & status) { ReportError([CHIPError errorForIMStatus:status]); }
 
 void SubscriptionCallback::ReportError(NSError * _Nullable err)
 {

--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -20,9 +20,28 @@
 NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSErrorDomain const CHIPErrorDomain;
 
+FOUNDATION_EXPORT NSErrorDomain const MatterInteractionErrorDomain;
+
+/**
+ * ChipErrorDomain contains errors caused by data processing the framework
+ * itself is performing.  These can be caused by invalid values provided to a
+ * framework API, failure to decode an incoming message, and so forth.
+ *
+ * Errors reported by the other side of a Matter interaction use
+ * MatterInteractionErrorDomain instead.
+ */
 // clang-format off
 typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode){
-    CHIPErrorCodeUndefinedError       = 1,
+    /**
+     * CHIPErrorCodeGeneralError represents a generic Matter error with no
+     * further categorization.
+     *
+     * The userInfo will have a key named @"errorCode" whose value will be an
+     * integer representing the underlying Matter error code.  These integer
+     * values should not be assumed to be stable across releases, but may be
+     * useful in logging and debugging.
+     */
+    CHIPErrorCodeGeneralError         = 1,
     CHIPErrorCodeInvalidStringLength  = 2,
     CHIPErrorCodeInvalidIntegerValue  = 3,
     CHIPErrorCodeInvalidArgument      = 4,
@@ -30,16 +49,54 @@ typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode){
     CHIPErrorCodeInvalidState         = 6,
     CHIPErrorCodeWrongAddressType     = 7,
     CHIPErrorCodeIntegrityCheckFailed = 8,
-    CHIPErrorCodeDuplicateExists      = 9,
-    CHIPErrorCodeUnsupportedEndpoint  = 0x7F,
-    CHIPErrorCodeUnsupportedCommand   = 0x81,
-    CHIPErrorCodeInvalidCommand       = 0x85,
-    CHIPErrorCodeUnsupportedAttribute = 0x86,
-    CHIPErrorCodeConstraintError      = 0x87,
-    CHIPErrorCodeUnsupportedWrite     = 0x88,
-    CHIPErrorCodeNotFound             = 0x8B,
-    CHIPErrorCodeInvalidDataType      = 0x8D,
-    CHIPErrorCodeUnsupportedCluster   = 0xC3,
+};
+// clang-format on
+
+/**
+ * MatterInteractionErrorDomain contains errors that represent a Matter
+ * StatusIB error.  These represent errors reported by the other side of a
+ * Matter interaction.
+ *
+ * When the code is MatterInteractionErrorCodeFailure the userInfo may have a
+ * key named @"clusterStatus" whose value is the cluster-specific status that
+ * was reported.  This key will be absent if there was no cluster-specific
+ * status.
+ */
+// clang-format off
+typedef NS_ERROR_ENUM(MatterInteractionErrorDomain, MatterInteractionErrorCode){
+    // These values come from the general status code table in the Matter
+    // Interaction Model specification.  Do not change these values unless the
+    // specification changes.
+    MatterInteractionErrorCodeFailure                = 0x01,
+    MatterInteractionErrorCodeInvalidSubscription    = 0x7d,
+    MatterInteractionErrorCodeUnsupportedAccess      = 0x7e,
+    MatterInteractionErrorCodeUnsupportedEndpoint    = 0x7f,
+    MatterInteractionErrorCodeInvalidAction          = 0x80,
+    MatterInteractionErrorCodeUnsupportedCommand     = 0x81,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeInvalidCommand         = 0x85,
+    MatterInteractionErrorCodeUnsupportedAttribute   = 0x86,
+    MatterInteractionErrorCodeConstraintError        = 0x87,
+    MatterInteractionErrorCodeUnsupportedWrite       = 0x88,
+    MatterInteractionErrorCodeResourceExhausted      = 0x89,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeNotFound               = 0x8b,
+    MatterInteractionErrorCodeUnreportableAttribute  = 0x8c,
+    MatterInteractionErrorCodeInvalidDataType        = 0x8d,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeUnsupportedRead        = 0x8f,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeDataVersionMismatch    = 0x92,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeTimeout                = 0x94,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeBusy                   = 0x9c,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeUnsupportedCluster     = 0xc3,
+    // Gap in values is intentional.
+    MatterInteractionErrorCodeNoUpstreamSubscription = 0xc5,
+    MatterInteractionErrorCodeNeedsTimedInteraction  = 0xc6,
+    MatterInteractionErrorCodeUnsupportedEvent       = 0xc7,
 };
 // clang-format on
 

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -26,6 +26,8 @@
 
 NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
 
+NSString * const MatterInteractionErrorDomain = @"MatterInteractionErrorDomain";
+
 @implementation CHIPError
 
 + (NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
@@ -36,8 +38,7 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
 
     if (errorCode.IsIMStatus()) {
         chip::app::StatusIB status(errorCode);
-        // TODO: What about the cluster-specific part of the status?
-        return [CHIPError errorForZCLErrorCode:chip::app::ToEmberAfStatus(status.mStatus)];
+        return [CHIPError errorForIMStatus:status];
     }
 
     if (errorCode == CHIP_ERROR_INVALID_STRING_LENGTH) {
@@ -76,88 +77,147 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Integrity check failed.", nil) }];
     }
 
-    if (errorCode == CHIP_ERROR_IM_CONSTRAINT_ERROR) {
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeConstraintError
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Value out of range.", nil) }];
-    }
-
     return [NSError errorWithDomain:CHIPErrorDomain
-                               code:CHIPErrorCodeUndefinedError
+                               code:CHIPErrorCodeGeneralError
                            userInfo:@{
-                               NSLocalizedDescriptionKey :
-                                   [NSString stringWithFormat:NSLocalizedString(@"Undefined error:%u.", nil), errorCode.AsInteger()]
+                               NSLocalizedDescriptionKey : [NSString
+                                   stringWithFormat:NSLocalizedString(@"Undefined error:%u.", nil), errorCode.AsInteger()],
+                               @"errorCode" : @(errorCode.AsInteger()),
                            }];
     ;
 }
 
-+ (NSError *)errorForZCLErrorCode:(uint8_t)errorCode
++ (NSError *)errorForIMStatus:(const chip::app::StatusIB &)status
 {
-    switch (errorCode) {
-    case EMBER_ZCL_STATUS_DUPLICATE_EXISTS:
-        return [NSError
-            errorWithDomain:CHIPErrorDomain
-                       code:CHIPErrorCodeDuplicateExists
-                   userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A Duplicate entry or setting exists.", nil) }];
-    case EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT:
-        return
-            [NSError errorWithDomain:CHIPErrorDomain
-                                code:CHIPErrorCodeUnsupportedEndpoint
-                            userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Target endpoint does not exist.", nil) }];
-    case EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND:
-        return
-            [NSError errorWithDomain:CHIPErrorDomain
-                                code:CHIPErrorCodeUnsupportedCommand
-                            userInfo:@{
-                                NSLocalizedDescriptionKey : NSLocalizedString(@"Command is not supported on target cluster.", nil)
-                            }];
-    case EMBER_ZCL_STATUS_INVALID_COMMAND:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeInvalidCommand
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Command payload is invalid.", nil) }];
-    case EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeUnsupportedAttribute
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Attribute is not supported.", nil) }];
-    case EMBER_ZCL_STATUS_CONSTRAINT_ERROR:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeConstraintError
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Value out of range.", nil) }];
-    case EMBER_ZCL_STATUS_UNSUPPORTED_WRITE:
-        return [NSError
-            errorWithDomain:CHIPErrorDomain
-                       code:CHIPErrorCodeUnsupportedWrite
-                   userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Attempt to write read-only attribute.", nil) }];
-    case EMBER_ZCL_STATUS_NOT_FOUND:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeNotFound
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Data not found.", nil) }];
-    case EMBER_ZCL_STATUS_INVALID_DATA_TYPE:
-        return [NSError
-            errorWithDomain:CHIPErrorDomain
-                       code:CHIPErrorCodeInvalidDataType
-                   userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Data type is not correct for a field.", nil) }];
-    case EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER:
-        return
-            [NSError errorWithDomain:CHIPErrorDomain
-                                code:CHIPErrorCodeUnsupportedCluster
-                            userInfo:@{
-                                NSLocalizedDescriptionKey : NSLocalizedString(@"Cluster is not supported on target endpoint.", nil)
-                            }];
-    default:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeUndefinedError
-                               userInfo:@{
-                                   NSLocalizedDescriptionKey : [NSString
-                                       stringWithFormat:NSLocalizedString(@"Undefined data model error:%u.", nil), errorCode]
-                               }];
+    if (status.IsSuccess()) {
+        return nil;
     }
+
+    NSString * description;
+    using chip::Protocols::InteractionModel::Status;
+    switch (status.mStatus) {
+    case Status::Failure:
+    default: {
+        description = NSLocalizedString(@"Operation was not successful.", nil);
+        break;
+    }
+    case Status::InvalidSubscription: {
+        description = NSLocalizedString(@"Subscription ID is not active.", nil);
+        break;
+    }
+    case Status::UnsupportedAccess: {
+        description = NSLocalizedString(@"The sender of the action or command does not have authorization or access.", nil);
+        break;
+    }
+    case Status::UnsupportedEndpoint: {
+        description = NSLocalizedString(@"The endpoint indicated is unsupported on the node.", nil);
+        break;
+    }
+    case Status::InvalidAction: {
+        description = NSLocalizedString(
+            @"The action is malformed, has missing fields, or fields with invalid values. Action not carried out.", nil);
+        break;
+    }
+    case Status::UnsupportedCommand: {
+        description = NSLocalizedString(
+            @"The specified action or command indicated is not supported on the device. Command or action not carried out.", nil);
+        break;
+    }
+    case Status::InvalidCommand: {
+        description = NSLocalizedString(
+            @"The cluster command is malformed, has missing fields, or fields with invalid values. Command not carried out.", nil);
+        break;
+    }
+    case Status::UnsupportedAttribute: {
+        description
+            = NSLocalizedString(@"The specified attribute or attribute data field or entry does not exist on the device.", nil);
+        break;
+    }
+    case Status::ConstraintError: {
+        description = NSLocalizedString(@"Out of range error or set to a reserved value.", nil);
+        break;
+    }
+    case Status::UnsupportedWrite: {
+        description = NSLocalizedString(@"Attempt to write a read-only attribute.", nil);
+        break;
+    }
+    case Status::ResourceExhausted: {
+        description = NSLocalizedString(@"An action or operation failed due to insufficient available resources. ", nil);
+        break;
+    }
+    case Status::NotFound: {
+        description = NSLocalizedString(@"The indicated data field or entry could not be found.", nil);
+        break;
+    }
+    case Status::UnreportableAttribute: {
+        description = NSLocalizedString(@"Reports cannot be issued for this attribute.", nil);
+        break;
+    }
+    case Status::InvalidDataType: {
+        description = NSLocalizedString(
+            @"The data type indicated is undefined or invalid for the indicated data field. Command or action not carried out.",
+            nil);
+        break;
+    }
+    case Status::UnsupportedRead: {
+        description = NSLocalizedString(@"Attempt to read a write-only attribute.", nil);
+        break;
+    }
+    case Status::DataVersionMismatch: {
+        description = NSLocalizedString(@"Cluster instance data version did not match request path.", nil);
+        break;
+    }
+    case Status::Timeout: {
+        description = NSLocalizedString(@"The transaction was aborted due to time being exceeded.", nil);
+        break;
+    }
+    case Status::Busy: {
+        description = NSLocalizedString(
+            @"The receiver is busy processing another action that prevents the execution of the incoming action.", nil);
+        break;
+    }
+    case Status::UnsupportedCluster: {
+        description = NSLocalizedString(@"The cluster indicated is not supported", nil);
+        break;
+    }
+    // Gap in values is intentional.
+    case Status::NoUpstreamSubscription: {
+        description = NSLocalizedString(@"Proxy does not have a subscription to the source.", nil);
+        break;
+    }
+    case Status::NeedsTimedInteraction: {
+        description = NSLocalizedString(@"An Untimed Write or Untimed Invoke interaction was used for an attribute or command that "
+                                        @"requires a Timed Write or Timed Invoke.",
+            nil);
+        break;
+    }
+    case Status::UnsupportedEvent: {
+        description = NSLocalizedString(@"The event indicated is unsupported on the cluster.", nil);
+        break;
+    }
+    }
+
+    NSMutableDictionary * userInfo = [[NSMutableDictionary alloc] init];
+    userInfo[NSLocalizedDescriptionKey] = description;
+    if (status.mClusterStatus.HasValue()) {
+        userInfo[@"clusterStatus"] = @(status.mClusterStatus.Value());
+    }
+
+    return [NSError errorWithDomain:MatterInteractionErrorDomain code:chip::to_underlying(status.mStatus) userInfo:userInfo];
 }
 
 + (CHIP_ERROR)errorToCHIPErrorCode:(NSError * _Nullable)error
 {
     if (error == nil) {
         return CHIP_NO_ERROR;
+    }
+
+    if (error.domain == MatterInteractionErrorDomain) {
+        chip::app::StatusIB status(static_cast<chip::Protocols::InteractionModel::Status>(error.code));
+        if (error.userInfo[@"clusterStatus"] != nil) {
+            status.mClusterStatus.Emplace([error.userInfo[@"clusterStatus"] unsignedCharValue]);
+        }
+        return status.ToChipError();
     }
 
     if (error.domain != CHIPErrorDomain) {
@@ -177,48 +237,9 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
         return CHIP_ERROR_INCORRECT_STATE;
     case CHIPErrorCodeIntegrityCheckFailed:
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
-    case CHIPErrorCodeConstraintError:
-        return CHIP_ERROR_IM_CONSTRAINT_ERROR;
     default:
         return CHIP_ERROR_INTERNAL;
     }
 }
 
-+ (uint8_t)errorToZCLErrorCode:(NSError * _Nullable)error
-{
-    // If this is changed, change CHIPErrorTestUtils' version of
-    // errorToZCLErrorCode too.
-    if (error == nil) {
-        return EMBER_ZCL_STATUS_SUCCESS;
-    }
-
-    if (error.domain != CHIPErrorDomain) {
-        return EMBER_ZCL_STATUS_FAILURE;
-    }
-
-    switch (error.code) {
-    case CHIPErrorCodeDuplicateExists:
-        return EMBER_ZCL_STATUS_DUPLICATE_EXISTS;
-    case CHIPErrorCodeUnsupportedEndpoint:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
-    case CHIPErrorCodeUnsupportedCommand:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND;
-    case CHIPErrorCodeInvalidCommand:
-        return EMBER_ZCL_STATUS_INVALID_COMMAND;
-    case CHIPErrorCodeUnsupportedAttribute:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
-    case CHIPErrorCodeConstraintError:
-        return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
-    case CHIPErrorCodeUnsupportedWrite:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
-    case CHIPErrorCodeNotFound:
-        return EMBER_ZCL_STATUS_NOT_FOUND;
-    case CHIPErrorCodeInvalidDataType:
-        return EMBER_ZCL_STATUS_INVALID_DATA_TYPE;
-    case CHIPErrorCodeUnsupportedCluster:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
-    default:
-        return EMBER_ZCL_STATUS_FAILURE;
-    }
-}
 @end

--- a/src/darwin/Framework/CHIP/CHIPError_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPError_Internal.h
@@ -17,15 +17,15 @@
 
 #import <Foundation/Foundation.h>
 
+#include <app/MessageDef/StatusIB.h>
 #include <lib/core/CHIPError.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPError : NSObject
 + (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
-+ (nullable NSError *)errorForZCLErrorCode:(uint8_t)errorCode;
++ (nullable NSError *)errorForIMStatus:(const chip::app::StatusIB &)status;
 + (CHIP_ERROR)errorToCHIPErrorCode:(NSError * _Nullable)error;
-+ (uint8_t)errorToZCLErrorCode:(NSError * _Nullable)error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -74,7 +74,7 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
         NSLog(@"{{label}} Error: %@", err);
 
         {{#if optional}}
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -2633,7 +2633,7 @@ CHIPDevice * GetConnectedDevice(void)
         readAttributeCoupleColorTempToLevelMinMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Read the optional attribute: CoupleColorTempToLevelMinMireds Error: %@", err);
 
-            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                 [expectation fulfill];
                 return;
             }
@@ -2663,7 +2663,8 @@ CHIPDevice * GetConnectedDevice(void)
                                                             @"CoupleColorTempToLevelMinMireds Error: %@",
                                                           err);
 
-                                                      if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                      if (err.domain == MatterInteractionErrorDomain
+                                                          && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                           [expectation fulfill];
                                                           return;
                                                       }
@@ -2689,7 +2690,7 @@ CHIPDevice * GetConnectedDevice(void)
         readAttributeCoupleColorTempToLevelMinMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Reads back optional attribute: CoupleColorTempToLevelMinMireds Error: %@", err);
 
-            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                 [expectation fulfill];
                 return;
             }
@@ -2720,7 +2721,7 @@ CHIPDevice * GetConnectedDevice(void)
         readAttributeStartUpColorTemperatureMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Read the optional attribute: StartUpColorTemperatureMireds Error: %@", err);
 
-            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                 [expectation fulfill];
                 return;
             }
@@ -2763,7 +2764,8 @@ CHIPDevice * GetConnectedDevice(void)
                                                           @"StartUpColorTemperatureMireds Error: %@",
                                                         err);
 
-                                                    if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                    if (err.domain == MatterInteractionErrorDomain
+                                                        && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                         [expectation fulfill];
                                                         return;
                                                     }
@@ -2789,7 +2791,7 @@ CHIPDevice * GetConnectedDevice(void)
         readAttributeStartUpColorTemperatureMiredsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
             NSLog(@"Reads back optional attribute: StartUpColorTemperatureMireds Error: %@", err);
 
-            if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+            if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                 [expectation fulfill];
                 return;
             }
@@ -2818,7 +2820,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeRemainingTimeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the Optional attribute: RemainingTime Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -2847,7 +2849,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeRemainingTimeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Validate constraints of attribute: RemainingTime Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -2889,7 +2891,8 @@ CHIPDevice * GetConnectedDevice(void)
                            completionHandler:^(NSError * _Nullable err) {
                                NSLog(@"Write the default values to optional attribute: RemainingTime Error: %@", err);
 
-                               if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                               if (err.domain == MatterInteractionErrorDomain
+                                   && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                    [expectation fulfill];
                                    return;
                                }
@@ -2912,7 +2915,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeRemainingTimeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads back optional attribute: RemainingTime Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -2941,7 +2944,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeDriftCompensationWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: DriftCompensation Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -2983,7 +2986,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default values to optional attribute: DriftCompensation Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -3006,7 +3010,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeDriftCompensationWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads back optional attribute: DriftCompensation Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -3035,7 +3039,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeCompensationTextWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: CompensationText Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -3069,7 +3073,8 @@ CHIPDevice * GetConnectedDevice(void)
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write the default values to optional attribute: CompensationText Error: %@", err);
 
-                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                  if (err.domain == MatterInteractionErrorDomain
+                                      && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                       [expectation fulfill];
                                       return;
                                   }
@@ -3092,7 +3097,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeCompensationTextWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads back optional attribute: CompensationText Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4237,7 +4242,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeWhitePointXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: WhitePointX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4277,7 +4282,8 @@ CHIPDevice * GetConnectedDevice(void)
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write the default optional attribute: WhitePointX Error: %@", err);
 
-                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                  if (err.domain == MatterInteractionErrorDomain
+                                      && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                       [expectation fulfill];
                                       return;
                                   }
@@ -4301,7 +4307,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeWhitePointXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: WhitePointX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4330,7 +4336,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeWhitePointYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: WhitePointY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4370,7 +4376,8 @@ CHIPDevice * GetConnectedDevice(void)
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write the default optional attribute: WhitePointY Error: %@", err);
 
-                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                  if (err.domain == MatterInteractionErrorDomain
+                                      && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                       [expectation fulfill];
                                       return;
                                   }
@@ -4394,7 +4401,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeWhitePointYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: WhitePointY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4423,7 +4430,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointRX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4463,7 +4470,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointRX Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -4487,7 +4495,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointRX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4516,7 +4524,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointRY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4556,7 +4564,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointRY Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -4580,7 +4589,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointRY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4609,7 +4618,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointRIntensity Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4637,7 +4646,8 @@ CHIPDevice * GetConnectedDevice(void)
                                        completionHandler:^(NSError * _Nullable err) {
                                            NSLog(@"Write the default optional attribute: ColorPointRIntensity Error: %@", err);
 
-                                           if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                           if (err.domain == MatterInteractionErrorDomain
+                                               && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                [expectation fulfill];
                                                return;
                                            }
@@ -4661,7 +4671,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointRIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointRIntensity Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4690,7 +4700,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointGX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4730,7 +4740,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointGX Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -4754,7 +4765,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointGX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4783,7 +4794,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointGY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4823,7 +4834,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointGY Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -4847,7 +4859,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointGY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4876,7 +4888,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointGIntensity Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4904,7 +4916,8 @@ CHIPDevice * GetConnectedDevice(void)
                                        completionHandler:^(NSError * _Nullable err) {
                                            NSLog(@"Write the default optional attribute: ColorPointGIntensity Error: %@", err);
 
-                                           if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                           if (err.domain == MatterInteractionErrorDomain
+                                               && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                [expectation fulfill];
                                                return;
                                            }
@@ -4928,7 +4941,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointGIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointGIntensity Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4957,7 +4970,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointBXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointBX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -4997,7 +5010,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointBX Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -5021,7 +5035,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointBXWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointBX Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -5050,7 +5064,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointBYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointBY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -5090,7 +5104,8 @@ CHIPDevice * GetConnectedDevice(void)
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"Write the default optional attribute: ColorPointBY Error: %@", err);
 
-                                   if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                   if (err.domain == MatterInteractionErrorDomain
+                                       && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                        [expectation fulfill];
                                        return;
                                    }
@@ -5114,7 +5129,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointBYWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointBY Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -5143,7 +5158,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointBIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read the optional attribute: ColorPointBIntensity Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -5171,7 +5186,8 @@ CHIPDevice * GetConnectedDevice(void)
                                        completionHandler:^(NSError * _Nullable err) {
                                            NSLog(@"Write the default optional attribute: ColorPointBIntensity Error: %@", err);
 
-                                           if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                           if (err.domain == MatterInteractionErrorDomain
+                                               && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                [expectation fulfill];
                                                return;
                                            }
@@ -5195,7 +5211,7 @@ CHIPDevice * GetConnectedDevice(void)
     [cluster readAttributeColorPointBIntensityWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back the optional attribute: ColorPointBIntensity Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11126,7 +11142,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeManufacturingDateWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query ManufacturingDate Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11159,7 +11175,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributePartNumberWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query PartNumber Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11188,7 +11204,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeProductURLWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query ProductURL Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11217,7 +11233,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeProductLabelWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query ProductLabel Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11246,7 +11262,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeSerialNumberWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query SerialNumber Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11275,7 +11291,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeLocalConfigDisabledWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query LocalConfigDisabled Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11299,7 +11315,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeReachableWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query Reachable Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11323,7 +11339,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeUniqueIDWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query UniqueID Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11361,7 +11377,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeMaxNetworksWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query MaxNetworks Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11385,7 +11401,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeNetworksWithCompletionHandler:^(NSArray * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Query Networks Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11807,7 +11823,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Tolerance Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11836,7 +11852,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Tolerance Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -11876,7 +11892,8 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"write the default value to optional attribute: Tolerance Error: %@", err);
 
-                                if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                if (err.domain == MatterInteractionErrorDomain
+                                    && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                     [expectation fulfill];
                                     return;
                                 }
@@ -11899,7 +11916,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Tolerance Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -17954,7 +17971,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -17980,7 +17997,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18006,7 +18023,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinCompPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18032,7 +18049,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxCompPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18058,7 +18075,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstSpeed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18084,7 +18101,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstSpeed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18110,7 +18127,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstFlow Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18136,7 +18153,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstFlow Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18162,7 +18179,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstTemp Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18195,7 +18212,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstTemp Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18228,7 +18245,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18259,7 +18276,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18285,7 +18302,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Speed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18311,7 +18328,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18343,7 +18360,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18369,7 +18386,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributePowerWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Power Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18395,7 +18412,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18427,7 +18444,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18456,7 +18473,8 @@ NSNumber * _Nonnull currentTarget;
                                          completionHandler:^(NSError * _Nullable err) {
                                              NSLog(@"write to the optional attribute: LifetimeEnergyConsumed Error: %@", err);
 
-                                             if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                             if (err.domain == MatterInteractionErrorDomain
+                                                 && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                  [expectation fulfill];
                                                  return;
                                              }
@@ -18482,7 +18500,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18508,7 +18526,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18534,7 +18552,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinCompPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18560,7 +18578,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxCompPressureWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxCompPressure Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18586,7 +18604,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstSpeed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18612,7 +18630,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstSpeed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18638,7 +18656,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstFlow Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18664,7 +18682,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstFlowWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstFlow Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18690,7 +18708,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MinConstTemp Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18723,7 +18741,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMaxConstTempWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: MaxConstTemp Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18756,7 +18774,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18787,7 +18805,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributePumpStatusWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: PumpStatus Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18813,7 +18831,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeSpeedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Speed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18866,7 +18884,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeRunningHoursWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeRunningHours Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18892,7 +18910,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributePowerWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Power Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18918,7 +18936,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -18950,7 +18968,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeLifetimeEnergyConsumedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: LifetimeEnergyConsumed Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -19429,7 +19447,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads the optional attribute: Tolerance Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -19460,7 +19478,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of attribute: Tolerance Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -20153,7 +20171,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeToleranceWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"read the optional attribute: Tolerance Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21654,7 +21672,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinSetpointDeadBandWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads optional attributes from DUT: MinSetpointDeadBand Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21684,7 +21702,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinSetpointDeadBandWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: MinSetpointDeadBand Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21727,7 +21745,8 @@ NSNumber * _Nonnull currentTarget;
                                                 @"MinSetpointDeadBand Error: %@",
                                               err);
 
-                                          if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                          if (err.domain == MatterInteractionErrorDomain
+                                              && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                               [expectation fulfill];
                                               return;
                                           }
@@ -21752,7 +21771,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeMinSetpointDeadBandWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back optional attributes from DUT: MinSetpointDeadBand Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21782,7 +21801,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeStartOfWeekWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: StartOfWeek Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21824,7 +21843,8 @@ NSNumber * _Nonnull currentTarget;
                                   NSLog(@"Writes the respective default value to optional attributes to DUT: StartOfWeek Error: %@",
                                       err);
 
-                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                  if (err.domain == MatterInteractionErrorDomain
+                                      && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                       [expectation fulfill];
                                       return;
                                   }
@@ -21847,7 +21867,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeStartOfWeekWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read back optional attributes from DUT: StartOfWeek Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21877,7 +21897,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeNumberOfWeeklyTransitionsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: NumberOfWeeklyTransitions Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21907,7 +21927,8 @@ NSNumber * _Nonnull currentTarget;
                                                       @"NumberOfWeeklyTransitions Error: %@",
                                                     err);
 
-                                                if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                                if (err.domain == MatterInteractionErrorDomain
+                                                    && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                     [expectation fulfill];
                                                     return;
                                                 }
@@ -21932,7 +21953,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeNumberOfDailyTransitionsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads constraints of optional attributes from DUT: NumberOfDailyTransitions Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -21962,7 +21983,8 @@ NSNumber * _Nonnull currentTarget;
                                                      @"NumberOfDailyTransitions Error: %@",
                                                    err);
 
-                                               if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                               if (err.domain == MatterInteractionErrorDomain
+                                                   && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                                    [expectation fulfill];
                                                    return;
                                                }
@@ -29486,7 +29508,7 @@ NSNumber * _Nonnull currentTarget;
     [cluster readAttributeUnsupportedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Read attribute UNSUPPORTED Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -29518,7 +29540,8 @@ NSNumber * _Nonnull currentTarget;
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Writeattribute UNSUPPORTED Error: %@", err);
 
-                                  if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+                                  if (err.domain == MatterInteractionErrorDomain
+                                      && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
                                       [expectation fulfill];
                                       return;
                                   }
@@ -43440,7 +43463,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     [cluster readAttributeCurrentHeapFreeWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads CurrentHeapFree non-global attribute value from DUT Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -43465,7 +43488,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     [cluster readAttributeCurrentHeapUsedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads CurrentHeapUsed non-global attribute value from DUT Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -43490,7 +43513,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     [cluster readAttributeCurrentHeapHighWatermarkWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads CurrentHeapHighWaterMark non-global attribute value from DUT Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -43542,7 +43565,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     [cluster readAttributeCurrentHeapUsedWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads CurrentHeapUsed attribute value from DUT Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }
@@ -43571,7 +43594,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     [cluster readAttributeCurrentHeapHighWatermarkWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
         NSLog(@"Reads CurrentHeapHighWaterMark attribute value from DUT Error: %@", err);
 
-        if (err.code == CHIPErrorCodeUnsupportedAttribute) {
+        if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
             [expectation fulfill];
             return;
         }

--- a/src/darwin/Framework/CHIPTests/CHIPErrorTestUtils.mm
+++ b/src/darwin/Framework/CHIPTests/CHIPErrorTestUtils.mm
@@ -33,34 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
     if (error == nil) {
         return EMBER_ZCL_STATUS_SUCCESS;
     }
-    if (error.domain != CHIPErrorDomain) {
+
+    if (error.domain != MatterInteractionErrorDomain) {
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
-    switch (error.code) {
-    case CHIPErrorCodeDuplicateExists:
-        return EMBER_ZCL_STATUS_DUPLICATE_EXISTS;
-    case CHIPErrorCodeUnsupportedEndpoint:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
-    case CHIPErrorCodeUnsupportedCommand:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND;
-    case CHIPErrorCodeInvalidCommand:
-        return EMBER_ZCL_STATUS_INVALID_COMMAND;
-    case CHIPErrorCodeUnsupportedAttribute:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
-    case CHIPErrorCodeConstraintError:
-        return EMBER_ZCL_STATUS_CONSTRAINT_ERROR;
-    case CHIPErrorCodeUnsupportedWrite:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
-    case CHIPErrorCodeNotFound:
-        return EMBER_ZCL_STATUS_NOT_FOUND;
-    case CHIPErrorCodeInvalidDataType:
-        return EMBER_ZCL_STATUS_INVALID_DATA_TYPE;
-    case CHIPErrorCodeUnsupportedCluster:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
-    default:
-        return EMBER_ZCL_STATUS_FAILURE;
-    }
+    return error.code;
 }
 @end
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2385,22 +2385,13 @@ using CHIP_ERROR = ::chip::ChipError;
 #define CHIP_ERROR_MISSING_URI_SEPARATOR             CHIP_CORE_ERROR(0xd7)
 
 /**
- * @def CHIP_ERROR_IM_CONSTRAINT_ERROR
- *
- * @brief
- *   The equivalent of a CONSTRAINT_ERROR status: a value was out of the valid
- *   range.
- */
-#define CHIP_ERROR_IM_CONSTRAINT_ERROR               CHIP_CORE_ERROR(0xd8)
-
-/**
  * @def CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE
  *
  * @brief
  *   The Attribute DataElement is malformed: it either does not contain
  *   the required elements
  */
-#define CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE                    CHIP_CORE_ERROR(0xd9)
+#define CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE                    CHIP_CORE_ERROR(0xd8)
 
 /**
  * @def CHIP_ERROR_IM_MALFORMED_TIMED_REQUEST_MESSAGE
@@ -2409,7 +2400,7 @@ using CHIP_ERROR = ::chip::ChipError;
  *   The Attribute DataElement is malformed: it either does not contain
  *   the required elements
  */
-#define CHIP_ERROR_IM_MALFORMED_TIMED_REQUEST_MESSAGE                    CHIP_CORE_ERROR(0xda)
+#define CHIP_ERROR_IM_MALFORMED_TIMED_REQUEST_MESSAGE                    CHIP_CORE_ERROR(0xd9)
 
 /**
  * @def CHIP_ERROR_INVALID_FILE_IDENTIFIER
@@ -2418,7 +2409,7 @@ using CHIP_ERROR = ::chip::ChipError;
  *   The file identifier, encoded in the first few bytes of a processed file,
  *   has unexpected value.
  */
-#define CHIP_ERROR_INVALID_FILE_IDENTIFIER                     CHIP_CORE_ERROR(0xdb)
+#define CHIP_ERROR_INVALID_FILE_IDENTIFIER                     CHIP_CORE_ERROR(0xda)
 
 /**
  *  @}


### PR DESCRIPTION
We kept having to add IM errors one at a time.  Just add them all at
once.

Also more clearly disambiguates "IM error status returned" from
"something went wrong on our end".

#### Problem
See above.

#### Change overview
See above.

#### Testing
Should be no behavior changes.  Tests all pass.  Framework consumers can get more informative errors.