### PR TITLE
[android] Use specified PIN code in ECM

### DIFF
--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -29,7 +29,7 @@ public:
         mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
-        AddArgument("option", 0, UINT8_MAX, &mCommissioningWindowOption);
+        AddArgument("option", 0, 2, &mCommissioningWindowOption);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
         AddArgument("iteration", chip::kPBKDFMinimumIterations, chip::kPBKDFMaximumIterations, &mIteration);
         AddArgument("discriminator", 0, 4096, &mDiscriminator);
@@ -41,7 +41,7 @@ public:
 
 private:
     NodeId mNodeId;
-    uint8_t mCommissioningWindowOption;
+    ChipDeviceController::CommissioningWindowOption mCommissioningWindowOption;
     uint16_t mTimeout;
     uint32_t mIteration;
     uint16_t mDiscriminator;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -178,7 +178,7 @@ public:
     DeviceController();
     virtual ~DeviceController() {}
 
-    enum class CommissioningWindowOption
+    enum class CommissioningWindowOption : uint8_t
     {
         kOriginalSetupCode = 0,
         kTokenWithRandomPIN,
@@ -271,7 +271,7 @@ public:
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR OpenCommissioningWindow(NodeId deviceId, uint16_t timeout, uint32_t iteration, uint16_t discriminator,
-                                       uint8_t option, SetupPayload & payload)
+                                       CommissioningWindowOption option, SetupPayload & payload)
     {
         mSuggestedSetUpPINCode = payload.setUpPINCode;
         ReturnErrorOnFailure(OpenCommissioningWindowWithCallback(deviceId, timeout, iteration, discriminator, option, nullptr));
@@ -302,7 +302,8 @@ public:
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint32_t iteration, uint16_t discriminator,
-                                                   uint8_t option, Callback::Callback<OnOpenCommissioningWindow> * callback,
+                                                   CommissioningWindowOption option,
+                                                   Callback::Callback<OnOpenCommissioningWindow> * callback,
                                                    bool readVIDPIDAttributes = false);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -531,8 +531,10 @@ JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle
         return false;
     }
 
-    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err = wrapper->Controller()->OpenCommissioningWindow(chipDevice->GetDeviceId(), duration, 0, 0, 0, setupPayload);
+    AndroidDeviceControllerWrapper * wrapper           = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+    DeviceController::CommissioningWindowOption option = DeviceController::CommissioningWindowOption::kOriginalSetupCode;
+
+    err = wrapper->Controller()->OpenCommissioningWindow(chipDevice->GetDeviceId(), duration, 0, 0, option, setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -559,8 +561,10 @@ JNI_METHOD(jboolean, openPairingWindowWithPIN)
         return false;
     }
 
-    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err = wrapper->Controller()->OpenCommissioningWindow(chipDevice->GetDeviceId(), duration, iteration, discriminator, 1,
+    AndroidDeviceControllerWrapper * wrapper           = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+    DeviceController::CommissioningWindowOption option = DeviceController::CommissioningWindowOption::kTokenWithProvidedPIN;
+
+    err = wrapper->Controller()->OpenCommissioningWindow(chipDevice->GetDeviceId(), duration, iteration, discriminator, option,
                                                          setupPayload);
 
     if (err != CHIP_NO_ERROR)

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -146,7 +146,7 @@ ChipError::StorageType pychip_DeviceController_PostTaskOnChipThread(ChipThreadTa
 
 ChipError::StorageType pychip_DeviceController_OpenCommissioningWindow(chip::Controller::DeviceCommissioner * devCtrl,
                                                                        chip::NodeId nodeid, uint16_t timeout, uint32_t iteration,
-                                                                       uint16_t discriminator, uint8_t option);
+                                                                       uint16_t discriminator, uint8_t optionInt);
 
 void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceCommissioner * devCtrl);
 bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
@@ -435,9 +435,11 @@ pychip_DeviceController_DiscoverCommissionableNodesCommissioningEnabled(chip::Co
 
 ChipError::StorageType pychip_DeviceController_OpenCommissioningWindow(chip::Controller::DeviceCommissioner * devCtrl,
                                                                        chip::NodeId nodeid, uint16_t timeout, uint32_t iteration,
-                                                                       uint16_t discriminator, uint8_t option)
+                                                                       uint16_t discriminator, uint8_t optionInt)
 {
     SetupPayload payload;
+    const auto option = static_cast<Controller::DeviceController::CommissioningWindowOption>(optionInt);
+
     return devCtrl->OpenCommissioningWindow(nodeid, timeout, iteration, discriminator, option, payload).AsInteger();
 }
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -510,7 +510,8 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     }
 
     chip::SetupPayload setupPayload;
-    err = self.cppCommissioner->OpenCommissioningWindow(deviceID, (uint16_t) duration, 0, 0, 0, setupPayload);
+    err = self.cppCommissioner->OpenCommissioningWindow(deviceID, (uint16_t) duration, 0, 0,
+        chip::Controller::DeviceController::CommissioningWindowOption::kOriginalSetupCode, setupPayload);
 
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%s): Open Pairing Window failed", chip::ErrorStr(err));
@@ -554,8 +555,8 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     setupPIN &= ((1 << chip::kSetupPINCodeFieldLengthInBits) - 1);
     setupPayload.setUpPINCode = (uint32_t) setupPIN;
 
-    err = self.cppCommissioner->OpenCommissioningWindow(
-        deviceID, (uint16_t) duration, 1000, (uint16_t) discriminator, 2, setupPayload);
+    err = self.cppCommissioner->OpenCommissioningWindow(deviceID, (uint16_t) duration, 1000, (uint16_t) discriminator,
+        chip::Controller::DeviceController::CommissioningWindowOption::kTokenWithProvidedPIN, setupPayload);
 
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%s): Open Pairing Window failed", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
Android CHIPTool provides UI for specifying PIN code to be used for the opened commissioning window, but then it ignores the input value and uses random PIN code.

#### Change overview
Use the right commissioning window option. Also change the code to use enum instead of raw uint8_t for clarity.

#### Testing
Tested Multi-admin by opening the window on Android CHIPTool (using a custom PINcode) and then used the same PIN code to commission the device with Python CHIP Controller.
