### PR TITLE
[Group ]Group msg counter

### DIFF
--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -92,10 +92,11 @@ tests:
       arguments:
           values:
               - name: "GroupKeySet"
-                value:
-                    {
+                value: {
                         GroupKeySetID: 0x01a2,
-                        GroupKeySecurityPolicy: 1,
+                        GroupKeySecurityPolicy: 0,
+                        #  TODO Revert this once MCSP is implemented
+                        # GroupKeySecurityPolicy: 1,
                         EpochKey0: "\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf",
                         EpochStartTime0: 2220000,
                         EpochKey1: "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef",

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -74,10 +74,11 @@ tests:
       arguments:
           values:
               - name: "GroupKeySet"
-                value:
-                    {
+                value: {
                         GroupKeySetID: 0x01a1,
-                        GroupKeySecurityPolicy: 0,
+                        #  TODO Revert this once MCSP is implemented
+                        # GroupKeySecurityPolicy: 0,
+                        GroupKeySecurityPolicy: 1, # 1 => LowLatency => TrustFirst
                         EpochKey0: "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
                         EpochStartTime0: 1110000,
                         EpochKey1: "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
@@ -92,11 +93,10 @@ tests:
       arguments:
           values:
               - name: "GroupKeySet"
-                value: {
+                value:
+                    {
                         GroupKeySetID: 0x01a2,
-                        GroupKeySecurityPolicy: 0,
-                        #  TODO Revert this once MCSP is implemented
-                        # GroupKeySecurityPolicy: 1,
+                        GroupKeySecurityPolicy: 1,
                         EpochKey0: "\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf",
                         EpochStartTime0: 2220000,
                         EpochKey1: "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef",

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1273,6 +1273,27 @@
 #endif // CHIP_CONFIG_MAX_FABRICS
 
 /**
+ *  @def CHIP_CONFIG_MAX_GROUP_DATA_PEERS
+ *
+ *  @brief
+ *    Maximum number of Peer within a fabric that can send group data message to a device.
+ *
+ */
+#ifndef CHIP_CONFIG_MAX_GROUP_DATA_PEERS
+#define CHIP_CONFIG_MAX_GROUP_DATA_PEERS 15
+#endif // CHIP_CONFIG_MAX_GROUP_DATA_PEERS
+
+/**
+ *  @def CHIP_CONFIG_MAX_GROUP_CONTROL_PEERS
+ *
+ *  @brief
+ *   Maximum number of Peer within a fabric that can send group control message to a device.
+ */
+#ifndef CHIP_CONFIG_MAX_GROUP_CONTROL_PEERS
+#define CHIP_CONFIG_MAX_GROUP_CONTROL_PEERS 2
+#endif // CHIP_CONFIG_MAX_GROUP_CONTROL_PEER
+
+/**
  * @def CHIP_NON_PRODUCTION_MARKER
  *
  * @brief Defines the name of a mark symbol whose presence signals that the chip code

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -46,6 +46,10 @@ public:
         return Format("acl/%x", static_cast<unsigned int>(index));
     }
 
+    // Group Message Counters
+    const char * GroupDataCounter() { return Format("gdc"); }
+    const char * GroupControlCounter() { return Format("gcc"); }
+
     // Group Data Provider
 
     const char * FabricTable() { return Format("f/t"); }

--- a/src/platform/telink/CHIPPlatformConfig.h
+++ b/src/platform/telink/CHIPPlatformConfig.h
@@ -35,6 +35,18 @@
 
 #define CHIP_CONFIG_ERROR_CLASS 1
 
+/**
+ *  @def CHIP_CONFIG_MAX_FABRICS
+ *
+ *  @brief
+ *    Maximum number of fabrics the device can participate in.  Each fabric can
+ *    provision the device with its unique operational credentials and manage
+ *    its own access control lists.
+ */
+#ifndef CHIP_CONFIG_MAX_FABRICS
+#define CHIP_CONFIG_MAX_FABRICS 5 // 4 fabrics + 1 for rotation slack
+#endif
+
 // ==================== Security Adaptations ====================
 
 // ==================== General Configuration Overrides ====================

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -25,6 +25,8 @@ static_library("transport") {
     "CryptoContext.cpp",
     "CryptoContext.h",
     "GroupSession.h",
+    "GroupPeerMessageCounter.cpp",
+    "GroupPeerMessageCounter.h",
     "MessageCounter.cpp",
     "MessageCounter.h",
     "MessageCounterManagerInterface.h",

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -24,9 +24,9 @@ static_library("transport") {
   sources = [
     "CryptoContext.cpp",
     "CryptoContext.h",
-    "GroupSession.h",
     "GroupPeerMessageCounter.cpp",
     "GroupPeerMessageCounter.h",
+    "GroupSession.h",
     "MessageCounter.cpp",
     "MessageCounter.h",
     "MessageCounterManagerInterface.h",

--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -1,0 +1,285 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the Matter Group message counters of remote nodes for groups.
+ *
+ */
+
+#include <transport/GroupPeerMessageCounter.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+
+
+namespace chip {
+namespace Transport {
+
+
+CHIP_ERROR GroupPeerTable::FindOrAddPeer(FabricId fabricId, NodeId nodeId, bool isControl, chip::Transport::PeerMessageCounter * & counter)
+{
+    if (fabricId == kUndefinedFabricId || nodeId == kUndefinedNodeId)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    {
+        if (mGroupFabrics[it].mFabricId == kUndefinedFabricId)
+        {
+            // Already iterate through all known fabricId
+            // Add the new peer to save some processing time
+            mGroupFabrics[it].mFabricId = fabricId;
+            if (isControl)
+            {
+                mGroupFabrics[it].mControlGroupSenders[0].mNodeId = nodeId;
+                counter = &(mGroupFabrics[it].mControlGroupSenders[0].msgCounter);
+                mGroupFabrics[it].mControlPeerCount++;
+            }
+            else
+            {
+                mGroupFabrics[it].mDataGroupSenders[0].mNodeId = nodeId;
+                counter = &(mGroupFabrics[it].mDataGroupSenders[0].msgCounter);
+                mGroupFabrics[it].mDataPeerCount++;
+            }
+            return CHIP_NO_ERROR;
+        }
+
+        if (fabricId == mGroupFabrics[it].mFabricId)
+        {
+            if (isControl)
+            {
+                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER ; nodeIt++)
+                {
+                    if (mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId == kUndefinedNodeId)
+                    {
+                        // Already iterate through all known NodeId
+                        // Add the new peer to save some processing time
+                        mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId = nodeId;
+                        counter = &(mGroupFabrics[it].mControlGroupSenders[nodeIt].msgCounter);
+                        mGroupFabrics[it].mControlPeerCount++;
+                        return CHIP_NO_ERROR;
+                    }
+
+                    if (mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId == nodeId)
+                    {
+                        counter = &(mGroupFabrics[it].mControlGroupSenders[nodeIt].msgCounter);
+                        return CHIP_NO_ERROR;
+                    }
+                }
+            }
+            else
+            {
+                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER ; nodeIt++)
+                {
+                    if (mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId == kUndefinedNodeId)
+                    {
+                        // Already iterate through all known NodeId
+                        // Add the new peer to save some processing time
+                        mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId = nodeId;
+                        counter = &(mGroupFabrics[it].mDataGroupSenders[nodeIt].msgCounter);
+                        mGroupFabrics[it].mDataPeerCount++;
+                        return CHIP_NO_ERROR;
+                    }
+
+                    if (mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId == nodeId)
+                    {
+                        counter = &(mGroupFabrics[it].mDataGroupSenders[nodeIt].msgCounter);
+                        return CHIP_NO_ERROR;
+                    }
+                }
+            }
+            // Exceed the Max number of Group peer
+            return CHIP_ERROR_TOO_MANY_PEER_NODES;
+        }
+    }
+
+    // Exceed the Max number of Group peer
+    return CHIP_ERROR_TOO_MANY_PEER_NODES;
+}
+
+// Used in case of MCSP failure
+CHIP_ERROR GroupPeerTable::RemovePeer(FabricId fabricId, NodeId nodeId, bool isControl)
+{
+    CHIP_ERROR err = CHIP_ERROR_NOT_FOUND;
+    uint32_t fabricIndex = CHIP_CONFIG_MAX_FABRICS;
+
+    if (fabricId == kUndefinedFabricId || nodeId == kUndefinedNodeId)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    {
+        if (fabricId == mGroupFabrics[it].mFabricId)
+        {
+            if (isControl)
+            {
+                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER ; nodeIt++)
+                {
+                    if (mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId == nodeId)
+                    {
+                        fabricIndex = it;
+                        mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId = kUndefinedNodeId;
+                        mGroupFabrics[it].mControlGroupSenders[nodeIt].msgCounter.Reset();
+                        mGroupFabrics[it].mControlPeerCount--;
+                        err = CHIP_NO_ERROR;
+                        //return CHIP_NO_ERROR;
+                    }
+                }
+            }
+            else
+            {
+                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER ; nodeIt++)
+                {
+                    if (mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId == nodeId)
+                    {
+                        fabricIndex = it;
+                        mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId = kUndefinedNodeId;
+                        mGroupFabrics[it].mDataGroupSenders[nodeIt].msgCounter.Reset();
+                        mGroupFabrics[it].mDataPeerCount--;
+                        err = CHIP_NO_ERROR;
+                        //return CHIP_NO_ERROR;
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    //Remove Fabric entry from PeerTable if empty
+    if(fabricIndex < CHIP_CONFIG_MAX_FABRICS)
+    {
+        if(mGroupFabrics[fabricIndex].mDataPeerCount == 0 && mGroupFabrics[fabricIndex].mControlPeerCount == 0)
+        {
+            mGroupFabrics[fabricIndex].mFabricId = kUndefinedFabricId;
+            // To maintain Logic Integrety Fabric array cannot have empty slot in between data
+            // Move Fabric around
+            for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS ;)
+            {
+                GroupFabric buf = mGroupFabrics[it];
+                if(buf.mFabricId != kUndefinedFabricId)
+                {
+                    it++;
+                    continue;
+                }
+                // Find the last non empty element
+                for (uint32_t i = CHIP_CONFIG_MAX_FABRICS - 1; i > it; i--)
+                {
+                    if(mGroupFabrics[i].mFabricId != kUndefinedFabricId)
+                    {
+                        // Logic works since all buffer are static
+                        // move it up front
+                        memcpy(static_cast<void *>(mGroupFabrics + it), static_cast<void *>(mGroupFabrics + i) , sizeof(GroupFabric));
+                        // replace with empty object (easiest way to make sure everything is cleared)
+                        memcpy(static_cast<void *>(mGroupFabrics + i), static_cast<void *>(&buf), sizeof(GroupFabric));
+                        it++;
+                        break;
+                    }
+                }
+                // Nothing to move around
+                break;
+            }
+        }
+    }
+
+    // Cannot find Peer to remove
+    return err;
+}
+
+// For Unit Test
+FabricId GroupPeerTable::GetFabricIdAt(uint8_t index)
+{
+    if(index < CHIP_CONFIG_MAX_FABRICS)
+    {
+        return mGroupFabrics[index].mFabricId;
+    }
+
+    return kUndefinedFabricId;
+}
+
+GroupClientCounters::GroupClientCounters(chip::PersistentStorageDelegate * storage_delegate)
+{
+    Init(storage_delegate);
+}
+
+CHIP_ERROR GroupClientCounters::Init(chip::PersistentStorageDelegate * storage_delegate)
+{
+
+    if (storage_delegate == nullptr)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    // TODO Implement Logic for first time use / factory reset to be random
+    // Spec 4.5.1.3
+    mStorage = storage_delegate;
+    uint16_t size = static_cast<uint16_t>(sizeof(uint32_t));
+    DefaultStorageKeyAllocator key;
+    mStorage->SyncGetKeyValue(key.GroupControlCounter(), &mGroupControlCounter, size);
+    mStorage->SyncGetKeyValue(key.GroupDataCounter(), &mGroupDataCounter, size);
+
+    uint32_t temp = mGroupControlCounter + GROUP_MSG_COUNTER_MIN_INCREMENT;
+    mStorage->SyncSetKeyValue(key.GroupControlCounter(), &temp, size);
+
+    temp = mGroupDataCounter + GROUP_MSG_COUNTER_MIN_INCREMENT;
+    mStorage->SyncSetKeyValue(key.GroupDataCounter(), &temp, size);
+
+    return CHIP_NO_ERROR;
+
+}
+
+uint32_t GroupClientCounters::GetCounter(bool isControl)
+{
+    return (isControl) ? mGroupControlCounter : mGroupDataCounter;
+}
+
+
+void GroupClientCounters::SetCounter(bool isControl, uint32_t value)
+{
+    uint32_t temp = 0;
+    uint16_t size = static_cast<uint16_t>(sizeof(uint32_t));
+    DefaultStorageKeyAllocator key;
+
+    if (mStorage == nullptr)
+    {
+        return;
+    }
+
+    if (isControl)
+    {
+        mStorage->SyncGetKeyValue(key.GroupControlCounter(), &temp, size);
+        if(temp <= value || ((temp > (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT)) && (value < GROUP_MSG_COUNTER_MIN_INCREMENT)))
+        {
+            temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
+            mStorage->SyncSetKeyValue(key.GroupControlCounter(), &temp, sizeof(uint32_t));
+
+        }
+        mGroupControlCounter = value;
+    }
+    else
+    {
+        mStorage->SyncGetKeyValue(key.GroupDataCounter(), &temp, size);
+        if(temp <= value || ((temp > (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT)) && (value < GROUP_MSG_COUNTER_MIN_INCREMENT)))
+        {
+            temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
+            mStorage->SyncSetKeyValue(key.GroupDataCounter(), &temp, sizeof(uint32_t));
+        }
+        mGroupDataCounter = value;
+    }
+}
+
+} // Transport
+} // chip

--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -249,6 +249,10 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
         // TODO handle this case
         mGroupControlCounter = 0; // TODO should be random
     }
+    else if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
     else
     {
         mGroupControlCounter = temp;
@@ -260,6 +264,10 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
         // might be the first time we retrieve the value
         // TODO handle this case
         mGroupDataCounter = 0; //  TODO should be random
+    }
+    else if (err != CHIP_NO_ERROR)
+    {
+        return err;
     }
     else
     {

--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -20,48 +20,47 @@
  *
  */
 
-#include <transport/GroupPeerMessageCounter.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
-
+#include <transport/GroupPeerMessageCounter.h>
 
 namespace chip {
 namespace Transport {
 
-
-CHIP_ERROR GroupPeerTable::FindOrAddPeer(FabricId fabricId, NodeId nodeId, bool isControl, chip::Transport::PeerMessageCounter * & counter)
+CHIP_ERROR GroupPeerTable::FindOrAddPeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl,
+                                         chip::Transport::PeerMessageCounter *& counter)
 {
-    if (fabricId == kUndefinedFabricId || nodeId == kUndefinedNodeId)
+    if (fabricIndex == kUndefinedFabricIndex || nodeId == kUndefinedNodeId)
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS; it++)
     {
-        if (mGroupFabrics[it].mFabricId == kUndefinedFabricId)
+        if (mGroupFabrics[it].mFabricIndex == kUndefinedFabricIndex)
         {
-            // Already iterate through all known fabricId
+            // Already iterate through all known fabricIndex
             // Add the new peer to save some processing time
-            mGroupFabrics[it].mFabricId = fabricId;
+            mGroupFabrics[it].mFabricIndex = fabricIndex;
             if (isControl)
             {
                 mGroupFabrics[it].mControlGroupSenders[0].mNodeId = nodeId;
-                counter = &(mGroupFabrics[it].mControlGroupSenders[0].msgCounter);
+                counter                                           = &(mGroupFabrics[it].mControlGroupSenders[0].msgCounter);
                 mGroupFabrics[it].mControlPeerCount++;
             }
             else
             {
                 mGroupFabrics[it].mDataGroupSenders[0].mNodeId = nodeId;
-                counter = &(mGroupFabrics[it].mDataGroupSenders[0].msgCounter);
+                counter                                        = &(mGroupFabrics[it].mDataGroupSenders[0].msgCounter);
                 mGroupFabrics[it].mDataPeerCount++;
             }
             return CHIP_NO_ERROR;
         }
 
-        if (fabricId == mGroupFabrics[it].mFabricId)
+        if (fabricIndex == mGroupFabrics[it].mFabricIndex)
         {
             if (isControl)
             {
-                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER ; nodeIt++)
+                for (uint32_t nodeIt = 0; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; nodeIt++)
                 {
                     if (mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId == kUndefinedNodeId)
                     {
@@ -82,7 +81,7 @@ CHIP_ERROR GroupPeerTable::FindOrAddPeer(FabricId fabricId, NodeId nodeId, bool 
             }
             else
             {
-                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER ; nodeIt++)
+                for (uint32_t nodeIt = 0; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER; nodeIt++)
                 {
                     if (mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId == kUndefinedNodeId)
                     {
@@ -111,47 +110,45 @@ CHIP_ERROR GroupPeerTable::FindOrAddPeer(FabricId fabricId, NodeId nodeId, bool 
 }
 
 // Used in case of MCSP failure
-CHIP_ERROR GroupPeerTable::RemovePeer(FabricId fabricId, NodeId nodeId, bool isControl)
+CHIP_ERROR GroupPeerTable::RemovePeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl)
 {
-    CHIP_ERROR err = CHIP_ERROR_NOT_FOUND;
-    uint32_t fabricIndex = CHIP_CONFIG_MAX_FABRICS;
+    CHIP_ERROR err       = CHIP_ERROR_NOT_FOUND;
+    uint32_t fabricIt    = CHIP_CONFIG_MAX_FABRICS;
 
-    if (fabricId == kUndefinedFabricId || nodeId == kUndefinedNodeId)
+    if (fabricIndex == kUndefinedFabricIndex || nodeId == kUndefinedNodeId)
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS; it++)
     {
-        if (fabricId == mGroupFabrics[it].mFabricId)
+        if (fabricIndex == mGroupFabrics[it].mFabricIndex)
         {
             if (isControl)
             {
-                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER ; nodeIt++)
+                for (uint32_t nodeIt = 0; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; nodeIt++)
                 {
                     if (mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId == nodeId)
                     {
-                        fabricIndex = it;
+                        fabricIt                                            = it;
                         mGroupFabrics[it].mControlGroupSenders[nodeIt].mNodeId = kUndefinedNodeId;
                         mGroupFabrics[it].mControlGroupSenders[nodeIt].msgCounter.Reset();
                         mGroupFabrics[it].mControlPeerCount--;
                         err = CHIP_NO_ERROR;
-                        //return CHIP_NO_ERROR;
                     }
                 }
             }
             else
             {
-                for (uint32_t nodeIt = 0 ; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER ; nodeIt++)
+                for (uint32_t nodeIt = 0; nodeIt < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER; nodeIt++)
                 {
                     if (mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId == nodeId)
                     {
-                        fabricIndex = it;
+                        fabricIt                                         = it;
                         mGroupFabrics[it].mDataGroupSenders[nodeIt].mNodeId = kUndefinedNodeId;
                         mGroupFabrics[it].mDataGroupSenders[nodeIt].msgCounter.Reset();
                         mGroupFabrics[it].mDataPeerCount--;
                         err = CHIP_NO_ERROR;
-                        //return CHIP_NO_ERROR;
                     }
                 }
             }
@@ -159,18 +156,18 @@ CHIP_ERROR GroupPeerTable::RemovePeer(FabricId fabricId, NodeId nodeId, bool isC
         }
     }
 
-    //Remove Fabric entry from PeerTable if empty
-    if(fabricIndex < CHIP_CONFIG_MAX_FABRICS)
+    // Remove Fabric entry from PeerTable if empty
+    if (fabricIt < CHIP_CONFIG_MAX_FABRICS)
     {
-        if(mGroupFabrics[fabricIndex].mDataPeerCount == 0 && mGroupFabrics[fabricIndex].mControlPeerCount == 0)
+        if (mGroupFabrics[fabricIt].mDataPeerCount == 0 && mGroupFabrics[fabricIt].mControlPeerCount == 0)
         {
-            mGroupFabrics[fabricIndex].mFabricId = kUndefinedFabricId;
-            // To maintain Logic Integrety Fabric array cannot have empty slot in between data
+            mGroupFabrics[fabricIt].mFabricIndex = kUndefinedFabricIndex;
+            // To maintain logic integrety Fabric array cannot have empty slot in between data
             // Move Fabric around
-            for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS ;)
+            for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS;)
             {
                 GroupFabric buf = mGroupFabrics[it];
-                if(buf.mFabricId != kUndefinedFabricId)
+                if (buf.mFabricIndex != kUndefinedFabricIndex)
                 {
                     it++;
                     continue;
@@ -178,11 +175,12 @@ CHIP_ERROR GroupPeerTable::RemovePeer(FabricId fabricId, NodeId nodeId, bool isC
                 // Find the last non empty element
                 for (uint32_t i = CHIP_CONFIG_MAX_FABRICS - 1; i > it; i--)
                 {
-                    if(mGroupFabrics[i].mFabricId != kUndefinedFabricId)
+                    if (mGroupFabrics[i].mFabricIndex != kUndefinedFabricIndex)
                     {
                         // Logic works since all buffer are static
                         // move it up front
-                        memcpy(static_cast<void *>(mGroupFabrics + it), static_cast<void *>(mGroupFabrics + i) , sizeof(GroupFabric));
+                        memcpy(static_cast<void *>(mGroupFabrics + it), static_cast<void *>(mGroupFabrics + i),
+                               sizeof(GroupFabric));
                         // replace with empty object (easiest way to make sure everything is cleared)
                         memcpy(static_cast<void *>(mGroupFabrics + i), static_cast<void *>(&buf), sizeof(GroupFabric));
                         it++;
@@ -200,14 +198,14 @@ CHIP_ERROR GroupPeerTable::RemovePeer(FabricId fabricId, NodeId nodeId, bool isC
 }
 
 // For Unit Test
-FabricId GroupPeerTable::GetFabricIdAt(uint8_t index)
+FabricIndex GroupPeerTable::GetFabricIndexAt(uint8_t index)
 {
-    if(index < CHIP_CONFIG_MAX_FABRICS)
+    if (index < CHIP_CONFIG_MAX_FABRICS)
     {
-        return mGroupFabrics[index].mFabricId;
+        return mGroupFabrics[index].mFabricIndex;
     }
 
-    return kUndefinedFabricId;
+    return kUndefinedFabricIndex;
 }
 
 GroupClientCounters::GroupClientCounters(chip::PersistentStorageDelegate * storage_delegate)
@@ -225,7 +223,7 @@ CHIP_ERROR GroupClientCounters::Init(chip::PersistentStorageDelegate * storage_d
 
     // TODO Implement Logic for first time use / factory reset to be random
     // Spec 4.5.1.3
-    mStorage = storage_delegate;
+    mStorage      = storage_delegate;
     uint16_t size = static_cast<uint16_t>(sizeof(uint32_t));
     DefaultStorageKeyAllocator key;
     mStorage->SyncGetKeyValue(key.GroupControlCounter(), &mGroupControlCounter, size);
@@ -238,14 +236,12 @@ CHIP_ERROR GroupClientCounters::Init(chip::PersistentStorageDelegate * storage_d
     mStorage->SyncSetKeyValue(key.GroupDataCounter(), &temp, size);
 
     return CHIP_NO_ERROR;
-
 }
 
 uint32_t GroupClientCounters::GetCounter(bool isControl)
 {
     return (isControl) ? mGroupControlCounter : mGroupDataCounter;
 }
-
 
 void GroupClientCounters::SetCounter(bool isControl, uint32_t value)
 {
@@ -261,18 +257,17 @@ void GroupClientCounters::SetCounter(bool isControl, uint32_t value)
     if (isControl)
     {
         mStorage->SyncGetKeyValue(key.GroupControlCounter(), &temp, size);
-        if(temp <= value || ((temp > (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT)) && (value < GROUP_MSG_COUNTER_MIN_INCREMENT)))
+        if (temp <= value || ((temp > (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT)) && (value < GROUP_MSG_COUNTER_MIN_INCREMENT)))
         {
             temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
             mStorage->SyncSetKeyValue(key.GroupControlCounter(), &temp, sizeof(uint32_t));
-
         }
         mGroupControlCounter = value;
     }
     else
     {
         mStorage->SyncGetKeyValue(key.GroupDataCounter(), &temp, size);
-        if(temp <= value || ((temp > (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT)) && (value < GROUP_MSG_COUNTER_MIN_INCREMENT)))
+        if (temp <= value || ((temp > (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT)) && (value < GROUP_MSG_COUNTER_MIN_INCREMENT)))
         {
             temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
             mStorage->SyncSetKeyValue(key.GroupDataCounter(), &temp, sizeof(uint32_t));
@@ -281,5 +276,5 @@ void GroupClientCounters::SetCounter(bool isControl, uint32_t value)
     }
 }
 
-} // Transport
-} // chip
+} // namespace Transport
+} // namespace chip

--- a/src/transport/GroupPeerMessageCounter.h
+++ b/src/transport/GroupPeerMessageCounter.h
@@ -1,0 +1,98 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the Matter Group message counters of remote nodes for groups.
+ *
+ */
+#pragma once
+
+#include <array>
+#include <bitset>
+
+#include <lib/support/Span.h>
+#include <transport/PeerMessageCounter.h>
+#include <lib/core/NodeId.h>
+#include <lib/core/PeerId.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+
+
+#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER     15
+#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER  15
+
+#define GROUP_MSG_COUNTER_MIN_INCREMENT                     1000
+
+namespace chip {
+namespace Transport {
+
+class GroupSender
+{
+    public:
+    NodeId mNodeId=kUndefinedNodeId;
+    PeerMessageCounter msgCounter = {true};
+};
+
+class GroupFabric
+{
+    public :
+    FabricId mFabricId = kUndefinedFabricId;
+    uint8_t mControlPeerCount = 0;
+    uint8_t mDataPeerCount = 0;
+    GroupSender mDataGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER];
+    GroupSender mControlGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER];
+
+};
+
+
+class GroupPeerTable
+{
+    public:
+
+    CHIP_ERROR FindOrAddPeer(FabricId fabricId, NodeId nodeId, bool isControl, chip::Transport::PeerMessageCounter * & counter);
+
+    // Used in case of MCSP failure
+    CHIP_ERROR RemovePeer(FabricId fabricId, NodeId nodeId, bool isControl);
+
+
+    // For Unit Test
+    FabricId GetFabricIdAt(uint8_t index);
+
+
+    private:
+    GroupFabric mGroupFabrics[CHIP_CONFIG_MAX_FABRICS];
+
+};
+
+// Might want to rename this so that it is explicitly the sending side of counters
+class GroupClientCounters
+{
+public:
+    GroupClientCounters(){};
+    GroupClientCounters(chip::PersistentStorageDelegate * storage_delegate);
+    CHIP_ERROR Init(chip::PersistentStorageDelegate * storage_delegate);
+    uint32_t GetCounter(bool isControl);
+    void SetCounter(bool isControl, uint32_t value);
+private:
+    // TODO Initialize those to random value
+    uint32_t mGroupDataCounter = 0;
+    uint32_t mGroupControlCounter = 0;
+    chip::PersistentStorageDelegate * mStorage = nullptr;
+};
+
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/GroupPeerMessageCounter.h
+++ b/src/transport/GroupPeerMessageCounter.h
@@ -31,9 +31,6 @@
 #include <lib/support/Span.h>
 #include <transport/PeerMessageCounter.h>
 
-#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER 15
-#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER 15
-
 #define GROUP_MSG_COUNTER_MIN_INCREMENT 1000
 
 namespace chip {
@@ -52,8 +49,8 @@ public:
     FabricIndex mFabricIndex  = kUndefinedFabricIndex;
     uint8_t mControlPeerCount = 0;
     uint8_t mDataPeerCount    = 0;
-    GroupSender mDataGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER];
-    GroupSender mControlGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER];
+    GroupSender mDataGroupSenders[CHIP_CONFIG_MAX_GROUP_DATA_PEERS];
+    GroupSender mControlGroupSenders[CHIP_CONFIG_MAX_GROUP_CONTROL_PEERS];
 };
 
 class GroupPeerTable
@@ -81,7 +78,7 @@ public:
     GroupOutgoingCounters(chip::PersistentStorageDelegate * storage_delegate);
     CHIP_ERROR Init(chip::PersistentStorageDelegate * storage_delegate);
     uint32_t GetCounter(bool isControl);
-    void IncrementCounter(bool isControl);
+    CHIP_ERROR IncrementCounter(bool isControl);
 
     // Protected for Unit Tests inheritance
 protected:

--- a/src/transport/GroupPeerMessageCounter.h
+++ b/src/transport/GroupPeerMessageCounter.h
@@ -24,57 +24,51 @@
 #include <array>
 #include <bitset>
 
-#include <lib/support/Span.h>
-#include <transport/PeerMessageCounter.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/NodeId.h>
 #include <lib/core/PeerId.h>
-#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/support/Span.h>
+#include <transport/PeerMessageCounter.h>
+#include <lib/core/DataModelTypes.h>
 
+#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER 15
+#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER 15
 
-#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER     15
-#define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER  15
-
-#define GROUP_MSG_COUNTER_MIN_INCREMENT                     1000
+#define GROUP_MSG_COUNTER_MIN_INCREMENT 1000
 
 namespace chip {
 namespace Transport {
 
 class GroupSender
 {
-    public:
-    NodeId mNodeId=kUndefinedNodeId;
-    PeerMessageCounter msgCounter = {true};
+public:
+    NodeId mNodeId                = kUndefinedNodeId;
+    PeerMessageCounter msgCounter = { true };
 };
 
 class GroupFabric
 {
-    public :
-    FabricId mFabricId = kUndefinedFabricId;
+public:
+    FabricIndex mFabricIndex        = kUndefinedFabricIndex;
     uint8_t mControlPeerCount = 0;
-    uint8_t mDataPeerCount = 0;
+    uint8_t mDataPeerCount    = 0;
     GroupSender mDataGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER];
     GroupSender mControlGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER];
-
 };
-
 
 class GroupPeerTable
 {
-    public:
-
-    CHIP_ERROR FindOrAddPeer(FabricId fabricId, NodeId nodeId, bool isControl, chip::Transport::PeerMessageCounter * & counter);
+public:
+    CHIP_ERROR FindOrAddPeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl, chip::Transport::PeerMessageCounter *& counter);
 
     // Used in case of MCSP failure
-    CHIP_ERROR RemovePeer(FabricId fabricId, NodeId nodeId, bool isControl);
-
+    CHIP_ERROR RemovePeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl);
 
     // For Unit Test
-    FabricId GetFabricIdAt(uint8_t index);
+    FabricIndex GetFabricIndexAt(uint8_t index);
 
-
-    private:
+private:
     GroupFabric mGroupFabrics[CHIP_CONFIG_MAX_FABRICS];
-
 };
 
 // Might want to rename this so that it is explicitly the sending side of counters
@@ -86,13 +80,13 @@ public:
     CHIP_ERROR Init(chip::PersistentStorageDelegate * storage_delegate);
     uint32_t GetCounter(bool isControl);
     void SetCounter(bool isControl, uint32_t value);
+
 private:
     // TODO Initialize those to random value
-    uint32_t mGroupDataCounter = 0;
-    uint32_t mGroupControlCounter = 0;
+    uint32_t mGroupDataCounter                 = 0;
+    uint32_t mGroupControlCounter              = 0;
     chip::PersistentStorageDelegate * mStorage = nullptr;
 };
-
 
 } // namespace Transport
 } // namespace chip

--- a/src/transport/GroupPeerMessageCounter.h
+++ b/src/transport/GroupPeerMessageCounter.h
@@ -25,11 +25,11 @@
 #include <bitset>
 
 #include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/NodeId.h>
 #include <lib/core/PeerId.h>
 #include <lib/support/Span.h>
 #include <transport/PeerMessageCounter.h>
-#include <lib/core/DataModelTypes.h>
 
 #define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER 15
 #define GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER 15
@@ -49,7 +49,7 @@ public:
 class GroupFabric
 {
 public:
-    FabricIndex mFabricIndex        = kUndefinedFabricIndex;
+    FabricIndex mFabricIndex  = kUndefinedFabricIndex;
     uint8_t mControlPeerCount = 0;
     uint8_t mDataPeerCount    = 0;
     GroupSender mDataGroupSenders[GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER];
@@ -59,29 +59,32 @@ public:
 class GroupPeerTable
 {
 public:
-    CHIP_ERROR FindOrAddPeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl, chip::Transport::PeerMessageCounter *& counter);
+    CHIP_ERROR FindOrAddPeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl,
+                             chip::Transport::PeerMessageCounter *& counter);
 
     // Used in case of MCSP failure
     CHIP_ERROR RemovePeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl);
 
-    // For Unit Test
-    FabricIndex GetFabricIndexAt(uint8_t index);
+// Protected for Unit Tests inheritance
+protected:
+    bool RemoveSpecificPeer(GroupSender * list, NodeId nodeId, uint32_t size);
+    void CompactPeers(GroupSender * list, uint32_t size);
 
-private:
     GroupFabric mGroupFabrics[CHIP_CONFIG_MAX_FABRICS];
 };
 
 // Might want to rename this so that it is explicitly the sending side of counters
-class GroupClientCounters
+class GroupOutgoingCounters
 {
 public:
-    GroupClientCounters(){};
-    GroupClientCounters(chip::PersistentStorageDelegate * storage_delegate);
+    GroupOutgoingCounters(){};
+    GroupOutgoingCounters(chip::PersistentStorageDelegate * storage_delegate);
     CHIP_ERROR Init(chip::PersistentStorageDelegate * storage_delegate);
     uint32_t GetCounter(bool isControl);
-    void SetCounter(bool isControl, uint32_t value);
+    void IncrementCounter(bool isControl);
 
-private:
+    // Protected for Unit Tests inheritance
+protected:
     // TODO Initialize those to random value
     uint32_t mGroupDataCounter                 = 0;
     uint32_t mGroupControlCounter              = 0;

--- a/src/transport/GroupPeerMessageCounter.h
+++ b/src/transport/GroupPeerMessageCounter.h
@@ -42,8 +42,8 @@ namespace Transport {
 class GroupSender
 {
 public:
-    NodeId mNodeId                = kUndefinedNodeId;
-    PeerMessageCounter msgCounter = { true };
+    NodeId mNodeId = kUndefinedNodeId;
+    PeerMessageCounter msgCounter;
 };
 
 class GroupFabric
@@ -65,7 +65,7 @@ public:
     // Used in case of MCSP failure
     CHIP_ERROR RemovePeer(FabricIndex fabricIndex, NodeId nodeId, bool isControl);
 
-// Protected for Unit Tests inheritance
+    // Protected for Unit Tests inheritance
 protected:
     bool RemoveSpecificPeer(GroupSender * list, NodeId nodeId, uint32_t size);
     void CompactPeers(GroupSender * list, uint32_t size);

--- a/src/transport/PeerMessageCounter.h
+++ b/src/transport/PeerMessageCounter.h
@@ -95,7 +95,8 @@ public:
 
         if (counter <= mSynced.mMaxCounter)
         {
-            uint32_t offset = mSynced.mMaxCounter - counter;;
+            uint32_t offset = mSynced.mMaxCounter - counter;
+            ;
 
             if (mIsGroup && (offset > (UINT32_MAX / 2)))
             {
@@ -110,13 +111,10 @@ public:
                 }
             }
 
-
             if (offset >= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
             {
                 return CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW; // outside valid range
             }
-
-
 
             if (mSynced.mWindow.test(offset))
             {
@@ -138,7 +136,6 @@ public:
         case Status::Synced: {
             CHIP_ERROR err = Verify(counter);
             if (err == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW && !mIsGroup)
-            // if (err == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW)
             {
                 // According to chip spec, when global unencrypted message
                 // counter is out of window, the peer may have reset and is
@@ -178,7 +175,6 @@ public:
                 {
                     offset = secondOffset;
                 }
-
             }
 
             mSynced.mWindow.set(offset);

--- a/src/transport/PeerMessageCounter.h
+++ b/src/transport/PeerMessageCounter.h
@@ -96,7 +96,6 @@ public:
         if (counter <= mSynced.mMaxCounter)
         {
             uint32_t offset = mSynced.mMaxCounter - counter;
-            ;
 
             if (mIsGroup && (offset > (UINT32_MAX / 2)))
             {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -720,7 +720,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
         return;
     }
 
-    counter->Commit(packetHeader.GetMessageCounter());
+    counter->CommitWithRollOver(packetHeader.GetMessageCounter());
 
     if (mCB != nullptr)
     {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -693,7 +693,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
 
         if (Credentials::GroupDataProvider::SecurityPolicy::kLowLatency == groupContext.security_policy)
         {
-            err = counter->VerifyOrTrustFirst(packetHeader.GetMessageCounter());
+            err = counter->VerifyOrTrustFirst(packetHeader.GetMessageCounter(), true);
         }
         else
         {
@@ -703,7 +703,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
             return;
 
             // cache and sync
-            // err = counter->Verify(packetHeader.GetMessageCounter());
+            // err = counter->Verify(packetHeader.GetMessageCounter(), true);
         }
 
         if (err != CHIP_NO_ERROR)

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -36,6 +36,7 @@
 #include <messaging/ReliableMessageProtocolConfig.h>
 #include <protocols/secure_channel/Constants.h>
 #include <transport/CryptoContext.h>
+#include <transport/GroupPeerMessageCounter.h>
 #include <transport/GroupSession.h>
 #include <transport/MessageCounterManagerInterface.h>
 #include <transport/SecureSessionTable.h>
@@ -257,6 +258,7 @@ private:
     Transport::SecureSessionTable<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mSecureSessions;
     Transport::GroupSessionTable<CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE> mGroupSessions;
     State mState; // < Initialization state of the object
+    chip::Transport::GroupClientCounters mGroupClientCounter;
 
     SessionMessageDelegate * mCB = nullptr;
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -258,7 +258,7 @@ private:
     Transport::SecureSessionTable<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mSecureSessions;
     Transport::GroupSessionTable<CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE> mGroupSessions;
     State mState; // < Initialization state of the object
-    chip::Transport::GroupClientCounters mGroupClientCounter;
+    chip::Transport::GroupOutgoingCounters mGroupClientCounter;
 
     SessionMessageDelegate * mCB = nullptr;
 
@@ -267,9 +267,6 @@ private:
 
     TransportMgrBase * mTransportMgr                                   = nullptr;
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;
-
-    // Will be use once PR 14996 is merged
-    chip::PersistentStorageDelegate * mStorage = nullptr;
 
     GlobalUnencryptedMessageCounter mGlobalUnencryptedMessageCounter;
     GlobalEncryptedMessageCounter mGlobalEncryptedMessageCounter;

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -23,6 +23,7 @@ chip_test_suite("tests") {
   output_name = "libTransportLayerTests"
 
   test_sources = [
+    "TestGroupMessageCounter.cpp",
     "TestPairingSession.cpp",
     "TestPeerConnections.cpp",
     "TestSecureSession.cpp",

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -1,0 +1,346 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the SessionManager implementation.
+ */
+
+#include <lib/support/UnitTestRegistration.h>
+#include <transport/GroupPeerMessageCounter.h>
+#include <transport/PeerMessageCounter.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+
+#include <nlbyteorder.h>
+#include <nlunit-test.h>
+
+#include <errno.h>
+
+
+
+namespace {
+
+using namespace chip;
+
+
+void AddPeerTest(nlTestSuite * inSuite, void * inContext)
+{
+    NodeId peerNodeId = 1234;
+    FabricId fabricId = 1;
+    uint32_t i = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Transport::PeerMessageCounter * counter = nullptr;
+    chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
+
+    do
+    {
+        err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId++, false, counter);
+        i++;
+
+    }while(err != CHIP_ERROR_TOO_MANY_PEER_NODES );
+
+    NL_TEST_ASSERT(inSuite, i == GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER + 1);
+
+    i = 1;
+    do
+    {
+        err = mGroupPeerMsgCounter.FindOrAddPeer(++fabricId, peerNodeId, false, counter);
+        i++;
+    }while(err != CHIP_ERROR_TOO_MANY_PEER_NODES);
+    NL_TEST_ASSERT(inSuite, i == CHIP_CONFIG_MAX_FABRICS + 1);
+
+}
+
+void RemovePeerTest(nlTestSuite * inSuite, void * inContext)
+{
+    NodeId peerNodeId = 1234;
+    FabricId fabricId = 1;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Transport::PeerMessageCounter * counter = nullptr;
+    chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
+
+    // Fill table up (max fabric and mac peer)
+    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    {
+        for(uint32_t peerId = 0; peerId < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; peerId++)
+        {
+            err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId++, true, counter);
+        }
+        fabricId++;
+    }
+    // Verify that table is indeed full (for control Peer)
+    err = mGroupPeerMsgCounter.FindOrAddPeer(99, 99, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TOO_MANY_PEER_NODES);
+
+    // Clear all Peer
+    fabricId = 1;
+    peerNodeId = 1234;
+    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    {
+        for(uint32_t peerId = 0; peerId < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; peerId++)
+        {
+            err = mGroupPeerMsgCounter.RemovePeer(fabricId, peerNodeId++, true);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+        fabricId++;
+    }
+
+    // Try re-adding the previous peer without any erros
+    err = mGroupPeerMsgCounter.FindOrAddPeer(99, 99, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+}
+
+void PeerRetrievalTest(nlTestSuite * inSuite, void * inContext)
+{
+    NodeId peerNodeId = 1234;
+    FabricId fabricId = 1;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Transport::PeerMessageCounter * counter = nullptr;
+    chip::Transport::PeerMessageCounter * counter2 = nullptr;
+    chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
+
+    err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter != nullptr);
+
+    err = mGroupPeerMsgCounter.FindOrAddPeer(99, 99, true, counter2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter2 != nullptr);
+    NL_TEST_ASSERT(inSuite, counter2 != counter);
+
+    err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId, true, counter2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter2 == counter);
+
+}
+
+void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Transport::PeerMessageCounter * counter = nullptr;
+    chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
+
+    err = mGroupPeerMsgCounter.FindOrAddPeer(99, 99, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter != nullptr);
+
+    err = counter->VerifyOrTrustFirst(5656);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->Commit(5656);
+
+
+    err = counter->VerifyOrTrustFirst(5756);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->Commit(5756);
+
+    err = counter->VerifyOrTrustFirst(4756);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+
+
+    // test sequential reception
+    err = counter->VerifyOrTrustFirst(5757);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->Commit(5757);
+
+    err = counter->VerifyOrTrustFirst(5758);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->Commit(5758);
+
+    err = counter->VerifyOrTrustFirst(5756);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+
+    // Test Roll over
+    err = mGroupPeerMsgCounter.FindOrAddPeer(1, 99, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter != nullptr);
+
+    err = counter->VerifyOrTrustFirst(UINT32_MAX - 1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->Commit(UINT32_MAX - 1);
+
+    err = counter->VerifyOrTrustFirst(5);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+}
+
+void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Transport::PeerMessageCounter * counter = nullptr;
+    chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
+
+    err = mGroupPeerMsgCounter.FindOrAddPeer(1, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(2, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(3, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(4, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(5, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(6, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(7, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(8, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, true, counter);
+
+    err = counter->VerifyOrTrustFirst(5656);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->Commit(5656);
+
+    err = counter->VerifyOrTrustFirst(4756);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+
+
+    err = mGroupPeerMsgCounter.FindOrAddPeer(10, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(11, 1, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(12, 1, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, counter != nullptr);
+
+
+    err = mGroupPeerMsgCounter.RemovePeer(3, 1, true);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(2) == 12);
+    err = mGroupPeerMsgCounter.RemovePeer(8, 1, true);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(7) == 11);
+    err = mGroupPeerMsgCounter.RemovePeer(11, 1, true);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(7) == 10);
+    err = mGroupPeerMsgCounter.RemovePeer(1, 1, true);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(0) == 9);
+    err = mGroupPeerMsgCounter.RemovePeer(10, 1, true);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(7) == 0);
+
+    // Validate that counter value were moved around correctly
+    err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, true, counter);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = counter->VerifyOrTrustFirst(4756);
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+}
+
+void GroupMessageCounterTest(nlTestSuite * inSuite, void * inContext)
+{
+    chip::TestPersistentStorageDelegate delegate;
+    chip::Transport::GroupClientCounters groupCientCounter(&delegate);
+    uint32_t counter = 99;
+
+    // Start Test with Control counter
+    counter = groupCientCounter.GetCounter(true);
+    NL_TEST_ASSERT(inSuite, counter == 0);
+
+    groupCientCounter.SetCounter(true, 563);
+    counter = groupCientCounter.GetCounter(true);
+    NL_TEST_ASSERT(inSuite, counter == 563);
+    counter = groupCientCounter.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == 0);
+
+    // Test Persistence
+    chip::Transport::GroupClientCounters groupCientCounter2(&delegate);
+    counter = groupCientCounter2.GetCounter(true);
+    // Expect GROUP_MSG_COUNTER_MIN_INCREMENT since new object is initialized
+    // with persistent data
+    NL_TEST_ASSERT(inSuite, counter == GROUP_MSG_COUNTER_MIN_INCREMENT);
+    counter = groupCientCounter2.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == GROUP_MSG_COUNTER_MIN_INCREMENT);
+
+    // Test Roll over
+    counter = UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT - 1;
+    groupCientCounter2.SetCounter(true, counter);
+    counter = groupCientCounter2.GetCounter(true);
+    NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT - 1));
+
+    // As of now value in persistent storage should be of
+    // UINT32_MAX - 1
+    chip::Transport::GroupClientCounters groupCientCounter3(&delegate);
+    counter = groupCientCounter3.GetCounter(true);
+    NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - 1));
+
+    counter = 256; // To simulate roll over
+    groupCientCounter3.SetCounter(true, counter);
+    counter = groupCientCounter3.GetCounter(true);
+    NL_TEST_ASSERT(inSuite, counter == 256);
+
+    // Verify Persistence value again
+    chip::Transport::GroupClientCounters groupCientCounter4(&delegate);
+    counter = groupCientCounter4.GetCounter(true);
+    NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - 1 + GROUP_MSG_COUNTER_MIN_INCREMENT));
+
+
+    // Redo some of the test but with the Data counter
+
+    counter = groupCientCounter.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == 0);
+
+    groupCientCounter.SetCounter(false, 563);
+    counter = groupCientCounter.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == 563);
+
+     // Test Roll over
+    counter = UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT - 4;
+    groupCientCounter2.SetCounter(false, counter);
+    counter = groupCientCounter2.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT - 4));
+
+    // As of now value in persistent storage should be of
+    // UINT32_MAX - 1
+    chip::Transport::GroupClientCounters groupCientCounter5(&delegate);
+    counter = groupCientCounter5.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - 4));
+
+    counter = 512; // To simulate roll over
+    groupCientCounter5.SetCounter(false, counter);
+    counter = groupCientCounter5.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == 512);
+
+    // Verify Persistence value again
+    chip::Transport::GroupClientCounters groupCientCounter6(&delegate);
+    counter = groupCientCounter6.GetCounter(false);
+    NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - 4 + GROUP_MSG_COUNTER_MIN_INCREMENT));
+
+
+
+
+}
+
+} // namespace
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("Add Peer",               AddPeerTest),
+    NL_TEST_DEF("Remove Peer",            RemovePeerTest),
+    NL_TEST_DEF("Peer retrieval",         PeerRetrievalTest),
+    NL_TEST_DEF("Counter Trust first",    CounterTrustFirstTest),
+    NL_TEST_DEF("Reorder Fabric Removal", ReorderFabricRemovalTest),
+    NL_TEST_DEF("Group Message Counter",  GroupMessageCounterTest),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+/**
+ *  Main
+ */
+int TestGroupMessageCounter()
+{
+    // Run test suit against one context
+
+    nlTestSuite theSuite = { "Transport-TestGroupMessageCounter", &sTests[0], nullptr, nullptr };
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestGroupMessageCounter);

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -21,101 +21,96 @@
  *      This file implements unit tests for the SessionManager implementation.
  */
 
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <transport/GroupPeerMessageCounter.h>
 #include <transport/PeerMessageCounter.h>
-#include <lib/support/TestPersistentStorageDelegate.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
 
 #include <errno.h>
 
-
-
 namespace {
 
 using namespace chip;
 
-
 void AddPeerTest(nlTestSuite * inSuite, void * inContext)
 {
-    NodeId peerNodeId = 1234;
-    FabricId fabricId = 1;
-    uint32_t i = 0;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    NodeId peerNodeId                             = 1234;
+    FabricIndex fabricIndex                       = 1;
+    uint32_t i                                    = 0;
+    CHIP_ERROR err                                = CHIP_NO_ERROR;
     chip::Transport::PeerMessageCounter * counter = nullptr;
     chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
 
     do
     {
-        err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId++, false, counter);
+        err = mGroupPeerMsgCounter.FindOrAddPeer(fabricIndex, peerNodeId++, false, counter);
         i++;
 
-    }while(err != CHIP_ERROR_TOO_MANY_PEER_NODES );
+    } while (err != CHIP_ERROR_TOO_MANY_PEER_NODES);
 
     NL_TEST_ASSERT(inSuite, i == GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_DATA_PEER + 1);
 
     i = 1;
     do
     {
-        err = mGroupPeerMsgCounter.FindOrAddPeer(++fabricId, peerNodeId, false, counter);
+        err = mGroupPeerMsgCounter.FindOrAddPeer(++fabricIndex, peerNodeId, false, counter);
         i++;
-    }while(err != CHIP_ERROR_TOO_MANY_PEER_NODES);
+    } while (err != CHIP_ERROR_TOO_MANY_PEER_NODES);
     NL_TEST_ASSERT(inSuite, i == CHIP_CONFIG_MAX_FABRICS + 1);
