### PR TITLE
[OTA] Set default configuration values for OTA Provider to prevent crash

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -54,6 +54,7 @@ ApplicationId
 ApplicationIdentifier
 ApplicationLauncher
 ApplyUpdateRequest
+ApplyUpdateResponse
 approver
 appspot
 aps
@@ -280,6 +281,7 @@ debianutils
 DEDEDEDE
 deepnote
 DelayedActionTime
+delayedActionTimeSec
 demangle
 deployable
 depottools
@@ -855,6 +857,7 @@ QRCodeUrl
 QSPI
 QueryImage
 QueryImageResponse
+queryImageStatus
 qvCHIP
 RADVD
 raspberryPi
@@ -966,6 +969,7 @@ SoftDevice
 softmmu
 SoftwareDiagnostics
 SoftwareVersion
+softwareVersionStr
 SoftwareVersionString
 softwareVersionValid
 SPI
@@ -1085,12 +1089,16 @@ UniFlash
 unpair
 unprovisioned
 untrusted
+updateAvailable
+updateNotAvailable
 UpdateTokens
 upstreamed
 URI
 usbmodem
 USBtoUART
 uscif
+UserConsentNeeded
+userConsentState
 userguide
 USERINTERFACE
 UserLabel

--- a/examples/ota-provider-app/linux/README.md
+++ b/examples/ota-provider-app/linux/README.md
@@ -6,56 +6,54 @@ Cluster Server.
 ## Building
 
 Suggest doing the following:
-`scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false`
+
+```
+scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false
+```
 
 ## Usage
 
-`./ota-provider-app [-f/--filepath \<file\>] [-o/--otaImageList \<file\>]`
+| Command Line Options                                                  | Description                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -f/--filepath <file>                                                  | Path to a file containing an OTA image                                                                                                                                                                                                                                                                                                                                                |
+| -o/--otaImageList <file>                                              | Path to a file containing a list of OTA images                                                                                                                                                                                                                                                                                                                                        |
+| -q/--queryImageStatus <updateAvailable \| busy \| updateNotAvailable> | Value for the Status field in the QueryImageResponse                                                                                                                                                                                                                                                                                                                                  |
+| -t/--delayedActionTimeSec <time>                                      | Value in seconds for the DelayedActionTime field in the QueryImageResponse and ApplyUpdateResponse                                                                                                                                                                                                                                                                                    |
+| -u/--userConsentState <granted \| denied \| deferred>                 | Current user consent state which results in various values for Status field in QueryImageResponse <br> Note that -q/--queryImageStatus overrides this option <li> granted: Status field in QueryImageResponse is set to updateAvailable <li> denied: Status field in QueryImageResponse is set to updateNotAvailable <li> deferred: Status field in QueryImageResponse is set to busy |
+| -s/--softwareVersion <version>                                        | Value for the SoftwareVersion field in the QueryImageResponse <br> Note that -o/--otaImageList overrides this option                                                                                                                                                                                                                                                                  |
+| -S/--softwareVersionStr <version string>                              | Value for the SoftwareVersionString field in the QueryImageResponse <br> Note that -o/--otaImageList overrides this option                                                                                                                                                                                                                                                            |
+| -c/--UserConsentNeeded                                                | If provided, value of UserConsentNeeded in the Query Image Response is set to true                                                                                                                                                                                                                                                                                                    |
 
-If `--filepath` is supplied, `ota-provider-app` will automatically serve that
-file to the OTA Requestor (SoftwareVersion will be Requester version + 1).
+**Using `--filepath` and `--otaImageList`**
 
-If `--otaImageList` is supplied, `ota-provider-app` will parse the JSON file and
-extract all required data. Then the most recent, valid software version will be
-selected and the corresponding ota-file will be sent to the OTA Requestor.
+-   The two options cannot be supplied together
+-   If neither option is supplied, the application will respond with
+    `NotAvailable` status
+-   If `--filepath` is supplied, the application will automatically serve that
+    file to the OTA Requestor (SoftwareVersion will be requester software
+    version + 1)
+-   If `--otaImageList` is supplied, the application will parse the JSON file
+    and extract all required data. The most recent/valid software version will
+    be selected and the corresponding OTA file will be sent to the OTA Requestor
 
