### PR TITLE
[YAML] Add a simple pairing API for YAML

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -43,7 +43,7 @@ void TestCommand::OnDeviceConnectedFn(void * context, chip::OperationalDevicePro
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Device connected, but cannot run the test, as the context is null"));
     command->mDevices[command->GetIdentity()] = device;
 
-    command->ContinueOnChipMainThread();
+    LogErrorOnFailure(command->ContinueOnChipMainThread(CHIP_NO_ERROR));
 }
 
 void TestCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error)
@@ -53,7 +53,7 @@ void TestCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHI
     auto * command = static_cast<TestCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Test command context is null"));
 
-    command->ContinueOnChipMainThread();
+    LogErrorOnFailure(command->ContinueOnChipMainThread(CHIP_NO_ERROR));
 }
 
 void TestCommand::Exit(std::string message)

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -69,7 +69,15 @@ protected:
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
-    CHIP_ERROR ContinueOnChipMainThread() override { return WaitForMs(0); };
+    CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override
+    {
+        if (CHIP_NO_ERROR == err)
+        {
+            return WaitForMs(0);
+        }
+        Exit(chip::ErrorStr(err));
+        return CHIP_NO_ERROR;
+    }
 
     void Exit(std::string message) override;
     void ThrowFailureResponse();

--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -62,9 +62,16 @@ public:
         return 0;
     }
 
-    CHIP_ERROR ContinueOnChipMainThread() override
+    CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override
     {
-        NextTest();
+        if (CHIP_NO_ERROR == err)
+        {
+            NextTest();
+        }
+        else
+        {
+            Exit(chip::ErrorStr(err));
+        }
         return CHIP_NO_ERROR;
     }
 

--- a/src/app/tests/suites/commands/commissioner/BUILD.gn
+++ b/src/app/tests/suites/commands/commissioner/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+static_library("commissioner") {
+  output_name = "libCommissionerCommands"
+
+  sources = [
+    "CommissionerCommands.cpp",
+    "CommissionerCommands.h",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/controller",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
@@ -1,0 +1,90 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CommissionerCommands.h"
+
+constexpr uint16_t kPayloadMaxSize = 64;
+
+CHIP_ERROR CommissionerCommands::PairWithQRCode(chip::NodeId nodeId, const chip::CharSpan payload)
+{
+    VerifyOrReturnError(payload.size() > 0 && payload.size() < kPayloadMaxSize, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GetCurrentCommissioner().RegisterPairingDelegate(this);
+
+    char qrCode[kPayloadMaxSize];
+    memcpy(qrCode, payload.data(), payload.size());
+    return GetCurrentCommissioner().PairDevice(nodeId, qrCode);
+}
+
+CHIP_ERROR CommissionerCommands::PairWithManualCode(chip::NodeId nodeId, const chip::CharSpan payload)
+{
+    VerifyOrReturnError(payload.size() > 0 && payload.size() < kPayloadMaxSize, CHIP_ERROR_INVALID_ARGUMENT);
+
+    GetCurrentCommissioner().RegisterPairingDelegate(this);
+
+    char manualCode[kPayloadMaxSize];
+    memcpy(manualCode, payload.data(), payload.size());
+    return GetCurrentCommissioner().PairDevice(nodeId, manualCode);
+}
+
+CHIP_ERROR CommissionerCommands::Unpair(chip::NodeId nodeId)
+{
+    return GetCurrentCommissioner().UnpairDevice(nodeId);
+}
+
+void CommissionerCommands::OnStatusUpdate(DevicePairingDelegate::Status status)
+{
+    switch (status)
+    {
+    case DevicePairingDelegate::Status::SecurePairingSuccess:
+        ChipLogProgress(chipTool, "Secure Pairing Success");
+        break;
+    case DevicePairingDelegate::Status::SecurePairingFailed:
+        ChipLogError(chipTool, "Secure Pairing Failed");
+        break;
+    }
+}
+
+void CommissionerCommands::OnPairingComplete(CHIP_ERROR err)
+{
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(chipTool, "Pairing Complete Failure: %s", ErrorStr(err));
+        LogErrorOnFailure(ContinueOnChipMainThread(err));
+    }
+}
+
+void CommissionerCommands::OnPairingDeleted(CHIP_ERROR err)
+{
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(chipTool, "Pairing Delete Failure: %s", ErrorStr(err));
+    }
+
+    LogErrorOnFailure(ContinueOnChipMainThread(err));
+}
+
+void CommissionerCommands::OnCommissioningComplete(chip::NodeId nodeId, CHIP_ERROR err)
+{
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(chipTool, "Commissioning Complete Failure: %s", ErrorStr(err));
+    }
+
+    LogErrorOnFailure(ContinueOnChipMainThread(err));
+}

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <controller/CHIPDeviceController.h>
+#include <lib/support/CodeUtils.h>
+
+class CommissionerCommands : public chip::Controller::DevicePairingDelegate
+{
+public:
+    CommissionerCommands(){};
+    virtual ~CommissionerCommands(){};
+
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)             = 0;
+    virtual chip::Controller::DeviceCommissioner & GetCurrentCommissioner() = 0;
+
+    CHIP_ERROR PairWithQRCode(chip::NodeId nodeId, const chip::CharSpan payload);
+    CHIP_ERROR PairWithManualCode(chip::NodeId nodeId, const chip::CharSpan payload);
+    CHIP_ERROR Unpair(chip::NodeId nodeId);
+
+    /////////// DevicePairingDelegate Interface /////////
+    void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
+    void OnPairingComplete(CHIP_ERROR error) override;
+    void OnPairingDeleted(CHIP_ERROR error) override;
+    void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
+};