-
 }
 
 void RemovePeerTest(nlTestSuite * inSuite, void * inContext)
 {
-    NodeId peerNodeId = 1234;
-    FabricId fabricId = 1;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    NodeId peerNodeId                             = 1234;
+    FabricIndex fabricIndex                             = 1;
+    CHIP_ERROR err                                = CHIP_NO_ERROR;
     chip::Transport::PeerMessageCounter * counter = nullptr;
     chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
 
     // Fill table up (max fabric and mac peer)
-    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS; it++)
     {
-        for(uint32_t peerId = 0; peerId < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; peerId++)
+        for (uint32_t peerId = 0; peerId < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; peerId++)
         {
-            err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId++, true, counter);
+            err = mGroupPeerMsgCounter.FindOrAddPeer(fabricIndex, peerNodeId++, true, counter);
         }
-        fabricId++;
+        fabricIndex++;
     }
     // Verify that table is indeed full (for control Peer)
     err = mGroupPeerMsgCounter.FindOrAddPeer(99, 99, true, counter);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TOO_MANY_PEER_NODES);
 
     // Clear all Peer
-    fabricId = 1;
+    fabricIndex   = 1;
     peerNodeId = 1234;
-    for(uint32_t it = 0 ; it < CHIP_CONFIG_MAX_FABRICS; it ++ )
+    for (uint32_t it = 0; it < CHIP_CONFIG_MAX_FABRICS; it++)
     {
-        for(uint32_t peerId = 0; peerId < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; peerId++)
+        for (uint32_t peerId = 0; peerId < GROUP_MSG_COUNTER_MAX_NUMBER_OF_GROUP_CONTROL_PEER; peerId++)
         {
-            err = mGroupPeerMsgCounter.RemovePeer(fabricId, peerNodeId++, true);
+            err = mGroupPeerMsgCounter.RemovePeer(fabricIndex, peerNodeId++, true);
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         }
-        fabricId++;
+        fabricIndex++;
     }
 
