### PR TITLE
Integrate pigweed tokenizer logging

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -698,6 +698,7 @@ LinkSoftwareAndDocumentationPack
 LinuxOTAImageProcessor
 LinuxOTARequestorDriver
 LocalConfigDisabled
+localedef
 localhost
 LocalizationConfiguration
 localstatedir
@@ -804,6 +805,7 @@ MX
 mydir
 MyPASSWORD
 MySSID
+nameserver
 namespacing
 nano
 natively
@@ -824,6 +826,7 @@ NitrogenDioxideConcentrationMeasurement
 nl
 NLUnitTest
 NLUnitTests
+nmcli
 noc
 NodeId
 nongnu
@@ -1273,6 +1276,7 @@ USERINTERFACE
 UserLabel
 usermod
 usr
+UTF
 util
 utils
 UUID

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -334,6 +334,8 @@ depottools
 deps
 desc
 descheduled
+detokenization
+detokenizer
 dev
 devcontainer
 devCtrl
@@ -1031,6 +1033,7 @@ RGB
 riscv
 rloc
 rmw
+rodata
 Rollershade
 rootfs
 RPC
@@ -1174,6 +1177,7 @@ TestCluster
 TestConstraints
 TestEmptyString
 TestGenExample
+TestGroupDemoConfig
 TestMultiRead
 TESTPASSWD
 TestPICS
@@ -1207,6 +1211,7 @@ tngvndl
 TODO
 toJson
 tokenized
+tokenizer
 toolchain
 toolchains
 topologies
@@ -1373,19 +1378,3 @@ zephyrproject
 Zigbee
 zigbeealliance
 zigbeethread
-libshell
-TestGroupDemoConfig
-ACLs
-AddNOC
-CHIPConfig
-CHIPProjectAppConfig
-CaseAdminNode
-DataVersion
-ProxyView
-ReadAttribute
-WriteAttribute
-kAdminister
-kManage
-kOperate
-kView
-xFFFFFFFD

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -71,6 +71,7 @@ jobs:
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target k32w-light-release \
+                      --target k32w-light-tokenizer-release \
                       --target k32w-lock-low-power-release \
                       --target k32w-shell-release \
                       build \

--- a/examples/lighting-app/nxp/k32w/k32w0/BUILD.gn
+++ b/examples/lighting-app/nxp/k32w/k32w0/BUILD.gn
@@ -20,7 +20,13 @@ import("${k32w0_sdk_build_root}/k32w0_executable.gni")
 import("${k32w0_sdk_build_root}/k32w0_sdk.gni")
 
 import("${chip_root}/src/crypto/crypto.gni")
+import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/platform/device.gni")
+
+if (chip_pw_tokenizer_logging) {
+  import("//build_overrides/pigweed.gni")
+  import("$dir_pw_tokenizer/database.gni")
+}
 
 assert(current_os == "freertos")
 
@@ -105,8 +111,20 @@ k32w0_executable("light_app") {
   output_dir = root_out_dir
 }
 
