### PR TITLE
Make sure to queue m5stack actions to the Matter thread as needed.

### DIFF
--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -99,6 +99,13 @@ exit:
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & path, uint8_t mask, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
+    TaskHandle_t task = xTaskGetCurrentTaskHandle();
+    const char * name = pcTaskGetName(task);
+    if (!strcmp(name, "CHIP"))
+    {
+        ESP_LOGE("all-clusters-app", "Attribute changed on non-Matter task '%s'\n", name);
+    }
+
     chip::DeviceManager::CHIPDeviceManagerCallbacks * cb =
         chip::DeviceManager::CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
     if (cb != nullptr)


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/15065

#### Problem
Touching Matter stuff on the wrong thread.

#### Change overview
Use the right thread.

#### Testing
Used the buttons, logs showed post-attribute-change callback now running on the right thread.