### PR TITLE
Remove mMessageWriter member of WriteHandler.

### DIFF
--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -47,8 +47,6 @@ void WriteHandler::Close()
 {
     VerifyOrReturn(mState != State::Uninitialized);
 
-    mMessageWriter.Reset();
-
     if (mpExchangeCtx != nullptr)
     {
         mpExchangeCtx->SetDelegate(nullptr);
@@ -83,8 +81,9 @@ Status WriteHandler::HandleWriteRequestMessage(Messaging::ExchangeContext * apEx
     System::PacketBufferHandle packet = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
     VerifyOrReturnError(!packet.IsNull(), Status::Failure);
 
-    mMessageWriter.Init(std::move(packet));
-    VerifyOrReturnError(mWriteResponseBuilder.Init(&mMessageWriter) == CHIP_NO_ERROR, Status::Failure);
+    System::PacketBufferTLVWriter messageWriter;
+    messageWriter.Init(std::move(packet));
+    VerifyOrReturnError(mWriteResponseBuilder.Init(&messageWriter) == CHIP_NO_ERROR, Status::Failure);
 
     mWriteResponseBuilder.CreateWriteResponses();
     VerifyOrReturnError(mWriteResponseBuilder.GetError() == CHIP_NO_ERROR, Status::Failure);
@@ -94,7 +93,7 @@ Status WriteHandler::HandleWriteRequestMessage(Messaging::ExchangeContext * apEx
     // Do not send response on Group Write
     if (status == Status::Success && !apExchangeContext->IsGroupExchangeContext())
     {
-        CHIP_ERROR err = SendWriteResponse();
+        CHIP_ERROR err = SendWriteResponse(std::move(messageWriter));
         if (err != CHIP_NO_ERROR)
         {
             status = Status::Failure;
@@ -167,25 +166,25 @@ void WriteHandler::OnResponseTimeout(Messaging::ExchangeContext * apExchangeCont
     Close();
 }
 
-CHIP_ERROR WriteHandler::FinalizeMessage(System::PacketBufferHandle & packet)
+CHIP_ERROR WriteHandler::FinalizeMessage(System::PacketBufferTLVWriter && aMessageWriter, System::PacketBufferHandle & packet)
 {
     VerifyOrReturnError(mState == State::AddStatus, CHIP_ERROR_INCORRECT_STATE);
     AttributeStatusIBs::Builder & attributeStatusIBs = mWriteResponseBuilder.GetWriteResponses().EndOfAttributeStatuses();
     ReturnErrorOnFailure(attributeStatusIBs.GetError());
     mWriteResponseBuilder.EndOfWriteResponseMessage();
     ReturnErrorOnFailure(mWriteResponseBuilder.GetError());
-    ReturnErrorOnFailure(mMessageWriter.Finalize(&packet));
+    ReturnErrorOnFailure(aMessageWriter.Finalize(&packet));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WriteHandler::SendWriteResponse()
+CHIP_ERROR WriteHandler::SendWriteResponse(System::PacketBufferTLVWriter && aMessageWriter)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle packet;
 
     VerifyOrExit(mState == State::AddStatus, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = FinalizeMessage(packet);
+    err = FinalizeMessage(std::move(aMessageWriter), packet);
     SuccessOrExit(err);
 
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -124,8 +124,8 @@ private:
     Protocols::InteractionModel::Status HandleWriteRequestMessage(Messaging::ExchangeContext * apExchangeContext,
                                                                   System::PacketBufferHandle && aPayload, bool aIsTimedWrite);
 
-    CHIP_ERROR FinalizeMessage(System::PacketBufferHandle & packet);
-    CHIP_ERROR SendWriteResponse();
+    CHIP_ERROR FinalizeMessage(System::PacketBufferTLVWriter && aMessageWriter, System::PacketBufferHandle & packet);
+    CHIP_ERROR SendWriteResponse(System::PacketBufferTLVWriter && aMessageWriter);
 
     void MoveToState(const State aTargetState);
     void ClearState();
@@ -143,7 +143,6 @@ private: // ExchangeDelegate
 private:
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;
-    System::PacketBufferTLVWriter mMessageWriter;
     State mState                                  = State::Uninitialized;
     bool mIsTimedRequest                          = false;
     bool mHasMoreChunks                           = false;


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/14943

#### Problem
Member that really has stack lifetime and use.

#### Change overview
Put it on the stack.  Save a few hundred bytes .bss.

#### Testing
No behavior changes.