### PR TITLE
Add persistent storage to session manager

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -48,8 +48,9 @@ CHIP_ERROR CHIPCommand::Run()
     ReturnLogErrorOnFailure(mFabricStorage.Initialize(&mDefaultStorage));
 
     chip::Controller::FactoryInitParams factoryInitParams;
-    factoryInitParams.fabricStorage = &mFabricStorage;
-    factoryInitParams.listenPort    = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerId());
+    factoryInitParams.fabricStorage   = &mFabricStorage;
+    factoryInitParams.storageDelegate = &mDefaultStorage;
+    factoryInitParams.listenPort      = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerId());
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
     ReturnLogErrorOnFailure(InitializeCommissioner(kIdentityNull, kIdentityNullFabricId));

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -48,9 +48,9 @@ CHIP_ERROR CHIPCommand::Run()
     ReturnLogErrorOnFailure(mFabricStorage.Initialize(&mDefaultStorage));
 
     chip::Controller::FactoryInitParams factoryInitParams;
-    factoryInitParams.fabricStorage   = &mFabricStorage;
-    factoryInitParams.storageDelegate = &mDefaultStorage;
-    factoryInitParams.listenPort      = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerId());
+    factoryInitParams.fabricStorage            = &mFabricStorage;
+    factoryInitParams.fabricIndependentStorage = &mDefaultStorage;
+    factoryInitParams.listenPort               = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerId());
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
     ReturnLogErrorOnFailure(InitializeCommissioner(kIdentityNull, kIdentityNullFabricId));

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -306,7 +306,7 @@ void StartPinging(streamer_t * stream, char * destination)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gPingArguments.IsUsingTCP())
     {
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);
@@ -315,7 +315,7 @@ void StartPinging(streamer_t * stream, char * destination)
     else
 #endif
     {
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -227,7 +227,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     {
         peerAddress = Transport::PeerAddress::TCP(gDestAddr, gSendArguments.GetPort());
 
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
     }
     else
@@ -235,7 +235,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     {
         peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), chip::Inet::InterfaceId::Null());
 
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
     }
 

--- a/examples/shell/shell_common/globals.cpp
+++ b/examples/shell/shell_common/globals.cpp
@@ -22,6 +22,7 @@ chip::Messaging::ExchangeManager gExchangeManager;
 chip::SessionManager gSessionManager;
 chip::Inet::IPAddress gDestAddr;
 chip::SessionHolder gSession;
+chip::TestPersistentStorageDelegate gStorage;
 
 chip::FabricIndex gFabricIndex = 0;
 

--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <lib/core/CHIPCore.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionHolder.h>
@@ -36,6 +37,7 @@ extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::SessionManager gSessionManager;
 extern chip::Inet::IPAddress gDestAddr;
 extern chip::SessionHolder gSession;
+extern chip::TestPersistentStorageDelegate gStorage;
 
 extern chip::FabricIndex gFabricIndex;
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 #endif
     SuccessOrExit(err);
 
-    err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mMessageCounterManager);
+    err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mMessageCounterManager, &mDeviceStorage);
     SuccessOrExit(err);
 
     err = mExchangeMgr.Init(&mSessions);

--- a/src/app/tests/TestOperationalDeviceProxy.cpp
+++ b/src/app/tests/TestOperationalDeviceProxy.cpp
@@ -18,6 +18,7 @@
 #include <app/OperationalDeviceProxy.h>
 #include <inet/IPAddress.h>
 #include <lib/support/CHIPMem.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