--- a/src/app/tests/suites/commands/delay/DelayCommands.cpp
+++ b/src/app/tests/suites/commands/delay/DelayCommands.cpp
@@ -61,5 +61,5 @@ CHIP_ERROR DelayCommands::WaitForOperationalAdvertisement()
 CHIP_ERROR DelayCommands::RunInternal(const char * command)
 {
     VerifyOrReturnError(system(command) == 0, CHIP_ERROR_INTERNAL);
-    return ContinueOnChipMainThread();
+    return ContinueOnChipMainThread(CHIP_NO_ERROR);
 }

--- a/src/app/tests/suites/commands/delay/DelayCommands.h
+++ b/src/app/tests/suites/commands/delay/DelayCommands.h
@@ -28,8 +28,8 @@ public:
     DelayCommands(){};
     virtual ~DelayCommands(){};
 
-    virtual CHIP_ERROR ContinueOnChipMainThread() = 0;
-    virtual void OnWaitForMs()                    = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
+    virtual void OnWaitForMs()                                  = 0;
 
     virtual CHIP_ERROR WaitForCommissionee() { return CHIP_ERROR_NOT_IMPLEMENTED; };
     virtual CHIP_ERROR WaitForCommissioning() { return CHIP_ERROR_NOT_IMPLEMENTED; };

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
@@ -49,7 +49,7 @@ public:
     DiscoveryCommands(){};
     virtual ~DiscoveryCommands(){};
 
-    virtual CHIP_ERROR ContinueOnChipMainThread() = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 
     CHIP_ERROR FindCommissionable();
     CHIP_ERROR FindCommissionableByShortDiscriminator(uint64_t value);

