### PR TITLE
Add IPv4 and IPv6 addresses to General Diagnostics cluster

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1456,11 +1456,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -388,11 +388,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/door-lock-app/door-lock-common/door-lock-app.matter
+++ b/examples/door-lock-app/door-lock-common/door-lock-app.matter
@@ -866,11 +866,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -577,11 +577,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -582,11 +582,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -328,11 +328,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -313,11 +313,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -333,11 +333,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -326,11 +326,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -347,11 +347,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -713,11 +713,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1379,11 +1379,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -296,11 +296,13 @@ server cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -68,11 +68,13 @@ limitations under the License.
   <struct name="NetworkInterfaceType">
     <cluster code="0x0033"/>
     <item name="Name" type="CHAR_STRING" length="32"/>
-    <item name="FabricConnected" type="BOOLEAN"/>
+    <item name="IsOperational" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv4" type="BOOLEAN" isNullable="true"/>
     <item name="OffPremiseServicesReachableIPv6" type="BOOLEAN" isNullable="true"/>
     <!-- TODO(#14075): HWADR not supported yet -->
     <item name="HardwareAddress" type="OCTET_STRING" length="8"/>
+    <item name="IPv4Addresses" type="OCTET_STRING" array="true" length="4"/>
+    <item name="IPv6Addresses" type="OCTET_STRING" array="true" length="8"/>
     <item name="Type" type="InterfaceType"/>
   </struct>
   <cluster>
@@ -86,9 +88,9 @@ limitations under the License.
     <attribute side="server" code="0x02" define="UPTIME" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">UpTime</attribute>
     <attribute side="server" code="0x03" define="TOTAL_OPERATIONAL_HOURS" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true">TotalOperationalHours</attribute>
     <attribute side="server" code="0x04" define="BOOT_REASONS" type="ENUM8" writable="false" optional="true">BootReasons</attribute>
-    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="ARRAY" entryType="ENUM8" length="254" writable="false" optional="true">ActiveHardwareFaults</attribute>
-    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="ARRAY" entryType="ENUM8" length="254" writable="false" optional="true">ActiveRadioFaults</attribute>
-    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" entryType="ENUM8" length="254" writable="false" optional="true">ActiveNetworkFaults</attribute>
+    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="ARRAY" entryType="ENUM8" length="11" writable="false" optional="true">ActiveHardwareFaults</attribute>
+    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="ARRAY" entryType="ENUM8" length="7" writable="false" optional="true">ActiveRadioFaults</attribute>
+    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" entryType="ENUM8" length="4" writable="false" optional="true">ActiveNetworkFaults</attribute>
     <event side="server" code="0x00" name="HardwareFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of hardware faults currently detected by the Node.</description>
       <field id="0" name="Current" type="HardwareFaultType" array="true"/>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -73,8 +73,8 @@ limitations under the License.
     <item name="OffPremiseServicesReachableIPv6" type="BOOLEAN" isNullable="true"/>
     <!-- TODO(#14075): HWADR not supported yet -->
     <item name="HardwareAddress" type="OCTET_STRING" length="8"/>
-    <item name="IPv4Addresses" type="OCTET_STRING" array="true" length="4"/>
-    <item name="IPv6Addresses" type="OCTET_STRING" array="true" length="8"/>
+    <item name="IPv4Addresses" type="OCTET_STRING" array="true"/>
+    <item name="IPv6Addresses" type="OCTET_STRING" array="true"/>
     <item name="Type" type="InterfaceType"/>
   </struct>
   <cluster>
@@ -88,9 +88,9 @@ limitations under the License.
     <attribute side="server" code="0x02" define="UPTIME" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">UpTime</attribute>
     <attribute side="server" code="0x03" define="TOTAL_OPERATIONAL_HOURS" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true">TotalOperationalHours</attribute>
     <attribute side="server" code="0x04" define="BOOT_REASONS" type="ENUM8" writable="false" optional="true">BootReasons</attribute>
-    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="ARRAY" entryType="ENUM8" length="11" writable="false" optional="true">ActiveHardwareFaults</attribute>
-    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="ARRAY" entryType="ENUM8" length="7" writable="false" optional="true">ActiveRadioFaults</attribute>
-    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" entryType="ENUM8" length="4" writable="false" optional="true">ActiveNetworkFaults</attribute>
+    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="ARRAY" entryType="ENUM8" writable="false" optional="true">ActiveHardwareFaults</attribute>
+    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="ARRAY" entryType="ENUM8" writable="false" optional="true">ActiveRadioFaults</attribute>
+    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" entryType="ENUM8" writable="false" optional="true">ActiveNetworkFaults</attribute>
     <event side="server" code="0x00" name="HardwareFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of hardware faults currently detected by the Node.</description>
       <field id="0" name="Current" type="HardwareFaultType" array="true"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1783,11 +1783,13 @@ client cluster GeneralDiagnostics = 51 {
 
   struct NetworkInterfaceType {
     CHAR_STRING<32> name = 0;
-    BOOLEAN fabricConnected = 1;
+    BOOLEAN isOperational = 1;
     nullable BOOLEAN offPremiseServicesReachableIPv4 = 2;
     nullable BOOLEAN offPremiseServicesReachableIPv6 = 3;
     OCTET_STRING<8> hardwareAddress = 4;
-    InterfaceType type = 5;
+    OCTET_STRING IPv4Addresses[] = 5;
+    OCTET_STRING IPv6Addresses[] = 6;
+    InterfaceType type = 7;
   }
 
   critical event HardwareFaultChange = 0 {

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -5659,12 +5659,12 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 jobject newElement_0;
                 jobject newElement_0_name;
                 newElement_0_name = env->NewStringUTF(std::string(entry_0.name.data(), entry_0.name.size()).c_str());
-                jobject newElement_0_fabricConnected;
-                std::string newElement_0_fabricConnectedClassName     = "java/lang/Boolean";
-                std::string newElement_0_fabricConnectedCtorSignature = "(Z)V";
-                chip::JniReferences::GetInstance().CreateBoxedObject<bool>(newElement_0_fabricConnectedClassName.c_str(),
-                                                                           newElement_0_fabricConnectedCtorSignature.c_str(),
-                                                                           entry_0.fabricConnected, newElement_0_fabricConnected);
+                jobject newElement_0_isOperational;
+                std::string newElement_0_isOperationalClassName     = "java/lang/Boolean";
+                std::string newElement_0_isOperationalCtorSignature = "(Z)V";
+                chip::JniReferences::GetInstance().CreateBoxedObject<bool>(newElement_0_isOperationalClassName.c_str(),
+                                                                           newElement_0_isOperationalCtorSignature.c_str(),
+                                                                           entry_0.isOperational, newElement_0_isOperational);
                 jobject newElement_0_offPremiseServicesReachableIPv4;
                 if (entry_0.offPremiseServicesReachableIPv4.IsNull())
                 {
@@ -5700,6 +5700,34 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                         static_cast<jsize>(entry_0.hardwareAddress.size()),
                                         reinterpret_cast<const jbyte *>(entry_0.hardwareAddress.data()));
                 newElement_0_hardwareAddress = newElement_0_hardwareAddressByteArray;
+                jobject newElement_0_IPv4Addresses;
+                chip::JniReferences::GetInstance().CreateArrayList(newElement_0_IPv4Addresses);
+
+                auto iter_newElement_0_IPv4Addresses_NaN = entry_0.IPv4Addresses.begin();
+                while (iter_newElement_0_IPv4Addresses_NaN.Next())
+                {
+                    auto & entry_NaN = iter_newElement_0_IPv4Addresses_NaN.GetValue();
+                    jobject newElement_NaN;
+                    jbyteArray newElement_NaNByteArray = env->NewByteArray(static_cast<jsize>(entry_NaN.size()));
+                    env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
+                                            reinterpret_cast<const jbyte *>(entry_NaN.data()));
+                    newElement_NaN = newElement_NaNByteArray;
+                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv4Addresses, newElement_NaN);
+                }
+                jobject newElement_0_IPv6Addresses;
+                chip::JniReferences::GetInstance().CreateArrayList(newElement_0_IPv6Addresses);
+
+                auto iter_newElement_0_IPv6Addresses_NaN = entry_0.IPv6Addresses.begin();
+                while (iter_newElement_0_IPv6Addresses_NaN.Next())
+                {
+                    auto & entry_NaN = iter_newElement_0_IPv6Addresses_NaN.GetValue();
+                    jobject newElement_NaN;
+                    jbyteArray newElement_NaNByteArray = env->NewByteArray(static_cast<jsize>(entry_NaN.size()));
+                    env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
+                                            reinterpret_cast<const jbyte *>(entry_NaN.data()));
+                    newElement_NaN = newElement_NaNByteArray;
+                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv6Addresses, newElement_NaN);
+                }
                 jobject newElement_0_type;
                 std::string newElement_0_typeClassName     = "java/lang/Integer";
                 std::string newElement_0_typeCtorSignature = "(I)V";
