### PR TITLE
[YAML] Get nodeId to be an optional parameter for tests

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -30,10 +30,10 @@ CHIP_ERROR TestCommand::RunCommand()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TestCommand::WaitForCommissionee()
+CHIP_ERROR TestCommand::WaitForCommissionee(chip::NodeId nodeId)
 {
-    CurrentCommissioner().ReleaseOperationalDevice(mNodeId);
-    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    CurrentCommissioner().ReleaseOperationalDevice(nodeId);
+    return CurrentCommissioner().GetConnectedDevice(nodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }
 
 void TestCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -45,7 +45,6 @@ public:
         CHIPCommand(commandName, credsIssuerConfig), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
-        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
         AddArgument("PICS", &mPICSFilePath);
     }
@@ -60,11 +59,10 @@ public:
 
 protected:
     /////////// DelayCommands Interface /////////
-    CHIP_ERROR WaitForCommissionee() override;
+    CHIP_ERROR WaitForCommissionee(chip::NodeId nodeId) override;
     void OnWaitForMs() override { NextTest(); };
 
     std::map<std::string, ChipDevice *> mDevices;
-    chip::NodeId mNodeId;
 
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
@@ -87,6 +85,5 @@ protected:
     };
     chip::Optional<uint64_t> mDelayInMs;
     chip::Optional<char *> mPICSFilePath;
-    chip::Optional<chip::EndpointId> mEndpointId;
     chip::Optional<uint16_t> mTimeout;
 };

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -232,7 +232,7 @@ class TestDefinition:
             runner.RunSubprocess(tool_cmd + ['pairing', 'qrcode', TEST_NODE_ID, app.setupCode],
                                  name='PAIR', dependencies=[apps_register])
 