+if (chip_pw_tokenizer_logging) {
+  pw_tokenizer_database("light_app.database") {
+    database = "$root_build_dir/chip-k32w061-light-example-database.bin"
+    create = "binary"
+    deps = [ ":light_app" ]
+    optional_paths = [ "$root_build_dir/chip-k32w061-light-example" ]
+  }
+}
+
 group("k32w0") {
   deps = [ ":light_app" ]
+  if (chip_pw_tokenizer_logging) {
+    deps += [ ":light_app.database" ]
+  }
 }
 
 group("default") {

--- a/examples/lighting-app/nxp/k32w/k32w0/detokenizer.py
+++ b/examples/lighting-app/nxp/k32w/k32w0/detokenizer.py
@@ -1,0 +1,148 @@
+import argparse
+import sys
+import os
+import serial
+import pw_tokenizer
+
+
+def parse_args():
+    """Parse input arguments
+
+    Return:
+        parsed arguments struncture
+    """
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='type')
+    subparsers.required = True
+
+    parser_file = subparsers.add_parser('file')
+    parser_file.add_argument(
+        "-i", "--input", help="Input file name.", required=True)
+    parser_file.add_argument(
+        "-d", "--database", help="Token database.", required=True)
+    parser_file.add_argument(
+        "-o", "--output", help="Output file name.", required=True)
+
+    parser_file = subparsers.add_parser('serial')
+    parser_file.add_argument(
+        "-i", "--input", help="Input serial port name.", required=True)
+    parser_file.add_argument(
+        "-d", "--database", help="Token database.", required=True)
+    parser_file.add_argument(
+        "-o", "--output", help="Output file name. Write to stdout and to file.")
+
+    return parser.parse_args()
+
+
+def decode_string(tstr, detok):
+    """Decodes a single token.
+
+    Args:
+        tstr        - encoded input string
+        detok       - detokenizer
+
+    Return:
+        decoded string or None
+    """
+    try:
+        t = bytes.fromhex(tstr)
+        s = str(detok.detokenize(t))
+
+        if s.find('$') == 0:
+            return None
+        return s
+    except:
+        return None
+
+
+def decode_serial(serialport, outfile, database):
+    """Decodes logs from serial port.
+
+    Args:
+        infile      - path to input file
+        outfile     - path to output file
+        database    - path to token database
+    """
+
+    detokenizer = pw_tokenizer.Detokenizer(database)
+    input = serial.Serial(serialport, 115200, timeout=None)
+
+    output = None
+    if outfile:
+        output = open(outfile, 'w')
+
+    if input:
+
+        try:
+            while(True):
+                if(input.in_waiting > 0):
+                    # read line from serial port and ascii decode
+                    line = input.readline().decode('ascii').strip()
+                    # find token start and detokenize
+                    idx = line.rfind(']')
+                    dstr = decode_string(line[idx + 1:], detokenizer)
+                    if dstr:
+                        line = line[:idx+1] + dstr
+                    print(line, file=sys.stdout)
+                    if output:
+                        print(line, file=output)
+        except:
+            print("Serial error or program closed", file=sys.stderr)
+
+        if output:
+            input.close()
+            output.close()
+
+    else:
+        print("Invalid or closed serial port.", file=sys.stderr)
+
+
+def decode_file(infile, outfile, database):
+    """Decodes logs from input file.
+
+    Args:
+        infile      - path to input file
+        outfile     - path to output file
+        database    - path to token database
+    """
+
+    if os.path.isfile(infile):
+
+        detokenizer = pw_tokenizer.Detokenizer(database)
+
+        output = open(outfile, 'w')
+
+        with open(infile, 'rb') as file:
+            for line in file:
+                try:
+                    # ascii decode line
+                    # serial terminals may include non ascii characters
+                    line = line.decode('ascii').strip()
+                except:
+                    continue
+                # find token start and detokenize
+                idx = line.rfind(']')
+                dstr = decode_string(line[idx + 1:], detokenizer)
+                if dstr:
+                    line = line[:idx+1] + dstr
+                print(line, file=output)
+        output.close()
+
+    else:
+        print("File does not exist or is not a file.", file=sys.stderr)
+
+
+def detokenize_input():
+
+    args = parse_args()
+
+    if args.type == 'file':
+        decode_file(args.input, args.output, args.database)
+    if args.type == 'serial':
+        decode_serial(args.input, args.output, args.database)
+
+
+if __name__ == '__main__':
+    detokenize_input()
+    sys.exit(0)

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -416,7 +416,7 @@ void AppTask::ResetActionEventHandler(AppEvent * aEvent)
             return;
         }
 
-        K32W_LOG("Factory Reset Triggered. Push the RESET button within %u ms to cancel!", resetTimeout);
+        K32W_LOG("Factory Reset Triggered. Push the RESET button within %lu ms to cancel!", resetTimeout);
         sAppTask.mFunction = kFunction_FactoryReset;
 
         /* LEDs will start blinking to signal that a Factory Reset was scheduled */