@@ -5716,19 +5744,20 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$GeneralDiagnosticsClusterNetworkInterfaceType");
                     return nullptr;
                 }
-                jmethodID networkInterfaceTypeStructCtor = env->GetMethodID(
-                    networkInterfaceTypeStructClass, "<init>",
-                    "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/lang/Integer;)V");
+                jmethodID networkInterfaceTypeStructCtor =
+                    env->GetMethodID(networkInterfaceTypeStructClass, "<init>",
+                                     "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/util/"
+                                     "ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
                 if (networkInterfaceTypeStructCtor == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$GeneralDiagnosticsClusterNetworkInterfaceType constructor");
                     return nullptr;
                 }
 
-                newElement_0 =
-                    env->NewObject(networkInterfaceTypeStructClass, networkInterfaceTypeStructCtor, newElement_0_name,
-                                   newElement_0_fabricConnected, newElement_0_offPremiseServicesReachableIPv4,
-                                   newElement_0_offPremiseServicesReachableIPv6, newElement_0_hardwareAddress, newElement_0_type);
+                newElement_0 = env->NewObject(networkInterfaceTypeStructClass, networkInterfaceTypeStructCtor, newElement_0_name,
+                                              newElement_0_isOperational, newElement_0_offPremiseServicesReachableIPv4,
+                                              newElement_0_offPremiseServicesReachableIPv6, newElement_0_hardwareAddress,
+                                              newElement_0_IPv4Addresses, newElement_0_IPv6Addresses, newElement_0_type);
                 chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
             }
             return value;

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -7657,12 +7657,12 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
         jobject newElement_0;
         jobject newElement_0_name;
         newElement_0_name = env->NewStringUTF(std::string(entry_0.name.data(), entry_0.name.size()).c_str());