-    // Try re-adding the previous peer without any erros
+    // Try re-adding the previous peer without any error
     err = mGroupPeerMsgCounter.FindOrAddPeer(99, 99, true, counter);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
 }
 
 void PeerRetrievalTest(nlTestSuite * inSuite, void * inContext)
 {
-    NodeId peerNodeId = 1234;
-    FabricId fabricId = 1;
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Transport::PeerMessageCounter * counter = nullptr;
+    NodeId peerNodeId                              = 1234;
+    FabricIndex fabricIndex                              = 1;
+    CHIP_ERROR err                                 = CHIP_NO_ERROR;
+    chip::Transport::PeerMessageCounter * counter  = nullptr;
     chip::Transport::PeerMessageCounter * counter2 = nullptr;
     chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
 
-    err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId, true, counter);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(fabricIndex, peerNodeId, true, counter);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
@@ -124,15 +119,14 @@ void PeerRetrievalTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, counter2 != nullptr);
     NL_TEST_ASSERT(inSuite, counter2 != counter);
 
-    err = mGroupPeerMsgCounter.FindOrAddPeer(fabricId, peerNodeId, true, counter2);
+    err = mGroupPeerMsgCounter.FindOrAddPeer(fabricIndex, peerNodeId, true, counter2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter2 == counter);
-
 }
 
 void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                                = CHIP_NO_ERROR;
     chip::Transport::PeerMessageCounter * counter = nullptr;
     chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
 
