### PR TITLE
[all-clusters-app] Allow more subscriptions opened at the same time

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -80,14 +80,7 @@
 //
 #define CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS 16
 
-//
-// Set this to a value greater than the value for CHIP_IM_MAX_NUM_READ_HANDLER
-// to ensure some of the tests for validating resource exhaustion and heap allocation
-// pass correctly.
-//
-// TODO: Once we fix ReadClients to be heap allocated, we no longer need this override.
-//
-#define CHIP_IM_MAX_NUM_READ_CLIENT 6
+#define CHIP_IM_MAX_NUM_READ_HANDLER 5
 
 #define CONFIG_IM_BUILD_FOR_UNIT_TEST 1
 

--- a/examples/platform/qpg/project_include/CHIPProjectConfig.h
+++ b/examples/platform/qpg/project_include/CHIPProjectConfig.h
@@ -133,7 +133,6 @@
  *
  *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
  *      * #CHIP_IM_MAX_NUM_READ_HANDLER
- *      * #CHIP_IM_MAX_NUM_READ_CLIENT
  *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
  *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
  *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
@@ -155,13 +154,6 @@
  * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
  */
 #define CHIP_IM_MAX_NUM_READ_HANDLER 3
-
-/**
- * @def CHIP_IM_MAX_NUM_READ_CLIENT
- *
- * @brief Defines the maximum number of ReadClient, limits the number of active read transactions on client.
- */
-#define CHIP_IM_MAX_NUM_READ_CLIENT 2
 
 /**
  * @def CHIP_IM_MAX_REPORTS_IN_FLIGHT

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1328,7 +1328,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  *
  *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
  *      * #CHIP_IM_MAX_NUM_READ_HANDLER
- *      * #CHIP_IM_MAX_NUM_READ_CLIENT
  *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
  *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
  *      * #CHIP_IM_SERVER_MAX_NUM_DIRTY_SET
@@ -1355,15 +1354,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  */
 #ifndef CHIP_IM_MAX_NUM_READ_HANDLER
 #define CHIP_IM_MAX_NUM_READ_HANDLER 4
-#endif
-
-/**
- * @def CHIP_IM_MAX_NUM_READ_CLIENT
- *
- * @brief Defines the maximum number of ReadClient, limits the number of active read transactions on client.
- */
-#ifndef CHIP_IM_MAX_NUM_READ_CLIENT
-#define CHIP_IM_MAX_NUM_READ_CLIENT 4
 #endif
 
 /**


### PR DESCRIPTION
#### Problem

ToT is randomly red with the Darwin CI because #14606 has added more subscriptions and the accessory can not keep up.

#### Change overview
 * Augment the number of read handlers on the accessory side
 * Remove the unused `CHIP_IM_MAX_NUM_READ_CLIENT` macro
 
#### Testing
 I have tried by running `xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx` 3 times in a row without failure.