### PR TITLE
Issue#11399 - [ota-requestor-app] Make RequestorCanConsent field of Query Image request configurable

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -94,9 +94,11 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "        From boot up, the amount of time to wait before triggering the QueryImage\n"
                              "        command. If none or zero is supplied, QueryImage will not be triggered.\n"
                              "  -c/--RequestorCanConsent\n"
-                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.\n" };
+                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.
+                             Else,
+                             it is set to false. \n " };
 
-HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]", "1.0");
+                             HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]", "1.0");
 
 OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 
@@ -182,7 +184,6 @@ void ApplicationInit()
     if (gRequestorCanConsent.HasValue())
     {
         gRequestorCore.SetProviderParameters(gRequestorCanConsent.Value());
-        ChipLogProgress(SoftwareUpdate, "Setting RequestorCanConsent to %d", gRequestorCanConsent.Value());
     }
 
     // Initialize all OTA download components

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -94,8 +94,8 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "        From boot up, the amount of time to wait before triggering the QueryImage\n"
                              "        command. If none or zero is supplied, QueryImage will not be triggered.\n"
                              "  -c/--RequestorCanConsent\n"
-                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.\n"
-                             "        Else, it is set to false.\n " };
+                             "        If provided, the RequestorCanConsent field of the QueryImage command is set to true.\n"
+                             "        Else, the value is determined by the driver.\n " };
 
 HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]", "1.0");
 

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -94,11 +94,10 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "        From boot up, the amount of time to wait before triggering the QueryImage\n"
                              "        command. If none or zero is supplied, QueryImage will not be triggered.\n"
                              "  -c/--RequestorCanConsent\n"
-                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.
-                             Else,
-                             it is set to false. \n " };
+                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.\n"
+                             "        Else, it is set to false.\n " };
 
-                             HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]", "1.0");
+HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]", "1.0");
 
 OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 
@@ -183,7 +182,7 @@ void ApplicationInit()
 
     if (gRequestorCanConsent.HasValue())
     {
-        gRequestorCore.SetProviderParameters(gRequestorCanConsent.Value());
+        gRequestorCore.SetRequestorCanConsent(gRequestorCanConsent.Value());
     }
 
     // Initialize all OTA download components

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -54,12 +54,12 @@ OTAImageProcessorImpl gImageProcessor;
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
 void OnStartDelayTimerHandler(Layer * systemLayer, void * appState);
 
-constexpr uint16_t kOptionProviderNodeId         = 'n';
-constexpr uint16_t kOptionProviderFabricIndex    = 'f';
-constexpr uint16_t kOptionUdpPort                = 'u';
-constexpr uint16_t kOptionDiscriminator          = 'd';
-constexpr uint16_t kOptionDelayQuery             = 'q';
-constexpr uint16_t kOptionRequestorCanConsent    = 'c';
+constexpr uint16_t kOptionProviderNodeId      = 'n';
+constexpr uint16_t kOptionProviderFabricIndex = 'f';
+constexpr uint16_t kOptionUdpPort             = 'u';
+constexpr uint16_t kOptionDiscriminator       = 'd';
+constexpr uint16_t kOptionDelayQuery          = 'q';
+constexpr uint16_t kOptionRequestorCanConsent = 'c';
 
 NodeId providerNodeId           = 0x0;
 FabricIndex providerFabricIndex = 1;
@@ -92,9 +92,9 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "        advertisements. If none is specified, default value is 3840.\n"
                              "  -q/--delayQuery <Time in seconds>\n"
                              "        From boot up, the amount of time to wait before triggering the QueryImage\n"
-                             "        command. If none or zero is supplied, QueryImage will not be triggered.\n" 
+                             "        command. If none or zero is supplied, QueryImage will not be triggered.\n"
                              "  -c/--RequestorCanConsent\n"
-                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.\n"};
+                             "        If provided, the RequestorCanConsent field of the Query Image request is set to true.\n" };
 
 HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]", "1.0");
 
@@ -124,7 +124,7 @@ static void InitOTARequestor(void)
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
     bool retval = true;
-    
+
     switch (aIdentifier)
     {
     case kOptionProviderNodeId:
@@ -182,7 +182,7 @@ void ApplicationInit()
     if (gRequestorCanConsent.HasValue())
     {
         gRequestorCore.SetProviderParameters(gRequestorCanConsent.Value());
-        ChipLogProgress(SoftwareUpdate, "Setting RequestorCanConsent to %d", gRequestorCanConsent.Value() );
+        ChipLogProgress(SoftwareUpdate, "Setting RequestorCanConsent to %d", gRequestorCanConsent.Value());
     }
 
     // Initialize all OTA download components

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -551,7 +551,6 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
 
     args.protocolsSupported = kProtocolsSupported;
     args.requestorCanConsent.SetValue(mRequestorCanConsent.ValueOr(mOtaRequestorDriver->CanConsent()));
-    ChipLogProgress(SoftwareUpdate, "Setting requestorCanConsent to: %d", args.requestorCanConsent.Value());
 
     uint16_t hardwareVersion;
     if (DeviceLayer::ConfigurationMgr().GetHardwareVersion(hardwareVersion) == CHIP_NO_ERROR)

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -550,7 +550,8 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
     ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(args.softwareVersion));
 
     args.protocolsSupported = kProtocolsSupported;
