### PR TITLE
Prevent the DUT from getting killed with the signal to trigger the event

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -74,39 +74,39 @@ void SignalHandler(int signum)
         ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
-    case SIGHUP:
+    case SIGALRM:
         ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::BrownOutReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
-    case SIGTERM:
+    case SIGVTALRM:
         ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::PowerOnReboot);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
-    case SIGUSR1:
+    case SIGTRAP:
         ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::HardwareWatchdogReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
-    case SIGUSR2:
+    case SIGILL:
         ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
-    case SIGTSTP:
+    case SIGIO:
         ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareUpdateCompleted);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
-    case SIGTRAP:
+    case SIGUSR1:
         PlatformMgrImpl().HandleSoftwareFault(SoftwareDiagnostics::Events::SoftwareFault::Id);
         break;
-    case SIGILL:
+    case SIGUSR2:
         PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::HardwareFaultChange::Id);
         break;
-    case SIGALRM:
+    case SIGHUP:
         PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::RadioFaultChange::Id);
         break;
-    case SIGVTALRM:
+    case SIGTERM:
         PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::NetworkFaultChange::Id);
         break;
-    case SIGIO:
+    case SIGTSTP:
         PlatformMgrImpl().HandleSwitchEvent(Switch::Events::SwitchLatched::Id);
         break;
     default:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* From CSG  
"We launched the DUT and commissioned with TH and later killed the DUT by passing "kill -SIGTRAP pid "command, then we again reprovisioned the app, read and subscribed the software-fault event its passing with success code but didnt get expected outcome."

Currently, the event is not preserved over the power cycle, the subscribers of those events might not be able to receive those events before the app get killed. 

#### Change overview
Prevent the DUT from getting killed with the signal to trigger the event

#### Testing
How was this tested? (at least one bullet point required)
* Confirm the event are logged and DUT is not rebooted.
```
client:
yufengw@yufengw-SEi:~$ kill -SIGUSR1 182021
yufengw@yufengw-SEi:~$ 
yufengw@yufengw-SEi:~$ kill -SIGUSR2 182021
yufengw@yufengw-SEi:~$ 
yufengw@yufengw-SEi:~$ kill -SIGHUP 182021
yufengw@yufengw-SEi:~$ 
yufengw@yufengw-SEi:~$ kill -SIGTERM 182021
yufengw@yufengw-SEi:~$ 
yufengw@yufengw-SEi:~$ kill -SIGTSTP 182021

server:
[1644458674.224290][182021:182021] CHIP:DL: Caught signal 10
[1644458674.224325][182021:182021] CHIP:ZCL: SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected
[1644458674.224360][182021:182021] CHIP:EVL: LogEvent event number: 0x0000000000020001 priority: 1, endpoint id:  0x0 cluster id: 0x0000_0034 event id: 0x0 Sys timestamp: 0x000000000A789693
[1644458674.224380][182021:182021] CHIP:DL: select failed: ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/system/SystemLayerImplSelect.cpp:378: OS Error 0x02000004: Interrupted system call

[1644458678.394146][182021:182021] CHIP:DL: Caught signal 12
[1644458678.394241][182021:182021] CHIP:ZCL: GeneralDiagnosticsDelegate: OnHardwareFaultsDetected
[1644458678.394283][182021:182021] CHIP:DMG: Endpoint 0, Cluster 0x0000_0033 update version to b22c0522
[1644458678.394430][182021:182021] CHIP:EVL: LogEvent event number: 0x0000000000020002 priority: 2, endpoint id:  0x0 cluster id: 0x0000_0033 event id: 0x0 Sys timestamp: 0x000000000A78A6DD
[1644458678.394529][182021:182021] CHIP:DL: select failed: ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/system/SystemLayerImplSelect.cpp:378: OS Error 0x02000004: Interrupted system call

[1644458695.649630][182021:182021] CHIP:DL: Caught signal 1
[1644458695.649715][182021:182021] CHIP:ZCL: GeneralDiagnosticsDelegate: OnHardwareFaultsDetected
[1644458695.649748][182021:182021] CHIP:DMG: Endpoint 0, Cluster 0x0000_0033 update version to b22c0523
[1644458695.649902][182021:182021] CHIP:EVL: LogEvent event number: 0x0000000000020003 priority: 2, endpoint id:  0x0 cluster id: 0x0000_0033 event id: 0x1 Sys timestamp: 0x000000000A78EA44
[1644458695.649993][182021:182021] CHIP:DL: select failed: ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/system/SystemLayerImplSelect.cpp:378: OS Error 0x02000004: Interrupted system call

[1644458720.416125][182021:182021] CHIP:DL: Caught signal 15
[1644458720.416207][182021:182021] CHIP:ZCL: GeneralDiagnosticsDelegate: OnHardwareFaultsDetected
[1644458720.416244][182021:182021] CHIP:DMG: Endpoint 0, Cluster 0x0000_0033 update version to b22c0524
[1644458720.416436][182021:182021] CHIP:EVL: LogEvent event number: 0x0000000000020004 priority: 2, endpoint id:  0x0 cluster id: 0x0000_0033 event id: 0x2 Sys timestamp: 0x000000000A794B03
[1644458720.416517][182021:182021] CHIP:DL: select failed: ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/system/SystemLayerImplSelect.cpp:378: OS Error 0x02000004: Interrupted system call

[1644458767.246083][182021:182021] CHIP:DL: Caught signal 20
[1644458767.246166][182021:182021] CHIP:ZCL: SwitchDelegate: OnSwitchLatched
[1644458767.246283][182021:182021] CHIP:EVL: LogEvent event number: 0x0000000000020005 priority: 1, endpoint id:  0x0 cluster id: 0x0000_003B event id: 0x0 Sys timestamp: 0x000000000A7A01F0
[1644458767.246372][182021:182021] CHIP:DL: select failed: ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/system/SystemLayerImplSelect.cpp:378: OS Error 0x02000004: Interrupted system call
```
