### PR TITLE
Fix printing of long onboarding code to actually print long onboarding code

### DIFF
--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -79,7 +79,8 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
         ChipLogError(AppServer, "Getting manual pairing code failed!");
     }
 
-    if (GetLongManualPairingCode(manualPairingCode, payload) == CHIP_NO_ERROR)
+    // Hand a copy of the payload to GetLongManualPairingCode.
+    if (GetLongManualPairingCode(manualPairingCode, chip::SetupPayload(payload)) == CHIP_NO_ERROR)
     {
         ChipLogProgress(AppServer, "Long manual pairing code: [%s]", manualPairingCode.c_str());
     }
@@ -202,13 +203,14 @@ CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::
         ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
         return err;
     }
-    // TODO: Why is this being set to custom?
-    payload.commissioningFlow = chip::CommissioningFlow::kCustom;
-    return GetLongManualPairingCode(aLongManualPairingCode, payload);
+    return GetLongManualPairingCode(aLongManualPairingCode, std::move(payload));
 }
 
-CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, const chip::SetupPayload & payload)
+CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::SetupPayload && payload)
 {
+    // To get payloadDecimalStringRepresentation to produce a long manual
+    // pairing code, the commissioning flow in the payload needs to be kCustom.
+    payload.commissioningFlow = chip::CommissioningFlow::kCustom;
 
     CHIP_ERROR err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aLongManualPairingCode);
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -27,7 +27,7 @@ CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
 CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, const chip::SetupPayload & payload);
+CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::SetupPayload && payload);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 


### PR DESCRIPTION
#### Problem
all-clusters-app printing this during startup:
```
[1644544661006] [58675:15845573] CHIP: [SVR] Manual pairing code: [34970112332]
[1644544661006] [58675:15845573] CHIP: [SVR] Long manual pairing code: [34970112332]
```

#### Change overview
Make the long code actually be long.

#### Testing
Ran all-clusters-app got:
```
[1644545162692] [59016:15851756] CHIP: [SVR] Manual pairing code: [34970112332]
[1644545162692] [59016:15851756] CHIP: [SVR] Long manual pairing code: [749701123365521327694]
```