### PR TITLE
Use XX instead of WW in src/controller/CHIPDeviceController.cpp for u…

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1794,7 +1794,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         }
 
         static constexpr size_t kMaxCountryCodeSize = 3;
-        char countryCodeStr[kMaxCountryCodeSize]    = "WW";
+        char countryCodeStr[kMaxCountryCodeSize]    = "XX";
         size_t actualCountryCodeSize                = 2;
 
 #if CONFIG_DEVICE_LAYER
@@ -1804,7 +1804,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
 #endif
         if (status != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "Unable to find country code, defaulting to WW");
+            ChipLogError(Controller, "Unable to find country code, defaulting to XX");
         }
         chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);
 


### PR DESCRIPTION
…nknown country code

#### Problem

`src/controller/CHIPDeviceController.cpp` defines the country code as `WW` when it is unknown. I really don't know what is the origin of this value - there may be something that I have just missed.

In any case, my understanding is that the spec expects `XX` should be used instead: `The special value `XX` SHALL indicate that region-agnostic mode is used.`

#### Change overview
 * Replace `WW` instead of `XX`

#### Testing
I have seen that when working on https://github.com/project-chip/connectedhomeip/pull/14660 where I end up with the test failing because `WW` is stored instead of `XX`