--- a/src/app/tests/suites/commands/log/LogCommands.cpp
+++ b/src/app/tests/suites/commands/log/LogCommands.cpp
@@ -21,13 +21,11 @@
 CHIP_ERROR LogCommands::Log(const char * message)
 {
     ChipLogDetail(chipTool, "%s", message);
-    ReturnErrorOnFailure(ContinueOnChipMainThread());
-    return CHIP_NO_ERROR;
+    return ContinueOnChipMainThread(CHIP_NO_ERROR);
 }
 
 CHIP_ERROR LogCommands::UserPrompt(const char * message)
 {
     ChipLogDetail(chipTool, "USER_PROMPT: %s", message);
-    ReturnErrorOnFailure(ContinueOnChipMainThread());
-    return CHIP_NO_ERROR;
+    return ContinueOnChipMainThread(CHIP_NO_ERROR);
 }

--- a/src/app/tests/suites/commands/log/LogCommands.h
+++ b/src/app/tests/suites/commands/log/LogCommands.h
@@ -26,7 +26,7 @@ public:
     LogCommands(){};
     virtual ~LogCommands(){};
 
-    virtual CHIP_ERROR ContinueOnChipMainThread() = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 
     CHIP_ERROR Log(const char * message);
     CHIP_ERROR UserPrompt(const char * message);

--- a/src/app/tests/suites/commands/system/SystemCommands.cpp
+++ b/src/app/tests/suites/commands/system/SystemCommands.cpp
@@ -71,5 +71,5 @@ CHIP_ERROR SystemCommands::FactoryReset()
 CHIP_ERROR SystemCommands::RunInternal(const char * command)
 {
     VerifyOrReturnError(system(command) == 0, CHIP_ERROR_INTERNAL);
-    return ContinueOnChipMainThread();
+    return ContinueOnChipMainThread(CHIP_NO_ERROR);
 }

--- a/src/app/tests/suites/commands/system/SystemCommands.h
+++ b/src/app/tests/suites/commands/system/SystemCommands.h
@@ -26,7 +26,7 @@ public:
     SystemCommands(){};
     virtual ~SystemCommands(){};
 
-    virtual CHIP_ERROR ContinueOnChipMainThread() = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 
     CHIP_ERROR Start(uint16_t discriminator);
     CHIP_ERROR Stop();

--- a/src/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/*
+ * This file declare test suites utilities methods for commissioner commands.
+ *
+ * Each method declared in this file needs to be implemented on a per-language
+ * basis and permits to exposes methods to the test suites that are not part
+ * of the regular cluster set of APIs.
+ *
+ */
+
+const PairWithQRCode = {
+  name : 'PairWithQRCode',
+  arguments : [ { type : 'NODE_ID', name : 'nodeId' }, { type : 'CHAR_STRING', name : 'payload' } ],
+  response : { arguments : [] }
+};
+
+const PairWithManualCode = {
+  name : 'PairWithManualCode',
+  arguments : [ { type : 'NODE_ID', name : 'nodeId' }, { type : 'CHAR_STRING', name : 'payload' } ],
+  response : { arguments : [] }
+};
+
+const Unpair = {
+  name : 'PairWithManualCode',
+  arguments : [ { type : 'NODE_ID', name : 'nodeId' } ],
+  response : { arguments : [] }
+};
+
+const name     = 'CommissionerCommands';
+const commands = [ PairWithQRCode, PairWithManualCode, Unpair ];
+
+const CommissionerCommands = {
+  name,
+  commands
+};
+
+//
+// Module exports
+//
+exports.cluster = CommissionerCommands;

--- a/src/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
@@ -37,7 +37,7 @@ const PairWithManualCode = {
 };
 
 const Unpair = {
-  name : 'PairWithManualCode',
+  name : 'Unpair',
   arguments : [ { type : 'NODE_ID', name : 'nodeId' } ],
   response : { arguments : [] }
 };


### PR DESCRIPTION
#### Problem

YAML does not have a wait to commission the alternatives identities

#### Change overview
 * Add a commissioner commands module

#### Testing
I have locally tested it with a test that makes use of multiple fabrics at https://github.com/vivien-apple/connectedhomeip-1/blob/TestMultiAdmin/src/app/tests/suites/TestMultiAdmin.yaml
I'm working on moving forward to get it in the tree.