@@ -50,12 +51,13 @@ void TestOperationalDeviceProxy_EstablishSessionDirectly(nlTestSuite * inSuite, 
     FabricTable * fabrics = Platform::New<FabricTable>();
     FabricInfo * fabric   = fabrics->FindFabricWithIndex(1);
     secure_channel::MessageCounterManager messageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
     SessionIDAllocator idAllocator;
 
     systemLayer.Init();
     udpEndPointManager.Init(systemLayer);
     transportMgr.Init(UdpListenParameters(udpEndPointManager).SetAddressType(Inet::IPAddressType::kIPv4).SetListenPort(CHIP_PORT));
-    sessionManager.Init(&systemLayer, &transportMgr, &messageCounterManager);
+    sessionManager.Init(&systemLayer, &transportMgr, &messageCounterManager, &deviceStorage);
     exchangeMgr.Init(&sessionManager);
     messageCounterManager.Init(&exchangeMgr);
 

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -703,7 +703,7 @@ int main(int argc, char * argv[])
                                      .SetListenPort(IM_CLIENT_PORT));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager);
+    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager, &gStorage);
     SuccessOrExit(err);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -173,7 +173,7 @@ int main(int argc, char * argv[])
                                      .SetAddressType(chip::Inet::IPAddressType::kIPv6));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager);
+    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager, &gStorage);
     SuccessOrExit(err);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -36,6 +36,7 @@ chip::Messaging::ExchangeManager gExchangeManager;
 chip::SessionManager gSessionManager;
 chip::secure_channel::MessageCounterManager gMessageCounterManager;
 chip::SessionHolder gSession;
+chip::TestPersistentStorageDelegate gStorage;
 
 void InitializeChip(void)
 {

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionHolder.h>
@@ -36,6 +37,7 @@ extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::SessionManager gSessionManager;
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
 extern chip::SessionHolder gSession;
+extern chip::TestPersistentStorageDelegate gStorage;
 
 constexpr chip::NodeId kTestNodeId         = 0x1ULL;
 constexpr chip::NodeId kTestNodeId1        = 0x2ULL;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -50,9 +50,9 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
         return CHIP_NO_ERROR;
     }
 
-    mListenPort    = params.listenPort;
-    mFabricStorage = params.fabricStorage;
-    mStorage       = params.storageDelegate;
+    mListenPort               = params.listenPort;
+    mFabricStorage            = params.fabricStorage;
+    mFabricIndependentStorage = params.fabricIndependentStorage;
 
     CHIP_ERROR err = InitSystemState(params);
 
@@ -72,7 +72,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState()
 #endif
     }
 
-    params.storageDelegate = mStorage;
+    params.fabricIndependentStorage = mFabricIndependentStorage;
 
     return InitSystemState(params);
 }
@@ -142,7 +142,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     ReturnErrorOnFailure(stateParams.fabricTable->Init(mFabricStorage));
 
     ReturnErrorOnFailure(stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr,
-                                                      stateParams.messageCounterManager, params.storageDelegate));
+                                                      stateParams.messageCounterManager, params.fabricIndependentStorage));
     ReturnErrorOnFailure(stateParams.exchangeMgr->Init(stateParams.sessionMgr));
     ReturnErrorOnFailure(stateParams.messageCounterManager->Init(stateParams.exchangeMgr));
 
@@ -179,7 +179,6 @@ void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controll
 CHIP_ERROR DeviceControllerFactory::SetupController(SetupParams params, DeviceController & controller)
 {
     VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mStorage = params.storageDelegate;
     ReturnErrorOnFailure(InitSystemState());
 
     ControllerInitParams controllerParams;
@@ -192,7 +191,6 @@ CHIP_ERROR DeviceControllerFactory::SetupController(SetupParams params, DeviceCo
 CHIP_ERROR DeviceControllerFactory::SetupCommissioner(SetupParams params, DeviceCommissioner & commissioner)
 {
     VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mStorage = params.storageDelegate;
     ReturnErrorOnFailure(InitSystemState());
 
     CommissionerInitParams commissionerParams;
@@ -228,8 +226,8 @@ void DeviceControllerFactory::Shutdown()
         chip::Platform::Delete(mSystemState);
         mSystemState = nullptr;
     }
-    mFabricStorage = nullptr;
-    mStorage       = nullptr;
+    mFabricStorage            = nullptr;
+    mFabricIndependentStorage = nullptr;
 }
 
 CHIP_ERROR DeviceControllerSystemState::Shutdown()

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -52,6 +52,7 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
 
     mListenPort    = params.listenPort;
     mFabricStorage = params.fabricStorage;
+    mStorage       = params.storageDelegate;
 
     CHIP_ERROR err = InitSystemState(params);
 
@@ -70,6 +71,8 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState()
         params.bleLayer = mSystemState->BleLayer();
 #endif
     }