-Here's an example of the otaImageList file contents:
+An example of the `--otaImageList` file contents:
 
-{ "foo": 1, // ignored by parser "deviceSoftwareVersionModel": [ { "vendorId":
-1, "productId": 1, "softwareVersion": 10, "softwareVersionString": "1.0.0",
-"cDVersionNumber": 18, "softwareVersionValid": true,
-"minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
-"otaURL": "/tmp/ota.txt" }, { "vendorId": 1, "productId": 1, "softwareVersion":
-20, "softwareVersionString": "1.0.1", "cDVersionNumber": 18,
-"softwareVersionValid": false, "minApplicableSoftwareVersion": 0,
-"maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }, { "vendorId":
-1, "productId": 1, "softwareVersion": 30, "softwareVersionString": "1.0.2",
-"cDVersionNumber": 18, "softwareVersionValid": true,
-"minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
-"otaURL": "/tmp/ota.txt" }, { "vendorId": 1, "productId": 1, "softwareVersion":
-40, "softwareVersionString": "1.1.0", "cDVersionNumber": 18,
-"softwareVersionValid": true, "minApplicableSoftwareVersion": 0,
-"maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }, { "vendorId":
-1, "productId": 1, "softwareVersion": 50, "softwareVersionString": "1.1.1",
-"cDVersionNumber": 18, "softwareVersionValid": false,
-"minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100,
-"otaURL": "/tmp/ota.txt" } ] }
+```
+{ "foo": 1, // ignored by parser
+  "deviceSoftwareVersionModel":
+  [
+      { "vendorId": 1, "productId": 1, "softwareVersion": 10, "softwareVersionString": "1.0.0", "cDVersionNumber": 18, "softwareVersionValid": true, "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" },
+      { "vendorId": 1, "productId": 1, "softwareVersion": 20, "softwareVersionString": "1.0.1", "cDVersionNumber": 18, "softwareVersionValid": false, "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" },
+      { "vendorId": 1, "productId": 1, "softwareVersion": 30, "softwareVersionString": "1.0.2", "cDVersionNumber": 18, "softwareVersionValid": true, "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" },
+      { "vendorId": 1, "productId": 1, "softwareVersion": 40, "softwareVersionString": "1.1.0", "cDVersionNumber": 18, "softwareVersionValid": true, "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" },
+      { "vendorId": 1, "productId": 1, "softwareVersion": 50, "softwareVersionString": "1.1.1", "cDVersionNumber": 18, "softwareVersionValid": false, "minApplicableSoftwareVersion": 0, "maxApplicableSoftwareVersion": 100, "otaURL": "/tmp/ota.txt" }
+  ]
+}
+```
 
-If neither `--filepath` nor `--otaImageList` are supplied, `ota-provider-app`
-will respond to `QueryImage` with `NotAvailable` status.
-
-## Current Features/Limitations
-
-### Features
-
--   can provide local filepath to serve as OTA image
--   can complete full BDX transfer
--   supports variable-length / startoffset for BDX transfer
-
-### Limitations:
+## Current Limitations
 
 -   Synchronous BDX transfer only
--   using hardcoded test values for local and peer Node IDs
--   does not check VID/PID
--   no configuration for `AwaitNextAction`
--   only one transfer at a time (does not check incoming `UpdateTokens`)
+-   Does not check VID/PID
+-   No configuration for `AwaitNextAction`
+-   Only one transfer at a time (does not check incoming `UpdateTokens`)

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -33,7 +33,6 @@
 
 using chip::BitFlags;
 using chip::app::Clusters::OTAProviderDelegate;
-using chip::ArgParser::HelpOptions;
 using chip::ArgParser::OptionDef;
 using chip::ArgParser::OptionSet;
 using chip::ArgParser::PrintArgError;
