### PR TITLE
[chip-tool] Allow to specify BLE adapter

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR CHIPCommand::Run()
 
 #if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     // By default, Linux device is configured as a BLE peripheral while the controller needs a BLE central.
-    ReturnLogErrorOnFailure(chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(0, true));
+    ReturnLogErrorOnFailure(chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(mBleAdapterId.ValueOr(0), true));
 #endif
 
     ReturnLogErrorOnFailure(mDefaultStorage.Init());

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -60,6 +60,7 @@ public:
         AddArgument("trace_file", &mTraceFile);
         AddArgument("trace_log", 0, 1, &mTraceLog);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+        AddArgument("ble-adapter", 0, UINT64_MAX, &mBleAdapterId);
     }
 
     /////////// Command Interface /////////
@@ -106,6 +107,7 @@ private:
     chip::FabricId CurrentCommissionerId();
     std::map<std::string, std::unique_ptr<ChipDeviceCommissioner>> mCommissioners;
     chip::Optional<char *> mCommissionerName;
+    chip::Optional<uint16_t> mBleAdapterId;
 
     static void RunQueuedCommand(intptr_t commandArg);
 


### PR DESCRIPTION
#### Problem
chip-tool always uses hci0 adapter on Linux.

#### Change overview
Add an optional argument: "--ble-adapter <int>" for choosing a different BLE adapter.

#### Testing
Tested commissioning using hci1 adapter.