--- a/examples/lighting-app/nxp/k32w/k32w0/main/include/app_config.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/include/app_config.h
@@ -45,7 +45,11 @@
 #define SWU_INTERVAl_WINDOW_MAX_MS (24 * 60 * 60 * 1000) // 24 hours
 
 #if K32W_LOG_ENABLED
+#if CHIP_PW_TOKENIZER_LOGGING
+#define K32W_LOG(MSG, ...) ChipLogDetail(Echo, MSG, __VA_ARGS__);
+#else
 #define K32W_LOG(...) otPlatLog(OT_LOG_LEVEL_NONE, OT_LOG_REGION_API, ##__VA_ARGS__);
+#endif
 #else
 #define K32W_LOG(...)
 #endif

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -368,6 +368,7 @@ def K32WTargets():
     yield target.Extend('light', app=K32WApp.LIGHT).GlobBlacklist("Debug builds broken due to LWIP_DEBUG redefition")
 
     yield target.Extend('light-release', app=K32WApp.LIGHT, release=True)
+    yield target.Extend('light-tokenizer-release', app=K32WApp.LIGHT, tokenizer=True, release=True).GlobBlacklist("Only on demand build")
     yield target.Extend('shell-release', app=K32WApp.SHELL, release=True)
     yield target.Extend('lock-release', app=K32WApp.LOCK, release=True)
     yield target.Extend('lock-low-power-release', app=K32WApp.LOCK, low_power=True, release=True).GlobBlacklist("Only on demand build")

--- a/scripts/build/builders/k32w.py
+++ b/scripts/build/builders/k32w.py
@@ -54,13 +54,15 @@ class K32WBuilder(GnBuilder):
                  runner,
                  app: K32WApp = K32WApp.LIGHT,
                  release: bool = False,
-                 low_power: bool = False):
+                 low_power: bool = False,
+                 tokenizer: bool = False):
         super(K32WBuilder, self).__init__(
             root=app.BuildRoot(root),
             runner=runner)
         self.code_root = root
         self.app = app
         self.low_power = low_power
+        self.tokenizer = tokenizer
         self.release = release
 
     def GnBuildArgs(self):
@@ -72,6 +74,9 @@ class K32WBuilder(GnBuilder):
             args.append('chip_with_low_power=1')
         else:
             args.append('chip_with_low_power=0')
+            
+        if self.tokenizer:
+            args.append('chip_pw_tokenizer_logging=true')
 
         if self.release:
             args.append('is_debug=false')

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -92,6 +92,7 @@ infineon-p6-light
 infineon-p6-lock
 k32w-light (NOGLOB: Debug builds broken due to LWIP_DEBUG redefition)
 k32w-light-release
+k32w-light-tokenizer-release (NOGLOB: Only on demand build)
 k32w-lock-low-power-release (NOGLOB: Only on demand build)
 k32w-lock-release
 k32w-shell-release

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -524,6 +524,11 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 
 {root}/third_party/nxp/k32w0_sdk/sdk_fixes/patch_k32w_sdk.sh
 
+# Generating k32w-light-tokenizer-release
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/nxp/k32w/k32w0 '--args=k32w0_sdk_root="TEST_NXP_K32W061_SDK_ROOT" chip_with_low_power=0 chip_pw_tokenizer_logging=true is_debug=false' {out}/k32w-light-tokenizer-release
+
+{root}/third_party/nxp/k32w0_sdk/sdk_fixes/patch_k32w_sdk.sh
+
 # Generating k32w-lock-low-power-release
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/nxp/k32w/k32w0 '--args=k32w0_sdk_root="TEST_NXP_K32W061_SDK_ROOT" chip_with_low_power=1 is_debug=false' {out}/k32w-lock-low-power-release
 
@@ -1218,6 +1223,9 @@ ninja -C {out}/k32w-light
 
 # Building k32w-light-release
 ninja -C {out}/k32w-light-release
+
+# Building k32w-light-tokenizer-release
+ninja -C {out}/k32w-light-tokenizer-release
 
 # Building k32w-lock-low-power-release
 ninja -C {out}/k32w-lock-low-power-release