-        jobject newElement_0_fabricConnected;
-        std::string newElement_0_fabricConnectedClassName     = "java/lang/Boolean";
-        std::string newElement_0_fabricConnectedCtorSignature = "(Z)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<bool>(newElement_0_fabricConnectedClassName.c_str(),
-                                                                   newElement_0_fabricConnectedCtorSignature.c_str(),
-                                                                   entry_0.fabricConnected, newElement_0_fabricConnected);
+        jobject newElement_0_isOperational;
+        std::string newElement_0_isOperationalClassName     = "java/lang/Boolean";
+        std::string newElement_0_isOperationalCtorSignature = "(Z)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<bool>(newElement_0_isOperationalClassName.c_str(),
+                                                                   newElement_0_isOperationalCtorSignature.c_str(),
+                                                                   entry_0.isOperational, newElement_0_isOperational);
         jobject newElement_0_offPremiseServicesReachableIPv4;
         if (entry_0.offPremiseServicesReachableIPv4.IsNull())
         {
@@ -7696,6 +7696,34 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
         env->SetByteArrayRegion(newElement_0_hardwareAddressByteArray, 0, static_cast<jsize>(entry_0.hardwareAddress.size()),
                                 reinterpret_cast<const jbyte *>(entry_0.hardwareAddress.data()));
         newElement_0_hardwareAddress = newElement_0_hardwareAddressByteArray;
+        jobject newElement_0_IPv4Addresses;
+        chip::JniReferences::GetInstance().CreateArrayList(newElement_0_IPv4Addresses);
+
+        auto iter_newElement_0_IPv4Addresses_NaN = entry_0.IPv4Addresses.begin();
+        while (iter_newElement_0_IPv4Addresses_NaN.Next())
+        {
+            auto & entry_NaN = iter_newElement_0_IPv4Addresses_NaN.GetValue();
+            jobject newElement_NaN;
+            jbyteArray newElement_NaNByteArray = env->NewByteArray(static_cast<jsize>(entry_NaN.size()));
+            env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
+                                    reinterpret_cast<const jbyte *>(entry_NaN.data()));
+            newElement_NaN = newElement_NaNByteArray;
+            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv4Addresses, newElement_NaN);
+        }
+        jobject newElement_0_IPv6Addresses;
+        chip::JniReferences::GetInstance().CreateArrayList(newElement_0_IPv6Addresses);
+
+        auto iter_newElement_0_IPv6Addresses_NaN = entry_0.IPv6Addresses.begin();
+        while (iter_newElement_0_IPv6Addresses_NaN.Next())
+        {
+            auto & entry_NaN = iter_newElement_0_IPv6Addresses_NaN.GetValue();
+            jobject newElement_NaN;
+            jbyteArray newElement_NaNByteArray = env->NewByteArray(static_cast<jsize>(entry_NaN.size()));
+            env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
+                                    reinterpret_cast<const jbyte *>(entry_NaN.data()));
+            newElement_NaN = newElement_NaNByteArray;
+            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv6Addresses, newElement_NaN);
+        }
         jobject newElement_0_type;
         std::string newElement_0_typeClassName     = "java/lang/Integer";
         std::string newElement_0_typeCtorSignature = "(I)V";
@@ -7714,17 +7742,18 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
         }
         jmethodID networkInterfaceTypeStructCtor =
             env->GetMethodID(networkInterfaceTypeStructClass, "<init>",
-                             "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/lang/Integer;)V");
+                             "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/util/"
+                             "ArrayList;Ljava/util/ArrayList;Ljava/lang/Integer;)V");
         if (networkInterfaceTypeStructCtor == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$GeneralDiagnosticsClusterNetworkInterfaceType constructor");
             return;
         }
 