@@ -45,17 +44,15 @@ constexpr chip::EndpointId kOtaProviderEndpoint = 0;
 
 constexpr uint16_t kOptionFilepath             = 'f';
 constexpr uint16_t kOptionOtaImageList         = 'o';
-constexpr uint16_t kOptionQueryImageBehavior   = 'q';
+constexpr uint16_t kOptionQueryImageStatus     = 'q';
 constexpr uint16_t kOptionUserConsentState     = 'u';
 constexpr uint16_t kOptionDelayedActionTimeSec = 't';
-constexpr uint16_t kOptionDiscriminator        = 'd';
 constexpr uint16_t kOptionSoftwareVersion      = 's';
 constexpr uint16_t kOptionSoftwareVersionStr   = 'S';
 constexpr uint16_t kOptionUserConsentNeeded    = 'c';
 
-static constexpr uint16_t kMaximumDiscriminatorValue = 0xFFF;
-
 OTAProviderExample gOtaProvider;
+chip::ota::DefaultUserConsentProvider gUserConsentProvider;
 
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
 static OTAProviderExample::QueryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUnknown;
@@ -64,7 +61,6 @@ static const char * gOtaFilepath                                      = nullptr;
 static const char * gOtaImageListFilepath                             = nullptr;
 static chip::ota::UserConsentState gUserConsentState                  = chip::ota::UserConsentState::kUnknown;
 static bool gUserConsentNeeded                                        = false;
-static chip::Optional<uint16_t> gSetupDiscriminator;
 static chip::Optional<uint32_t> gSoftwareVersion;
 static const char * gSoftwareVersionString = nullptr;
 
@@ -163,27 +159,27 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
             gOtaImageListFilepath = aValue;
         }
         break;
-    case kOptionQueryImageBehavior:
+    case kOptionQueryImageStatus:
         if (aValue == NULL)
         {
-            PrintArgError("%s: ERROR: NULL QueryImageBehavior parameter\n", aProgram);
+            PrintArgError("%s: ERROR: NULL queryImageStatus parameter\n", aProgram);
             retval = false;
         }
-        else if (strcmp(aValue, "UpdateAvailable") == 0)
+        else if (strcmp(aValue, "updateAvailable") == 0)
         {
             gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
         }
-        else if (strcmp(aValue, "Busy") == 0)
+        else if (strcmp(aValue, "busy") == 0)
         {
             gQueryImageBehavior = OTAProviderExample::kRespondWithBusy;
         }
-        else if (strcmp(aValue, "UpdateNotAvailable") == 0)
+        else if (strcmp(aValue, "updateNotAvailable") == 0)
         {
             gQueryImageBehavior = OTAProviderExample::kRespondWithNotAvailable;
         }
         else
         {
-            PrintArgError("%s: ERROR: Invalid QueryImageBehavior parameter:  %s\n", aProgram, aValue);
+            PrintArgError("%s: ERROR: Invalid queryImageStatus parameter:  %s\n", aProgram, aValue);
             retval = false;
         }
         break;
@@ -214,16 +210,6 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
             retval = false;
         }
         break;
-    case kOptionDiscriminator: {
-        uint16_t discriminator = static_cast<uint16_t>(strtoul(aValue, NULL, 0));
-        if (discriminator > kMaximumDiscriminatorValue)
-        {
-            PrintArgError("%s: Input ERROR: setupDiscriminator value %s is out of range \n", aProgram, aValue);
-            retval = false;
-        }
-        gSetupDiscriminator.SetValue(discriminator);
-        break;
-    }
     case kOptionSoftwareVersion:
         gSoftwareVersion.SetValue(static_cast<uint32_t>(strtoul(aValue, NULL, 0)));
         break;