--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -42,6 +42,7 @@ void emberAfPrint(int category, const char * format, ...)
 #endif
 }
 
+#if !CHIP_PW_TOKENIZER_LOGGING
 void emberAfPrintln(int category, const char * format, ...)
 {
 #if _CHIP_USE_LOGGING
@@ -54,6 +55,7 @@ void emberAfPrintln(int category, const char * format, ...)
     }
 #endif
 }
+#endif
 
 // TODO: add unit tests.
 

--- a/src/app/util/ember-print.h
+++ b/src/app/util/ember-print.h
@@ -35,7 +35,11 @@ void emberAfPrint(int category, const char * format, ...) ENFORCE_FORMAT(2, 3);
  * @param category - Currently ignored as zcl categories do not map to chip categories. Defaults to kLogCategory_Progress
  * @param format - Format string to print
  * */
+#if CHIP_PW_TOKENIZER_LOGGING
+#define emberAfPrintln(MOD, MSG, ...) ChipLogProgress(Zcl, MSG, __VA_ARGS__);
+#else
 void emberAfPrintln(int category, const char * format, ...) ENFORCE_FORMAT(2, 3);
+#endif
 
 /**
  * @brief Prints a buffer

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -45,6 +45,7 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_PROGRESS_LOGGING=${chip_progress_logging}",
     "CHIP_DETAIL_LOGGING=${chip_detail_logging}",
     "CHIP_AUTOMATION_LOGGING=${chip_automation_logging}",
+    "CHIP_PW_TOKENIZER_LOGGING=${chip_pw_tokenizer_logging}",
     "CHIP_CONFIG_SHORT_ERROR_STR=${chip_config_short_error_str}",
     "CHIP_CONFIG_ENABLE_ARG_PARSER=${chip_config_enable_arg_parser}",
     "CHIP_TARGET_STYLE_UNIX=${chip_target_style_unix}",

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -33,6 +33,9 @@ declare_args() {
   # Enable automation logging.
   chip_automation_logging = chip_logging
 
+  # Enable pigweed tokenizer logging.
+  chip_pw_tokenizer_logging = false
+
   # Enable short error strings.
   chip_config_short_error_str = false
 

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -22,6 +22,10 @@ import("${chip_root}/build/chip/chip_version.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
+if (chip_pw_tokenizer_logging) {
+  import("//build_overrides/pigweed.gni")
+}
+
 action("gen_chip_version") {
   script = "${chip_root}/scripts/gen_chip_version.py"
 
@@ -174,6 +178,10 @@ static_library("support") {
       "CHIPFaultInjection.h",
     ]
     public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
+  }
+
+  if (chip_pw_tokenizer_logging) {
+    public_deps += [ "${dir_pw_tokenizer}:global_handler_with_payload" ]
   }
 
   if (chip_config_memory_debug_dmalloc) {

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -36,6 +36,28 @@
 
 #include <atomic>
 
+#if CHIP_PW_TOKENIZER_LOGGING
+
+extern "C" void pw_tokenizer_HandleEncodedMessageWithPayload(uintptr_t levels, const uint8_t encoded_message[], size_t size_bytes)
+{
+    uint8_t log_category = levels >> 8 & 0xFF;
+    uint8_t log_module   = levels & 0xFF;
+    char * buffer        = (char *) malloc(2 * size_bytes + 1);
+
+    if (buffer)
+    {
+        for (int i = 0; i < size_bytes; i++)
+        {
+            sprintf(buffer + 2 * i, "%02x", encoded_message[i]);
+        }
+        buffer[2 * size_bytes] = '\0';
+        chip::Logging::Log(log_module, log_category, "%s", buffer);
+        free(buffer);
+    }
+}
+
+#endif
+
 namespace chip {
 namespace Logging {
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -46,6 +46,10 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+#if CHIP_PW_TOKENIZER_LOGGING
+#include "pw_tokenizer/tokenize_to_global_handler_with_payload.h"
+#endif
+
 /**
  *   @namespace chip::Logging
  *
@@ -106,8 +110,14 @@ void SetLogFilter(uint8_t category);
  *
  */
 #ifndef ChipLogError