-        newElement_0 =
-            env->NewObject(networkInterfaceTypeStructClass, networkInterfaceTypeStructCtor, newElement_0_name,
-                           newElement_0_fabricConnected, newElement_0_offPremiseServicesReachableIPv4,
-                           newElement_0_offPremiseServicesReachableIPv6, newElement_0_hardwareAddress, newElement_0_type);
+        newElement_0 = env->NewObject(networkInterfaceTypeStructClass, networkInterfaceTypeStructCtor, newElement_0_name,
+                                      newElement_0_isOperational, newElement_0_offPremiseServicesReachableIPv4,
+                                      newElement_0_offPremiseServicesReachableIPv6, newElement_0_hardwareAddress,
+                                      newElement_0_IPv4Addresses, newElement_0_IPv6Addresses, newElement_0_type);
         chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
     }
 

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
@@ -672,24 +672,30 @@ public class ChipStructs {
 
   public static class GeneralDiagnosticsClusterNetworkInterfaceType {
     public String name;
-    public Boolean fabricConnected;
+    public Boolean isOperational;
     public @Nullable Boolean offPremiseServicesReachableIPv4;
     public @Nullable Boolean offPremiseServicesReachableIPv6;
     public byte[] hardwareAddress;
+    public ArrayList<byte[]> IPv4Addresses;
+    public ArrayList<byte[]> IPv6Addresses;
     public Integer type;
 
     public GeneralDiagnosticsClusterNetworkInterfaceType(
         String name,
-        Boolean fabricConnected,
+        Boolean isOperational,
         @Nullable Boolean offPremiseServicesReachableIPv4,
         @Nullable Boolean offPremiseServicesReachableIPv6,
         byte[] hardwareAddress,
+        ArrayList<byte[]> IPv4Addresses,
+        ArrayList<byte[]> IPv6Addresses,
         Integer type) {
       this.name = name;
-      this.fabricConnected = fabricConnected;
+      this.isOperational = isOperational;
       this.offPremiseServicesReachableIPv4 = offPremiseServicesReachableIPv4;
       this.offPremiseServicesReachableIPv6 = offPremiseServicesReachableIPv6;
       this.hardwareAddress = hardwareAddress;
+      this.IPv4Addresses = IPv4Addresses;
+      this.IPv6Addresses = IPv6Addresses;
       this.type = type;
     }
 
@@ -700,8 +706,8 @@ public class ChipStructs {
       output.append("\tname: ");
       output.append(name);
       output.append("\n");
-      output.append("\tfabricConnected: ");
-      output.append(fabricConnected);
+      output.append("\tisOperational: ");
+      output.append(isOperational);
       output.append("\n");
       output.append("\toffPremiseServicesReachableIPv4: ");
       output.append(offPremiseServicesReachableIPv4);
@@ -711,6 +717,12 @@ public class ChipStructs {
       output.append("\n");
       output.append("\thardwareAddress: ");
       output.append(Arrays.toString(hardwareAddress));
+      output.append("\n");
+      output.append("\tIPv4Addresses: ");
+      output.append(IPv4Addresses);
+      output.append("\n");
+      output.append("\tIPv6Addresses: ");
+      output.append(IPv6Addresses);
       output.append("\n");
       output.append("\ttype: ");
       output.append(type);

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -10233,18 +10233,22 @@ class GeneralDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="name", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="fabricConnected", Tag=1, Type=bool),
+                            ClusterObjectFieldDescriptor(Label="isOperational", Tag=1, Type=bool),
                             ClusterObjectFieldDescriptor(Label="offPremiseServicesReachableIPv4", Tag=2, Type=typing.Union[Nullable, bool]),
                             ClusterObjectFieldDescriptor(Label="offPremiseServicesReachableIPv6", Tag=3, Type=typing.Union[Nullable, bool]),
                             ClusterObjectFieldDescriptor(Label="hardwareAddress", Tag=4, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="type", Tag=5, Type=GeneralDiagnostics.Enums.InterfaceType),
+                            ClusterObjectFieldDescriptor(Label="IPv4Addresses", Tag=5, Type=typing.List[bytes]),
+                            ClusterObjectFieldDescriptor(Label="IPv6Addresses", Tag=6, Type=typing.List[bytes]),
+                            ClusterObjectFieldDescriptor(Label="type", Tag=7, Type=GeneralDiagnostics.Enums.InterfaceType),
                     ])
 
             name: 'str' = ""
-            fabricConnected: 'bool' = False
+            isOperational: 'bool' = False
             offPremiseServicesReachableIPv4: 'typing.Union[Nullable, bool]' = NullValue
             offPremiseServicesReachableIPv6: 'typing.Union[Nullable, bool]' = NullValue
             hardwareAddress: 'bytes' = b""
+            IPv4Addresses: 'typing.List[bytes]' = field(default_factory=lambda: [])
+            IPv6Addresses: 'typing.List[bytes]' = field(default_factory=lambda: [])
             type: 'GeneralDiagnostics.Enums.InterfaceType' = 0
 
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -4724,7 +4724,7 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                     newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
                                                                  length:entry_0.name.size()
                                                                encoding:NSUTF8StringEncoding];
-                    newElement_0.fabricConnected = [NSNumber numberWithBool:entry_0.fabricConnected];
+                    newElement_0.isOperational = [NSNumber numberWithBool:entry_0.isOperational];
                     if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
                         newElement_0.offPremiseServicesReachableIPv4 = nil;
                     } else {
@@ -4739,6 +4739,38 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                     }
                     newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
                                                                   length:entry_0.hardwareAddress.size()];
+                    { // Scope for our temporary variables
+                        auto * array_2 = [NSMutableArray new];
+                        auto iter_2 = entry_0.IPv4Addresses.begin();
+                        while (iter_2.Next()) {
+                            auto & entry_2 = iter_2.GetValue();
+                            NSData * newElement_2;
+                            newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                            [array_2 addObject:newElement_2];
+                        }
+                        CHIP_ERROR err = iter_2.GetStatus();
+                        if (err != CHIP_NO_ERROR) {
+                            *aError = err;
+                            return nil;
+                        }
+                        newElement_0.iPv4Addresses = array_2;
+                    }
+                    { // Scope for our temporary variables
+                        auto * array_2 = [NSMutableArray new];
+                        auto iter_2 = entry_0.IPv6Addresses.begin();
+                        while (iter_2.Next()) {
+                            auto & entry_2 = iter_2.GetValue();
+                            NSData * newElement_2;
+                            newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                            [array_2 addObject:newElement_2];
+                        }
+                        CHIP_ERROR err = iter_2.GetStatus();
+                        if (err != CHIP_NO_ERROR) {
+                            *aError = err;
+                            return nil;
+                        }
+                        newElement_0.iPv6Addresses = array_2;
+                    }
                     newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
                     [array_0 addObject:newElement_0];
                 }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -4442,7 +4442,7 @@ void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucce
             newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
                                                          length:entry_0.name.size()
                                                        encoding:NSUTF8StringEncoding];