+
+    params.storageDelegate = mStorage;
 
     return InitSystemState(params);
 }
@@ -137,8 +140,9 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.messageCounterManager = chip::Platform::New<secure_channel::MessageCounterManager>();
 
     ReturnErrorOnFailure(stateParams.fabricTable->Init(mFabricStorage));
-    ReturnErrorOnFailure(
-        stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr, stateParams.messageCounterManager));
+
+    ReturnErrorOnFailure(stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr,
+                                                      stateParams.messageCounterManager, params.storageDelegate));
     ReturnErrorOnFailure(stateParams.exchangeMgr->Init(stateParams.sessionMgr));
     ReturnErrorOnFailure(stateParams.messageCounterManager->Init(stateParams.exchangeMgr));
 
@@ -175,6 +179,7 @@ void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controll
 CHIP_ERROR DeviceControllerFactory::SetupController(SetupParams params, DeviceController & controller)
 {
     VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mStorage = params.storageDelegate;
     ReturnErrorOnFailure(InitSystemState());
 
     ControllerInitParams controllerParams;
@@ -187,6 +192,7 @@ CHIP_ERROR DeviceControllerFactory::SetupController(SetupParams params, DeviceCo
 CHIP_ERROR DeviceControllerFactory::SetupCommissioner(SetupParams params, DeviceCommissioner & commissioner)
 {
     VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mStorage = params.storageDelegate;
     ReturnErrorOnFailure(InitSystemState());
 
     CommissionerInitParams commissionerParams;
@@ -223,6 +229,7 @@ void DeviceControllerFactory::Shutdown()
         mSystemState = nullptr;
     }
     mFabricStorage = nullptr;
+    mStorage       = nullptr;
 }
 
 CHIP_ERROR DeviceControllerSystemState::Shutdown()

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -70,6 +70,7 @@ struct FactoryInitParams
 {
     FabricStorage * fabricStorage                                 = nullptr;
     System::Layer * systemLayer                                   = nullptr;
+    PersistentStorageDelegate * storageDelegate                   = nullptr;
     Inet::EndPointManager<Inet::TCPEndPoint> * tcpEndPointManager = nullptr;
     Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPointManager = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
@@ -132,6 +133,7 @@ private:
     uint16_t mListenPort;
     FabricStorage * mFabricStorage             = nullptr;
     DeviceControllerSystemState * mSystemState = nullptr;
+    PersistentStorageDelegate * mStorage       = nullptr;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -70,7 +70,7 @@ struct FactoryInitParams
 {
     FabricStorage * fabricStorage                                 = nullptr;
     System::Layer * systemLayer                                   = nullptr;
-    PersistentStorageDelegate * storageDelegate                   = nullptr;
+    PersistentStorageDelegate * fabricIndependentStorage          = nullptr;
     Inet::EndPointManager<Inet::TCPEndPoint> * tcpEndPointManager = nullptr;
     Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPointManager = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
@@ -131,9 +131,9 @@ private:
     CHIP_ERROR InitSystemState();
 
     uint16_t mListenPort;
-    FabricStorage * mFabricStorage             = nullptr;
-    DeviceControllerSystemState * mSystemState = nullptr;
-    PersistentStorageDelegate * mStorage       = nullptr;
+    FabricStorage * mFabricStorage                        = nullptr;
+    DeviceControllerSystemState * mSystemState            = nullptr;
+    PersistentStorageDelegate * mFabricIndependentStorage = nullptr;
 };
 
 } // namespace Controller

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -128,7 +128,7 @@ AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControlle
     setupParams.storageDelegate                = wrapper.get();
     setupParams.pairingDelegate                = wrapper.get();
     setupParams.operationalCredentialsDelegate = opCredsIssuer;
-    initParams.storageDelegate = setupParams.storageDelegate;
+    initParams.fabricIndependentStorage        = setupParams.storageDelegate;
 
     opCredsIssuer->Initialize(*wrapper.get(), wrapper.get()->mJavaObjectRef);
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -119,6 +119,7 @@ AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControlle
     initParams.tcpEndPointManager = tcpEndPointManager;
     initParams.udpEndPointManager = udpEndPointManager;
     initParams.fabricStorage      = wrapper.get();
+
     // move bleLayer into platform/android to share with app server
 #if CONFIG_NETWORK_LAYER_BLE
     initParams.bleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
@@ -127,6 +128,7 @@ AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControlle
     setupParams.storageDelegate                = wrapper.get();
     setupParams.pairingDelegate                = wrapper.get();
     setupParams.operationalCredentialsDelegate = opCredsIssuer;
+    initParams.storageDelegate = setupParams.storageDelegate;
 
     opCredsIssuer->Initialize(*wrapper.get(), wrapper.get()->mJavaObjectRef);
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -224,7 +224,8 @@ ChipError::StorageType pychip_DeviceController_StackInit()
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
     FactoryInitParams factoryParams;
-    factoryParams.fabricStorage = &sFabricStorage;
+    factoryParams.fabricStorage   = &sFabricStorage;
+    factoryParams.storageDelegate = sStorageAdapter;
 
     ReturnErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryParams).AsInteger());
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -224,8 +224,8 @@ ChipError::StorageType pychip_DeviceController_StackInit()
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
     FactoryInitParams factoryParams;
