### PR TITLE
[Group] Decryption optimization

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -601,7 +601,6 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
     PayloadHeader payloadHeader;
     SessionMessageDelegate::DuplicateMessage isDuplicate = SessionMessageDelegate::DuplicateMessage::No;
     Credentials::GroupDataProvider * groups              = Credentials::GetGroupDataProvider();
-    GroupId groupId;
     VerifyOrReturn(nullptr != groups);
 
     if (!packetHeader.GetDestinationGroupId().HasValue())
@@ -609,7 +608,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
         return; // malformed packet
     }
 
-    groupId = packetHeader.GetDestinationGroupId().Value();
+    GroupId groupId = packetHeader.GetDestinationGroupId().Value();
 
     if (msg.IsNull())
     {
@@ -633,7 +632,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
     bool decrypted = false;
     while (!decrypted && iter->Next(groupContext))
     {
-        // Optimization to reduce number of decryption attempt
+        // Optimization to reduce number of decryption attempts
         if (groupId != groupContext.group_id)
         {
             continue;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -630,6 +630,11 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
     bool decrypted = false;
     while (!decrypted && iter->Next(groupContext))
     {
+        // Optimization to reduce number of decryption attempt
+        if (groupId != groupContext.group_id)
+        {
+            continue;
+        }
         msgCopy = msg.CloneData();
         decrypted =
             (CHIP_NO_ERROR == SecureMessageCodec::Decrypt(CryptoContext(groupContext.key), payloadHeader, packetHeader, msgCopy));

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -601,12 +601,15 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
     PayloadHeader payloadHeader;
     SessionMessageDelegate::DuplicateMessage isDuplicate = SessionMessageDelegate::DuplicateMessage::No;
     Credentials::GroupDataProvider * groups              = Credentials::GetGroupDataProvider();
+    GroupId groupId;
     VerifyOrReturn(nullptr != groups);
 
     if (!packetHeader.GetDestinationGroupId().HasValue())
     {
         return; // malformed packet
     }
+
+    groupId = packetHeader.GetDestinationGroupId().Value();
 
     if (msg.IsNull())
     {


### PR DESCRIPTION
#### Problem
For now we decrypt with all possible keys matching the hash provided in the packet header. 
We can further decrease the number of iteration by also checking for a match with the groupId provided in the same packet header.

#### Change overview
Add a check for the groupId prior to decryption attempt. 
#### Testing
Unit test
Test suite