@@ -258,10 +244,9 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
 OptionDef cmdLineOptionsDef[] = {
     { "filepath", chip::ArgParser::kArgumentRequired, kOptionFilepath },
     { "otaImageList", chip::ArgParser::kArgumentRequired, kOptionOtaImageList },
-    { "QueryImageBehavior", chip::ArgParser::kArgumentRequired, kOptionQueryImageBehavior },
-    { "DelayedActionTimeSec", chip::ArgParser::kArgumentRequired, kOptionDelayedActionTimeSec },
-    { "UserConsentState", chip::ArgParser::kArgumentRequired, kOptionUserConsentState },
-    { "discriminator", chip::ArgParser::kArgumentRequired, kOptionDiscriminator },
+    { "queryImageStatus", chip::ArgParser::kArgumentRequired, kOptionQueryImageStatus },
+    { "delayedActionTimeSec", chip::ArgParser::kArgumentRequired, kOptionDelayedActionTimeSec },
+    { "userConsentState", chip::ArgParser::kArgumentRequired, kOptionUserConsentState },
     { "softwareVersion", chip::ArgParser::kArgumentRequired, kOptionSoftwareVersion },
     { "softwareVersionStr", chip::ArgParser::kArgumentRequired, kOptionSoftwareVersionStr },
     { "UserConsentNeeded", chip::ArgParser::kNoArgument, kOptionUserConsentNeeded },
@@ -270,43 +255,33 @@ OptionDef cmdLineOptionsDef[] = {
 
 OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS",
                              "  -f/--filepath <file>\n"
-                             "        Path to a file containing an OTA image.\n"
+                             "        Path to a file containing an OTA image\n"
                              "  -o/--otaImageList <file>\n"
-                             "        Path to a file containing a list of OTA images.\n"
-                             "  -q/--QueryImageBehavior <UpdateAvailable | Busy | UpdateNotAvailable>\n"
-                             "        Status value in the Query Image Response\n"
-                             "  -t/--DelayedActionTimeSec <time>\n"
-                             "        Value in seconds for the DelayedActionTime in the Query Image Response\n"
-                             "        and Apply Update Response\n"
-                             "  -u/--UserConsentState <granted | denied | deferred>\n"
-                             "        granted: Status value in QueryImageResponse is set to UpdateAvailable\n"
-                             "        denied: Status value in QueryImageResponse is set to UpdateNotAvailable\n"
-                             "        deferred: Status value in QueryImageResponse is set to Busy\n"
-                             "        -q/--QueryImageBehavior overrides this option\n"
-                             "  -d/--discriminator <discriminator>\n"
-                             "        A 12-bit value used to discern between multiple commissionable CHIP device\n"
-                             "        advertisements. If none is specified, default value is 3840.\n"
+                             "        Path to a file containing a list of OTA images\n"
+                             "  -q/--queryImageStatus <updateAvailable | busy | updateNotAvailable>\n"
+                             "        Value for the Status field in the QueryImageResponse\n"
+                             "  -t/--delayedActionTimeSec <time>\n"
+                             "        Value in seconds for the DelayedActionTime field in the QueryImageResponse\n"
+                             "        and ApplyUpdateResponse\n"
+                             "  -u/--userConsentState <granted | denied | deferred>\n"
+                             "        granted: Status field in QueryImageResponse is set to updateAvailable\n"
+                             "        denied: Status field in QueryImageResponse is set to updateNotAvailable\n"
+                             "        deferred: Status field in QueryImageResponse is set to busy\n"
+                             "        -q/--queryImageStatus overrides this option\n"
                              "  -s/--softwareVersion <version>\n"
-                             "        Value of SoftwareVersion in the Query Image Response\n"
-                             "        If ota image list is present along with this option\n"
-                             "        then value from ota image list is used.\n"
-                             "        Otherwise, this value will be used is then value from that will be used\n"
+                             "        Value for the SoftwareVersion field in the QueryImageResponse\n"
+                             "        -o/--otaImageList overrides this option\n"
                              "  -S/--softwareVersionStr <version string>\n"
-                             "        Value of SoftwareVersionString in the Query Image Response\n"
-                             "        If ota image list is present along with this option\n"
-                             "        then value from ota image list is used.\n"
-                             "        Otherwise, this value will be used is then value from that will be used\n"
+                             "        Value for the SoftwareVersionString field in the QueryImageResponse\n"
+                             "        -o/--otaImageList overrides this option\n"
                              "  -c/--UserConsentNeeded\n"
                              "        If provided, value of UserConsentNeeded in the Query Image Response is set to true\n" };
 
-HelpOptions helpOptions("ota-provider-app", "Usage: ota-provider-app [options]", "1.0");
-
-OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
+OptionSet * allOptions[] = { &cmdLineOptions, nullptr };
 
 void ApplicationInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::ota::DefaultUserConsentProvider userConsentProvider;
 
     BdxOtaSender * bdxOtaSender = gOtaProvider.GetBdxOtaSender();
     VerifyOrReturn(bdxOtaSender != nullptr);
@@ -338,8 +313,8 @@ void ApplicationInit()
 
     if (gUserConsentState != chip::ota::UserConsentState::kUnknown)
     {
-        userConsentProvider.SetGlobalUserConsentState(gUserConsentState);
-        gOtaProvider.SetUserConsentDelegate(&userConsentProvider);
+        gUserConsentProvider.SetGlobalUserConsentState(gUserConsentState);
+        gOtaProvider.SetUserConsentDelegate(&gUserConsentProvider);
     }
 
     if (gUserConsentNeeded)

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -153,9 +153,9 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 {
     OTAQueryStatus queryStatus = OTAQueryStatus::kNotAvailable;
     OTAProviderExample::DeviceSoftwareVersionModel candidate;
-    uint32_t newSoftwareVersion           = 0;
-    const char * newSoftwareVersionString = nullptr;
-    const char * otaFilePath              = nullptr;
+    uint32_t newSoftwareVersion           = commandData.softwareVersion + 1;
+    const char * newSoftwareVersionString = "Example-Image-V0.1";
+    const char * otaFilePath              = mOTAFilePath;
     uint8_t updateToken[kUpdateTokenLen]  = { 0 };
     char strBuf[kUpdateTokenStrLen]       = { 0 };
     char uriBuf[kUriMaxLen]               = { 0 };
@@ -172,23 +172,18 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
         {
             // TODO: Following details shall be read from the OTA file
 
-            // If software version is provided using command line then use it.
-            // Otherwise, bump the software version received in QueryImage by 1.
-            newSoftwareVersion = commandData.softwareVersion + 1;
+            // If software version is provided using command line then use it
             if (mSoftwareVersion.HasValue())
             {
                 newSoftwareVersion = mSoftwareVersion.Value();
             }
 
-            // If software version string is provided using command line then use it.
-            // Otherwise, use default string.
-            newSoftwareVersionString = "Example-Image-V0.1";
+            // If software version string is provided using command line then use it
             if (mSoftwareVersionString)
             {
                 newSoftwareVersionString = mSoftwareVersionString;
             }
 
-            otaFilePath = mOTAFilePath;
             queryStatus = OTAQueryStatus::kUpdateAvailable;
         }
         else if (!mCandidates.empty()) // If list of OTA candidates is supplied instead


### PR DESCRIPTION
#### Problem
The OTAProviderExample class defaults some values to `nullptr`. Some paths (depending on various command line options used) do not update these values, resulting in application crash.

Also, with https://github.com/project-chip/connectedhomeip/pull/14931, the application now initializes application-specific items in `ApplicationInit` (which used to reside in `main`). Any local variables defined/used in `ApplicationInit` now needs to be global so the value remains valid after the function returns

Fixes: https://github.com/project-chip/connectedhomeip/issues/15048

#### Change overview
- Set default values for pointers in OTAProviderExample to prevent crash from paths that do not explicitly update these pointers
- Make `DefaultUserConsentProvider` a global variable
- Remove discriminator command line option as this is generically supported by the Linux platform
- Align some of the command line option casing so all options are more consistent
- Update help text for the command line options
- Update README on application usage

#### Testing
- Verified that all command line options for the provider application does not result in a crash
- Verified that the happy path still works (file transfers successfully)