@@ -144,14 +138,12 @@ void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     counter->Commit(5656);
 
-
     err = counter->VerifyOrTrustFirst(5756);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     counter->Commit(5756);
 
     err = counter->VerifyOrTrustFirst(4756);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
-
 
     // test sequential reception
     err = counter->VerifyOrTrustFirst(5757);
@@ -176,12 +168,11 @@ void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
 
     err = counter->VerifyOrTrustFirst(5);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
 }
 
 void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                                = CHIP_NO_ERROR;
     chip::Transport::PeerMessageCounter * counter = nullptr;
     chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
 
@@ -202,24 +193,22 @@ void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
     err = counter->VerifyOrTrustFirst(4756);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
-
     err = mGroupPeerMsgCounter.FindOrAddPeer(10, 1, true, counter);
     err = mGroupPeerMsgCounter.FindOrAddPeer(11, 1, true, counter);
     err = mGroupPeerMsgCounter.FindOrAddPeer(12, 1, true, counter);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
-
     err = mGroupPeerMsgCounter.RemovePeer(3, 1, true);
-    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(2) == 12);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIndexAt(2) == 12);
     err = mGroupPeerMsgCounter.RemovePeer(8, 1, true);
-    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(7) == 11);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIndexAt(7) == 11);
     err = mGroupPeerMsgCounter.RemovePeer(11, 1, true);