-    factoryParams.fabricStorage   = &sFabricStorage;
-    factoryParams.storageDelegate = sStorageAdapter;
+    factoryParams.fabricStorage            = &sFabricStorage;
+    factoryParams.fabricIndependentStorage = sStorageAdapter;
 
     ReturnErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryParams).AsInteger());
 

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -116,7 +116,8 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         err = gFabricStorage.Initialize(&gServerStorage);
         SuccessOrExit(err);
 
-        factoryParams.fabricStorage = &gFabricStorage;
+        factoryParams.fabricStorage   = &gFabricStorage;
+        factoryParams.storageDelegate = &gServerStorage;
 
         commissionerParams.pairingDelegate = &gPairingDelegate;
         commissionerParams.storageDelegate = &gServerStorage;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -116,8 +116,8 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         err = gFabricStorage.Initialize(&gServerStorage);
         SuccessOrExit(err);
 
-        factoryParams.fabricStorage   = &gFabricStorage;
-        factoryParams.storageDelegate = &gServerStorage;
+        factoryParams.fabricStorage            = &gFabricStorage;
+        factoryParams.fabricIndependentStorage = &gServerStorage;
 
         commissionerParams.pairingDelegate = &gPairingDelegate;
         commissionerParams.storageDelegate = &gServerStorage;

--- a/src/controller/tests/TestDevice.cpp
+++ b/src/controller/tests/TestDevice.cpp
@@ -22,6 +22,7 @@
 #include <inet/IPAddress.h>
 #include <inetInetLayer.h>
 #include <lib/support/CHIPMem.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -51,6 +52,8 @@ void TestDevice_EstablishSessionDirectly(nlTestSuite * inSuite, void * inContext
     ExchangeManager exchangeMgr;
     Inet::UDPEndPointManagerImpl udpEndPointManager;
     System::LayerImpl systemLayer;
+    chip::TestPersistentStorageDelegate deviceStorage;
+
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer blelayer;
 #endif // CONFIG_NETWORK_LAYER_BLE