+#if CHIP_PW_TOKENIZER_LOGGING
+#define ChipLogError(MOD, MSG, ...)                                                                                                \
+    PW_TOKENIZE_TO_GLOBAL_HANDLER_WITH_PAYLOAD(                                                                                    \
+        (pw_tokenizer_Payload)((chip::Logging::kLogCategory_Error << 8) | chip::Logging::kLogModule_##MOD), MSG, __VA_ARGS__)
+#else
 #define ChipLogError(MOD, MSG, ...)                                                                                                \
     chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Error, MSG, ##__VA_ARGS__)
+#endif
 #endif
 #else
 #define ChipLogError(MOD, MSG, ...) ((void) 0)
@@ -127,8 +137,14 @@ void SetLogFilter(uint8_t category);
  *
  */
 #ifndef ChipLogProgress
+#if CHIP_PW_TOKENIZER_LOGGING
+#define ChipLogProgress(MOD, MSG, ...)                                                                                             \
+    PW_TOKENIZE_TO_GLOBAL_HANDLER_WITH_PAYLOAD(                                                                                    \
+        (pw_tokenizer_Payload)((chip::Logging::kLogCategory_Progress << 8) | chip::Logging::kLogModule_##MOD), MSG, __VA_ARGS__)
+#else
 #define ChipLogProgress(MOD, MSG, ...)                                                                                             \
     chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Progress, MSG, ##__VA_ARGS__)
+#endif
 #endif
 #else
 #define ChipLogProgress(MOD, MSG, ...) ((void) 0)
@@ -148,8 +164,14 @@ void SetLogFilter(uint8_t category);
  *
  */
 #ifndef ChipLogDetail
+#if CHIP_PW_TOKENIZER_LOGGING
+#define ChipLogDetail(MOD, MSG, ...)                                                                                               \
+    PW_TOKENIZE_TO_GLOBAL_HANDLER_WITH_PAYLOAD(                                                                                    \
+        (pw_tokenizer_Payload)((chip::Logging::kLogCategory_Detail << 8) | chip::Logging::kLogModule_##MOD), MSG, __VA_ARGS__)
+#else
 #define ChipLogDetail(MOD, MSG, ...)                                                                                               \
     chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Detail, MSG, ##__VA_ARGS__)
+#endif
 #endif
 #else
 #define ChipLogDetail(MOD, MSG, ...) ((void) 0)
@@ -178,8 +200,15 @@ void SetLogFilter(uint8_t category);
  *
  */
 #ifndef ChipLogAutomation
+#if CHIP_PW_TOKENIZER_LOGGING
+#define ChipLogAutomation(MSG, ...)                                                                                                \
+    PW_TOKENIZE_TO_GLOBAL_HANDLER_WITH_PAYLOAD(                                                                                    \
+        (pw_tokenizer_Payload)((chip::Logging::kLogModule_Automation << 8) | chip::Logging::kLogModule_Automation), MSG,           \
+        __VA_ARGS__)
+#else
 #define ChipLogAutomation(MSG, ...)                                                                                                \
     chip::Logging::Log(chip::Logging::kLogModule_Automation, chip::Logging::kLogCategory_Automation, MSG, ##__VA_ARGS__)
+#endif
 #endif
 #else
 #define ChipLogAutomation(MOD, MSG, ...) ((void) 0)

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -708,12 +708,14 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
                     "Leader Router ID: %u\n"
                     "Parent Avg RSSI:  %d\n"
                     "Parent Last RSSI: %d\n"
-                    "Partition ID:     %" PRIu32 "\n"
+                    "Partition ID:     %" PRIu32 "\n",
+                    rloc16, routerId, leaderRouterId, parentAverageRssi, parentLastRssi, partitionId);
+
+    ChipLogProgress(DeviceLayer,
                     "Extended Address: %02X%02X:%02X%02X:%02X%02X:%02X%02X\n"
                     "Instant RSSI:     %d\n",
-                    rloc16, routerId, leaderRouterId, parentAverageRssi, parentLastRssi, partitionId, extAddress->m8[0],
-                    extAddress->m8[1], extAddress->m8[2], extAddress->m8[3], extAddress->m8[4], extAddress->m8[5],
-                    extAddress->m8[6], extAddress->m8[7], instantRssi);
+                    extAddress->m8[0], extAddress->m8[1], extAddress->m8[2], extAddress->m8[3], extAddress->m8[4],
+                    extAddress->m8[5], extAddress->m8[6], extAddress->m8[7], instantRssi);
 
 exit:
     Impl()->UnlockThreadStack();
@@ -746,7 +748,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
     otNeighborInfo neighborInfo[TELEM_NEIGHBOR_TABLE_SIZE];
     otNeighborInfoIterator iter;
     otNeighborInfoIterator iterCopy;
-    char printBuf[TELEM_PRINT_BUFFER_SIZE];
+    char printBuf[TELEM_PRINT_BUFFER_SIZE] = {0};
     uint16_t rloc16;
     uint16_t routerId;
     uint16_t leaderRouterId;
@@ -806,30 +808,37 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
         iterCopy = iter;
     }
 
+    snprintf(printBuf, TELEM_PRINT_BUFFER_SIZE, "%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X",
+             leaderAddr->mFields.m8[0], leaderAddr->mFields.m8[1], leaderAddr->mFields.m8[2], leaderAddr->mFields.m8[3],
+             leaderAddr->mFields.m8[4], leaderAddr->mFields.m8[5], leaderAddr->mFields.m8[6], leaderAddr->mFields.m8[7],
+             leaderAddr->mFields.m8[8], leaderAddr->mFields.m8[9], leaderAddr->mFields.m8[10], leaderAddr->mFields.m8[11],
+             leaderAddr->mFields.m8[12], leaderAddr->mFields.m8[13], leaderAddr->mFields.m8[14], leaderAddr->mFields.m8[15]);
+
     ChipLogProgress(DeviceLayer,
                     "Thread Topology:\n"
                     "RLOC16:                        %04X\n"
                     "Router ID:                     %u\n"
                     "Leader Router ID:              %u\n"
-                    "Leader Address:                %02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X\n"
+                    "Leader Address:                %s\n"
                     "Leader Weight:                 %d\n"
                     "Local Leader Weight:           %d\n"
                     "Network Data Len:              %d\n"
                     "Network Data Version:          %d\n"
-                    "Stable Network Data Version:   %d\n"
+                    "Stable Network Data Version:   %d\n",
+                    rloc16, routerId, leaderRouterId, printBuf, leaderWeight, leaderLocalWeight, networkDataLen, networkDataVersion,
+                    stableNetworkDataVersion);
+
+    memset(printBuf, 0x00, TELEM_PRINT_BUFFER_SIZE);
+
+    ChipLogProgress(DeviceLayer,
                     "Extended Address:              %02X%02X:%02X%02X:%02X%02X:%02X%02X\n"
                     "Partition ID:                  %" PRIx32 "\n"
                     "Instant RSSI:                  %d\n"
                     "Neighbor Table Length:         %d\n"
                     "Child Table Length:            %d\n",
-                    rloc16, routerId, leaderRouterId, leaderAddr->mFields.m8[0], leaderAddr->mFields.m8[1],
-                    leaderAddr->mFields.m8[2], leaderAddr->mFields.m8[3], leaderAddr->mFields.m8[4], leaderAddr->mFields.m8[5],
-                    leaderAddr->mFields.m8[6], leaderAddr->mFields.m8[7], leaderAddr->mFields.m8[8], leaderAddr->mFields.m8[9],
-                    leaderAddr->mFields.m8[10], leaderAddr->mFields.m8[11], leaderAddr->mFields.m8[12], leaderAddr->mFields.m8[13],
-                    leaderAddr->mFields.m8[14], leaderAddr->mFields.m8[15], leaderWeight, leaderLocalWeight, networkDataLen,
-                    networkDataVersion, stableNetworkDataVersion, extAddress->m8[0], extAddress->m8[1], extAddress->m8[2],
-                    extAddress->m8[3], extAddress->m8[4], extAddress->m8[5], extAddress->m8[6], extAddress->m8[7], partitionId,
-                    instantRssi, neighborTableSize, childTableSize);
+                    extAddress->m8[0], extAddress->m8[1], extAddress->m8[2], extAddress->m8[3], extAddress->m8[4],
+                    extAddress->m8[5], extAddress->m8[6], extAddress->m8[7], partitionId, instantRssi, neighborTableSize,
+                    childTableSize);
 
     // Handle each neighbor event seperatly.
     for (uint32_t i = 0; i < neighborTableSize; i++)
@@ -856,19 +865,22 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
                         "Age:               %3" PRIu32 "\n"
                         "LQI:               %1d\n"
                         "AvgRSSI:           %3d\n"
-                        "LastRSSI:          %3d\n"
+                        "LastRSSI:          %3d\n",
+                        i, neighbor->mExtAddress.m8[0], neighbor->mExtAddress.m8[1], neighbor->mExtAddress.m8[2],
+                        neighbor->mExtAddress.m8[3], neighbor->mExtAddress.m8[4], neighbor->mExtAddress.m8[5],
+                        neighbor->mExtAddress.m8[6], neighbor->mExtAddress.m8[7], neighbor->mRloc16, neighbor->mAge,
+                        neighbor->mLinkQualityIn, neighbor->mAverageRssi, neighbor->mLastRssi);
+
+        ChipLogProgress(DeviceLayer,
                         "LinkFrameCounter:  %10" PRIu32 "\n"
                         "MleFrameCounter:   %10" PRIu32 "\n"
                         "RxOnWhenIdle:      %c\n"
                         "FullFunction:      %c\n"
                         "FullNetworkData:   %c\n"
                         "IsChild:           %c%s\n",
-                        i, neighbor->mExtAddress.m8[0], neighbor->mExtAddress.m8[1], neighbor->mExtAddress.m8[2],
-                        neighbor->mExtAddress.m8[3], neighbor->mExtAddress.m8[4], neighbor->mExtAddress.m8[5],
-                        neighbor->mExtAddress.m8[6], neighbor->mExtAddress.m8[7], neighbor->mRloc16, neighbor->mAge,
-                        neighbor->mLinkQualityIn, neighbor->mAverageRssi, neighbor->mLastRssi, neighbor->mLinkFrameCounter,
-                        neighbor->mMleFrameCounter, neighbor->mRxOnWhenIdle ? 'Y' : 'n', neighbor->mFullThreadDevice ? 'Y' : 'n',
-                        neighbor->mFullNetworkData ? 'Y' : 'n', neighbor->mIsChild ? 'Y' : 'n', printBuf);
+                        neighbor->mLinkFrameCounter, neighbor->mMleFrameCounter, neighbor->mRxOnWhenIdle ? 'Y' : 'n',
+                        neighbor->mFullThreadDevice ? 'Y' : 'n', neighbor->mFullNetworkData ? 'Y' : 'n',
+                        neighbor->mIsChild ? 'Y' : 'n', printBuf);
     }
 
 exit:


### PR DESCRIPTION
Signed-off-by: Andrei Menzopol <andrei.menzopol@nxp.com>

#### Problem
Integrate pigweed tokenizer for logging.

#### Change overview
*add pw_tokenizer build changes.
*add build changes in nxp k32w lighting-app.
*update nxp k32w lighting-app README.
*change logging functions to use the tokenizer.
*guard tokenizer changes with define.
*split logs where too many arguments.
*create build test for k32w lighting-app with tokenizer.
*update .wordlist.txt and remove duplicates.
#### Testing
Tested on NXP K32W061 DK6 board with lighting-app example
