### PR TITLE
[Android] Reject complex types in global response checker

### DIFF
--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -163,21 +163,16 @@ function chip_server_global_responses(options)
   return asBlocks.call(this, getServerGlobalAttributeResponses(this), options);
 }
 
-async function if_in_global_responses(options)
+async function if_basic_global_response(options)
 {
   const attribute          = this.response.arguments[0];
   const globalResponses    = await getServerGlobalAttributeResponses(this);
-  const responseTypeExists = globalResponses.find(
-      // Some fields of item/attribute here may be undefined.
-      item => item.isArray == attribute.isArray && item.isStruct == attribute.isStruct && item.chipType == attribute.chipType
-          && item.isNullable == attribute.isNullable && item.isOptional == attribute.isOptional)
+  const complexType        = attribute.isNullable || attribute.isOptional || attribute.isStruct || attribute.isArray;
+  const responseTypeExists = globalResponses.find(item => item.chipType == attribute.chipType);
 
-  if (responseTypeExists)
-  {
+  if (!complexType && responseTypeExists) {
     return options.fn(this);
-  }
-  else
-  {
+  } else {
     return options.inverse(this);
   }
 }
@@ -522,6 +517,6 @@ exports.chip_endpoints                                       = chip_endpoints;
 exports.chip_endpoint_clusters                               = chip_endpoint_clusters;
 exports.if_chip_enum                                         = if_chip_enum;
 exports.if_chip_complex                                      = if_chip_complex;
-exports.if_in_global_responses                               = if_in_global_responses;
+exports.if_basic_global_response                             = if_basic_global_response;
 exports.chip_cluster_specific_structs                        = chip_cluster_specific_structs;
 exports.chip_shared_structs                                  = chip_shared_structs;

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -97,11 +97,11 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, subscribe{{asCamelCased 
 {
     chip::DeviceLayer::StackLock lock;
     {{~#*inline "callbackName"~}}
-    {{~#if_in_global_responses~}}
+    {{~#if_basic_global_response~}}
     CHIP{{chipCallback.name}}AttributeCallback
     {{~else~}}
     CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback
-    {{~/if_in_global_responses~}}
+    {{~/if_basic_global_response~}}
     {{~/inline}}
 
     std::unique_ptr<{{>callbackName}}, void (*)({{>callbackName}} *)> onSuccess(Platform::New<{{>callbackName}}>(callback, true), chip::Platform::Delete<{{>callbackName}}>);

--- a/src/controller/java/templates/CHIPReadCallbacks-src.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks-src.zapt
@@ -88,7 +88,7 @@ void CHIP{{chipCallback.name}}AttributeCallback::CallbackFn(void * context, {{ch
 {{! TODO: Add support for struct-typed attributes }}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 
-{{#if_in_global_responses}}
+{{#if_basic_global_response}}
 {{else}}
 CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback(jobject javaCallback, bool keepAlive) :
     chip::Callback::Callback<CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallbackType>(CallbackFn, this), keepAlive(keepAlive)
@@ -114,7 +114,7 @@ CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::
     }
     env->DeleteGlobalRef(javaCallbackRef);
 }
-{{/if_in_global_responses}}
+{{/if_basic_global_response}}
 
 {{#if isArray}}
 void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list)
@@ -142,7 +142,7 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
     env->CallVoidMethod(javaCallbackRef, javaMethod, arrayListObj);
 }
 {{else}}
-  {{#if_in_global_responses}}
+  {{#if_basic_global_response}}
   {{else}}
     void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} value)
     {
@@ -166,7 +166,7 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, javaValue);
     }
-  {{/if_in_global_responses}}
+  {{/if_basic_global_response}}
 {{/if}}
 {{/unless}}
 {{/chip_server_cluster_attributes}}

--- a/src/controller/java/templates/CHIPReadCallbacks.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks.zapt
@@ -39,7 +39,7 @@ private:
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
-{{#if_in_global_responses}}
+{{#if_basic_global_response}}
 {{else}}
 class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback : public chip::Callback::Callback<CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallbackType>
 {
@@ -65,7 +65,7 @@ private:
     jobject javaCallbackRef;
     bool keepAlive;
 };
-{{/if_in_global_responses}}
+{{/if_basic_global_response}}
 
 {{/unless}}
 {{/chip_server_cluster_attributes}}

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -124,7 +124,7 @@ public class ChipClusters {
 
   {{#chip_server_cluster_attributes}}
   {{#unless (isStrEqual chipCallback.name "Unsupported")}}
-  {{#if_in_global_responses}}
+  {{#if_basic_global_response}}
   {{else}}
     {{! NOTE: asJavaType ends up sniffing for isArray on the context. Since we want the type of our _entry_, force isArray to
           false. }}
@@ -142,7 +142,7 @@ public class ChipClusters {
         default void onSubscriptionEstablished() {}
       }
     {{/if}}
-  {{/if_in_global_responses}}
+  {{/if_basic_global_response}}
   {{/unless}}
   {{/chip_server_cluster_attributes}}
   {{#chip_server_cluster_attributes}}
@@ -150,11 +150,11 @@ public class ChipClusters {
   {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 
     public void read{{asUpperCamelCase name}}Attribute(
-    {{#if_in_global_responses}}
+    {{#if_basic_global_response}}
       {{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback callback
     {{else}}
       {{asUpperCamelCase name}}AttributeCallback callback
-    {{/if_in_global_responses}}
+    {{/if_basic_global_response}}
     ) {
       read{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback);
     }
@@ -171,11 +171,11 @@ public class ChipClusters {
   {{/if}}
   {{#if isReportableAttribute}}
     public void subscribe{{asCamelCased name false}}Attribute(
-      {{#if_in_global_responses}}
+      {{#if_basic_global_response}}
         {{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback callback
       {{else}}
         {{asUpperCamelCase name}}AttributeCallback callback
-      {{/if_in_global_responses}},
+      {{/if_basic_global_response}},
       int minInterval, int maxInterval) {
       subscribe{{asCamelCased name false}}Attribute(chipClusterPtr, callback, minInterval, maxInterval);
     }
@@ -187,11 +187,11 @@ public class ChipClusters {
   {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 
     private native void read{{asUpperCamelCase name}}Attribute(long chipClusterPtr,
-      {{#if_in_global_responses}}
+      {{#if_basic_global_response}}
         {{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback callback
       {{else}}
         {{asUpperCamelCase name}}AttributeCallback callback
-      {{/if_in_global_responses}}
+      {{/if_basic_global_response}}
     );
   {{#if isWritableAttribute}}
 
@@ -199,11 +199,11 @@ public class ChipClusters {
   {{/if}}
   {{#if isReportableAttribute}}
     private native void subscribe{{asCamelCased name false}}Attribute(long chipClusterPtr,
-      {{#if_in_global_responses}}
+      {{#if_basic_global_response}}
         {{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback callback
       {{else}}
         {{asUpperCamelCase name}}AttributeCallback callback
-      {{/if_in_global_responses}}, int minInterval, int maxInterval);
+      {{/if_basic_global_response}}, int minInterval, int maxInterval);
   {{/if}}
   {{/unless}}
   {{/chip_server_cluster_attributes}}

--- a/src/controller/java/templates/ClusterInfo-read-interaction.zapt
+++ b/src/controller/java/templates/ClusterInfo-read-interaction.zapt
@@ -22,11 +22,11 @@ public class ClusterReadMapping {
         InteractionInfo read{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}AttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {
             ((ChipClusters.{{asUpperCamelCase ../name}}Cluster) cluster).read{{asUpperCamelCase name}}Attribute(
-              ({{#if_in_global_responses}}
+              ({{#if_basic_global_response}}
                 ChipClusters.{{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback
               {{else}}
                 ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{asUpperCamelCase name}}AttributeCallback
-              {{/if_in_global_responses}}) callback
+              {{/if_basic_global_response}}) callback
             );
           },
           {{#if isArray}}


### PR DESCRIPTION
#### Problem
* `if_in_global_responses` needs to reject complex types like nullable, optional, etc., or else Java code can erroneously use (for example) IntegerCallback where for a nullable int. 

#### Change overview
* Rename to `if_basic_global_response`, and call inverse if nullable/optional/etc.

#### Testing
* CI
* Allows #14755 to compile