@@ -72,7 +75,7 @@ void TestDevice_EstablishSessionDirectly(nlTestSuite * inSuite, void * inContext
                       BleListenParameters(&blelayer)
 #endif
     );
-    sessionManager.Init(&systemLayer, &transportMgr, &messageCounterManager);
+    sessionManager.Init(&systemLayer, &transportMgr, &messageCounterManager, &deviceStorage;);
     exchangeMgr.Init(&sessionManager);
     messageCounterManager.Init(&exchangeMgr);
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -196,6 +196,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier(testingRootStore));
 
         params.fabricStorage = _fabricStorage;
+        params.storageDelegate = _persistentStorageDelegateBridge;
         commissionerParams.storageDelegate = _persistentStorageDelegateBridge;
         commissionerParams.deviceAddressUpdateDelegate = _pairingDelegateBridge;
         commissionerParams.pairingDelegate = _pairingDelegateBridge;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -196,7 +196,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier(testingRootStore));
 
         params.fabricStorage = _fabricStorage;
-        params.storageDelegate = _persistentStorageDelegateBridge;
+        params.fabricIndependentStorage = _persistentStorageDelegateBridge;
         commissionerParams.storageDelegate = _persistentStorageDelegateBridge;
         commissionerParams.deviceAddressUpdateDelegate = _pairingDelegateBridge;
         commissionerParams.pairingDelegate = _pairingDelegateBridge;

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR MessagingContext::Init(TransportMgrBase * transport, IOContext * ioCo
     mTransport = transport;
 
     ReturnErrorOnFailure(PlatformMemoryUser::Init());
-    ReturnErrorOnFailure(mSessionManager.Init(&GetSystemLayer(), transport, &mMessageCounterManager));
+    ReturnErrorOnFailure(mSessionManager.Init(&GetSystemLayer(), transport, &mMessageCounterManager, &mStorage));
 
     ReturnErrorOnFailure(mExchangeManager.Init(&mSessionManager));
     ReturnErrorOnFailure(mMessageCounterManager.Init(&mExchangeManager));

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
@@ -145,7 +146,8 @@ private:
     Messaging::ExchangeManager mExchangeManager;
     secure_channel::MessageCounterManager mMessageCounterManager;
     IOContext * mIOContext;
-    TransportMgrBase * mTransport; // Only needed for InitFromExisting.
+    TransportMgrBase * mTransport;                // Only needed for InitFromExisting.
+    chip::TestPersistentStorageDelegate mStorage; // for SessionManagerInit
 
     NodeId mBobNodeId       = 123654;
     NodeId mAliceNodeId     = 111222333;

--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -33,6 +33,7 @@
 chip::SessionManager gSessionManager;
 chip::Messaging::ExchangeManager gExchangeManager;
 chip::secure_channel::MessageCounterManager gMessageCounterManager;
+chip::TestPersistentStorageDelegate gStorage;
 
 void InitializeChip(void)
 {

--- a/src/messaging/tests/echo/common.h
+++ b/src/messaging/tests/echo/common.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionManager.h>
@@ -35,6 +36,7 @@ constexpr size_t kNetworkSleepTimeMsecs       = (100 * 1000);
 extern chip::SessionManager gSessionManager;
 extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
+extern chip::TestPersistentStorageDelegate gStorage;
 
 void InitializeChip(void);
 void ShutdownChip(void);

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -238,7 +238,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
     }
     else
@@ -248,7 +248,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
     }
 

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -93,7 +93,7 @@ int main(int argc, char * argv[])
         );
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
     }
     else