-    args.requestorCanConsent.SetValue(mOtaRequestorDriver->CanConsent());
+    args.requestorCanConsent.SetValue(mRequestorCanConsent.ValueOr(mOtaRequestorDriver->CanConsent()));
+    ChipLogProgress(SoftwareUpdate, "Setting requestorCanConsent to: %d", args.requestorCanConsent.Value());
 
     uint16_t hardwareVersion;
     if (DeviceLayer::ConfigurationMgr().GetHardwareVersion(hardwareVersion) == CHIP_NO_ERROR)

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -121,10 +121,7 @@ public:
     }
 
     // Called to set optional RequestorCanConsent value provided by Requestor.
-    void SetProviderParameters(bool RequestorCanConsent) override
-    {
-        mRequestorCanConsent.SetValue(RequestorCanConsent);
-    }
+    void SetProviderParameters(bool RequestorCanConsent) override { mRequestorCanConsent.SetValue(RequestorCanConsent); }
 
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
     // cleared, UpdateState is reset to Idle
@@ -284,10 +281,10 @@ private:
     BDXMessenger mBdxMessenger;                          // TODO: ideally this is held by the application
     uint8_t mUpdateTokenBuffer[kMaxUpdateTokenLen];
     ByteSpan mUpdateToken;
-    uint32_t mCurrentVersion                  = 0;
-    uint32_t mTargetVersion                   = 0;
-    OTAUpdateStateEnum mCurrentUpdateState    = OTAUpdateStateEnum::kIdle;
-    Server * mServer                          = nullptr;
+    uint32_t mCurrentVersion               = 0;
+    uint32_t mTargetVersion                = 0;
+    OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kIdle;
+    Server * mServer                       = nullptr;
     chip::Optional<bool> mRequestorCanConsent;
 };
 

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -118,6 +118,12 @@ public:
         mProviderNodeId      = nodeId;
         mProviderFabricIndex = fabIndex;
         mProviderEndpointId  = endpointId;
+    }
+
+    // Called to set optional RequestorCanConsent value provided by Requestor.
+    void SetProviderParameters(bool RequestorCanConsent) override
+    {
+        mRequestorCanConsent.SetValue(RequestorCanConsent);
     }
 
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
@@ -278,10 +284,11 @@ private:
     BDXMessenger mBdxMessenger;                          // TODO: ideally this is held by the application
     uint8_t mUpdateTokenBuffer[kMaxUpdateTokenLen];
     ByteSpan mUpdateToken;
-    uint32_t mCurrentVersion               = 0;
-    uint32_t mTargetVersion                = 0;
-    OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kIdle;
-    Server * mServer                       = nullptr;
+    uint32_t mCurrentVersion                  = 0;
+    uint32_t mTargetVersion                   = 0;
+    OTAUpdateStateEnum mCurrentUpdateState    = OTAUpdateStateEnum::kIdle;
+    Server * mServer                          = nullptr;
+    chip::Optional<bool> mRequestorCanConsent;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -121,7 +121,7 @@ public:
     }
 
     // Called to set optional RequestorCanConsent value provided by Requestor.
-    void SetProviderParameters(bool RequestorCanConsent) override { mRequestorCanConsent.SetValue(RequestorCanConsent); }
+    void SetRequestorCanConsent(bool RequestorCanConsent) { mRequestorCanConsent.SetValue(RequestorCanConsent); }
 
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
     // cleared, UpdateState is reset to Idle

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -77,6 +77,9 @@ public:
     // Manually set OTA Provider parameters
     virtual void TestModeSetProviderParameters(NodeId nodeId, FabricIndex fabIndex, EndpointId endpointId) = 0;
 
+    // Called to set optional RequestorCanConsent value provided by Requestor.
+    virtual void SetProviderParameters(bool RequestorCanConsent) = 0;
+
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
     // cleared, UpdateState is reset to Idle
     virtual void CancelImageUpdate() = 0;

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -77,9 +77,6 @@ public:
     // Manually set OTA Provider parameters
     virtual void TestModeSetProviderParameters(NodeId nodeId, FabricIndex fabIndex, EndpointId endpointId) = 0;
 
-    // Called to set optional RequestorCanConsent value provided by Requestor.
-    virtual void SetProviderParameters(bool RequestorCanConsent) = 0;
-
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
     // cleared, UpdateState is reset to Idle
     virtual void CancelImageUpdate() = 0;


### PR DESCRIPTION
Issue#11399 - [ota-requestor-app] Make RequestorCanConsent field of Query Image request configurable

Added optional -c command line argument to Requestor App to configure the RequestorCanConsent field of the Query Image command.

Testing:

out/apps/ota-requestor/chip-ota-requestor-app --discriminator 30 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor 

out/apps/ota-requestor/chip-ota-requestor-app --discriminator 30 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor -c

#### Problem
RequestorCanConsent field of Requestor app's Query Image request was not configurable.

Fixes: https://github.com/project-chip/connectedhomeip/issues/11399

#### Change overview
Made RequestorCanConsent field of Requestor app's Query Image request configurable via the optional -c command line option.

#### Testing

- Tested Requestor App with and without the -c command line option.
- In 'CHIP: [ZCL] OTA Provider received QueryImage' log message, verified value of RequestorCanConsent field.
- In 'CHIP: [SWU] QueryImageResponse' log message, verified value of userConsentNeeded field.