-            newElement_0.fabricConnected = [NSNumber numberWithBool:entry_0.fabricConnected];
+            newElement_0.isOperational = [NSNumber numberWithBool:entry_0.isOperational];
             if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
                 newElement_0.offPremiseServicesReachableIPv4 = nil;
             } else {
@@ -4457,6 +4457,38 @@ void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucce
             }
             newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
                                                           length:entry_0.hardwareAddress.size()];
+            { // Scope for our temporary variables
+                auto * array_2 = [NSMutableArray new];
+                auto iter_2 = entry_0.IPv4Addresses.begin();
+                while (iter_2.Next()) {
+                    auto & entry_2 = iter_2.GetValue();
+                    NSData * newElement_2;
+                    newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                    [array_2 addObject:newElement_2];
+                }
+                CHIP_ERROR err = iter_2.GetStatus();
+                if (err != CHIP_NO_ERROR) {
+                    OnFailureFn(context, err);
+                    return;
+                }
+                newElement_0.iPv4Addresses = array_2;
+            }
+            { // Scope for our temporary variables
+                auto * array_2 = [NSMutableArray new];
+                auto iter_2 = entry_0.IPv6Addresses.begin();
+                while (iter_2.Next()) {
+                    auto & entry_2 = iter_2.GetValue();
+                    NSData * newElement_2;
+                    newElement_2 = [NSData dataWithBytes:entry_2.data() length:entry_2.size()];
+                    [array_2 addObject:newElement_2];
+                }
+                CHIP_ERROR err = iter_2.GetStatus();
+                if (err != CHIP_NO_ERROR) {
+                    OnFailureFn(context, err);
+                    return;
+                }
+                newElement_0.iPv6Addresses = array_2;
+            }
             newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
             [array_0 addObject:newElement_0];
         }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -161,10 +161,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPGeneralDiagnosticsClusterNetworkInterfaceType : NSObject
 @property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricConnected;
+@property (strong, nonatomic) NSNumber * _Nonnull isOperational;
 @property (strong, nonatomic) NSNumber * _Nullable offPremiseServicesReachableIPv4;
 @property (strong, nonatomic) NSNumber * _Nullable offPremiseServicesReachableIPv6;
 @property (strong, nonatomic) NSData * _Nonnull hardwareAddress;
+@property (strong, nonatomic) NSArray * _Nonnull iPv4Addresses;
+@property (strong, nonatomic) NSArray * _Nonnull iPv6Addresses;
 @property (strong, nonatomic) NSNumber * _Nonnull type;
 - (instancetype)init;
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -316,13 +316,17 @@ NS_ASSUME_NONNULL_BEGIN
 
         _name = @"";
 
-        _fabricConnected = @(0);
+        _isOperational = @(0);
 
         _offPremiseServicesReachableIPv4 = nil;
 
         _offPremiseServicesReachableIPv6 = nil;
 
         _hardwareAddress = [NSData data];
+
+        _iPv4Addresses = [NSArray array];
+
+        _iPv6Addresses = [NSArray array];
 
         _type = @(0);
     }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -6593,7 +6593,7 @@ using namespace chip::app::Clusters;
                         }
                         auto element_0 = (CHIPGeneralDiagnosticsClusterNetworkInterfaceType *) value[i_0];
                         listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i_0].fabricConnected = element_0.fabricConnected.boolValue;
+                        listHolder_0->mList[i_0].isOperational = element_0.isOperational.boolValue;
                         if (element_0.offPremiseServicesReachableIPv4 == nil) {
                             listHolder_0->mList[i_0].offPremiseServicesReachableIPv4.SetNull();
                         } else {
@@ -6607,6 +6607,52 @@ using namespace chip::app::Clusters;
                             nonNullValue_2 = element_0.offPremiseServicesReachableIPv6.boolValue;
                         }
                         listHolder_0->mList[i_0].hardwareAddress = [self asByteSpan:element_0.hardwareAddress];
+                        {
+                            using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].IPv4Addresses)>;
+                            using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                            if (element_0.iPv4Addresses.count != 0) {
+                                auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.iPv4Addresses.count);
+                                if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                                    return CHIP_ERROR_INVALID_ARGUMENT;
+                                }
+                                listFreer.add(listHolder_2);
+                                for (size_t i_2 = 0; i_2 < element_0.iPv4Addresses.count; ++i_2) {
+                                    if (![element_0.iPv4Addresses[i_2] isKindOfClass:[NSData class]]) {
+                                        // Wrong kind of value.
+                                        return CHIP_ERROR_INVALID_ARGUMENT;
+                                    }
+                                    auto element_2 = (NSData *) element_0.iPv4Addresses[i_2];
+                                    listHolder_2->mList[i_2] = [self asByteSpan:element_2];
+                                }
+                                listHolder_0->mList[i_0].IPv4Addresses
+                                    = ListType_2(listHolder_2->mList, element_0.iPv4Addresses.count);
+                            } else {
+                                listHolder_0->mList[i_0].IPv4Addresses = ListType_2();
+                            }
+                        }
+                        {
+                            using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].IPv6Addresses)>;
+                            using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                            if (element_0.iPv6Addresses.count != 0) {
+                                auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.iPv6Addresses.count);
+                                if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                                    return CHIP_ERROR_INVALID_ARGUMENT;
+                                }
+                                listFreer.add(listHolder_2);
+                                for (size_t i_2 = 0; i_2 < element_0.iPv6Addresses.count; ++i_2) {
+                                    if (![element_0.iPv6Addresses[i_2] isKindOfClass:[NSData class]]) {
+                                        // Wrong kind of value.
+                                        return CHIP_ERROR_INVALID_ARGUMENT;
+                                    }
+                                    auto element_2 = (NSData *) element_0.iPv6Addresses[i_2];
+                                    listHolder_2->mList[i_2] = [self asByteSpan:element_2];
+                                }
+                                listHolder_0->mList[i_0].IPv6Addresses
+                                    = ListType_2(listHolder_2->mList, element_0.iPv6Addresses.count);
+                            } else {
+                                listHolder_0->mList[i_0].IPv6Addresses = ListType_2();
+                            }
+                        }
                         listHolder_0->mList[i_0].type
                             = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].type)>>(
                                 element_0.type.unsignedCharValue);

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -36,6 +36,11 @@ static constexpr size_t kMaxThreadNameLength = 32;
 // 48-bit IEEE MAC Address or a 64-bit IEEE MAC Address (e.g. EUI-64).
 constexpr size_t kMaxHardwareAddrSize = 8;
 
