### PR TITLE
Move the peer address size to a config variable that can be overriden per project

### DIFF
--- a/examples/platform/qpg/project_include/CHIPProjectConfig.h
+++ b/examples/platform/qpg/project_include/CHIPProjectConfig.h
@@ -190,3 +190,5 @@
  * @brief Defines the maximum number of WriteClient, limits the number of active write transactions on client.
  */
 #define CHIP_IM_MAX_NUM_WRITE_CLIENT 2
+
+#define CHIP_CONFIG_PEER_ADDRESS_MULTI_DESTINATION_SIZE 2

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1769,6 +1769,20 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #define CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE 1003
 #endif // CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE
 
+/*
+ * @def CHIP_CONFIG_PEER_ADDRESS_MULTI_DESTINATION_SIZE
+ *
+ * @brief Number of separate addresses that is kept for a single Peer address.
+ *
+ * As nodes are discovered via DNSSD, the address records will likely contain
+ * more than a single address (like GUA or LLA or ULA). This setting allows
+ * Peer address objects to know of more than one available address and fall
+ * back to a different address if the first one fails.
+ */
+#ifndef CHIP_CONFIG_PEER_ADDRESS_MULTI_DESTINATION_SIZE
+#define CHIP_CONFIG_PEER_ADDRESS_MULTI_DESTINATION_SIZE 3
+#endif // CHIP_CONFIG_PEER_ADDRESS_MULTI_DESTINATION_SIZE
+
 /**
  * @}
  */

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -85,7 +85,7 @@ public:
 
     // When using DNSSD, a peer may be discovered at multiple addresses.
     // This controls how many addresses can be kept.
-    static constexpr unsigned kMaxPeerDestinations = 3;
+    static constexpr unsigned kMaxPeerDestinations = CHIP_CONFIG_PEER_ADDRESS_MULTI_DESTINATION_SIZE;
 
     PeerAddress() : mTransportType(Type::kUndefined) {}
     PeerAddress(const Inet::IPAddress & addr, Type type) : mTransportType(type)


### PR DESCRIPTION
#### Problem
Peer addresses are kept per-session and we have session pools, so any size increase in peer addresses is compounded by pool sizes. This means smaller devices need a way to tune cache sizes down while larger devices may want to tune it up to support more retries on all available addresses.

#### Change overview
Sets peer address destination size as a configuration variable. 
Changed QPG tuning from 3 to 2, where we expect to see a BSS decrease as a result.

#### Testing
Compilation testing should be sufficient as this replaces a constant with another.
Expect used BSS size to decrease for qpg buils.