@@ -102,7 +102,7 @@ int main(int argc, char * argv[])
                                    .SetAddressType(chip::Inet::IPAddressType::kIPv6));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager, &gStorage);
         SuccessOrExit(err);
     }
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -260,10 +260,10 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
-class TestPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
+class TestCASESessionPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
 {
 public:
-    TestPersistentStorageDelegate()
+    TestCASESessionPersistentStorageDelegate()
     {
         memset(keys, 0, sizeof(keys));
         memset(keysize, 0, sizeof(keysize));
@@ -271,7 +271,7 @@ public:
         memset(valuesize, 0, sizeof(valuesize));
     }
 
-    ~TestPersistentStorageDelegate() { Cleanup(); }
+    ~TestCASESessionPersistentStorageDelegate() { Cleanup(); }
 
     void Cleanup()
     {
@@ -347,8 +347,8 @@ private:
     uint16_t valuesize[16];
 };
 
-TestPersistentStorageDelegate gCommissionerStorageDelegate;
-TestPersistentStorageDelegate gDeviceStorageDelegate;
+TestCASESessionPersistentStorageDelegate gCommissionerStorageDelegate;
+TestCASESessionPersistentStorageDelegate gDeviceStorageDelegate;
 
 TestCASEServerIPK gPairingServer;
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -72,15 +72,18 @@ SessionManager::SessionManager() : mState(State::kNotReady) {}
 SessionManager::~SessionManager() {}
 
 CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * transportMgr,
-                                Transport::MessageCounterManagerInterface * messageCounterManager)
+                                Transport::MessageCounterManagerInterface * messageCounterManager,
+                                chip::PersistentStorageDelegate * storageDelegate)
 {
     VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(storageDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     mState                 = State::kInitialized;
     mSystemLayer           = systemLayer;
     mTransportMgr          = transportMgr;
     mMessageCounterManager = messageCounterManager;
+    mStorage               = storageDelegate;
 
     // TODO: Handle error from mGlobalEncryptedMessageCounter! Unit tests currently crash if you do!
     (void) mGlobalEncryptedMessageCounter.Init();

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -30,6 +30,7 @@
 #include <crypto/RandUtils.h>
 #include <inet/IPAddress.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
@@ -184,7 +185,8 @@ public:
      * @param messageCounterManager The message counter manager
      */
     CHIP_ERROR Init(System::Layer * systemLayer, TransportMgrBase * transportMgr,
-                    Transport::MessageCounterManagerInterface * messageCounterManager);
+                    Transport::MessageCounterManagerInterface * messageCounterManager,
+                    chip::PersistentStorageDelegate * storageDelegate);
 
     /**
      * @brief
@@ -263,6 +265,9 @@ private:
 
     TransportMgrBase * mTransportMgr                                   = nullptr;
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;
+
+    // Will be use once PR 14996 is merged
+    chip::PersistentStorageDelegate * mStorage = nullptr;
 
     GlobalUnencryptedMessageCounter mGlobalUnencryptedMessageCounter;
     GlobalEncryptedMessageCounter mGlobalEncryptedMessageCounter;

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -26,6 +26,7 @@
 
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <protocols/Protocols.h>
 #include <protocols/echo/Echo.h>
@@ -101,13 +102,14 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     TransportMgr<LoopbackTransport> transportMgr;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
 
     CHIP_ERROR err;
 
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager);
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
@@ -130,11 +132,12 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     TransportMgr<LoopbackTransport> transportMgr;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
 
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager);
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -222,11 +225,12 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     TransportMgr<LoopbackTransport> transportMgr;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
 
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager);
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -300,11 +304,12 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     TransportMgr<LoopbackTransport> transportMgr;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
 
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager);
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -406,11 +411,12 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
     TransportMgr<LoopbackTransport> transportMgr;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
 
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager);
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));


### PR DESCRIPTION
#### Problem
Break down of #14996 

Group message counter needs access to the persistent storage delegate so that they can persist between reboot (spec 4.5.1.3 )
#### Change overview
Add a PersistentStorageDelegate pointer to the constructor of `SessionManager` this pointer is unused for now but will be used once #14996 is merged

#### Testing
Same as 14996