+constexpr size_t kMaxIPv4AddrSize  = 4;
+constexpr size_t kMaxIPv6AddrSize  = 16;
+constexpr size_t kMaxIPv4AddrCount = 4;
+constexpr size_t kMaxIPv6AddrCount = 8;
+
 struct ThreadMetrics : public app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::Type
 {
     char NameBuf[kMaxThreadNameLength + 1];
@@ -46,6 +51,10 @@ struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::Net
 {
     char Name[Inet::InterfaceId::kMaxIfNameLength];
     uint8_t MacAddress[kMaxHardwareAddrSize];
+    uint8_t Ipv4AddressesBuffer[kMaxIPv4AddrCount][kMaxIPv4AddrSize];
+    uint8_t Ipv6AddressesBuffer[kMaxIPv6AddrCount][kMaxIPv6AddrSize];
+    chip::ByteSpan Ipv4Addresses[kMaxIPv4AddrCount];
+    chip::ByteSpan Ipv6Addresses[kMaxIPv6AddrCount];
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -53,8 +53,8 @@ struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::Net
     uint8_t MacAddress[kMaxHardwareAddrSize];
     uint8_t Ipv4AddressesBuffer[kMaxIPv4AddrCount][kMaxIPv4AddrSize];
     uint8_t Ipv6AddressesBuffer[kMaxIPv6AddrCount][kMaxIPv6AddrSize];
-    chip::ByteSpan Ipv4Addresses[kMaxIPv4AddrCount];
-    chip::ByteSpan Ipv6Addresses[kMaxIPv6AddrCount];
+    chip::ByteSpan Ipv4AddressSpans[kMaxIPv4AddrCount];
+    chip::ByteSpan Ipv6AddressSpans[kMaxIPv6AddrCount];
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -137,8 +137,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             strncpy(ifp->Name, ifa->name, Inet::InterfaceId::kMaxIfNameLength);
             ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
 
-            ifp->name            = CharSpan::fromCharString(ifp->Name);
-            ifp->fabricConnected = true;
+            ifp->name          = CharSpan::fromCharString(ifp->Name);
+            ifp->isOperational = true;
             if ((ifa->flags) & NETIF_FLAG_ETHERNET)
                 ifp->type = EMBER_ZCL_INTERFACE_TYPE_ETHERNET;
             else

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     const char * threadNetworkName = otThreadGetNetworkName(ThreadStackMgrImpl().OTInstance());
     ifp->name                      = Span<const char>(threadNetworkName, strlen(threadNetworkName));
-    ifp->fabricConnected           = true;
+    ifp->isOperational             = true;
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
     ifp->type = InterfaceType::EMBER_ZCL_INTERFACE_TYPE_THREAD;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -210,7 +210,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             strncpy(ifp->Name, esp_netif_get_ifkey(ifa), Inet::InterfaceId::kMaxIfNameLength);
             ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
             ifp->name                                          = CharSpan::fromCharString(ifp->Name);
-            ifp->fabricConnected                               = true;
+            ifp->isOperational                                 = true;
             ifp->type                                          = GetInterfaceType(esp_netif_get_desc(ifa));
             ifp->offPremiseServicesReachableIPv4.SetNull();
             ifp->offPremiseServicesReachableIPv6.SetNull();

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -444,9 +444,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
                 strncpy(ifp->Name, ifa->ifa_name, Inet::InterfaceId::kMaxIfNameLength);
                 ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
 
-                ifp->name            = CharSpan::fromCharString(ifp->Name);
-                ifp->fabricConnected = ifa->ifa_flags & IFF_RUNNING;
-                ifp->type            = ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name);
+                ifp->name          = CharSpan::fromCharString(ifp->Name);
+                ifp->isOperational = ifa->ifa_flags & IFF_RUNNING;
+                ifp->type          = ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name);
                 ifp->offPremiseServicesReachableIPv4.SetNull();
                 ifp->offPremiseServicesReachableIPv6.SetNull();
 