-    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(7) == 10);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIndexAt(7) == 10);
     err = mGroupPeerMsgCounter.RemovePeer(1, 1, true);
-    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(0) == 9);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIndexAt(0) == 9);
     err = mGroupPeerMsgCounter.RemovePeer(10, 1, true);
-    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIdAt(7) == 0);
+    NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetFabricIndexAt(7) == 0);
 
     // Validate that counter value were moved around correctly
     err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, true, counter);
@@ -275,7 +264,6 @@ void GroupMessageCounterTest(nlTestSuite * inSuite, void * inContext)
     counter = groupCientCounter4.GetCounter(true);
     NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - 1 + GROUP_MSG_COUNTER_MIN_INCREMENT));
 
-
     // Redo some of the test but with the Data counter
 
     counter = groupCientCounter.GetCounter(false);
@@ -285,7 +273,7 @@ void GroupMessageCounterTest(nlTestSuite * inSuite, void * inContext)
     counter = groupCientCounter.GetCounter(false);
     NL_TEST_ASSERT(inSuite, counter == 563);
 
-     // Test Roll over
+    // Test Roll over
     counter = UINT32_MAX - GROUP_MSG_COUNTER_MIN_INCREMENT - 4;
     groupCientCounter2.SetCounter(false, counter);
     counter = groupCientCounter2.GetCounter(false);