-            runner.RunSubprocess(tool_cmd + ['tests', self.run_name, TEST_NODE_ID],
+            runner.RunSubprocess(tool_cmd + ['tests', self.run_name],
                                  name='TEST', dependencies=[apps_register])
         except:
             logging.error("!!!!!!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!!!!!!!!")

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -15,6 +15,7 @@
 name: Door Lock Cluster Lock/Unlock tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Door Lock"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Create new PIN credential and lock/unlock user"
       command: "SetCredential"

--- a/src/app/tests/suites/DL_Schedules.yaml
+++ b/src/app/tests/suites/DL_Schedules.yaml
@@ -15,6 +15,7 @@
 name: Door Lock Cluster Schedules tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Door Lock"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Create new PIN credential and schedule user"
       command: "SetCredential"

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -15,6 +15,7 @@
 name: Door Lock Cluster Users and Credentials tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Door Lock"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read available user slot and verify response fields"
       command: "GetUser"

--- a/src/app/tests/suites/TV_AccountLoginCluster.yaml
+++ b/src/app/tests/suites/TV_AccountLoginCluster.yaml
@@ -15,6 +15,7 @@
 name: Account Login Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Account Login"
     endpoint: 3
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Get Setup PIN Command"
       command: "getSetupPINRequest"

--- a/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
@@ -15,6 +15,7 @@
 name: Application Basic Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Application Basic"
     endpoint: 3
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # TODO(#14054): Support chars validation
     - label: "Read attribute vendor name"

--- a/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
@@ -15,6 +15,7 @@
 name: Application Launcher Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Application Launcher"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute Application Launcher list"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_AudioOutputCluster.yaml
+++ b/src/app/tests/suites/TV_AudioOutputCluster.yaml
@@ -15,6 +15,7 @@
 name: Audio Output Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Audio Output"
     endpoint: 2
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute Audio Output list"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_ChannelCluster.yaml
+++ b/src/app/tests/suites/TV_ChannelCluster.yaml
@@ -15,6 +15,7 @@
 name: Channel Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Channel"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute Channel list"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_ContentLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ContentLauncherCluster.yaml
@@ -15,6 +15,7 @@
 name: Content Launcher Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Content Launcher"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute accept header list"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_KeypadInputCluster.yaml
+++ b/src/app/tests/suites/TV_KeypadInputCluster.yaml
@@ -15,6 +15,7 @@
 name: Keypad Input Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Keypad Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Key Command"
       command: "sendKeyRequest"

--- a/src/app/tests/suites/TV_LowPowerCluster.yaml
+++ b/src/app/tests/suites/TV_LowPowerCluster.yaml
@@ -15,6 +15,7 @@
 name: Low Power Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Low Power"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Sleep Input Status Command"
       command: "sleep"

--- a/src/app/tests/suites/TV_MediaInputCluster.yaml
+++ b/src/app/tests/suites/TV_MediaInputCluster.yaml
@@ -15,6 +15,7 @@
 name: Media Input Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute media input list"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -15,6 +15,7 @@
 name: Media Playback Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Playback"
     endpoint: 3
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute playback state"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
+++ b/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
@@ -15,6 +15,7 @@
 name: Target Navigator Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Target Navigator"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute Target Navigator list"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_WakeOnLanCluster.yaml
+++ b/src/app/tests/suites/TV_WakeOnLanCluster.yaml
@@ -15,6 +15,7 @@
 name: Wake on LAN Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Wake on LAN"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read mac address"
       command: "readAttribute"

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -15,6 +15,7 @@
 name: Basic Information Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read location"
       command: "readAttribute"

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -15,6 +15,7 @@
 name: Test Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Test Command"
       command: "test"

--- a/src/app/tests/suites/TestClusterComplexTypes.yaml
+++ b/src/app/tests/suites/TestClusterComplexTypes.yaml
@@ -15,6 +15,7 @@
 name: Test Cluster Complex Types Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Test Command with optional arg set to null."
       # Not in TestCluster.yaml for now because this test depends on

--- a/src/app/tests/suites/TestConfigVariables.yaml
+++ b/src/app/tests/suites/TestConfigVariables.yaml
@@ -15,6 +15,7 @@
 name: Test Cluster Config Variables Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
     arg1:
@@ -28,6 +29,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Test Add Arguments Command"
       command: "testAddArguments"

--- a/src/app/tests/suites/TestConstraints.yaml
+++ b/src/app/tests/suites/TestConstraints.yaml
@@ -15,6 +15,7 @@
 name: Test Cluster Constraints Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # Tests for INT32U attribute
 

--- a/src/app/tests/suites/TestDelayCommands.yaml
+++ b/src/app/tests/suites/TestDelayCommands.yaml
@@ -15,6 +15,7 @@
 name: Delay Commands Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Wait 100ms"
       cluster: "DelayCommands"

--- a/src/app/tests/suites/TestDescriptorCluster.yaml
+++ b/src/app/tests/suites/TestDescriptorCluster.yaml
@@ -15,6 +15,7 @@
 name: Descriptor Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Descriptor"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read attribute Device list"
       command: "readAttribute"

--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -15,6 +15,7 @@
 name: Test Discovery
 
 config:
+    nodeId: 0x12344321
     endpoint: 0
     discriminator:
         type: INT16U
@@ -41,6 +42,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Open Commissioning Window"
       cluster: "AdministratorCommissioning"
@@ -278,6 +283,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Open Commissioning Window"
       cluster: "AdministratorCommissioning"

--- a/src/app/tests/suites/TestGroupDemoCommand.yaml
+++ b/src/app/tests/suites/TestGroupDemoCommand.yaml
@@ -27,6 +27,7 @@
 name: Group Messaging Demo Commands
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 
@@ -34,6 +35,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # Toggle 1
     - label: "Turn On the light to see attribute change"

--- a/src/app/tests/suites/TestGroupDemoConfig.yaml
+++ b/src/app/tests/suites/TestGroupDemoConfig.yaml
@@ -26,6 +26,7 @@
 name: Group Messaging Demo - Configuration
 
 config:
+    nodeId: 0x12344321
     cluster: "Groups"
     endpoint: 0
 
@@ -33,6 +34,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Add Group 1 - endpoint 1"
       command: "AddGroup"

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -15,6 +15,7 @@
 name: GroupKeyManagement Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Group Key Management"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read maxGroupsPerFabric"
       command: "readAttribute"

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -21,6 +21,7 @@
 name: Basic Group Messaging Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 
@@ -28,6 +29,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Add Group 1 (endpoint 1)"
       cluster: "Groups"

--- a/src/app/tests/suites/TestGroupsCluster.yaml
+++ b/src/app/tests/suites/TestGroupsCluster.yaml
@@ -15,6 +15,7 @@
 name: Groups Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Groups"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "View Group 0 (invalid)"
       command: "ViewGroup"

--- a/src/app/tests/suites/TestIdentifyCluster.yaml
+++ b/src/app/tests/suites/TestIdentifyCluster.yaml
@@ -15,6 +15,7 @@
 name: Identify Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Identify"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Identify command and expect success response"
       command: "identify"

--- a/src/app/tests/suites/TestLogCommands.yaml
+++ b/src/app/tests/suites/TestLogCommands.yaml
@@ -15,6 +15,7 @@
 name: Log Commands Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Log a simple message"
       cluster: "LogCommands"

--- a/src/app/tests/suites/TestModeSelectCluster.yaml
+++ b/src/app/tests/suites/TestModeSelectCluster.yaml
@@ -15,6 +15,7 @@
 name: Mode Select Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Mode Select"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read CurrentMode"
       command: "readAttribute"

--- a/src/app/tests/suites/TestOperationalCredentialsCluster.yaml
+++ b/src/app/tests/suites/TestOperationalCredentialsCluster.yaml
@@ -15,6 +15,7 @@
 name: Operational Credentials Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Operational Credentials"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read number of supported fabrics"
       command: "readAttribute"

--- a/src/app/tests/suites/TestSaveAs.yaml
+++ b/src/app/tests/suites/TestSaveAs.yaml
@@ -15,6 +15,7 @@
 name: Test Cluster Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "Test Cluster"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Test Add Arguments Command"
       command: "testAddArguments"

--- a/src/app/tests/suites/TestSubscribe_OnOff.yaml
+++ b/src/app/tests/suites/TestSubscribe_OnOff.yaml
@@ -15,6 +15,7 @@
 name: Subscribe Tests - OnOff Cluster
 
 config:
+    nodeId: 0x12344321
     cluster: "On/Off"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Set OnOff Attribute to false"
       command: "Off"

--- a/src/app/tests/suites/TestSystemCommands.yaml
+++ b/src/app/tests/suites/TestSystemCommands.yaml
@@ -15,6 +15,7 @@
 name: System Commands Tests
 
 config:
+    nodeId: 0x12344321
     cluster: "SystemCommands"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Stop the accessory"
       command: "Stop"

--- a/src/app/tests/suites/certification/Test_TC_BDX_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BDX_1_1.yaml
@@ -15,6 +15,7 @@
 name: 28.1.1. [TC-BDX-1.1] Sender Initiated BDX Transfer session
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_BDX_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BDX_1_2.yaml
@@ -15,6 +15,7 @@
 name: 28.1.2. [TC-BDX-1.2] Receiver Initiated BDX Transfer session
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_BDX_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BDX_2_1.yaml
@@ -15,6 +15,7 @@
 name: 28.2.1. [TC-BDX-2.1] Synchronous file sending
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_BDX_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BDX_2_2.yaml
@@ -15,6 +15,7 @@
 name: 28.2.2. [TC-BDX-2.2] Synchronous file receiving
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
@@ -15,6 +15,7 @@
 name: 18.1.1. [TC-BI-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Binary Input (Basic)"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
@@ -15,6 +15,7 @@
 name: 18.2.1. [TC-BI-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Binary Input (Basic)"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read mandatory non-global attribute: OutOfService"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BI_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_2_2.yaml
@@ -15,6 +15,7 @@
 name: 18.2.2. [TC-BI-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Binary Input (Basic)"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads PresentValue attribute from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
@@ -15,6 +15,7 @@
 name: 68.1.1. [TC-BOOL-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Boolean State"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BOOL_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_2_1.yaml
@@ -15,6 +15,7 @@
 name: 68.2.1. [TC-BOOL-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Boolean State"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read mandatory non-global attribute: StateValue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BRAC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRAC_1_1.yaml
@@ -15,6 +15,7 @@
 name: 77.1.1. [TC-BRAC-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Bridged Actions"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
@@ -15,6 +15,7 @@
 name: 27.1.1. [TC-CC-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.1. [TC-CC-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads mandatory attribute: CurrentHue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.2. [TC-CC-3.1] Hue MoveTo functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_2.yaml
@@ -15,6 +15,7 @@
 name: 27.2.3. [TC-CC-3.2] Hue Move functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_3.yaml
@@ -15,6 +15,7 @@
 name: 27.2.4. [TC-CC-3.3] Hue Step functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.5. [TC-CC-4.1] Saturation MoveTo functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
@@ -15,6 +15,7 @@
 name: 27.2.6. [TC-CC-4.2] Saturation Move functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_4_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_3.yaml
@@ -15,6 +15,7 @@
 name: 27.2.7. [TC-CC-4.3] Saturation Step functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_4_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_4.yaml
@@ -16,6 +16,7 @@ name:
     27.2.8. [TC-CC-4.4] MoveToHueAndSaturation functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -23,6 +24,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.9. [TC-CC-5.1] Color MoveTo functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
@@ -15,6 +15,7 @@
 name: 27.2.10. [TC-CC-5.2] Color Move functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
@@ -15,6 +15,7 @@
 name: 27.2.11. [TC-CC-5.3] Color Step functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_1.yaml
@@ -17,6 +17,7 @@ name:
     DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -24,6 +25,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -16,6 +16,7 @@ name:
     27.2.13. [TC-CC-6.2] Color Temperature Move functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -23,6 +24,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
@@ -16,6 +16,7 @@ name:
     27.2.14. [TC-CC-6.3] Color Temperature Step functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -23,6 +24,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.15. [TC-CC-7.1] Enhanced MoveToHue functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_2.yaml
@@ -15,6 +15,7 @@
 name: 27.2.16. [TC-CC-7.2] Enhanced MoveHue functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_7_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_3.yaml
@@ -15,6 +15,7 @@
 name: 27.2.17. [TC-CC-7.3] Enhanced Step functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
@@ -17,6 +17,7 @@ name:
     server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -24,6 +25,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.19. [TC-CC-8.1] StopMoveStep functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
@@ -15,6 +15,7 @@
 name: 27.2.20. [TC-CC-9.1] ColorLoopSet Validation
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Precondition : Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
@@ -16,6 +16,7 @@ name:
     27.2.21. [TC-CC-9.2] ColorLoopSet Validation - change direction without stop
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -23,6 +24,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Precondition: Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
@@ -15,6 +15,7 @@
 name: 27.2.22. [TC-CC-9.3] ColorLoopSet Validation - change time without stop
 
 config:
+    nodeId: 0x12344321
     cluster: "Color Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Precondition: Turn on light for color control tests"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_DD_1_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_10.yaml
@@ -17,6 +17,7 @@ name:
     Commissioner]
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DD_1_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_5.yaml
@@ -15,6 +15,7 @@
 name: 7.1.5. [TC-DD-1.5] NFC Rules of advertisement and Onboarding
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DD_1_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_6.yaml
@@ -15,6 +15,7 @@
 name: 7.1.6. [TC-DD-1.6] QR Code Format and Label
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DD_1_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_7.yaml
@@ -15,6 +15,7 @@
 name: 7.1.7. [TC-DD-1.7] Setup Code Format and Label
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DD_1_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_8.yaml
@@ -17,6 +17,7 @@ name:
     Commissioner]
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DD_1_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_9.yaml
@@ -17,6 +17,7 @@ name:
     Commissioner]
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DIAG_TH_NW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DIAG_TH_NW_1_1.yaml
@@ -15,6 +15,7 @@
 name: 51.1. TC-DIAG-TH_NW-1.1 ResetCounts Command[DUT Server]
 
 config:
+    nodeId: 0x12344321
     cluster: "Thread Network Diagnostics"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Sends ResetCounts command"
       command: "ResetCounts"

--- a/src/app/tests/suites/certification/Test_TC_DM_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_1_1.yaml
@@ -15,6 +15,7 @@
 name: 10.1.1. [TC-DM-1.1] Basic Cluster Server Attributes
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Query Data Model Revision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_DM_1_3_Simulated.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_1_3_Simulated.yaml
@@ -15,6 +15,7 @@
 name: 10.1.3. [TC-DM-1.3] Basic Cluster Server Attributes [DUT - Controller]
 
 config:
+    nodeId: 0x12344321
     cluster: "Basic"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_2_2.yaml
@@ -15,6 +15,7 @@
 name: 3.2.2. [TC-DM-2.2] Operational Credential Attributes
 
 config:
+    nodeId: 0x12344321
     cluster: "Operational Credentials"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Query NOCs"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_DM_2_3_Simulated.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_2_3_Simulated.yaml
@@ -15,6 +15,7 @@
 name: 10.2.3. [TC-DM-2.3] Operational Credential Commands [DUT - Commissioner]
 
 config:
+    nodeId: 0x12344321
     cluster: "Operational Credentials"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_DM_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_3_1.yaml
@@ -15,6 +15,7 @@
 name: 10.3.1. [TC-DM-3.1] Network Commissioning Attributes
 
 config:
+    nodeId: 0x12344321
     cluster: "Network Commissioning"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Query MaxNetworks"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_DM_3_3_Simulated.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_3_3_Simulated.yaml
@@ -1,6 +1,7 @@
 name: 10.3.3. [TC-DM-3.3] Network Commissioning Commands [DUT - Commissioner]
 
 config:
+    nodeId: 0x12344321
     cluster: "Network Commissioning"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_EMR_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_EMR_1_1.yaml
@@ -15,6 +15,7 @@
 name: 13.1.1. [TC-EMR-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Electrical Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_ETHDIAG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ETHDIAG_1_1.yaml
@@ -15,6 +15,7 @@
 name: 48.1.1. [TC-ETHDIAG-1.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Ethernet Network Diagnostics"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled due to issue #11670 and #13648
     - label: "Read PHYRate attribute"

--- a/src/app/tests/suites/certification/Test_TC_ETHDIAG_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ETHDIAG_2_1.yaml
@@ -15,6 +15,7 @@
 name: 48.1.3. [TC-ETHDIAG-2.1] Command received functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Ethernet Network Diagnostics"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Below steps disabled due to issue #13648
     - label: "Sends ResetCounts command"

--- a/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
@@ -15,6 +15,7 @@
 name: 33.1.1. [TC-FLW-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Flow Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 3 but expecting 1
     - label: "read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_FLW_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_2_1.yaml
@@ -15,6 +15,7 @@
 name: 33.2.1. [TC-FLW-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Flow Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the mandatory attribute: MeasuredValue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_FLW_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_2_2.yaml
@@ -15,6 +15,7 @@
 name: 33.2.2. [TC-FLW-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Flow Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the mandatory attribute: MeasuredValue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_ILL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ILL_1_1.yaml
@@ -15,6 +15,7 @@
 name: 71.1.1. [TC-ILL-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Illuminance Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
@@ -15,6 +15,7 @@
 name: 18.1.1. [TC-LVL-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_2_1.yaml
@@ -15,6 +15,7 @@
 name: 24.2.1. [TC-LVL-2.1] Read cluster attributes (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # Temporary - see #13551
     - label: "Reset level to 254"

--- a/src/app/tests/suites/certification/Test_TC_LVL_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_2_2.yaml
@@ -15,6 +15,7 @@
 name: 24.2.2. [TC-LVL-2.2] Write cluster attributes (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads the OnOffTransitionTime attribute from the DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_3_1.yaml
@@ -15,6 +15,7 @@
 name: 24.3.1. [TC-LVL-3.1] MoveToLevel Verification (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "reads CurrentLevel attribute from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_4_1.yaml
@@ -15,6 +15,7 @@
 name: 24.4.1. [TC-LVL-4.1] Move Verification (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "reads CurrentLevel attribute from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_5_1.yaml
@@ -15,6 +15,7 @@
 name: 24.5.1. [TC-LVL-5.1] Step Verification (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Sending on command"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_LVL_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_6_1.yaml
@@ -15,6 +15,7 @@
 name: 24.6.1. [TC-LVL-6.1] Stop Verification (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Level Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Sending on command"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_MC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_1_1.yaml
@@ -15,6 +15,7 @@
 name: 15.1.1. [TC-MC-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_MC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_2_1.yaml
@@ -15,6 +15,7 @@
 name: 21.2.1. [TC-MC-2.1] Low Power Mode Verification (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Low Power"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Put the device into low power mode"
       command: "Sleep"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_1.yaml
@@ -15,6 +15,7 @@
 name: 21.3.1. [TC-MC-3.1] Navigation Keycode Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Keypad Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Select"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_3_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_10.yaml
@@ -15,6 +15,7 @@
 name: 21.5.3. [TC-MC-3.10] Show and Hide Input Status Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # TDOD: Enable when SDK supports command
     - label: "Hide Input Status Command"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_11.yaml
@@ -15,6 +15,7 @@
 name: 21.5.4. [TC-MC-3.11] Rename Input Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # Remove disable flag when SDK supports command.
     - label: "Rename Input Command"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_2.yaml
@@ -15,6 +15,7 @@
 name: 21.3.2. [TC-MC-3.2] Location Keys Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Keypad Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send RootMenu"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_3.yaml
@@ -15,6 +15,7 @@
 name: 21.3.3. [TC-MC-3.3] Number Keys Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Keypad Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Numbers1"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_3_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_4.yaml
@@ -15,6 +15,7 @@
 name: 21.3.4. [TC-MC-3.4] Press And Hold Key Press Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Keypad Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send RootMenu"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_3_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_5.yaml
@@ -15,6 +15,7 @@
 name: 21.4.1. [TC-MC-3.5] Catalog List Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Application Launcher"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # TODO: Need to enable when we can properly verify vendor id and uint16
     - label: "Read launch list attribute."

--- a/src/app/tests/suites/certification/Test_TC_MC_3_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_6.yaml
@@ -15,6 +15,7 @@
 name: 21.4.2. [TC-MC-3.6] Current App Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Application Launcher"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_7.yaml
@@ -15,6 +15,7 @@
 name: 21.4.2. [TC-MC-3.6] Current App Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Application Launcher"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_8.yaml
@@ -15,6 +15,7 @@
 name: 21.5.1. [TC-MC-3.8] Input List Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # TODO: Enable test and update response value when SDK supports.
     - label: "Read attribute media input list"

--- a/src/app/tests/suites/certification/Test_TC_MC_3_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_9.yaml
@@ -15,6 +15,7 @@
 name: 21.5.2. [TC-MC-3.9] Select Input Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Input"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     # Remove disable flag when SDK supports command.
     - label: "Select Input Command"

--- a/src/app/tests/suites/certification/Test_TC_MC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_5_1.yaml
@@ -15,6 +15,7 @@
 name: 21.7.1. [TC-MC-5.1] List TV Channels Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Channel"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue 13412 TODO: Enable test and update response value when SDK supports.
     - label: "Read attribute Channel list"

--- a/src/app/tests/suites/certification/Test_TC_MC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_5_2.yaml
@@ -15,6 +15,7 @@
 name: 21.7.2. [TC-MC-5.2] Change Channel by Number Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Channel"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled due to issue- #13029
     - label: "Reads the ChannelList attribute"

--- a/src/app/tests/suites/certification/Test_TC_MC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_5_3.yaml
@@ -15,6 +15,7 @@
 name: 21.7.3. [TC-MC-5.3] Skip Channel Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Channel"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled due to issue- #13029
     - label: "Reads the ChannelList attribute from the DUT"

--- a/src/app/tests/suites/certification/Test_TC_MC_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_1.yaml
@@ -15,6 +15,7 @@
 name: 21.8.1. [TC-MC-6.1] Mandatory Media Playback Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Playback"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
     - labe: "Precondition: Connect media content available for playback"

--- a/src/app/tests/suites/certification/Test_TC_MC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_2.yaml
@@ -15,6 +15,7 @@
 name: 21.8.2. [TC-MC-6.2] Optional Media Playback Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Playback"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
     - labe: "Precondition: Connect media content available for playback"

--- a/src/app/tests/suites/certification/Test_TC_MC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_3.yaml
@@ -15,6 +15,7 @@
 name: 21.8.3. [TC-MC-6.3] Advanced Seek Media Playback Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Playback"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
     - labe: "Precondition: Connect media content available for playback"

--- a/src/app/tests/suites/certification/Test_TC_MC_6_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_4.yaml
@@ -15,6 +15,7 @@
 name: 21.8.4. [TC-MC-6.4] Variable Speed Media Playback Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Media Playback"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
     - labe: "Precondition: Connect media content available for playback"

--- a/src/app/tests/suites/certification/Test_TC_MC_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_7_1.yaml
@@ -15,6 +15,7 @@
 name: 21.9.1. [TC-MC-7.1] Select Output Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Audio Output"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled due to issue- #13029
     - label: "Reads the OutputList attribute"

--- a/src/app/tests/suites/certification/Test_TC_MC_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_7_2.yaml
@@ -15,6 +15,7 @@
 name: 21.9.2. [TC-MC-7.2] Rename Output Verification
 
 config:
+    nodeId: 0x12344321
     cluster: "Audio Output"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled due to issue- #13029
     - label: "Reads the OutputList attribute from the DUT"

--- a/src/app/tests/suites/certification/Test_TC_MC_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_8_1.yaml
@@ -15,6 +15,7 @@
 name: 21.10.1. [TC-MC-8.1] Navigate Target Verification (DUT as Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Target Navigator"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Precondition: one or more navigation targets available"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_9_1.yaml
@@ -17,6 +17,7 @@ name:
     Server)
 
 config:
+    nodeId: 0x12344321
     cluster: "Application Basic"
     endpoint: 1
 
@@ -24,6 +25,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Precondition"
       cluster: "LogCommands"

--- a/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
@@ -15,6 +15,7 @@
 name: 24.1.1. [TC-OCC-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Occupancy Sensing"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 3 but expecting 2
     - label: "read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_OCC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_2_1.yaml
@@ -15,6 +15,7 @@
 name: 30.2.1. [TC-OCC-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Occupancy Sensing"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads mandatory attribute: Occupancy"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_OCC_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_2_2.yaml
@@ -15,6 +15,7 @@
 name: 30.2.2. [TC-OCC-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Occupancy Sensing"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Issue #10816 Disabled as values needs to be stored for comparison
     - label: "Reads Occupancy attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
@@ -15,6 +15,7 @@
 name: 3.1.1. [TC-OO-1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "On/Off"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_OO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_1.yaml
@@ -15,6 +15,7 @@
 name: 3.2.1. [TC-OO-2] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "On/Off"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the mandatory attribute: OnOff"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_OO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_2.yaml
@@ -15,6 +15,7 @@
 name: 3.2.2. [TC-OO-3] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "On/Off"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send Off Command"
       command: "Off"

--- a/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
@@ -15,6 +15,7 @@
 name: 3.2.3. [TC-OO-2.3] Secondary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "On/Off"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Send On Command"
       command: "On"

--- a/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
@@ -15,6 +15,7 @@
 name: 15.1.1. [TC-PCC-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Pump Configuration and Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 3 but expecting 1
     - label: "read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
@@ -15,6 +15,7 @@
 name: 15.2.1. [TC-PCC-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Pump Configuration and Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the mandatory attribute: MaxPressure"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_2.yaml
@@ -15,6 +15,7 @@
 name: 15.2.2. [TC-PCC-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Pump Configuration and Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Write 1 to the OperationMode attribute to DUT: OperationMode"
       command: "writeAttribute"

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_3.yaml
@@ -15,6 +15,7 @@
 name: 15.2.3. [TC-PCC-2.3] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Pump Configuration and Control"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Write 0 to the OperationMode attribute to DUT"
       command: "writeAttribute"

--- a/src/app/tests/suites/certification/Test_TC_PRS_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_1_1.yaml
@@ -15,6 +15,7 @@
 name: 36.1.1. [TC-PRS-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Pressure Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 3 but expecting 2
     - label: "Read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
@@ -15,6 +15,7 @@
 name: 36.2.1. [TC-PRS-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Pressure Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read the mandatory attribute constraints: MeasuredValue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_PS_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PS_1_1.yaml
@@ -15,6 +15,7 @@
 name: 62.1.1. [TC-PS-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Power Source"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
@@ -15,6 +15,7 @@
 name: 9.1.1. [TC-RH-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Relative Humidity Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 3 but expecting 2
     #referring default value of Water Content Measurement

--- a/src/app/tests/suites/certification/Test_TC_RH_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_2_1.yaml
@@ -15,6 +15,7 @@
 name: 9.2.1. [TC-RH-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Relative Humidity Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads the mandatory attribute: MeasuredValue"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_RH_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_2_2.yaml
@@ -15,6 +15,7 @@
 name: 9.2.2. [TC-RH-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Relative Humidity Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled as values needs to be stored for comparison
     - label: "Reads MeasuredValue attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_1_1.yaml
@@ -15,6 +15,7 @@
 name: 45.1.1. [TC-SWDIAG-1.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Software Diagnostics"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label:
           "Reads a list of ThreadMetrics struct non-global attribute from DUT."

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_2_1.yaml
@@ -15,6 +15,7 @@
 name: 45.1.3. [TC-SWDIAG-2.1] Event functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Software Diagnostics"
     endpoint: 0
 

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
@@ -15,6 +15,7 @@
 name: 45.1.4. [TC-SWDIAG-3.1] Command received functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Software Diagnostics"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Sends ResetWatermarks to DUT"
       command: "ResetWatermarks"

--- a/src/app/tests/suites/certification/Test_TC_SWTCH_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWTCH_2_1.yaml
@@ -15,6 +15,7 @@
 name: 74.2.1. [TC-SWTCH-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Switch"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Read NumberOfPositions attribute"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_SWTCH_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWTCH_2_2.yaml
@@ -15,6 +15,7 @@
 name: 74.2.2. [TC-SWTCH-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Switch"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #### 2: tests for Latching Switch
     - label: "User interaction needed"

--- a/src/app/tests/suites/certification/Test_TC_TM_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TM_1_1.yaml
@@ -15,6 +15,7 @@
 name: 6.1.1. [TC-TM-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Temperature Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 4 but expecting 3
     - label: "read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_TM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TM_2_1.yaml
@@ -15,6 +15,7 @@
 name: 6.2.1. [TC-TM-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Temperature Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the mandatory attribute: MeasuredValue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_TM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TM_2_2.yaml
@@ -15,6 +15,7 @@
 name: 6.2.2. [TC-TM-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Temperature Measurement"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Disabled as values needs to be stored for comparison
     - label: "Reads MeasuredValue attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
@@ -15,6 +15,7 @@
 name: 42.1.1. [TC-TSTAT-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Thermostat"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 5 but expecting 3
     - label: "read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -15,6 +15,7 @@
 name: 42.2.1. [TC-TSTAT-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Thermostat"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue  #11524 disabled steps are for attributes not supported in YAML framework
     - label: "Reads mandatory attributes from DUT: LocalTemperature"

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_2.yaml
@@ -15,6 +15,7 @@
 name: 42.2.2. [TC-TSTAT-2.2] Setpoint Test Cases with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Thermostat"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label:
           "Reads OccupiedCoolingSetpoint attribute from Server DUT and verifies

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
@@ -15,6 +15,7 @@
 name: 12.1.1. [TC-TSUIC-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Thermostat User Interface Configuration"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #issue #12190 as per spec default value is 2 but expecting 1
     - label: "read the global attribute: ClusterRevision"

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_2_1.yaml
@@ -15,6 +15,7 @@
 name: 12.2.1. [TC-TSUIC-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Thermostat User Interface Configuration"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "read the mandatory attribute: TemperatureDisplayMode"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_2_2.yaml
@@ -15,6 +15,7 @@
 name: 12.2.2. [TC-TSUIC-2.2] Primary functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Thermostat User Interface Configuration"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Writes a value of 0 to TemperatureDisplayMode attribute of DUT"
       command: "writeAttribute"

--- a/src/app/tests/suites/certification/Test_TC_WIFIDIAG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFIDIAG_1_1.yaml
@@ -15,6 +15,7 @@
 name: 54.1.1. [TC-WIFIDIAG-1.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "WiFi Network Diagnostics"
     endpoint: 0
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads NetworkInterface structure attribute from DUT"
       cluster: "General Diagnostics"

--- a/src/app/tests/suites/certification/Test_TC_WIFIDIAG_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFIDIAG_3_1.yaml
@@ -16,6 +16,7 @@ name:
     54.2.3. [TC-WIFIDIAG-3.1] Command received functionality with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "WiFi Network Diagnostics"
     endpoint: 0
 
@@ -23,6 +24,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Below steps disabled due to issue #13645
     # Also, ResetCounts may not work on some platforms yet?

--- a/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
@@ -15,6 +15,7 @@
 name: Window Covering [TC-WNCV-1.1] Global attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     ### MANDATORY GLOBAL Attributes
     ### Attribute[0xFFFD]: ClusterRevision =======================================

--- a/src/app/tests/suites/certification/Test_TC_WNCV_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_2_1.yaml
@@ -17,6 +17,7 @@
 name: Window Covering [TC-WNCV-2.1] Attributes with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -24,6 +25,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     ### MANDATORY Attributes
     ### Attribute[  0]: Type  =======================================

--- a/src/app/tests/suites/certification/Test_TC_WNCV_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_2_2.yaml
@@ -15,6 +15,7 @@
 name: 39.2.2. [TC-WNCV-2.2] ConfigStatus Attribute with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Issue #10811 if condition is required, need YAML support for this
     - label: "Reads ConfigStatus attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_2_4.yaml
@@ -15,6 +15,7 @@
 name: 39.2.4. [TC-WNCV-2.4] Type Attribute with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     #Issue #10811 if condition is required, need YAML support for this
     - label: "Reads Type attribute from DUT"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_2_5.yaml
@@ -15,6 +15,7 @@
 name: 39.2.5. [TC-WNCV-2.5] EndProductType Attribute with server as DUT
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -22,6 +23,10 @@ tests:
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     - label: "Reads EndProductType attribute from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_3_1.yaml
@@ -19,6 +19,7 @@ name:
 # TC-WNCV tests featuremap conditional dependencies -> use PICS
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -26,6 +27,10 @@ tests:
     - label: "0: Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     ################ Position Init Phase #############
     ### Step 1x -> Initialize the Covering position before any testing

--- a/src/app/tests/suites/certification/Test_TC_WNCV_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_3_2.yaml
@@ -19,6 +19,7 @@ name:
 # TC-WNCV tests featuremap conditional dependencies -> use PICS
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -26,6 +27,10 @@ tests:
     - label: "0: Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     ################ Position Init Phase #############
     ### Step 1x -> Initialize the Covering position before any testing

--- a/src/app/tests/suites/certification/Test_TC_WNCV_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_3_3.yaml
@@ -17,6 +17,7 @@ name: Window Covering [TC-WNCV-3.3] StopMotion Verification with server as DUT
 # TC-WNCV tests featuremap conditional dependencies -> use PICS
 
 config:
+    nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
 
@@ -24,6 +25,10 @@ tests:
     - label: "0: Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
 
     ################ Position Init Phase #############
     ### Step 1x -> Initialize the Covering position before any testing

--- a/src/app/tests/suites/commands/delay/DelayCommands.h
+++ b/src/app/tests/suites/commands/delay/DelayCommands.h
@@ -31,7 +31,7 @@ public:
     virtual CHIP_ERROR ContinueOnChipMainThread() = 0;
     virtual void OnWaitForMs()                    = 0;
 
-    virtual CHIP_ERROR WaitForCommissionee() { return CHIP_ERROR_NOT_IMPLEMENTED; };
+    virtual CHIP_ERROR WaitForCommissionee(chip::NodeId nodeId) { return CHIP_ERROR_NOT_IMPLEMENTED; };
     virtual CHIP_ERROR WaitForCommissioning() { return CHIP_ERROR_NOT_IMPLEMENTED; };
     CHIP_ERROR WaitForMs(uint16_t ms);
     CHIP_ERROR WaitForCommissionableAdvertisement();

--- a/src/app/zap-templates/common/simulated-clusters/clusters/DelayCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/DelayCommands.js
@@ -38,7 +38,7 @@ const WaitForCommissioning = {
 
 const WaitForCommissionee = {
   name : 'WaitForCommissionee',
-  arguments : [],
+  arguments : [ { type : 'NODE_ID', name : 'nodeId' } ],
   response : { arguments : [] }
 };
 

--- a/src/app/zap-templates/common/variables/Variables.js
+++ b/src/app/zap-templates/common/variables/Variables.js
@@ -27,6 +27,7 @@ const templateUtil = require(zapPath + 'generator/template-util.js')
 const { getCommands, getAttributes } = require('../simulated-clusters/SimulatedClusters.js');
 
 const knownVariables = {
+  'nodeId' : { type : 'NODE_ID', defaultValue : 0x12345 },
   'endpoint' : { type : 'ENDPOINT_NO', defaultValue : '' },
   'cluster' : { type : 'CHAR_STRING', defaultValue : '' },
   'timeout' : { type : 'INT16U', defaultValue : 30 },

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -20,7 +20,7 @@ const uint16_t kPairingTimeoutInSeconds = 10;
 const uint16_t kAddressResolveTimeoutInSeconds = 10;
 const uint16_t kCASESetupTimeoutInSeconds = 30;
 const uint16_t kTimeoutInSeconds = 5;
-const uint64_t kDeviceId = 1;
+const uint64_t nodeId = 0x12344321;
 const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;
 const uint16_t kRemotePort = 5540;
@@ -49,12 +49,12 @@ void UserPrompt(XCTestExpectation * expectation, dispatch_queue_t queue, NSStrin
     [expectation fulfill];
 }
 
-void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue)
+void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue, uint64_t deviceId)
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     XCTAssertNotNil(controller);
 
-    [controller getConnectedDevice:kDeviceId
+    [controller getConnectedDevice:deviceId
                              queue:dispatch_get_main_queue()
                  completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
                      XCTAssertEqual(error.code, 0);
@@ -132,7 +132,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTAssertTrue(started);
 
     NSError * error;
-    [controller pairDevice:kDeviceId
+    [controller pairDevice:nodeId
                    address:kAddress
                       port:kRemotePort
              discriminator:kDiscriminator
@@ -143,7 +143,7 @@ CHIPDevice * GetConnectedDevice(void)
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
 
     __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
-    [controller getConnectedDevice:kDeviceId
+    [controller getConnectedDevice:nodeId
                              queue:dispatch_get_main_queue()
                  completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
                      XCTAssertEqual(error.code, 0);
@@ -159,7 +159,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTAssertNotNil(controller);
 
     NSError * error;
-    [controller unpairDevice:kDeviceId error:&error];
+    [controller unpairDevice:nodeId error:&error];
     XCTAssertEqual(error.code, 0);
 
     BOOL stopped = [controller shutdown];
@@ -173,7 +173,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     __block CHIPDevice * device;
     __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
-    [controller getConnectedDevice:kDeviceId
+    [controller getConnectedDevice:nodeId
                              queue:dispatch_get_main_queue()
                  completionHandler:^(CHIPDevice * _Nullable retrievedDevice, NSError * _Nullable error) {
                      XCTAssertEqual(error.code, 0);

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -37,7 +37,7 @@ const uint16_t kPairingTimeoutInSeconds = 10;
 const uint16_t kAddressResolveTimeoutInSeconds = 10;
 const uint16_t kCASESetupTimeoutInSeconds = 30;
 const uint16_t kTimeoutInSeconds = 5;
-const uint64_t kDeviceId = 1;
+const uint64_t nodeId = 0x12344321;
 const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;
 const uint16_t kRemotePort = 5540;
@@ -65,12 +65,12 @@ void Log(XCTestExpectation * expectation, dispatch_queue_t queue, NSString * mes
 // Stub for User Prompts for XCTests to run.
 void UserPrompt(XCTestExpectation * expectation, dispatch_queue_t queue, NSString * message) { [expectation fulfill]; }
 
-void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue)
+void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue, uint64_t deviceId)
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     XCTAssertNotNil(controller);
 
-    [controller getConnectedDevice:kDeviceId
+    [controller getConnectedDevice:deviceId
                              queue:dispatch_get_main_queue()
                  completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
                      XCTAssertEqual(error.code, 0);
@@ -149,7 +149,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTAssertTrue(started);
 
     NSError * error;
-    [controller pairDevice:kDeviceId
+    [controller pairDevice:nodeId
                    address:kAddress
                       port:kRemotePort
              discriminator:kDiscriminator
@@ -160,7 +160,7 @@ CHIPDevice * GetConnectedDevice(void)
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
 
     __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
-    [controller getConnectedDevice:kDeviceId
+    [controller getConnectedDevice:nodeId
                              queue:dispatch_get_main_queue()
                  completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
                      XCTAssertEqual(error.code, 0);
@@ -176,7 +176,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTAssertNotNil(controller);
 
     NSError * error;
-    [controller unpairDevice:kDeviceId error:&error];
+    [controller unpairDevice:nodeId error:&error];
     XCTAssertEqual(error.code, 0);
 
     BOOL stopped = [controller shutdown];
@@ -190,7 +190,7 @@ CHIPDevice * GetConnectedDevice(void)
 
     __block CHIPDevice * device;
     __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
-    [controller getConnectedDevice:kDeviceId
+    [controller getConnectedDevice:nodeId
                              queue:dispatch_get_main_queue()
                  completionHandler:^(CHIPDevice * _Nullable retrievedDevice, NSError * _Nullable error) {
                      XCTAssertEqual(error.code, 0);
@@ -232,7 +232,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_BI_1_1_000001_ReadAttribute
@@ -350,7 +350,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_BI_2_1_000001_ReadAttribute
@@ -625,7 +625,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_BI_2_2_000001_ReadAttribute
@@ -826,7 +826,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_BOOL_1_1_000001_ReadAttribute
@@ -944,7 +944,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_BOOL_2_1_000001_ReadAttribute
@@ -1044,7 +1044,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_BRAC_1_1_000001_ReadAttribute
@@ -1096,7 +1096,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_1_1_000001_ReadAttribute
@@ -1166,7 +1166,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_2_1_000001_ReadAttribute
@@ -5234,7 +5234,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_3_1_000001_On
@@ -5465,7 +5465,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_3_2_000001_On
@@ -5660,7 +5660,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_3_3_000001_On
@@ -5807,7 +5807,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_4_1_000001_On
@@ -5927,7 +5927,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_4_2_000001_On
@@ -6172,7 +6172,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_4_3_000001_On
@@ -6319,7 +6319,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_4_4_000001_On
@@ -6440,7 +6440,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_5_1_000001_On
@@ -6561,7 +6561,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_5_2_000001_On
@@ -6704,7 +6704,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_5_3_000001_On
@@ -6825,7 +6825,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_6_1_000001_On
@@ -6945,7 +6945,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_6_2_000001_On
@@ -7234,7 +7234,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_6_3_000001_On
@@ -7385,7 +7385,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_7_1_000001_On
@@ -7610,7 +7610,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_7_2_000001_On
@@ -7837,7 +7837,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_7_3_000001_On
@@ -7984,7 +7984,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_7_4_000001_On
@@ -8105,7 +8105,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_8_1_000001_On
@@ -8505,7 +8505,7 @@ CHIPDevice * GetConnectedDevice(void)
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_9_1_000001_On
@@ -9830,7 +9830,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHue4;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_9_2_000001_On
@@ -10304,7 +10304,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_CC_9_3_000001_On
@@ -10880,7 +10880,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_DM_1_1_000001_ReadAttribute
@@ -11362,7 +11362,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_DM_3_1_000001_ReadAttribute
@@ -11419,7 +11419,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_EMR_1_1_000001_ReadAttribute
@@ -11537,7 +11537,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -11546,7 +11546,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -11555,7 +11555,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_FLW_1_1_000001_ReadAttribute
@@ -11625,7 +11625,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_FLW_2_1_000001_ReadAttribute
@@ -11939,7 +11939,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_FLW_2_2_000001_ReadAttribute
@@ -11986,7 +11986,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_ILL_1_1_000001_ReadAttribute
@@ -12114,7 +12114,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_1_1_000001_ReadAttribute
@@ -12273,7 +12273,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_2_1_000001_MoveToLevel
@@ -12602,7 +12602,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_2_2_000001_ReadAttribute
@@ -12963,7 +12963,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_3_1_000001_ReadAttribute
@@ -13272,7 +13272,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_4_1_000001_ReadAttribute
@@ -13614,7 +13614,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_5_1_000001_On
@@ -13868,7 +13868,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_LVL_6_1_000001_On
@@ -14101,7 +14101,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_1_1_000001_ReadAttribute
@@ -14219,7 +14219,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_2_1_000001_Sleep
@@ -14247,7 +14247,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14256,7 +14256,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14265,7 +14265,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14274,7 +14274,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14283,7 +14283,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14292,7 +14292,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14301,7 +14301,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14310,7 +14310,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14319,7 +14319,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14328,7 +14328,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14337,7 +14337,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14346,7 +14346,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_5_1_000001_ReadAttribute
@@ -14374,7 +14374,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_5_2_000001_UserPrompt
@@ -14391,7 +14391,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_5_3_000001_UserPrompt
@@ -14408,7 +14408,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_6_1_000001_UserPrompt
@@ -14473,7 +14473,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_6_2_000001_UserPrompt
@@ -14562,7 +14562,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_6_3_000001_UserPrompt
@@ -14595,7 +14595,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_6_4_000001_UserPrompt
@@ -14724,7 +14724,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14733,7 +14733,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -14742,7 +14742,7 @@ NSNumber * _Nonnull ColorLoopStoredEnhancedHueValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 NSNumber * _Nonnull currentTarget;
@@ -14795,7 +14795,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_MC_9_1_000001_Log
@@ -14946,7 +14946,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OCC_1_1_000001_ReadAttribute
@@ -15016,7 +15016,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OCC_2_1_000001_ReadAttribute
@@ -15268,7 +15268,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OCC_2_2_000001_ReadAttribute
@@ -15315,7 +15315,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OO_1_1_000001_ReadAttribute
@@ -15522,7 +15522,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OO_2_1_000001_ReadAttribute
@@ -15881,7 +15881,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OO_2_2_000001_Off
@@ -16193,7 +16193,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_OO_2_3_000001_On
@@ -17208,7 +17208,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PS_1_1_000001_ReadAttribute
@@ -17326,7 +17326,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PRS_1_1_000001_ReadAttribute
@@ -17396,7 +17396,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PRS_2_1_000001_ReadAttribute
@@ -17605,7 +17605,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PCC_1_1_000001_ReadAttribute
@@ -17702,7 +17702,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PCC_2_1_000001_ReadAttribute
@@ -18986,7 +18986,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PCC_2_2_000001_WriteAttribute
@@ -19070,7 +19070,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_PCC_2_3_000001_WriteAttribute
@@ -19299,7 +19299,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_RH_1_1_000001_ReadAttribute
@@ -19375,7 +19375,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_RH_2_1_000001_ReadAttribute
@@ -19509,7 +19509,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_RH_2_2_000001_ReadAttribute
@@ -19560,7 +19560,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_SWTCH_2_1_000001_ReadAttribute
@@ -19719,7 +19719,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_SWTCH_2_2_000001_UserPrompt
@@ -20057,7 +20057,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TM_1_1_000001_ReadAttribute
@@ -20133,7 +20133,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TM_2_1_000001_ReadAttribute
@@ -20202,7 +20202,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TM_2_2_000001_ReadAttribute
@@ -20253,7 +20253,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TSTAT_1_1_000001_ReadAttribute
@@ -20343,7 +20343,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TSTAT_2_1_000001_ReadAttribute
@@ -22002,7 +22002,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TSTAT_2_2_000001_ReadAttribute
@@ -23303,7 +23303,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TSUIC_1_1_000001_ReadAttribute
@@ -23376,7 +23376,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TSUIC_2_1_000001_ReadAttribute
@@ -23735,7 +23735,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_TSUIC_2_2_000001_WriteAttribute
@@ -23984,7 +23984,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_DIAG_TH_NW_1_1_000001_ResetCounts
@@ -24040,7 +24040,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WIFIDIAG_1_1_000001_ReadAttribute
@@ -24068,7 +24068,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -24077,7 +24077,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_1_1_000001_ReadAttribute
@@ -24266,7 +24266,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_2_1_000001_ReadAttribute
@@ -25824,7 +25824,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
@@ -25833,7 +25833,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_2_4_000001_ReadAttribute
@@ -25898,7 +25898,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_2_5_000001_ReadAttribute
@@ -25963,7 +25963,7 @@ NSNumber * _Nonnull currentTarget;
     XCTestExpectation * expectation = [self expectationWithDescription:@"0: Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_3_1_000001_DownOrClose
@@ -26554,7 +26554,7 @@ ResponseHandler test_Test_TC_WNCV_3_1_OperationalStatus_Reported = nil;
     XCTestExpectation * expectation = [self expectationWithDescription:@"0: Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_3_2_000001_UpOrOpen
@@ -27145,7 +27145,7 @@ ResponseHandler test_Test_TC_WNCV_3_2_OperationalStatus_Reported = nil;
     XCTestExpectation * expectation = [self expectationWithDescription:@"0: Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_WNCV_3_3_000001_DownOrClose
@@ -27491,7 +27491,7 @@ NSNumber * _Nullable attrCurrentPositionTilt;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestCluster_000001_Test
@@ -39884,7 +39884,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 NSNumber * _Nonnull TestAddArgumentDefaultValue;
@@ -42579,7 +42579,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestConstraints_000001_WriteAttribute
@@ -43105,7 +43105,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestDelayCommands_000001_WaitForMs
@@ -43122,7 +43122,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestDescriptorCluster_000001_ReadAttribute
@@ -43257,7 +43257,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestBasicInformation_000001_ReadAttribute
@@ -43403,7 +43403,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestGroupsCluster_000001_ViewGroup
@@ -43994,7 +43994,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestGroupKeyManagementCluster_000001_ReadAttribute
@@ -44493,7 +44493,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestIdentifyCluster_000001_Identify
@@ -44524,7 +44524,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestLogCommands_000001_Log
@@ -44549,7 +44549,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestOperationalCredentialsCluster_000001_ReadAttribute
@@ -44672,7 +44672,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestModeSelectCluster_000001_ReadAttribute
@@ -44877,7 +44877,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_SWDIAG_1_1_000001_ReadAttribute
@@ -44981,7 +44981,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTest_TC_SWDIAG_3_1_000001_ResetWatermarks
@@ -45067,7 +45067,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
 
     dispatch_queue_t queue = dispatch_get_main_queue();
-    WaitForCommissionee(expectation, queue);
+    WaitForCommissionee(expectation, queue, nodeId);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestSubscribe_OnOff_000001_Off

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -210,6 +210,7 @@ class Test_TC_BI_1_1 : public TestCommand
 public:
     Test_TC_BI_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BI_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -279,6 +280,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -344,7 +346,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -470,6 +472,7 @@ class Test_TC_BI_2_1 : public TestCommand
 public:
     Test_TC_BI_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BI_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -565,6 +568,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 12;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -684,7 +688,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeOutOfService_1()
@@ -951,6 +955,7 @@ class Test_TC_BI_2_2 : public TestCommand
 public:
     Test_TC_BI_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BI_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -1071,6 +1076,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 9;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -1169,7 +1175,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsPresentValueAttributeFromDut_1()
@@ -1371,6 +1377,7 @@ public:
     Test_TC_BOOL_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_BOOL_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -1440,6 +1447,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -1505,7 +1513,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -1632,6 +1640,7 @@ public:
     Test_TC_BOOL_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_BOOL_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -1697,6 +1706,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -1752,7 +1762,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeStateValue_1()
@@ -1856,6 +1866,7 @@ public:
     Test_TC_BRAC_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_BRAC_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -1912,6 +1923,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -1950,7 +1962,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -2006,6 +2018,7 @@ class Test_TC_CC_1_1 : public TestCommand
 public:
     Test_TC_CC_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -2067,6 +2080,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -2112,7 +2126,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -2190,6 +2204,7 @@ class Test_TC_CC_2_1 : public TestCommand
 public:
     Test_TC_CC_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -2859,6 +2874,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 154;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -4278,7 +4294,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsMandatoryAttributeCurrentHue_1()
@@ -7932,6 +7948,7 @@ class Test_TC_CC_3_1 : public TestCommand
 public:
     Test_TC_CC_3_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -8016,6 +8033,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -8064,7 +8082,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -8328,6 +8346,7 @@ class Test_TC_CC_3_2 : public TestCommand
 public:
     Test_TC_CC_3_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_3_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -8408,6 +8427,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 9;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -8446,7 +8466,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -8681,6 +8701,7 @@ class Test_TC_CC_3_3 : public TestCommand
 public:
     Test_TC_CC_3_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_3_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -8753,6 +8774,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -8791,7 +8813,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -8966,6 +8988,7 @@ class Test_TC_CC_4_1 : public TestCommand
 public:
     Test_TC_CC_4_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_4_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -9034,6 +9057,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -9072,7 +9096,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -9214,6 +9238,7 @@ class Test_TC_CC_4_2 : public TestCommand
 public:
     Test_TC_CC_4_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_4_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -9302,6 +9327,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 11;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -9340,7 +9366,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -9637,6 +9663,7 @@ class Test_TC_CC_4_3 : public TestCommand
 public:
     Test_TC_CC_4_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_4_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -9709,6 +9736,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -9747,7 +9775,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -9922,6 +9950,7 @@ class Test_TC_CC_4_4 : public TestCommand
 public:
     Test_TC_CC_4_4(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_4_4", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -9990,6 +10019,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -10028,7 +10058,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -10171,6 +10201,7 @@ class Test_TC_CC_5_1 : public TestCommand
 public:
     Test_TC_CC_5_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_5_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -10239,6 +10270,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -10277,7 +10309,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -10420,6 +10452,7 @@ class Test_TC_CC_5_2 : public TestCommand
 public:
     Test_TC_CC_5_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_5_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -10492,6 +10525,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -10530,7 +10564,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -10701,6 +10735,7 @@ class Test_TC_CC_5_3 : public TestCommand
 public:
     Test_TC_CC_5_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_5_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -10769,6 +10804,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -10807,7 +10843,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -10950,6 +10986,7 @@ class Test_TC_CC_6_1 : public TestCommand
 public:
     Test_TC_CC_6_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_6_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -11018,6 +11055,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -11056,7 +11094,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -11198,6 +11236,7 @@ class Test_TC_CC_6_2 : public TestCommand
 public:
     Test_TC_CC_6_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_6_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -11290,6 +11329,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 12;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -11338,7 +11378,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -11672,6 +11712,7 @@ class Test_TC_CC_6_3 : public TestCommand
 public:
     Test_TC_CC_6_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_6_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -11744,6 +11785,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -11782,7 +11824,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -11961,6 +12003,7 @@ class Test_TC_CC_7_1 : public TestCommand
 public:
     Test_TC_CC_7_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_7_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -12045,6 +12088,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -12083,7 +12127,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -12354,6 +12398,7 @@ class Test_TC_CC_7_2 : public TestCommand
 public:
     Test_TC_CC_7_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_7_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -12438,6 +12483,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -12486,7 +12532,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -12746,6 +12792,7 @@ class Test_TC_CC_7_3 : public TestCommand
 public:
     Test_TC_CC_7_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_7_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -12818,6 +12865,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -12856,7 +12904,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -13031,6 +13079,7 @@ class Test_TC_CC_7_4 : public TestCommand
 public:
     Test_TC_CC_7_4(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_7_4", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -13099,6 +13148,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -13137,7 +13187,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -13280,6 +13330,7 @@ class Test_TC_CC_8_1 : public TestCommand
 public:
     Test_TC_CC_8_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_8_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -13392,6 +13443,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 17;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -13510,7 +13562,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnLightForColorControlTests_1()
@@ -13950,6 +14002,7 @@ class Test_TC_CC_9_1 : public TestCommand
 public:
     Test_TC_CC_9_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_9_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -14450,6 +14503,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 54;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -14817,7 +14871,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestPreconditionTurnOnLightForColorControlTests_1()
@@ -16253,6 +16307,7 @@ class Test_TC_CC_9_2 : public TestCommand
 public:
     Test_TC_CC_9_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_9_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -16452,6 +16507,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 20;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -16603,7 +16659,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestPreconditionTurnOnLightForColorControlTests_1()
@@ -17117,6 +17173,7 @@ class Test_TC_CC_9_3 : public TestCommand
 public:
     Test_TC_CC_9_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CC_9_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -17316,6 +17373,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 20;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -17467,7 +17525,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestPreconditionTurnOnLightForColorControlTests_1()
@@ -17981,6 +18039,7 @@ class Test_TC_DM_1_1 : public TestCommand
 public:
     Test_TC_DM_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DM_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -18115,6 +18174,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 20;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -18323,7 +18383,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestQueryDataModelRevision_1()
@@ -18788,6 +18848,7 @@ class Test_TC_DM_3_1 : public TestCommand
 public:
     Test_TC_DM_3_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DM_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -18844,6 +18905,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -18885,7 +18947,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestQueryMaxNetworks_1()
@@ -18942,6 +19004,7 @@ class Test_TC_DM_2_2 : public TestCommand
 public:
     Test_TC_DM_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DM_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -19006,6 +19069,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -19068,7 +19132,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestQueryFabricsList_1()
@@ -19181,6 +19245,7 @@ class Test_TC_EMR_1_1 : public TestCommand
 public:
     Test_TC_EMR_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_EMR_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -19250,6 +19315,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -19315,7 +19381,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -19446,6 +19512,7 @@ public:
     Test_TC_ETHDIAG_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_ETHDIAG_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -19494,6 +19561,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -19512,7 +19580,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -19522,6 +19590,7 @@ public:
     Test_TC_ETHDIAG_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_ETHDIAG_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -19570,6 +19639,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -19588,7 +19658,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -19597,6 +19667,7 @@ class Test_TC_FLW_1_1 : public TestCommand
 public:
     Test_TC_FLW_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_FLW_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -19658,6 +19729,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -19703,7 +19775,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -19781,6 +19853,7 @@ class Test_TC_FLW_2_1 : public TestCommand
 public:
     Test_TC_FLW_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_FLW_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -19881,6 +19954,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 14;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -20017,7 +20091,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_1()
@@ -20329,6 +20403,7 @@ class Test_TC_FLW_2_2 : public TestCommand
 public:
     Test_TC_FLW_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_FLW_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -20385,6 +20460,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -20423,7 +20499,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_1()
@@ -20478,6 +20554,7 @@ class Test_TC_ILL_1_1 : public TestCommand
 public:
     Test_TC_ILL_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_ILL_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -20547,6 +20624,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -20612,7 +20690,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -20743,6 +20821,7 @@ class Test_TC_LVL_1_1 : public TestCommand
 public:
     Test_TC_LVL_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -20820,6 +20899,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -20902,7 +20982,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -21074,6 +21154,7 @@ class Test_TC_LVL_2_1 : public TestCommand
 public:
     Test_TC_LVL_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -21182,6 +21263,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -21330,7 +21412,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestResetLevelTo254_1()
@@ -21683,6 +21765,7 @@ class Test_TC_LVL_2_2 : public TestCommand
 public:
     Test_TC_LVL_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -21791,6 +21874,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -21938,7 +22022,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsTheOnOffTransitionTimeAttributeFromTheDut_1()
@@ -22304,6 +22388,7 @@ class Test_TC_LVL_3_1 : public TestCommand
 public:
     Test_TC_LVL_3_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -22412,6 +22497,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -22500,7 +22586,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_1()
@@ -22825,6 +22911,7 @@ class Test_TC_LVL_4_1 : public TestCommand
 public:
     Test_TC_LVL_4_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_4_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -22937,6 +23024,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 17;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -23032,7 +23120,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_1()
@@ -23381,6 +23469,7 @@ class Test_TC_LVL_5_1 : public TestCommand
 public:
     Test_TC_LVL_5_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_5_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -23481,6 +23570,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 14;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -23529,7 +23619,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendingOnCommand_1()
@@ -23815,6 +23905,7 @@ class Test_TC_LVL_6_1 : public TestCommand
 public:
     Test_TC_LVL_6_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_6_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -23907,6 +23998,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 12;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -23945,7 +24037,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendingOnCommand_1()
@@ -24196,6 +24288,7 @@ class Test_TC_MC_1_1 : public TestCommand
 public:
     Test_TC_MC_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24265,6 +24358,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24330,7 +24424,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -24456,6 +24550,7 @@ class Test_TC_MC_2_1 : public TestCommand
 public:
     Test_TC_MC_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24508,6 +24603,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24526,7 +24622,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestPutTheDeviceIntoLowPowerMode_1()
@@ -24562,6 +24658,7 @@ class Test_TC_MC_3_1 : public TestCommand
 public:
     Test_TC_MC_3_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24610,6 +24707,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24628,7 +24726,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -24637,6 +24735,7 @@ class Test_TC_MC_3_2 : public TestCommand
 public:
     Test_TC_MC_3_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24685,6 +24784,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24703,7 +24803,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -24712,6 +24812,7 @@ class Test_TC_MC_3_3 : public TestCommand
 public:
     Test_TC_MC_3_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24760,6 +24861,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24778,7 +24880,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -24787,6 +24889,7 @@ class Test_TC_MC_3_4 : public TestCommand
 public:
     Test_TC_MC_3_4(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_4", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24835,6 +24938,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24853,7 +24957,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -24862,6 +24966,7 @@ class Test_TC_MC_3_5 : public TestCommand
 public:
     Test_TC_MC_3_5(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_5", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24910,6 +25015,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -24928,7 +25034,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -24937,6 +25043,7 @@ class Test_TC_MC_3_6 : public TestCommand
 public:
     Test_TC_MC_3_6(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_6", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -24985,6 +25092,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25003,7 +25111,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -25012,6 +25120,7 @@ class Test_TC_MC_3_7 : public TestCommand
 public:
     Test_TC_MC_3_7(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_7", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25060,6 +25169,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25078,7 +25188,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -25087,6 +25197,7 @@ class Test_TC_MC_3_8 : public TestCommand
 public:
     Test_TC_MC_3_8(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_8", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25135,6 +25246,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25153,7 +25265,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -25162,6 +25274,7 @@ class Test_TC_MC_3_9 : public TestCommand
 public:
     Test_TC_MC_3_9(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_9", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25210,6 +25323,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25228,7 +25342,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -25237,6 +25351,7 @@ class Test_TC_MC_3_10 : public TestCommand
 public:
     Test_TC_MC_3_10(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_10", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25285,6 +25400,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25303,7 +25419,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -25312,6 +25428,7 @@ class Test_TC_MC_3_11 : public TestCommand
 public:
     Test_TC_MC_3_11(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_3_11", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25360,6 +25477,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25378,7 +25496,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -25387,6 +25505,7 @@ class Test_TC_MC_5_1 : public TestCommand
 public:
     Test_TC_MC_5_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_5_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25439,6 +25558,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25469,7 +25589,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsTheChannelListAttributeFromTheDut_1()
@@ -25502,6 +25622,7 @@ class Test_TC_MC_5_2 : public TestCommand
 public:
     Test_TC_MC_5_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_5_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25554,6 +25675,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25572,7 +25694,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogACommand_1()
@@ -25587,6 +25709,7 @@ class Test_TC_MC_5_3 : public TestCommand
 public:
     Test_TC_MC_5_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_5_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25639,6 +25762,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25657,7 +25781,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogACommand_1()
@@ -25672,6 +25796,7 @@ class Test_TC_MC_6_1 : public TestCommand
 public:
     Test_TC_MC_6_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_6_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25740,6 +25865,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25768,7 +25894,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogACommand_1()
@@ -25825,6 +25951,7 @@ class Test_TC_MC_6_2 : public TestCommand
 public:
     Test_TC_MC_6_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_6_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -25905,6 +26032,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 9;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -25933,7 +26061,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogACommand_1()
@@ -26008,6 +26136,7 @@ class Test_TC_MC_6_3 : public TestCommand
 public:
     Test_TC_MC_6_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_6_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -26068,6 +26197,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -26086,7 +26216,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogACommand_1()
@@ -26113,6 +26243,7 @@ class Test_TC_MC_6_4 : public TestCommand
 public:
     Test_TC_MC_6_4(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_6_4", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -26197,6 +26328,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -26245,7 +26377,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogACommand_1()
@@ -26362,6 +26494,7 @@ class Test_TC_MC_7_1 : public TestCommand
 public:
     Test_TC_MC_7_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_7_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -26410,6 +26543,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -26428,7 +26562,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -26437,6 +26571,7 @@ class Test_TC_MC_7_2 : public TestCommand
 public:
     Test_TC_MC_7_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_7_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -26485,6 +26620,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -26503,7 +26639,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -26512,6 +26648,7 @@ class Test_TC_MC_8_1 : public TestCommand
 public:
     Test_TC_MC_8_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_8_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -26568,6 +26705,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -26611,7 +26749,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsTheCurrentTargetAttribute_1()
@@ -26670,6 +26808,7 @@ class Test_TC_MC_9_1 : public TestCommand
 public:
     Test_TC_MC_9_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MC_9_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -26746,6 +26885,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -26824,7 +26964,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestPrecondition_1()
@@ -26981,6 +27121,7 @@ class Test_TC_OCC_1_1 : public TestCommand
 public:
     Test_TC_OCC_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OCC_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -27042,6 +27183,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -27087,7 +27229,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -27165,6 +27307,7 @@ class Test_TC_OCC_2_1 : public TestCommand
 public:
     Test_TC_OCC_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OCC_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -27253,6 +27396,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -27352,7 +27496,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsMandatoryAttributeConstrainsOccupancy_1()
@@ -27583,6 +27727,7 @@ class Test_TC_OCC_2_2 : public TestCommand
 public:
     Test_TC_OCC_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OCC_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -27649,6 +27794,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -27687,7 +27833,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsOccupancyAttributeFromDut_1()
@@ -27742,6 +27888,7 @@ class Test_TC_OO_1_1 : public TestCommand
 public:
     Test_TC_OO_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OO_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -27827,6 +27974,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -27929,7 +28077,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -28149,6 +28297,7 @@ class Test_TC_OO_2_1 : public TestCommand
 public:
     Test_TC_OO_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OO_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -28257,6 +28406,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -28410,7 +28560,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeOnOff_1()
@@ -28771,6 +28921,7 @@ class Test_TC_OO_2_2 : public TestCommand
 public:
     Test_TC_OO_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OO_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -28875,6 +29026,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 15;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -28963,7 +29115,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendOffCommand_1()
@@ -29329,6 +29481,7 @@ class Test_TC_OO_2_3 : public TestCommand
 public:
     Test_TC_OO_2_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_OO_2_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -29776,6 +29929,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 47;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -30124,7 +30278,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendOnCommand_1()
@@ -31213,6 +31367,7 @@ class Test_TC_PS_1_1 : public TestCommand
 public:
     Test_TC_PS_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PS_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -31282,6 +31437,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -31347,7 +31503,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_1()
@@ -31473,6 +31629,7 @@ class Test_TC_PRS_1_1 : public TestCommand
 public:
     Test_TC_PRS_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PRS_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -31534,6 +31691,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -31579,7 +31737,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -31658,6 +31816,7 @@ class Test_TC_PRS_2_1 : public TestCommand
 public:
     Test_TC_PRS_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PRS_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -31742,6 +31901,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -31841,7 +32001,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeConstraintsMeasuredValue_1()
@@ -32066,6 +32226,7 @@ class Test_TC_PCC_1_1 : public TestCommand
 public:
     Test_TC_PCC_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PCC_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -32131,6 +32292,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -32186,7 +32348,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -32291,6 +32453,7 @@ class Test_TC_PCC_2_1 : public TestCommand
 public:
     Test_TC_PCC_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PCC_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -32535,6 +32698,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 50;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -33040,7 +33204,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeMaxPressure_1()
@@ -34233,6 +34397,7 @@ class Test_TC_PCC_2_2 : public TestCommand
 public:
     Test_TC_PCC_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PCC_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -34308,6 +34473,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -34347,7 +34513,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestWrite1ToTheOperationModeAttributeToDutOperationMode_1()
@@ -34425,6 +34591,7 @@ class Test_TC_PCC_2_3 : public TestCommand
 public:
     Test_TC_PCC_2_3(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_PCC_2_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -34554,6 +34721,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -34641,7 +34809,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestWrite0ToTheOperationModeAttributeToDut_1()
@@ -34861,6 +35029,7 @@ class Test_TC_RH_1_1 : public TestCommand
 public:
     Test_TC_RH_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_RH_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -34922,6 +35091,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -34967,7 +35137,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -35048,6 +35218,7 @@ class Test_TC_RH_2_1 : public TestCommand
 public:
     Test_TC_RH_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_RH_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -35112,6 +35283,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -35170,7 +35342,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsConstraintsOfAttributeMeasuredValue_1()
@@ -35280,6 +35452,7 @@ class Test_TC_RH_2_2 : public TestCommand
 public:
     Test_TC_RH_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_RH_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -35346,6 +35519,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -35384,7 +35558,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsMeasuredValueAttributeFromDut_1()
@@ -35442,6 +35616,7 @@ public:
     Test_TC_SWTCH_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_SWTCH_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -35514,6 +35689,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -35592,7 +35768,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadNumberOfPositionsAttribute_1()
@@ -35746,6 +35922,7 @@ public:
     Test_TC_SWTCH_2_2(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_SWTCH_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -35942,6 +36119,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 38;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -35980,7 +36158,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestUserInteractionNeeded_1()
@@ -36248,6 +36426,7 @@ class Test_TC_TM_1_1 : public TestCommand
 public:
     Test_TC_TM_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_TM_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -36309,6 +36488,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -36354,7 +36534,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -36435,6 +36615,7 @@ class Test_TC_TM_2_1 : public TestCommand
 public:
     Test_TC_TM_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_TM_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -36491,6 +36672,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -36529,7 +36711,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_1()
@@ -36587,6 +36769,7 @@ class Test_TC_TM_2_2 : public TestCommand
 public:
     Test_TC_TM_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_TM_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -36653,6 +36836,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -36691,7 +36875,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsMeasuredValueAttributeFromDut_1()
@@ -36749,6 +36933,7 @@ public:
     Test_TC_TSTAT_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_TSTAT_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -36814,6 +36999,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -36869,7 +37055,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -36971,6 +37157,7 @@ public:
     Test_TC_TSTAT_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_TSTAT_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -37305,6 +37492,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 61;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -37875,7 +38063,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsConstraintsOfMandatoryAttributesFromDutLocalTemperature_1()
@@ -39318,6 +39506,7 @@ public:
     Test_TC_TSTAT_2_2(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_TSTAT_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -39874,6 +40063,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 50;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -40277,7 +40467,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsOccupiedCoolingSetpointAttributeFromServerDutAndVerifiesThatTheValueIsWithinRange_1()
@@ -41410,6 +41600,7 @@ public:
     Test_TC_TSUIC_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_TSUIC_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -41471,6 +41662,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -41516,7 +41708,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
@@ -41599,6 +41791,7 @@ public:
     Test_TC_TSUIC_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_TSUIC_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -41707,6 +41900,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -41866,7 +42060,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadTheMandatoryAttributeTemperatureDisplayMode_1()
@@ -42249,6 +42443,7 @@ public:
     Test_TC_TSUIC_2_2(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_TSUIC_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -42389,6 +42584,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 11;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -42477,7 +42673,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestWritesAValueOf0ToTemperatureDisplayModeAttributeOfDut_1()
@@ -42721,6 +42917,7 @@ public:
     Test_TC_DIAG_TH_NW_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_DIAG_TH_NW_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -42777,6 +42974,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -42805,7 +43003,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendsResetCountsCommand_1()
@@ -42867,6 +43065,7 @@ public:
     Test_TC_WIFIDIAG_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WIFIDIAG_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -42919,6 +43118,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -42950,7 +43150,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsNetworkInterfaceStructureAttributeFromDut_1()
@@ -42986,6 +43186,7 @@ public:
     Test_TC_WIFIDIAG_3_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WIFIDIAG_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -43034,6 +43235,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -43052,7 +43254,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -43062,6 +43264,7 @@ public:
     Test_TC_WNCV_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -43140,6 +43343,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -43222,7 +43426,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR Test2ReadTheGlobalAttributeClusterRevision_1()
@@ -43401,6 +43605,7 @@ public:
     Test_TC_WNCV_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -43698,6 +43903,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 55;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -44214,7 +44420,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR Test2ReadTheRoMandatoryAttributeDefaultType_1()
@@ -45582,6 +45788,7 @@ public:
     Test_TC_WNCV_2_2(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -45630,6 +45837,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -45648,7 +45856,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 };
 
@@ -45658,6 +45866,7 @@ public:
     Test_TC_WNCV_2_4(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_2_4", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -45724,6 +45933,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -45762,7 +45972,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsTypeAttributeFromDut_1()
@@ -45821,6 +46031,7 @@ public:
     Test_TC_WNCV_2_5(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_2_5", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -45887,6 +46098,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -45925,7 +46137,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsEndProductTypeAttributeFromDut_1()
@@ -45984,6 +46196,7 @@ public:
     Test_TC_WNCV_3_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -46203,6 +46416,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 25;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -46394,7 +46608,7 @@ private:
     CHIP_ERROR Test0WaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR Test1aThSendsDownOrCloseCommandToPrepositionTheDutInTheOppositeDirection_1()
@@ -46932,6 +47146,7 @@ public:
     Test_TC_WNCV_3_2(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_3_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -47150,6 +47365,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 25;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -47341,7 +47557,7 @@ private:
     CHIP_ERROR Test0WaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR Test1aThSendsUpOrOpenCommandToPrepositionTheDutInTheOppositeDirection_1()
@@ -47879,6 +48095,7 @@ public:
     Test_TC_WNCV_3_3(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_WNCV_3_3", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -48020,6 +48237,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -48137,7 +48355,7 @@ private:
     CHIP_ERROR Test0WaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR Test1aThSendsDownOrCloseCommandToPrepositionTheDutInTheOppositeDirection_1()
@@ -48490,6 +48708,7 @@ public:
     TV_TargetNavigatorCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_TargetNavigatorCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -48550,6 +48769,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -48591,7 +48811,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeTargetNavigatorList_1()
@@ -48701,6 +48921,7 @@ public:
     TV_AudioOutputCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_AudioOutputCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -48765,6 +48986,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -48806,7 +49028,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeAudioOutputList_1()
@@ -48941,6 +49163,7 @@ public:
     TV_ApplicationLauncherCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_ApplicationLauncherCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -49005,6 +49228,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -49033,7 +49257,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeApplicationLauncherList_1()
@@ -49189,6 +49413,7 @@ public:
     TV_KeypadInputCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_KeypadInputCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -49241,6 +49466,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -49259,7 +49485,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendKeyCommand_1()
@@ -49302,6 +49528,7 @@ public:
     TV_AccountLoginCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_AccountLoginCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -49362,6 +49589,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -49380,7 +49608,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestGetSetupPinCommand_1()
@@ -49482,6 +49710,7 @@ public:
     TV_WakeOnLanCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_WakeOnLanCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -49534,6 +49763,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -49562,7 +49792,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadMacAddress_1()
@@ -49596,6 +49826,7 @@ public:
     TV_ApplicationBasicCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_ApplicationBasicCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -49668,6 +49899,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -49746,7 +49978,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeVendorName_1()
@@ -49900,6 +50132,7 @@ public:
     TV_MediaPlaybackCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_MediaPlaybackCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -50016,6 +50249,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 18;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -50094,7 +50328,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributePlaybackState_1()
@@ -50607,6 +50841,7 @@ public:
     TV_ChannelCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_ChannelCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -50671,6 +50906,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -50701,7 +50937,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeChannelList_1()
@@ -50865,6 +51101,7 @@ public:
     TV_LowPowerCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_LowPowerCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -50917,6 +51154,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -50935,7 +51173,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSleepInputStatusCommand_1()
@@ -50972,6 +51210,7 @@ public:
     TV_ContentLauncherCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_ContentLauncherCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -51036,6 +51275,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -51074,7 +51314,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeAcceptHeaderList_1()
@@ -51310,6 +51550,7 @@ public:
     TV_MediaInputCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TV_MediaInputCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -51382,6 +51623,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -51423,7 +51665,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeMediaInputList_1()
@@ -51608,6 +51850,7 @@ class TestCluster : public TestCommand
 public:
     TestCluster(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -53696,6 +53939,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 482;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -57671,7 +57915,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendTestCommand_1()
@@ -70077,6 +70321,7 @@ public:
     TestClusterComplexTypes(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestClusterComplexTypes", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -70210,6 +70455,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 21;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -70347,7 +70593,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendTestCommandWithOptionalArgSetToNull_1()
@@ -70898,6 +71144,7 @@ class TestConstraints : public TestCommand
 public:
     TestConstraints(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestConstraints", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -71033,6 +71280,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 22;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -71234,7 +71482,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestWriteAttributeInt32uValue_1()
@@ -71722,6 +71970,7 @@ public:
     TestDelayCommands(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestDelayCommands", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -71774,6 +72023,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -71792,7 +72042,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestWait100ms_1()
@@ -71807,6 +72057,7 @@ class TestDiscovery : public TestCommand
 public:
     TestDiscovery(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestDiscovery", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
         AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("vendorId", 0, UINT16_MAX, &mVendorId);
@@ -72006,6 +72257,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 25;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mVendorId;
@@ -72150,7 +72402,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_1()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestOpenCommissioningWindow_2()
@@ -72294,7 +72546,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_21()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestOpenCommissioningWindow_22()
@@ -72344,6 +72596,7 @@ class TestLogCommands : public TestCommand
 public:
     TestLogCommands(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestLogCommands", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -72400,6 +72653,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -72418,7 +72672,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestLogASimpleMessage_1()
@@ -72439,6 +72693,7 @@ class TestSaveAs : public TestCommand
 public:
     TestSaveAs(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestSaveAs", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -72951,6 +73206,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 110;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -73931,7 +74187,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendTestAddArgumentsCommand_1()
@@ -76550,6 +76806,7 @@ public:
     TestConfigVariables(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestConfigVariables", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
         AddArgument("arg1", 0, UINT8_MAX, &mArg1);
@@ -76608,6 +76865,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint8_t> mArg1;
@@ -76630,7 +76888,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendTestAddArgumentsCommand_1()
@@ -76709,6 +76967,7 @@ public:
     TestDescriptorCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestDescriptorCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -76773,6 +77032,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -76833,7 +77093,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAttributeDeviceList_1()
@@ -77011,6 +77271,7 @@ public:
     TestBasicInformation(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestBasicInformation", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -77079,6 +77340,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -77141,7 +77403,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadLocation_1()
@@ -77312,6 +77574,7 @@ public:
     TestIdentifyCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestIdentifyCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -77364,6 +77627,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -77382,7 +77646,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendIdentifyCommandAndExpectSuccessResponse_1()
@@ -77420,6 +77684,7 @@ public:
     TestOperationalCredentialsCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestOperationalCredentialsCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -77484,6 +77749,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -77532,7 +77798,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadNumberOfSupportedFabrics_1()
@@ -77653,6 +77919,7 @@ public:
     TestModeSelectCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestModeSelectCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -77733,6 +78000,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 9;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -77814,7 +78082,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadCurrentMode_1()
@@ -78043,6 +78311,7 @@ public:
     TestSystemCommands(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestSystemCommands", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -78107,6 +78376,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -78125,7 +78395,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestStopTheAccessory_1()
@@ -78159,6 +78429,7 @@ public:
     Test_TC_SWDIAG_1_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_SWDIAG_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -78238,6 +78509,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -78299,7 +78571,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadsAListOfThreadMetricsStructNonGlobalAttributeFromDut_1()
@@ -78404,6 +78676,7 @@ public:
     Test_TC_SWDIAG_2_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_SWDIAG_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -78448,6 +78721,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 0;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -78470,6 +78744,7 @@ public:
     Test_TC_SWDIAG_3_1(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("Test_TC_SWDIAG_3_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -78545,6 +78820,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -78583,7 +78859,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSendsResetWatermarksToDut_1()
@@ -78669,6 +78945,7 @@ public:
     TestSubscribe_OnOff(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestSubscribe_OnOff", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -78745,6 +79022,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -78817,7 +79095,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestSetOnOffAttributeToFalse_1()
@@ -79019,6 +79297,7 @@ public:
     DL_UsersAndCredentials(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("DL_UsersAndCredentials", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -79479,6 +79758,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 102;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -79531,7 +79811,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadAvailableUserSlotAndVerifyResponseFields_1()
@@ -84406,6 +84686,7 @@ class DL_LockUnlock : public TestCommand
 public:
     DL_LockUnlock(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("DL_LockUnlock", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -84494,6 +84775,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 11;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -84556,7 +84838,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestCreateNewPinCredentialAndLockUnlockUser_1()
@@ -84869,6 +85151,7 @@ class DL_Schedules : public TestCommand
 public:
     DL_Schedules(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("DL_Schedules", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -85254,6 +85537,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 84;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -85306,7 +85590,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestCreateNewPinCredentialAndScheduleUser_1()
@@ -88419,6 +88703,7 @@ public:
     TestGroupMessaging(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestGroupMessaging", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -88512,6 +88797,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 12;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -88585,7 +88871,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestAddGroup1Endpoint1_1()
@@ -88957,6 +89243,7 @@ public:
     TestGroupsCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestGroupsCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -89077,6 +89364,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 19;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -89095,7 +89383,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestViewGroup0Invalid_1()
@@ -89761,6 +90049,7 @@ public:
     TestGroupKeyManagementCluster(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestGroupKeyManagementCluster", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -89873,6 +90162,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 17;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -89947,7 +90237,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestReadMaxGroupsPerFabric_1()
@@ -90527,6 +90817,7 @@ class Test_TC_DD_1_5 : public TestCommand
 public:
     Test_TC_DD_1_5(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DD_1_5", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -90575,6 +90866,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -90603,6 +90895,7 @@ class Test_TC_DD_1_6 : public TestCommand
 public:
     Test_TC_DD_1_6(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DD_1_6", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -90659,6 +90952,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -90700,6 +90994,7 @@ class Test_TC_DD_1_7 : public TestCommand
 public:
     Test_TC_DD_1_7(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DD_1_7", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -90752,6 +91047,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -90786,6 +91082,7 @@ class Test_TC_DD_1_8 : public TestCommand
 public:
     Test_TC_DD_1_8(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DD_1_8", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -90838,6 +91135,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -90872,6 +91170,7 @@ class Test_TC_DD_1_9 : public TestCommand
 public:
     Test_TC_DD_1_9(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DD_1_9", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -90928,6 +91227,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -90969,6 +91269,7 @@ class Test_TC_DD_1_10 : public TestCommand
 public:
     Test_TC_DD_1_10(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_DD_1_10", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -91013,6 +91314,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 0;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -91035,6 +91337,7 @@ public:
     TestGroupDemoCommand(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestGroupDemoCommand", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -91163,6 +91466,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 21;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -91181,7 +91485,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestTurnOnTheLightToSeeAttributeChange_1()
@@ -91571,6 +91875,7 @@ public:
     TestGroupDemoConfig(CredentialIssuerCommands * credsIssuerConfig) :
         TestCommand("TestGroupDemoConfig", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -91631,6 +91936,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -91656,7 +91962,7 @@ private:
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
     {
         SetIdentity(kIdentityAlpha);
-        return WaitForCommissionee();
+        return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
     }
 
     CHIP_ERROR TestAddGroup1Endpoint1_1()
@@ -91783,6 +92089,7 @@ class Test_TC_BDX_1_1 : public TestCommand
 public:
     Test_TC_BDX_1_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BDX_1_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -91827,6 +92134,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 0;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -91848,6 +92156,7 @@ class Test_TC_BDX_1_2 : public TestCommand
 public:
     Test_TC_BDX_1_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BDX_1_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -91892,6 +92201,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 0;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -91913,6 +92223,7 @@ class Test_TC_BDX_2_1 : public TestCommand
 public:
     Test_TC_BDX_2_1(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BDX_2_1", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -91957,6 +92268,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 0;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -91978,6 +92290,7 @@ class Test_TC_BDX_2_2 : public TestCommand
 public:
     Test_TC_BDX_2_2(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_BDX_2_2", credsIssuerConfig), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -92022,6 +92335,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 0;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 

--- a/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
@@ -26,6 +26,7 @@ class Test_TC_DM_1_3_Simulated : public TestCommand
 public:
     Test_TC_DM_1_3_Simulated() : TestCommand("Test_TC_DM_1_3_Simulated"), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -154,6 +155,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 21;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -400,6 +402,7 @@ class Test_TC_DM_3_3_Simulated : public TestCommand
 public:
     Test_TC_DM_3_3_Simulated() : TestCommand("Test_TC_DM_3_3_Simulated"), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -483,6 +486,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -579,6 +583,7 @@ class Test_TC_DM_2_3_Simulated : public TestCommand
 public:
     Test_TC_DM_2_3_Simulated() : TestCommand("Test_TC_DM_2_3_Simulated"), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -663,6 +668,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 

--- a/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
@@ -26,6 +26,7 @@ class Test_TC_DM_1_3_Simulated : public TestCommand
 public:
     Test_TC_DM_1_3_Simulated() : TestCommand("Test_TC_DM_1_3_Simulated"), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -154,6 +155,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 21;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -400,6 +402,7 @@ class Test_TC_DM_3_3_Simulated : public TestCommand
 public:
     Test_TC_DM_3_3_Simulated() : TestCommand("Test_TC_DM_3_3_Simulated"), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -483,6 +486,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 
@@ -579,6 +583,7 @@ class Test_TC_DM_2_3_Simulated : public TestCommand
 public:
     Test_TC_DM_2_3_Simulated() : TestCommand("Test_TC_DM_2_3_Simulated"), mTestIndex(0)
     {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
     }
@@ -663,6 +668,7 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 10;
 
+    chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
 


### PR DESCRIPTION
#### Problem

`WaitForCommissionee` which is used to retrieve a device when the test starts, or when a new device has been paired uses a nodeId that comes from the command line. But this nodeId is not exposed to YAML and there may be different nodeIds for tests that uses multiple fabrics.

#### Change overview
 * Get `nodeId` to be an optional parameter by declaring it on the config section
 * Update all the tests to use it

#### Testing
I have updated all the tests...