--- a/src/platform/P6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/P6/DiagnosticDataProviderImpl.cpp
@@ -159,7 +159,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     {
         /* Update Network Interface list */
         ifp->name                            = CharSpan::fromCharString(net_interface->name);
-        ifp->fabricConnected                 = net_interface->flags & NETIF_FLAG_LINK_UP;
+        ifp->isOperational                   = net_interface->flags & NETIF_FLAG_LINK_UP;
         ifp->type                            = EMBER_ZCL_INTERFACE_TYPE_WI_FI;
         ifp->offPremiseServicesReachableIPv4 = mipv4_offpremise;
         ifp->offPremiseServicesReachableIPv6 = mipv6_offpremise;

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -223,7 +223,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
                 if (interfaceAddressIterator.GetAddress(ipv6Address) == CHIP_NO_ERROR)
                 {
                     memcpy(ifp->Ipv6AddressesBuffer[ipv6AddressesCount], ipv6Address.Addr, kMaxIPv6AddrSize);
-                    ifp->Ipv6Addresses[ipv6AddressesCount] =
+                    ifp->Ipv6AddressSpans[ipv6AddressesCount] =
                         ByteSpan(ifp->Ipv6AddressesBuffer[ipv6AddressesCount], kMaxIPv6AddrSize);
                     ipv6AddressesCount++;
                 }
@@ -231,7 +231,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             interfaceAddressIterator.Next();
         }
 
-        ifp->IPv6Addresses = chip::app::DataModel::List<chip::ByteSpan>(ifp->Ipv6Addresses, ipv6AddressesCount);
+        ifp->IPv6Addresses = chip::app::DataModel::List<chip::ByteSpan>(ifp->Ipv6AddressSpans, ipv6AddressesCount);
         head               = ifp;
     }
 

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -361,10 +361,12 @@ typedef struct _NetworkInfo
 typedef struct _NetworkInterfaceType
 {
     chip::CharSpan Name;
-    bool FabricConnected;
+    bool IsOperational;
     bool OffPremiseServicesReachableIPv4;
     bool OffPremiseServicesReachableIPv6;
     chip::ByteSpan HardwareAddress;
+    /* TYPE WARNING: array array defaults to */ uint8_t * IPv4Addresses;
+    /* TYPE WARNING: array array defaults to */ uint8_t * IPv6Addresses;
     uint8_t Type;
 } NetworkInterfaceType;
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -8072,12 +8072,14 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kName)), name));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricConnected)), fabricConnected));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIsOperational)), isOperational));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kOffPremiseServicesReachableIPv4)),
                                            offPremiseServicesReachableIPv4));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kOffPremiseServicesReachableIPv6)),
                                            offPremiseServicesReachableIPv6));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kHardwareAddress)), hardwareAddress));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIPv4Addresses)), IPv4Addresses));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIPv6Addresses)), IPv6Addresses));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kType)), type));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
@@ -8098,8 +8100,8 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         case to_underlying(Fields::kName):
             ReturnErrorOnFailure(DataModel::Decode(reader, name));
             break;
-        case to_underlying(Fields::kFabricConnected):
-            ReturnErrorOnFailure(DataModel::Decode(reader, fabricConnected));
+        case to_underlying(Fields::kIsOperational):
+            ReturnErrorOnFailure(DataModel::Decode(reader, isOperational));
             break;
         case to_underlying(Fields::kOffPremiseServicesReachableIPv4):
             ReturnErrorOnFailure(DataModel::Decode(reader, offPremiseServicesReachableIPv4));
@@ -8109,6 +8111,12 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
             break;
         case to_underlying(Fields::kHardwareAddress):
             ReturnErrorOnFailure(DataModel::Decode(reader, hardwareAddress));
+            break;
+        case to_underlying(Fields::kIPv4Addresses):
+            ReturnErrorOnFailure(DataModel::Decode(reader, IPv4Addresses));
+            break;
+        case to_underlying(Fields::kIPv6Addresses):
+            ReturnErrorOnFailure(DataModel::Decode(reader, IPv6Addresses));
             break;
         case to_underlying(Fields::kType):
             ReturnErrorOnFailure(DataModel::Decode(reader, type));

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -12108,30 +12108,48 @@ namespace NetworkInterfaceType {
 enum class Fields
 {
     kName                            = 0,
-    kFabricConnected                 = 1,
+    kIsOperational                   = 1,
     kOffPremiseServicesReachableIPv4 = 2,
     kOffPremiseServicesReachableIPv6 = 3,
     kHardwareAddress                 = 4,
-    kType                            = 5,
+    kIPv4Addresses                   = 5,
+    kIPv6Addresses                   = 6,
+    kType                            = 7,
 };
 
 struct Type
 {
 public:
     chip::CharSpan name;
-    bool fabricConnected = static_cast<bool>(0);
+    bool isOperational = static_cast<bool>(0);
     DataModel::Nullable<bool> offPremiseServicesReachableIPv4;
     DataModel::Nullable<bool> offPremiseServicesReachableIPv6;
     chip::ByteSpan hardwareAddress;
+    DataModel::List<const chip::ByteSpan> IPv4Addresses;
+    DataModel::List<const chip::ByteSpan> IPv6Addresses;
     InterfaceType type = static_cast<InterfaceType>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
 
     static constexpr bool kIsFabricScoped = false;
 };
 
-using DecodableType = Type;
+struct DecodableType
+{
+public:
+    chip::CharSpan name;
+    bool isOperational = static_cast<bool>(0);
+    DataModel::Nullable<bool> offPremiseServicesReachableIPv4;
+    DataModel::Nullable<bool> offPremiseServicesReachableIPv6;
+    chip::ByteSpan hardwareAddress;
+    DataModel::DecodableList<chip::ByteSpan> IPv4Addresses;
+    DataModel::DecodableList<chip::ByteSpan> IPv6Addresses;
+    InterfaceType type = static_cast<InterfaceType>(0);
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+
+    static constexpr bool kIsFabricScoped = false;
+};
 
 } // namespace NetworkInterfaceType
 } // namespace Structs

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
@@ -1132,8 +1132,8 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.name", "name", value.isMember("name")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.fabricConnected", "fabricConnected",
-                                                                  value.isMember("fabricConnected")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.isOperational", "isOperational",
+                                                                  value.isMember("isOperational")));
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.offPremiseServicesReachableIPv4",
                                                                   "offPremiseServicesReachableIPv4",
                                                                   value.isMember("offPremiseServicesReachableIPv4")));