@@ -306,10 +294,6 @@ void GroupMessageCounterTest(nlTestSuite * inSuite, void * inContext)
     chip::Transport::GroupClientCounters groupCientCounter6(&delegate);
     counter = groupCientCounter6.GetCounter(false);
     NL_TEST_ASSERT(inSuite, counter == (UINT32_MAX - 4 + GROUP_MSG_COUNTER_MIN_INCREMENT));
-
-
-
-
 }
 
 } // namespace

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -401,7 +401,6 @@ void GroupMessageCounterTest(nlTestSuite * inSuite, void * inContext)
     TestGroupOutgoingCounters groupCientCounter2(&delegate);
 
     NL_TEST_ASSERT(inSuite, groupCientCounter2.GetCounter(true) == UINT32_MAX);
-    ChipLogDetail(Inet, "%u", groupCientCounter2.GetCounter(false));
     NL_TEST_ASSERT(inSuite, groupCientCounter2.GetCounter(false) == GROUP_MSG_COUNTER_MIN_INCREMENT);
 
     // Test Roll over

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -326,6 +326,8 @@ void ReorderPeerRemovalTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, mGroupPeerMsgCounter.GetNodeIdAt(1, 0, false) == 9);
 }
 
+#if !__ZEPHYR__
+
 void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err                                = CHIP_NO_ERROR;