@@ -1142,14 +1142,18 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
                                                                   value.isMember("offPremiseServicesReachableIPv6")));
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.hardwareAddress", "hardwareAddress",
                                                                   value.isMember("hardwareAddress")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.IPv4Addresses", "IPv4Addresses",
+                                                                  value.isMember("IPv4Addresses")));
+    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.IPv6Addresses", "IPv6Addresses",
+                                                                  value.isMember("IPv6Addresses")));
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("NetworkInterfaceType.type", "type", value.isMember("type")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "name");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.name, value["name"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "fabricConnected");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.fabricConnected, value["fabricConnected"]));
+    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "isOperational");
+    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.isOperational, value["isOperational"]));
 
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "offPremiseServicesReachableIPv4");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.offPremiseServicesReachableIPv4,
@@ -1162,6 +1166,12 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "hardwareAddress");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.hardwareAddress, value["hardwareAddress"]));
 
+    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "IPv4Addresses");
+    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.IPv4Addresses, value["IPv4Addresses"]));
+
+    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "IPv6Addresses");
+    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.IPv6Addresses, value["IPv6Addresses"]));
+
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "type");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.type, value["type"]));
 
@@ -1171,10 +1181,12 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
 void ComplexArgumentParser::Finalize(chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::Type & request)
 {
     ComplexArgumentParser::Finalize(request.name);
-    ComplexArgumentParser::Finalize(request.fabricConnected);
+    ComplexArgumentParser::Finalize(request.isOperational);
     ComplexArgumentParser::Finalize(request.offPremiseServicesReachableIPv4);
     ComplexArgumentParser::Finalize(request.offPremiseServicesReachableIPv6);
     ComplexArgumentParser::Finalize(request.hardwareAddress);
+    ComplexArgumentParser::Finalize(request.IPv4Addresses);
+    ComplexArgumentParser::Finalize(request.IPv6Addresses);
     ComplexArgumentParser::Finalize(request.type);
 }
 CHIP_ERROR ComplexArgumentParser::Setup(const char * label,

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -1220,10 +1220,10 @@ DataModelLogger::LogValue(const char * label, size_t indent,
         }
     }
     {
-        CHIP_ERROR err = LogValue("FabricConnected", indent + 1, value.fabricConnected);
+        CHIP_ERROR err = LogValue("IsOperational", indent + 1, value.isOperational);
         if (err != CHIP_NO_ERROR)
         {
-            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'FabricConnected'");
+            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'IsOperational'");
             return err;
         }
     }
@@ -1248,6 +1248,22 @@ DataModelLogger::LogValue(const char * label, size_t indent,
         if (err != CHIP_NO_ERROR)
         {
             DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'HardwareAddress'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("IPv4Addresses", indent + 1, value.IPv4Addresses);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'IPv4Addresses'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("IPv6Addresses", indent + 1, value.IPv6Addresses);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'IPv6Addresses'");
             return err;
         }
     }


### PR DESCRIPTION
#### Problem
Currently the General Diagnostics cluster implementation doesn't contain IPv4 and IPv6 addresses lists, so it's not
compatible with the spec.

Fixes: https://github.com/project-chip/connectedhomeip/issues/14879

#### Change overview
* To cluster .xml:
   * Added missing IPv4Addresses and IPv6Addresses lists
   * Changed fabricConnected argument name to isOperational
   to be compatible with the spec.
   * Changed length field for ACTIVE_HARDWARRE_FAULTS,
   ACTIVE_RADIO_FAULTS and ACTIVE_NETWORK_FAULTS as defined
   in the spec.
* Regenerated files with zap_regen_all.py
* Added buffers to keep ip addresses to the NetworkInterface
* Added inserting IPv6 addresses in GetNetworkInterfaces for the Zephyr platform

#### Testing
Tested manually with Python CHIP controller that IPv6 addresses list is returned on NetworkInterfaces attribute read:
> zclread GeneralDiagnostics NetworkInterfaces 1 0 0

Returned data:
>Data = 
{
 						0x0 = "IEEE802154_nrf5", 
 						0x1 = true, 
						0x2 = false, 
 						0x3 = false, 
 						0x4 = [
 							0xf4, 0xce, 0x36, 0x7b, 0x58, 0xf6, 0x25, 0xdd, 
 						]
 						0x5 = [

 						],
						0x6 = [
 							[
 								0xfd, 0xfd, 0x7c, 0xa4, 0x79, 0xb3, 0x1e, 0x72, 0xca, 0x9e, 0x65, 0x16, 0xb, 0x43, 0x45, 0x88, 
 							][
 								0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc, 0x76, 0xbc, 0x54, 0x4b, 0xf, 0x93, 0xb5, 
 							][
 								0xfd, 0x11, 0x0, 0x22, 0x0, 0x0, 0x0, 0x0, 0x2c, 0x38, 0x7e, 0xab, 0xd0, 0x62, 0x21, 0x80, 
 							]

 						],
 						0x7 = 4, 
 					},