@@ -378,7 +380,7 @@ void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
     err = counter->VerifyOrTrustFirst(4756, true);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
-
+#endif // !__ZEPHYR__
 void GroupMessageCounterTest(nlTestSuite * inSuite, void * inContext)
 {
 
@@ -447,7 +449,9 @@ const nlTest sTests[] =
     NL_TEST_DEF("Counter Rollover",       CounterCommitRolloverTest),
     NL_TEST_DEF("Counter Trust first",    CounterTrustFirstTest),
     NL_TEST_DEF("Reorder Peer removal",   ReorderPeerRemovalTest),
+    #if !__ZEPHYR__
     NL_TEST_DEF("Reorder Fabric Removal", ReorderFabricRemovalTest),
+    #endif
     NL_TEST_DEF("Group Message Counter",  GroupMessageCounterTest),
     NL_TEST_SENTINEL()
 };

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -199,27 +199,29 @@ void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
-    err = counter->VerifyOrTrustFirst(5656);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(5656);
+    ChipLogDetail(Inet, "%u", counter->kGroupOffset);
 
-    err = counter->VerifyOrTrustFirst(5756);
+    err = counter->VerifyOrTrustFirst(5656, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(5756);
 
-    err = counter->VerifyOrTrustFirst(4756);
+    counter->CommitWithRollOver(5656);
+
+    err = counter->VerifyOrTrustFirst(5756, true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    counter->CommitWithRollOver(5756);
+    err = counter->VerifyOrTrustFirst(4756, true);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     // test sequential reception
-    err = counter->VerifyOrTrustFirst(5757);
+    err = counter->VerifyOrTrustFirst(5757, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(5757);
+    counter->CommitWithRollOver(5757);
 
-    err = counter->VerifyOrTrustFirst(5758);
+    err = counter->VerifyOrTrustFirst(5758, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(5758);
+    counter->CommitWithRollOver(5758);
 
-    err = counter->VerifyOrTrustFirst(5756);
+    err = counter->VerifyOrTrustFirst(5756, true);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     // Test Roll over
@@ -227,41 +229,40 @@ void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX - 6);
+    err = counter->VerifyOrTrustFirst(UINT32_MAX - 6, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(UINT32_MAX - 6);
+    counter->CommitWithRollOver(UINT32_MAX - 6);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX - 1);
+    err = counter->VerifyOrTrustFirst(UINT32_MAX - 1, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(UINT32_MAX - 1);
+    counter->CommitWithRollOver(UINT32_MAX - 1);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    err = counter->VerifyOrTrustFirst(0);
+    err = counter->VerifyOrTrustFirst(UINT32_MAX, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(1);
+    err = counter->VerifyOrTrustFirst(0, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(2);
+    err = counter->VerifyOrTrustFirst(1, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(3);
+    err = counter->VerifyOrTrustFirst(2, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(4);
+    err = counter->VerifyOrTrustFirst(3, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(5);
+    err = counter->VerifyOrTrustFirst(4, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(6);
+    err = counter->VerifyOrTrustFirst(5, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(7);
+    err = counter->VerifyOrTrustFirst(6, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
+    err = counter->VerifyOrTrustFirst(7, true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
 void ReorderPeerRemovalTest(nlTestSuite * inSuite, void * inContext)
@@ -323,11 +324,11 @@ void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
     err = mGroupPeerMsgCounter.FindOrAddPeer(8, 1, true, counter);
     err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, true, counter);
 
-    err = counter->VerifyOrTrustFirst(5656);
+    err = counter->VerifyOrTrustFirst(5656, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->Commit(5656);
+    counter->CommitWithRollOver(5656);
 
-    err = counter->VerifyOrTrustFirst(4756);
+    err = counter->VerifyOrTrustFirst(4756, true);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     err = mGroupPeerMsgCounter.FindOrAddPeer(10, 1, true, counter);
@@ -356,7 +357,7 @@ void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
     // Validate that counter value were moved around correctly
     err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, true, counter);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = counter->VerifyOrTrustFirst(4756);
+    err = counter->VerifyOrTrustFirst(4756, true);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -91751,7 +91751,7 @@ private:
 
         request.groupKeySet.groupKeySetID = 418U;
         request.groupKeySet.groupKeySecurityPolicy =
-            static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(1);
+            static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(0);
         request.groupKeySet.epochKey0.SetNonNull();
         request.groupKeySet.epochKey0.Value() =
             chip::ByteSpan(chip::Uint8::from_const_char(

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -91698,7 +91698,7 @@ private:
 
         request.groupKeySet.groupKeySetID = 417U;
         request.groupKeySet.groupKeySecurityPolicy =
-            static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(0);
+            static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(1);
         request.groupKeySet.epochKey0.SetNonNull();
         request.groupKeySet.epochKey0.Value() =
             chip::ByteSpan(chip::Uint8::from_const_char(
@@ -91751,7 +91751,7 @@ private:
 
         request.groupKeySet.groupKeySetID = 418U;
         request.groupKeySet.groupKeySecurityPolicy =
-            static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(0);
+            static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(1);
         request.groupKeySet.epochKey0.SetNonNull();
         request.groupKeySet.epochKey0.Value() =
             chip::ByteSpan(chip::Uint8::from_const_char(


### PR DESCRIPTION
#### Problem
fix #11076 

#### Change overview
Group Messages counter implemented

Other changes related to the Group Message counter Implementation : 

Added `SourceNodeId` to `GroupSession` since Source Node ID is required by spec to be in the packet header. This was the easiest way to do so since accessing the Fabric Table from within the SessionManager would have link the App layer with the transport layer.

Added PersistentStorageDelegate to the SessionManager Init since we need to persist the group message counters.

#### Testing
- Unit tests
- Test suite
- EFR32 devices with controller.
